### PR TITLE
build(toolchain): add rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.96.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
This pull request introduces a `rust-toolchain.toml` file to pin the Rust toolchain version used by the project, ensuring consistent and reproducible builds across all development environments.

**Toolchain configuration:**
* Added a new `rust-toolchain.toml` file to declare the project's Rust toolchain, enabling automatic toolchain selection when working in the repository.