### PR TITLE
feat(itofin): scaffold core library modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,3 +5,61 @@ version = 4
 [[package]]
 name = "itofin"
 version = "0.1.0"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"

--- a/crates/itofin/Cargo.toml
+++ b/crates/itofin/Cargo.toml
@@ -7,3 +7,4 @@ edition.workspace = true
 name = "itofin"
 
 [dependencies]
+thiserror = "2.0.12"

--- a/crates/itofin/src/errors.rs
+++ b/crates/itofin/src/errors.rs
@@ -1,0 +1,141 @@
+//! Error handling.
+//!
+//! Port of `ql/errors.{hpp,cpp}` (design decision D4). QuantLib throws
+//! `QuantLib::Error` via the `QL_FAIL`, `QL_REQUIRE`, `QL_ASSERT` and
+//! `QL_ENSURE` macros; we model failures as a [`QlError`] returned through
+//! `Result<T, QlError>`, raised with the [`fail!`], [`require!`], [`assert_ql!`]
+//! and [`ensure!`] macros.
+
+use std::fmt;
+
+use thiserror::Error;
+
+/// Base error type, carrying the message and the source location that raised it.
+#[derive(Debug, Clone, Error)]
+pub struct QlError {
+    message: String,
+    file: &'static str,
+    line: u32,
+}
+
+impl QlError {
+    /// Builds an error from a message and the location it was raised at.
+    pub fn new(message: impl Into<String>, file: &'static str, line: u32) -> Self {
+        QlError {
+            message: message.into(),
+            file,
+            line,
+        }
+    }
+
+    /// The error message, without location information.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl fmt::Display for QlError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}: {}", self.file, self.line, self.message)
+    }
+}
+
+/// Convenience alias for fallible core operations.
+pub type QlResult<T> = Result<T, QlError>;
+
+/// Raises a [`QlError`] by returning `Err`, capturing the call site.
+///
+/// Mirrors `QL_FAIL`. Accepts `format!`-style arguments.
+#[macro_export]
+macro_rules! fail {
+    ($($arg:tt)*) => {
+        return ::core::result::Result::Err($crate::errors::QlError::new(
+            ::std::format!($($arg)*),
+            ::core::file!(),
+            ::core::line!(),
+        ))
+    };
+}
+
+/// Returns `Err` with a [`QlError`] if a pre-condition does not hold.
+///
+/// Mirrors `QL_REQUIRE`.
+#[macro_export]
+macro_rules! require {
+    ($cond:expr, $($arg:tt)*) => {
+        if !($cond) {
+            $crate::fail!($($arg)*);
+        }
+    };
+}
+
+/// Returns `Err` with a [`QlError`] if a post-condition does not hold.
+///
+/// Mirrors `QL_ENSURE`.
+#[macro_export]
+macro_rules! ensure {
+    ($cond:expr, $($arg:tt)*) => {
+        if !($cond) {
+            $crate::fail!($($arg)*);
+        }
+    };
+}
+
+/// Returns `Err` with a [`QlError`] if an invariant does not hold.
+///
+/// Mirrors `QL_ASSERT`. Named `assert_ql!` to avoid clashing with the
+/// std `assert!` macro.
+#[macro_export]
+macro_rules! assert_ql {
+    ($cond:expr, $($arg:tt)*) => {
+        if !($cond) {
+            $crate::fail!($($arg)*);
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fails_with(value: i32) -> QlResult<i32> {
+        fail!("bad value {value}");
+    }
+
+    fn requires_positive(value: i32) -> QlResult<i32> {
+        require!(value > 0, "value must be positive, got {value}");
+        Ok(value)
+    }
+
+    fn ensures_positive(value: i32) -> QlResult<i32> {
+        ensure!(value > 0, "post-condition violated: {value}");
+        Ok(value)
+    }
+
+    #[test]
+    fn fail_returns_err_with_message() {
+        let err = fails_with(7).unwrap_err();
+        assert_eq!(err.message(), "bad value 7");
+    }
+
+    #[test]
+    fn require_passes_and_fails() {
+        assert_eq!(requires_positive(3).unwrap(), 3);
+        let err = requires_positive(-1).unwrap_err();
+        assert_eq!(err.message(), "value must be positive, got -1");
+    }
+
+    #[test]
+    fn ensure_returns_err_on_violation() {
+        assert!(ensures_positive(1).is_ok());
+        assert!(ensures_positive(0).is_err());
+    }
+
+    #[test]
+    fn display_includes_location() {
+        let err = requires_positive(-1).unwrap_err();
+        let text = err.to_string();
+        assert!(text.contains("errors.rs"));
+        assert!(text.contains("value must be positive"));
+    }
+}

--- a/crates/itofin/src/handle.rs
+++ b/crates/itofin/src/handle.rs
@@ -1,0 +1,200 @@
+//! Relinkable shared handle to an observable.
+//!
+//! Port of `ql/handle.hpp` (design decision D2). All copies of a [`Handle`]
+//! share one inner `Link`; relinking through a [`RelinkableHandle`] swaps the
+//! pointee for every copy and notifies the link's observers.
+//!
+//! QuantLib's `Link` also registers as an *observer of its pointee* so that
+//! changes inside the pointee propagate through the handle. That wiring needs an
+//! observable pointee type (e.g. `Quote`, EPIC-3) and is added once such types
+//! exist; the EPIC-0 port covers the shared-link relink-and-notify behavior.
+
+use crate::errors::QlResult;
+use crate::patterns::observable::{Observable, Observer};
+use crate::require;
+use crate::shared::{Shared, SharedMut, shared_mut};
+
+/// Inner shared cell of a [`Handle`]: the current pointee plus the link's own
+/// observable, through which relinks are broadcast.
+pub struct Link<T> {
+    current: Option<Shared<T>>,
+    observable: Observable,
+}
+
+impl<T> Link<T> {
+    fn new(pointee: Option<Shared<T>>) -> Self {
+        Link {
+            current: pointee,
+            observable: Observable::new(),
+        }
+    }
+
+    fn link_to(&mut self, pointee: Option<Shared<T>>) {
+        self.current = pointee;
+        self.observable.notify_observers();
+    }
+
+    fn is_empty(&self) -> bool {
+        self.current.is_none()
+    }
+}
+
+/// Shared handle to an observable pointee.
+///
+/// Cloning a `Handle` shares the same underlying [`Link`]; see
+/// [`RelinkableHandle`] to relink it.
+pub struct Handle<T> {
+    link: SharedMut<Link<T>>,
+}
+
+impl<T> Handle<T> {
+    /// Creates an empty handle.
+    pub fn empty() -> Self {
+        Handle {
+            link: shared_mut(Link::new(None)),
+        }
+    }
+
+    /// Creates a handle pointing at `pointee`.
+    pub fn new(pointee: Shared<T>) -> Self {
+        Handle {
+            link: shared_mut(Link::new(Some(pointee))),
+        }
+    }
+
+    /// Returns the current pointee, or an error if the handle is empty.
+    ///
+    /// Mirrors QuantLib's `currentLink`/`operator*`, which require a non-empty
+    /// handle.
+    pub fn current_link(&self) -> QlResult<Shared<T>> {
+        require!(!self.is_empty(), "empty Handle cannot be dereferenced");
+        Ok(self.link.borrow().current.clone().unwrap())
+    }
+
+    /// Whether the contained pointer points at anything.
+    pub fn is_empty(&self) -> bool {
+        self.link.borrow().is_empty()
+    }
+
+    /// Registers an observer with the underlying link.
+    ///
+    /// The observer is notified whenever the handle is relinked.
+    pub fn register_observer(&self, observer: &SharedMut<dyn Observer>) -> bool {
+        self.link.borrow().observable.register_observer(observer)
+    }
+
+    /// Two handles are equal when they share the same underlying link.
+    pub fn points_to_same_link(&self, other: &Handle<T>) -> bool {
+        SharedMut::ptr_eq(&self.link, &other.link)
+    }
+}
+
+impl<T> Clone for Handle<T> {
+    fn clone(&self) -> Self {
+        Handle {
+            link: SharedMut::clone(&self.link),
+        }
+    }
+}
+
+/// A [`Handle`] that can be relinked, propagating the change to all its copies.
+pub struct RelinkableHandle<T> {
+    handle: Handle<T>,
+}
+
+impl<T> RelinkableHandle<T> {
+    /// Creates an empty relinkable handle.
+    pub fn empty() -> Self {
+        RelinkableHandle {
+            handle: Handle::empty(),
+        }
+    }
+
+    /// Creates a relinkable handle pointing at `pointee`.
+    pub fn new(pointee: Shared<T>) -> Self {
+        RelinkableHandle {
+            handle: Handle::new(pointee),
+        }
+    }
+
+    /// Points the shared link at `pointee`, notifying observers.
+    pub fn link_to(&self, pointee: Shared<T>) {
+        self.handle.link.borrow_mut().link_to(Some(pointee));
+    }
+
+    /// Clears the shared link, notifying observers.
+    pub fn reset(&self) {
+        self.handle.link.borrow_mut().link_to(None);
+    }
+
+    /// Borrows this as a plain [`Handle`] (e.g. to hand out non-relinkable copies).
+    pub fn handle(&self) -> Handle<T> {
+        self.handle.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::shared::{shared, shared_mut};
+
+    #[derive(Default)]
+    struct Flag {
+        up: bool,
+    }
+
+    impl Observer for Flag {
+        fn update(&mut self) {
+            self.up = true;
+        }
+    }
+
+    #[test]
+    fn empty_handle_cannot_be_dereferenced() {
+        let h: Handle<i32> = Handle::empty();
+        assert!(h.is_empty());
+        assert!(h.current_link().is_err());
+    }
+
+    #[test]
+    fn handle_dereferences_to_pointee() {
+        let h = Handle::new(shared(42_i32));
+        assert!(!h.is_empty());
+        assert_eq!(*h.current_link().unwrap(), 42);
+    }
+
+    #[test]
+    fn copies_share_one_link() {
+        let h = Handle::new(shared(1_i32));
+        let copy = h.clone();
+        assert!(h.points_to_same_link(&copy));
+    }
+
+    #[test]
+    fn relink_propagates_notification_to_observers() {
+        let rh = RelinkableHandle::new(shared(1_i32));
+        let observed = rh.handle();
+
+        let flag = shared_mut(Flag::default());
+        observed.register_observer(&(flag.clone() as SharedMut<dyn Observer>));
+
+        rh.link_to(shared(2_i32));
+
+        assert!(flag.borrow().up, "relink should notify observers");
+        // the change is visible through the copy that shares the link
+        assert_eq!(*observed.current_link().unwrap(), 2);
+    }
+
+    #[test]
+    fn reset_empties_and_notifies() {
+        let rh = RelinkableHandle::new(shared(1_i32));
+        let observed = rh.handle();
+        let flag = shared_mut(Flag::default());
+        observed.register_observer(&(flag.clone() as SharedMut<dyn Observer>));
+
+        rh.reset();
+
+        assert!(flag.borrow().up);
+        assert!(observed.is_empty());
+    }
+}

--- a/crates/itofin/src/lib.rs
+++ b/crates/itofin/src/lib.rs
@@ -2,3 +2,11 @@
 //!
 //! The core library (`libitofin`). Language bindings (Python via PyO3, a C ABI
 //! via cbindgen) live in sibling crates and depend on this one.
+
+pub mod errors;
+pub mod handle;
+pub mod patterns;
+pub mod settings;
+pub mod shared;
+pub mod types;
+pub mod utilities;

--- a/crates/itofin/src/patterns/lazyobject.rs
+++ b/crates/itofin/src/patterns/lazyobject.rs
@@ -1,0 +1,326 @@
+//! Calculation-on-demand with result caching.
+//!
+//! Port of `ql/patterns/lazyobject.hpp`. QuantLib's `LazyObject` multiply
+//! inherits from both `Observable` and `Observer`; in Rust we model it as a
+//! reusable helper that a concrete type embeds, exposing the calculation as a
+//! caller-supplied closure.
+//!
+//! The `LazyObject::Defaults` singleton is intentionally not ported: per design
+//! decision D5 the core avoids global singletons, so the "forward all
+//! notifications" vs "forward first only" choice is an explicit constructor
+//! argument instead of session-global state.
+
+use crate::errors::QlResult;
+use crate::patterns::observable::Observable;
+use crate::shared::SharedMut;
+
+use super::observable::Observer;
+
+/// Framework for calculation on demand and result caching.
+///
+/// Embed one in a type that derives results from observable inputs. Drive it
+/// through [`calculate`](LazyObject::calculate) (which runs the supplied closure
+/// at most once until invalidated) and feed it observer notifications via
+/// [`on_update`](LazyObject::on_update).
+pub struct LazyObject {
+    observable: Observable,
+    calculated: bool,
+    frozen: bool,
+    failed: bool,
+    always_forward: bool,
+    updating: bool,
+}
+
+impl LazyObject {
+    /// Creates a lazy object.
+    ///
+    /// `always_forward` selects the notification policy (QuantLib's
+    /// `LazyObject::Defaults`): `true` forwards every notification, `false`
+    /// forwards only the first received after a (re)calculation.
+    pub fn new(always_forward: bool) -> Self {
+        LazyObject {
+            observable: Observable::new(),
+            calculated: false,
+            frozen: false,
+            failed: false,
+            always_forward,
+            updating: false,
+        }
+    }
+
+    /// Access to the embedded observable for registering downstream observers.
+    pub fn observable(&mut self) -> &mut Observable {
+        &mut self.observable
+    }
+
+    /// Whether cached results are currently valid.
+    pub fn is_calculated(&self) -> bool {
+        self.calculated
+    }
+
+    /// Forces the policy to forward only the first notification.
+    pub fn forward_first_notification_only(&mut self) {
+        self.always_forward = false;
+    }
+
+    /// Forces the policy to forward all notifications.
+    pub fn always_forward_notifications(&mut self) {
+        self.always_forward = true;
+    }
+
+    /// Observer-side hook: handles a notification from an input observable.
+    ///
+    /// Implements the C++ `update()` logic, including the recursion guard that
+    /// breaks notification cycles. Returns `true` if observers were notified.
+    pub fn on_update(&mut self) -> bool {
+        if self.updating {
+            return false;
+        }
+        self.updating = true;
+        let mut notified = false;
+        if self.calculated || self.failed || self.always_forward {
+            self.calculated = false;
+            self.failed = false;
+            if !self.frozen {
+                self.observable.notify_observers();
+                notified = true;
+            }
+        }
+        self.updating = false;
+        notified
+    }
+
+    /// Runs `perform` to (re)compute results unless already cached or frozen.
+    ///
+    /// Mirrors `LazyObject::calculate`: marks the object calculated before
+    /// running `perform` (to break bootstrap recursion), and on failure reverts
+    /// to a not-calculated/failed state while propagating the error.
+    pub fn calculate(&mut self, perform: impl FnOnce() -> QlResult<()>) -> QlResult<()> {
+        if !self.calculated && !self.frozen {
+            self.calculated = true;
+            match perform() {
+                Ok(()) => self.failed = false,
+                Err(e) => {
+                    self.calculated = false;
+                    self.failed = true;
+                    return Err(e);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Forces a recalculation and notifies observers.
+    ///
+    /// Mirrors `LazyObject::recalculate`: clears the cached state, runs the
+    /// calculation, and notifies observers afterwards (even on failure).
+    pub fn recalculate(&mut self, perform: impl FnOnce() -> QlResult<()>) -> QlResult<()> {
+        let was_frozen = self.frozen;
+        self.calculated = false;
+        self.frozen = false;
+        self.failed = false;
+        let result = self.calculate(perform);
+        self.frozen = was_frozen;
+        self.observable.notify_observers();
+        result
+    }
+
+    /// Pins the currently cached results, suppressing recalculation.
+    pub fn freeze(&mut self) {
+        self.frozen = true;
+    }
+
+    /// Re-enables recalculation, notifying observers once if it was frozen.
+    pub fn unfreeze(&mut self) {
+        if self.frozen {
+            self.frozen = false;
+            self.observable.notify_observers();
+        }
+    }
+
+    /// Registers an observer with this object's embedded observable.
+    pub fn register_observer(&mut self, observer: &SharedMut<dyn Observer>) -> bool {
+        self.observable.register_observer(observer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fail;
+    use crate::shared::shared_mut;
+
+    /// Observer that records whether it received a notification, mirroring the
+    /// `Flag` helper used throughout the QuantLib test suite.
+    #[derive(Default)]
+    struct Flag {
+        up: bool,
+    }
+
+    impl Flag {
+        fn new() -> SharedMut<Flag> {
+            shared_mut(Flag::default())
+        }
+    }
+
+    impl Observer for Flag {
+        fn update(&mut self) {
+            self.up = true;
+        }
+    }
+
+    /// Minimal lazy object: caches a computed result and can be made to fail,
+    /// standing in for `Stock`/`Instrument` (EPIC-8) which the C++ tests use.
+    struct Lazy {
+        lazy: LazyObject,
+        fail: bool,
+        calc_count: usize,
+    }
+
+    impl Lazy {
+        fn new(always_forward: bool) -> Self {
+            Lazy {
+                lazy: LazyObject::new(always_forward),
+                fail: false,
+                calc_count: 0,
+            }
+        }
+
+        fn npv(&mut self) -> QlResult<()> {
+            let count = &mut self.calc_count;
+            let fail = self.fail;
+            self.lazy.calculate(|| {
+                *count += 1;
+                if fail {
+                    fail!("intentional failure");
+                }
+                Ok(())
+            })
+        }
+
+        /// Simulates the input observable changing (the quote firing `update()`).
+        fn on_input_change(&mut self) {
+            self.lazy.on_update();
+        }
+    }
+
+    #[test]
+    fn calculate_runs_once_until_invalidated() {
+        let mut s = Lazy::new(true);
+        s.npv().unwrap();
+        s.npv().unwrap();
+        assert_eq!(s.calc_count, 1);
+
+        // a notification invalidates the cache; the next NPV recomputes
+        s.on_input_change();
+        s.npv().unwrap();
+        assert_eq!(s.calc_count, 2);
+    }
+
+    #[test]
+    fn forward_first_notification_only() {
+        let mut s = Lazy::new(false);
+        let flag = Flag::new();
+        s.lazy
+            .register_observer(&(flag.clone() as SharedMut<dyn Observer>));
+
+        s.npv().unwrap();
+        s.on_input_change();
+        assert!(flag.borrow().up, "first change should be forwarded");
+
+        flag.borrow_mut().up = false;
+        s.on_input_change();
+        assert!(
+            !flag.borrow().up,
+            "second change without recalculation should be discarded"
+        );
+
+        flag.borrow_mut().up = false;
+        s.npv().unwrap();
+        s.on_input_change();
+        assert!(flag.borrow().up, "change after recalculation is forwarded");
+    }
+
+    #[test]
+    fn always_forward_notifications() {
+        let mut s = Lazy::new(true);
+        let flag = Flag::new();
+        s.lazy
+            .register_observer(&(flag.clone() as SharedMut<dyn Observer>));
+
+        s.npv().unwrap();
+        s.on_input_change();
+        assert!(flag.borrow().up);
+
+        flag.borrow_mut().up = false;
+        s.on_input_change();
+        assert!(flag.borrow().up, "every change should be forwarded");
+    }
+
+    #[test]
+    fn notification_after_failed_calculation() {
+        let mut s = Lazy::new(false);
+        let flag = Flag::new();
+        s.lazy
+            .register_observer(&(flag.clone() as SharedMut<dyn Observer>));
+
+        // successful calc, then change => notified
+        s.npv().unwrap();
+        s.on_input_change();
+        assert!(flag.borrow().up);
+        flag.borrow_mut().up = false;
+
+        // failed calc must not notify by itself
+        s.fail = true;
+        assert!(s.npv().is_err());
+        assert!(!flag.borrow().up);
+
+        // fix and change => notified despite the prior failure
+        s.fail = false;
+        s.on_input_change();
+        assert!(flag.borrow().up);
+        flag.borrow_mut().up = false;
+
+        // successful recalculation must not notify by itself
+        s.npv().unwrap();
+        assert!(!flag.borrow().up);
+
+        // after recovery, one change is forwarded...
+        s.on_input_change();
+        assert!(flag.borrow().up);
+        flag.borrow_mut().up = false;
+
+        // ...but a second change without recalculation is discarded
+        s.on_input_change();
+        assert!(!flag.borrow().up);
+    }
+
+    #[test]
+    fn recursive_update_is_broken_by_guard() {
+        // on_update() guards against re-entry; calling it from within update
+        // (simulated by a manual nested call) must not recurse forever.
+        let mut s = Lazy::new(true);
+        s.npv().unwrap();
+        // two notifications in a row simply re-fire; the guard only matters for
+        // true re-entrancy, which we assert does not deadlock or overflow here.
+        s.on_input_change();
+        s.on_input_change();
+        assert!(!s.lazy.is_calculated());
+    }
+
+    #[test]
+    fn freeze_suppresses_notifications() {
+        let mut s = Lazy::new(true);
+        let flag = Flag::new();
+        s.lazy
+            .register_observer(&(flag.clone() as SharedMut<dyn Observer>));
+
+        s.npv().unwrap();
+        s.lazy.freeze();
+        s.on_input_change();
+        assert!(!flag.borrow().up, "frozen object should not notify");
+
+        s.lazy.unfreeze();
+        assert!(flag.borrow().up, "unfreeze sends a catch-up notification");
+    }
+}

--- a/crates/itofin/src/patterns/mod.rs
+++ b/crates/itofin/src/patterns/mod.rs
@@ -1,0 +1,5 @@
+//! Foundational design patterns ported from `ql/patterns/`.
+
+pub mod lazyobject;
+pub mod observable;
+pub mod visitor;

--- a/crates/itofin/src/patterns/observable.rs
+++ b/crates/itofin/src/patterns/observable.rs
@@ -1,0 +1,227 @@
+//! Observer/observable pattern.
+//!
+//! Port of the single-threaded branch of `ql/patterns/observable.{hpp,cpp}`
+//! (design decision D1). The thread-safety machinery (`ObservableSettings`,
+//! deferred updates, recursive mutexes, the `Proxy` indirection) is skipped
+//! per the Rc-first port; only the observer registry and notification are kept.
+//!
+//! Observers are held by [`WeakMut`] back-references so the observer ⇄ observable
+//! graph cannot form an `Rc` cycle. [`Observable::notify_observers`] snapshots the
+//! live observers and drops every borrow before calling `update`, so an observer
+//! may freely register, unregister or mutate the graph while being notified.
+
+use std::cell::RefCell;
+
+use crate::shared::{SharedMut, WeakMut};
+
+/// Object that gets notified when an [`Observable`] it registered with changes.
+///
+/// Mirrors QuantLib's `Observer`. The corresponding `update()` is the single
+/// required method; the registry plumbing lives on [`Observable`].
+pub trait Observer {
+    /// Called by the observables this instance registered with on a change.
+    fn update(&mut self);
+}
+
+/// Object that notifies its changes to a set of observers.
+///
+/// Mirrors QuantLib's `Observable`. Embed one in any type that needs to notify;
+/// register observers with [`register_observer`](Observable::register_observer)
+/// and broadcast with [`notify_observers`](Observable::notify_observers).
+///
+/// The registry lives behind a `RefCell` so notification takes `&self` and never
+/// holds a borrow across `update`: an observer may freely register, unregister
+/// or otherwise touch this observable while being notified.
+#[derive(Default)]
+pub struct Observable {
+    observers: RefCell<Vec<WeakMut<dyn Observer>>>,
+}
+
+impl Observable {
+    /// Creates an observable with no registered observers.
+    pub fn new() -> Self {
+        Observable {
+            observers: RefCell::new(Vec::new()),
+        }
+    }
+
+    /// Registers an observer, returning `true` if it was newly added.
+    ///
+    /// Registration is idempotent by pointer identity, mirroring the
+    /// `std::set<Observer*>` semantics of the C++ implementation.
+    pub fn register_observer(&self, observer: &SharedMut<dyn Observer>) -> bool {
+        let weak = SharedMut::downgrade(observer);
+        let mut observers = self.observers.borrow_mut();
+        observers.retain(|w| w.strong_count() > 0);
+        if observers.iter().any(|w| w.ptr_eq(&weak)) {
+            return false;
+        }
+        observers.push(weak);
+        true
+    }
+
+    /// Unregisters an observer, returning `true` if it had been registered.
+    pub fn unregister_observer(&self, observer: &SharedMut<dyn Observer>) -> bool {
+        let target = SharedMut::downgrade(observer);
+        let mut observers = self.observers.borrow_mut();
+        let before = observers.len();
+        observers.retain(|w| !w.ptr_eq(&target) && w.strong_count() > 0);
+        before != observers.len()
+    }
+
+    /// Notifies every currently registered, still-live observer.
+    ///
+    /// The live observers are snapshotted (as strong refs) and the registry
+    /// borrow is dropped before any `update` runs, so re-entrant
+    /// registration/unregistration during `update` is safe and does not affect
+    /// this round of notification. Dropped observers are pruned.
+    pub fn notify_observers(&self) {
+        let snapshot: Vec<SharedMut<dyn Observer>> = {
+            let mut observers = self.observers.borrow_mut();
+            observers.retain(|w| w.strong_count() > 0);
+            observers.iter().filter_map(WeakMut::upgrade).collect()
+        };
+        for observer in snapshot {
+            observer.borrow_mut().update();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::shared::{Shared, SharedMut, shared_mut};
+
+    /// Mirrors the C++ test `UpdateCounter`: counts received notifications.
+    struct UpdateCounter {
+        counter: usize,
+    }
+
+    impl UpdateCounter {
+        fn new() -> SharedMut<UpdateCounter> {
+            shared_mut(UpdateCounter { counter: 0 })
+        }
+    }
+
+    impl Observer for UpdateCounter {
+        fn update(&mut self) {
+            self.counter += 1;
+        }
+    }
+
+    fn as_observer(obs: &SharedMut<UpdateCounter>) -> SharedMut<dyn Observer> {
+        obs.clone()
+    }
+
+    #[test]
+    fn notify_increments_registered_observers() {
+        let observable = Observable::new();
+        let counter = UpdateCounter::new();
+        assert!(observable.register_observer(&as_observer(&counter)));
+        assert_eq!(counter.borrow().counter, 0);
+
+        observable.notify_observers();
+        assert_eq!(counter.borrow().counter, 1);
+
+        observable.notify_observers();
+        assert_eq!(counter.borrow().counter, 2);
+    }
+
+    #[test]
+    fn registration_is_idempotent() {
+        let observable = Observable::new();
+        let counter = UpdateCounter::new();
+        assert!(observable.register_observer(&as_observer(&counter)));
+        assert!(!observable.register_observer(&as_observer(&counter)));
+
+        observable.notify_observers();
+        assert_eq!(counter.borrow().counter, 1);
+    }
+
+    #[test]
+    fn unregister_stops_notifications() {
+        let observable = Observable::new();
+        let counter = UpdateCounter::new();
+        observable.register_observer(&as_observer(&counter));
+
+        assert!(observable.unregister_observer(&as_observer(&counter)));
+        observable.notify_observers();
+        assert_eq!(counter.borrow().counter, 0);
+
+        // unregistering again reports no change
+        assert!(!observable.unregister_observer(&as_observer(&counter)));
+    }
+
+    #[test]
+    fn unregister_on_empty_is_harmless() {
+        let observable = Observable::new();
+        let counter = UpdateCounter::new();
+        assert!(!observable.unregister_observer(&as_observer(&counter)));
+    }
+
+    #[test]
+    fn dropped_observers_are_pruned() {
+        let observable = Observable::new();
+        let survivor = UpdateCounter::new();
+        observable.register_observer(&as_observer(&survivor));
+        {
+            let transient = UpdateCounter::new();
+            observable.register_observer(&as_observer(&transient));
+        }
+        // the transient observer was dropped; notifying must not panic and the
+        // survivor still gets its update
+        observable.notify_observers();
+        assert_eq!(survivor.borrow().counter, 1);
+    }
+
+    /// Mirrors `testAddAndDeleteObserverDuringNotifyObservers`: an observer that
+    /// registers more observers and drops some during its own `update()` must
+    /// not break notification of the initially-registered set.
+    struct ReentrantObserver {
+        updates: usize,
+        observable: Shared<Observable>,
+        spawned: SharedMut<Vec<SharedMut<UpdateCounter>>>,
+        spawn_count: usize,
+    }
+
+    impl Observer for ReentrantObserver {
+        fn update(&mut self) {
+            self.updates += 1;
+            for _ in 0..self.spawn_count {
+                let extra = UpdateCounter::new();
+                self.observable
+                    .register_observer(&(extra.clone() as SharedMut<dyn Observer>));
+                self.spawned.borrow_mut().push(extra);
+            }
+        }
+    }
+
+    #[test]
+    fn add_observers_during_notify_does_not_miss_initial_observers() {
+        // The observable is shared (not wrapped in a RefCell) precisely because
+        // notification now takes `&self`; an observer can re-enter it directly.
+        let observable = Shared::new(Observable::new());
+        let spawned: SharedMut<Vec<SharedMut<UpdateCounter>>> = shared_mut(Vec::new());
+
+        let plain = UpdateCounter::new();
+        observable.register_observer(&as_observer(&plain));
+
+        let reentrant = shared_mut(ReentrantObserver {
+            updates: 0,
+            observable: observable.clone(),
+            spawned: spawned.clone(),
+            spawn_count: 10,
+        });
+        observable.register_observer(&(reentrant.clone() as SharedMut<dyn Observer>));
+
+        observable.notify_observers();
+
+        // both initially-registered observers were updated exactly once...
+        assert_eq!(plain.borrow().counter, 1);
+        assert_eq!(reentrant.borrow().updates, 1);
+        // ...and the observers added mid-notification exist but were not part of
+        // this notification round (snapshot-before-notify semantics).
+        assert_eq!(spawned.borrow().len(), 10);
+        assert!(spawned.borrow().iter().all(|o| o.borrow().counter == 0));
+    }
+}

--- a/crates/itofin/src/patterns/visitor.rs
+++ b/crates/itofin/src/patterns/visitor.rs
@@ -1,0 +1,21 @@
+//! Visitor pattern.
+//!
+//! Port of `ql/patterns/visitor.hpp`. QuantLib's acyclic-visitor machinery
+//! (`AcyclicVisitor` base + `Visitor<T>` per type, recovered at runtime via
+//! `dynamic_cast`) exists to work around C++ single dispatch. In Rust the same
+//! intent is expressed directly with a trait per visited type, so we keep only
+//! the generic [`Visitor`] trait and drop the `AcyclicVisitor` base.
+//!
+//! The curiously-recurring template pattern (`ql/patterns/curiouslyrecurring.hpp`)
+//! is not ported as a type: it is a C++ static-dispatch idiom whose equivalent
+//! in Rust is provided by generics and trait default methods, so it has no
+//! runtime behavior and no test to satisfy.
+
+/// Visitor for a specific visited type `T`.
+///
+/// Mirrors QuantLib's `Visitor<T>`: a visited type calls `visit` on the
+/// concrete visitor. Implement once per `(visitor, T)` pair.
+pub trait Visitor<T> {
+    /// Visits a value of type `T`.
+    fn visit(&mut self, target: &mut T);
+}

--- a/crates/itofin/src/settings.rs
+++ b/crates/itofin/src/settings.rs
@@ -1,0 +1,155 @@
+//! Run-time evaluation settings.
+//!
+//! Port of `ql/settings.{hpp,cpp}` (design decision D5). QuantLib's `Settings`
+//! is a global singleton holding the evaluation date and a handful of pricing
+//! flags. Per D5 we deliberately do **not** reproduce the singleton: `Settings`
+//! is an explicit value object, passed by reference (`&Context`-style), so the
+//! evaluation date is visible to and overridable by callers (including future
+//! `rayon` compute threads, D6) rather than hidden in thread-local state.
+//!
+//! The evaluation date is generic over its payload `D` here because the
+//! concrete `Date` type belongs to EPIC-2; once `Date` lands, downstream code
+//! uses `Settings<Date>`. Assigning a *different* date notifies observers;
+//! assigning the same date does not, matching `settings.cpp`.
+
+use crate::patterns::observable::{Observable, Observer};
+use crate::shared::SharedMut;
+
+/// Run-time settings governing pricing.
+///
+/// `D` is the evaluation-date payload (a `Date` once EPIC-2 is ported).
+pub struct Settings<D> {
+    evaluation_date: Option<D>,
+    eval_date_observable: Observable,
+    include_reference_date_events: bool,
+    include_todays_cash_flows: Option<bool>,
+    enforces_todays_historic_fixings: bool,
+}
+
+impl<D> Default for Settings<D> {
+    fn default() -> Self {
+        Settings {
+            evaluation_date: None,
+            eval_date_observable: Observable::new(),
+            include_reference_date_events: false,
+            include_todays_cash_flows: None,
+            enforces_todays_historic_fixings: false,
+        }
+    }
+}
+
+impl<D: PartialEq + Clone> Settings<D> {
+    /// Creates settings with no explicit evaluation date set.
+    pub fn new() -> Self {
+        Settings::default()
+    }
+
+    /// The currently set evaluation date, if any.
+    ///
+    /// `None` corresponds to QuantLib's "use today's date" default; the
+    /// concrete today's-date fallback is resolved by the caller once `Date`
+    /// exists.
+    pub fn evaluation_date(&self) -> Option<&D> {
+        self.evaluation_date.as_ref()
+    }
+
+    /// Sets the evaluation date, notifying observers only if it actually changed.
+    pub fn set_evaluation_date(&mut self, date: D) {
+        if self.evaluation_date.as_ref() != Some(&date) {
+            self.evaluation_date = Some(date);
+            self.eval_date_observable.notify_observers();
+        }
+    }
+
+    /// Registers an observer to be notified on evaluation-date changes.
+    pub fn register_eval_date_observer(&mut self, observer: &SharedMut<dyn Observer>) -> bool {
+        self.eval_date_observable.register_observer(observer)
+    }
+
+    /// Whether events on the reference date are, by default, treated as not yet
+    /// occurred.
+    pub fn include_reference_date_events(&self) -> bool {
+        self.include_reference_date_events
+    }
+
+    /// Sets the [`include_reference_date_events`](Self::include_reference_date_events) flag.
+    pub fn set_include_reference_date_events(&mut self, value: bool) {
+        self.include_reference_date_events = value;
+    }
+
+    /// Whether cash flows on today's date enter the NPV, when set.
+    pub fn include_todays_cash_flows(&self) -> Option<bool> {
+        self.include_todays_cash_flows
+    }
+
+    /// Sets the [`include_todays_cash_flows`](Self::include_todays_cash_flows) flag.
+    pub fn set_include_todays_cash_flows(&mut self, value: Option<bool>) {
+        self.include_todays_cash_flows = value;
+    }
+
+    /// Whether today's historic fixings are enforced.
+    pub fn enforces_todays_historic_fixings(&self) -> bool {
+        self.enforces_todays_historic_fixings
+    }
+
+    /// Sets the [`enforces_todays_historic_fixings`](Self::enforces_todays_historic_fixings) flag.
+    pub fn set_enforces_todays_historic_fixings(&mut self, value: bool) {
+        self.enforces_todays_historic_fixings = value;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::shared::{SharedMut, shared_mut};
+
+    #[derive(Default)]
+    struct Flag {
+        up: bool,
+    }
+
+    impl Observer for Flag {
+        fn update(&mut self) {
+            self.up = true;
+        }
+    }
+
+    /// Mirrors `settings.cpp::testNotificationsOnDateChange`, using an integer
+    /// serial date in place of the EPIC-2 `Date`.
+    #[test]
+    fn notifies_only_on_actual_date_change() {
+        let mut settings: Settings<i64> = Settings::new();
+        let d1 = 44238_i64; // 11 Feb 2021
+        let d2 = 44239_i64; // 12 Feb 2021
+
+        settings.set_evaluation_date(d1);
+
+        let flag = shared_mut(Flag::default());
+        settings.register_eval_date_observer(&(flag.clone() as SharedMut<dyn Observer>));
+
+        // setting to the same date sends no notification
+        settings.set_evaluation_date(d1);
+        assert!(!flag.borrow().up);
+
+        // setting to a different date notifies
+        settings.set_evaluation_date(d2);
+        assert!(flag.borrow().up);
+        assert_eq!(settings.evaluation_date(), Some(&d2));
+    }
+
+    #[test]
+    fn flags_round_trip() {
+        let mut settings: Settings<i64> = Settings::new();
+        assert!(!settings.include_reference_date_events());
+        assert_eq!(settings.include_todays_cash_flows(), None);
+        assert!(!settings.enforces_todays_historic_fixings());
+
+        settings.set_include_reference_date_events(true);
+        settings.set_include_todays_cash_flows(Some(true));
+        settings.set_enforces_todays_historic_fixings(true);
+
+        assert!(settings.include_reference_date_events());
+        assert_eq!(settings.include_todays_cash_flows(), Some(true));
+        assert!(settings.enforces_todays_historic_fixings());
+    }
+}

--- a/crates/itofin/src/shared.rs
+++ b/crates/itofin/src/shared.rs
@@ -1,0 +1,58 @@
+//! Centralized smart-pointer aliases for the core.
+//!
+//! QuantLib uses `ext::shared_ptr<T>` pervasively. Per design decision D3 the
+//! core is single-threaded-mutable, so we map it to [`Rc`] now; a future switch
+//! to `Arc` (for `rayon`/PyO3) is a localized change to this module rather than
+//! a scattered rewrite. Everything downstream must go through these aliases.
+
+use std::cell::RefCell;
+use std::rc::{Rc, Weak};
+
+/// Shared ownership of an immutable pointee (`ext::shared_ptr<T>`).
+pub type Shared<T> = Rc<T>;
+
+/// Shared ownership of a mutable pointee (`ext::shared_ptr<T>` over mutable state).
+pub type SharedMut<T> = Rc<RefCell<T>>;
+
+/// Non-owning back-reference used to break reference cycles (observer graph).
+pub type WeakMut<T> = Weak<RefCell<T>>;
+
+/// Constructs a [`Shared`] from a value.
+pub fn shared<T>(value: T) -> Shared<T> {
+    Rc::new(value)
+}
+
+/// Constructs a [`SharedMut`] from a value.
+pub fn shared_mut<T>(value: T) -> SharedMut<T> {
+    Rc::new(RefCell::new(value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shared_clones_share_one_pointee() {
+        let a = shared(7_i32);
+        let b = Shared::clone(&a);
+        assert!(Shared::ptr_eq(&a, &b));
+        assert_eq!(Shared::strong_count(&a), 2);
+    }
+
+    #[test]
+    fn shared_mut_mutation_is_visible_through_clones() {
+        let a = shared_mut(1_i32);
+        let b = SharedMut::clone(&a);
+        *b.borrow_mut() = 42;
+        assert_eq!(*a.borrow(), 42);
+    }
+
+    #[test]
+    fn weak_does_not_keep_pointee_alive() {
+        let weak: WeakMut<i32> = {
+            let strong = shared_mut(3_i32);
+            SharedMut::downgrade(&strong)
+        };
+        assert!(weak.upgrade().is_none());
+    }
+}

--- a/crates/itofin/src/types.rs
+++ b/crates/itofin/src/types.rs
@@ -1,0 +1,71 @@
+//! Custom numeric types.
+//!
+//! Port of `ql/types.hpp`. QuantLib defines these as `typedef`s over the
+//! configurable macros `QL_REAL` (default `double`), `QL_INTEGER` (default
+//! `int`) and `QL_BIG_INTEGER` (default `long`); we pin them to their default
+//! widths.
+
+/// Integer number (`QL_INTEGER`, default `int`).
+pub type Integer = i32;
+
+/// Large integer number (`QL_BIG_INTEGER`, default `long`).
+pub type BigInteger = i64;
+
+/// Positive integer (`unsigned QL_INTEGER`).
+pub type Natural = u32;
+
+/// Large positive integer (`unsigned QL_BIG_INTEGER`).
+pub type BigNatural = u64;
+
+/// Real number (`QL_REAL`, default `double`).
+pub type Real = f64;
+
+/// Decimal number.
+pub type Decimal = Real;
+
+/// Size of a container (`std::size_t`).
+pub type Size = usize;
+
+/// Continuous quantity with 1-year units.
+pub type Time = Real;
+
+/// Discount factor between dates.
+pub type DiscountFactor = Real;
+
+/// Interest rate.
+pub type Rate = Real;
+
+/// Spread on an interest rate.
+pub type Spread = Real;
+
+/// Volatility.
+pub type Volatility = Real;
+
+/// Probability.
+pub type Probability = Real;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn type_widths_match_quantlib_defaults() {
+        assert_eq!(size_of::<Real>(), 8);
+        assert_eq!(size_of::<Integer>(), 4);
+        assert_eq!(size_of::<BigInteger>(), 8);
+        assert_eq!(size_of::<Natural>(), 4);
+        assert_eq!(size_of::<BigNatural>(), 8);
+        assert_eq!(size_of::<Size>(), size_of::<usize>());
+    }
+
+    #[test]
+    fn semantic_aliases_are_real() {
+        let _t: Time = 1.0;
+        let _r: Rate = 0.05;
+        let _s: Spread = 0.01;
+        let _v: Volatility = 0.2;
+        let _d: Decimal = 2.5;
+        let _df: DiscountFactor = 0.99;
+        let _p: Probability = 0.5;
+    }
+}

--- a/crates/itofin/src/utilities/clone.rs
+++ b/crates/itofin/src/utilities/clone.rs
@@ -1,0 +1,97 @@
+//! Cloning proxy to an owned object.
+//!
+//! Port of `ql/utilities/clone.hpp`. QuantLib's `Clone<T>` is a `unique_ptr`
+//! wrapper that deep-copies its pointee (via the pointee's `clone()`) on copy,
+//! giving value semantics to a polymorphic, heap-owned object.
+//!
+//! In Rust this is largely subsumed by `Box<T>`, whose `Clone` impl already
+//! deep-copies when `T: Clone`. [`Clone`] is kept as a thin owning box so the
+//! C++ call sites translate directly and the intent stays explicit.
+
+/// Owning box with deep-copy value semantics.
+pub struct Clone<T> {
+    ptr: Option<Box<T>>,
+}
+
+impl<T> Clone<T> {
+    /// An empty clone holding nothing.
+    pub fn empty() -> Self {
+        Clone { ptr: None }
+    }
+
+    /// Wraps an owned value.
+    pub fn new(value: T) -> Self {
+        Clone {
+            ptr: Some(Box::new(value)),
+        }
+    }
+
+    /// Whether there is no underlying object.
+    pub fn is_empty(&self) -> bool {
+        self.ptr.is_none()
+    }
+
+    /// Borrows the underlying object.
+    pub fn get(&self) -> Option<&T> {
+        self.ptr.as_deref()
+    }
+
+    /// Mutably borrows the underlying object.
+    pub fn get_mut(&mut self) -> Option<&mut T> {
+        self.ptr.as_deref_mut()
+    }
+
+    /// Swaps the contents of two clones.
+    pub fn swap(&mut self, other: &mut Clone<T>) {
+        std::mem::swap(&mut self.ptr, &mut other.ptr);
+    }
+}
+
+impl<T: std::clone::Clone> std::clone::Clone for Clone<T> {
+    fn clone(&self) -> Self {
+        Clone {
+            ptr: self.ptr.clone(),
+        }
+    }
+}
+
+impl<T> Default for Clone<T> {
+    fn default() -> Self {
+        Clone::empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_and_filled() {
+        let empty: Clone<i32> = Clone::empty();
+        assert!(empty.is_empty());
+        assert!(empty.get().is_none());
+
+        let filled = Clone::new(7_i32);
+        assert!(!filled.is_empty());
+        assert_eq!(filled.get(), Some(&7));
+    }
+
+    #[test]
+    fn clone_is_a_deep_copy() {
+        let original = Clone::new(vec![1, 2, 3]);
+        let mut copy = original.clone();
+        copy.get_mut().unwrap().push(4);
+
+        assert_eq!(original.get().unwrap().len(), 3);
+        assert_eq!(copy.get().unwrap().len(), 4);
+    }
+
+    #[test]
+    fn swap_exchanges_contents() {
+        let mut a = Clone::new(1_i32);
+        let mut b = Clone::new(2_i32);
+        a.swap(&mut b);
+        assert_eq!(a.get(), Some(&2));
+        assert_eq!(b.get(), Some(&1));
+    }
+}

--- a/crates/itofin/src/utilities/dataformatters.rs
+++ b/crates/itofin/src/utilities/dataformatters.rs
@@ -1,0 +1,78 @@
+//! Output formatters.
+//!
+//! Port of the low-cost subset of `ql/utilities/dataformatters.hpp`. QuantLib's
+//! `io::` manipulators are tied to C++ `std::ostream`; the genuinely useful,
+//! cheap ones are ported here as functions returning `String`. The container
+//! `sequence` / `power_of_two` manipulators are deferred (low value to the
+//! core).
+
+use crate::types::{Rate, Real, Size, Volatility};
+use crate::utilities::null::Null;
+
+/// Formats a value, emitting `"null"` for the type's [`Null`] sentinel.
+pub fn check_null<T: Null + std::fmt::Display>(value: T) -> String {
+    if value.is_null() {
+        "null".to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+/// Formats a count as an English ordinal: `1st`, `2nd`, `3rd`, `4th`, ...
+pub fn ordinal(n: Size) -> String {
+    let suffix = match (n % 10, n % 100) {
+        (1, 11) | (2, 12) | (3, 13) => "th",
+        (1, _) => "st",
+        (2, _) => "nd",
+        (3, _) => "rd",
+        _ => "th",
+    };
+    format!("{n}{suffix}")
+}
+
+/// Formats a real as a percentage, e.g. `0.05` → `"5.000000 %"`.
+pub fn percent(value: Real) -> String {
+    format!("{} %", value * 100.0)
+}
+
+/// Formats a rate as a percentage.
+pub fn rate(r: Rate) -> String {
+    percent(r)
+}
+
+/// Formats a volatility as a percentage.
+pub fn volatility(v: Volatility) -> String {
+    percent(v)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::Integer;
+
+    #[test]
+    fn check_null_emits_null_for_sentinel() {
+        assert_eq!(check_null(Integer::MAX), "null");
+        assert_eq!(check_null(7_i32), "7");
+    }
+
+    #[test]
+    fn ordinals() {
+        assert_eq!(ordinal(1), "1st");
+        assert_eq!(ordinal(2), "2nd");
+        assert_eq!(ordinal(3), "3rd");
+        assert_eq!(ordinal(4), "4th");
+        assert_eq!(ordinal(11), "11th");
+        assert_eq!(ordinal(12), "12th");
+        assert_eq!(ordinal(13), "13th");
+        assert_eq!(ordinal(21), "21st");
+        assert_eq!(ordinal(112), "112th");
+    }
+
+    #[test]
+    fn percentages() {
+        assert_eq!(percent(0.05), "5 %");
+        assert_eq!(rate(0.05), "5 %");
+        assert_eq!(volatility(0.2), "20 %");
+    }
+}

--- a/crates/itofin/src/utilities/mod.rs
+++ b/crates/itofin/src/utilities/mod.rs
@@ -1,0 +1,6 @@
+//! Foundational helpers ported from `ql/utilities/`.
+
+pub mod clone;
+pub mod dataformatters;
+pub mod null;
+pub mod steppingiterator;

--- a/crates/itofin/src/utilities/null.rs
+++ b/crates/itofin/src/utilities/null.rs
@@ -1,0 +1,62 @@
+//! Null sentinel values.
+//!
+//! Port of `ql/utilities/null.hpp`. QuantLib's `Null<T>` yields a per-type
+//! sentinel ("not set"): for floating-point types the largest `float`, for
+//! integral types the largest `int`. We expose it as a [`Null`] trait so any
+//! numeric type can provide and recognize its sentinel.
+
+use crate::types::{BigInteger, BigNatural, Integer, Natural, Real, Size};
+
+/// Provides a per-type "null"/unset sentinel value.
+pub trait Null: Sized + PartialEq {
+    /// The sentinel value for this type.
+    fn null() -> Self;
+
+    /// Whether `self` equals the sentinel.
+    fn is_null(&self) -> bool {
+        *self == Self::null()
+    }
+}
+
+impl Null for Real {
+    fn null() -> Self {
+        // a specific, unlikely value that fits into any Real (largest float)
+        f32::MAX as Real
+    }
+}
+
+macro_rules! impl_null_integral {
+    ($($t:ty),*) => {
+        $(
+            impl Null for $t {
+                fn null() -> Self {
+                    // fits into any Integer (largest int)
+                    Integer::MAX as $t
+                }
+            }
+        )*
+    };
+}
+
+impl_null_integral!(Integer, BigInteger, Natural, BigNatural, Size);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn real_null_is_largest_float() {
+        assert_eq!(Real::null(), f32::MAX as Real);
+        assert!(Real::null().is_null());
+        assert!(!(1.0 as Real).is_null());
+    }
+
+    #[test]
+    fn integral_null_is_largest_int() {
+        assert_eq!(Integer::null(), Integer::MAX);
+        assert_eq!(BigInteger::null(), Integer::MAX as BigInteger);
+        assert_eq!(Size::null(), Integer::MAX as Size);
+        assert!(Integer::MAX.is_null());
+        assert!(!0_i32.is_null());
+    }
+}

--- a/crates/itofin/src/utilities/steppingiterator.rs
+++ b/crates/itofin/src/utilities/steppingiterator.rs
@@ -1,0 +1,69 @@
+//! Iterator advancing in constant steps.
+//!
+//! Port of `ql/utilities/steppingiterator.hpp`. QuantLib's `step_iterator`
+//! adapts a random-access iterator so that each increment advances `step`
+//! positions. Over a Rust slice this is naturally an iterator yielding every
+//! `step`-th element; we expose it as [`StepIterator`] (plus the [`step_iter`]
+//! helper) rather than reimplementing C++ iterator arithmetic.
+
+use crate::types::Size;
+
+/// Iterator over a slice that advances by a fixed step.
+pub struct StepIterator<'a, T> {
+    data: &'a [T],
+    pos: Size,
+    step: Size,
+}
+
+impl<'a, T> Iterator for StepIterator<'a, T> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.pos >= self.data.len() {
+            return None;
+        }
+        let item = &self.data[self.pos];
+        self.pos += self.step;
+        Some(item)
+    }
+}
+
+/// Creates a stepping iterator over `data` advancing `step` positions each time.
+///
+/// `step` must be positive, mirroring the C++ pre-condition.
+pub fn step_iter<T>(data: &[T], step: Size) -> StepIterator<'_, T> {
+    assert!(step > 0, "step must be positive");
+    StepIterator { data, pos: 0, step }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn advances_in_constant_steps() {
+        let data = [0, 1, 2, 3, 4, 5, 6];
+        let collected: Vec<i32> = step_iter(&data, 2).copied().collect();
+        assert_eq!(collected, vec![0, 2, 4, 6]);
+    }
+
+    #[test]
+    fn step_of_one_yields_every_element() {
+        let data = [10, 20, 30];
+        let collected: Vec<i32> = step_iter(&data, 1).copied().collect();
+        assert_eq!(collected, vec![10, 20, 30]);
+    }
+
+    #[test]
+    fn step_larger_than_len_yields_first_only() {
+        let data = [10, 20, 30];
+        let collected: Vec<i32> = step_iter(&data, 10).copied().collect();
+        assert_eq!(collected, vec![10]);
+    }
+
+    #[test]
+    #[should_panic(expected = "step must be positive")]
+    fn zero_step_panics() {
+        let _ = step_iter(&[1, 2, 3], 0);
+    }
+}


### PR DESCRIPTION
This pull request establishes the foundational module structure for the `libitofin` core library, introducing the primary building blocks for the crate and wiring them into the library root.

**New core modules:**
* Added `errors`, `handle`, `settings`, `shared`, and `types` modules to define the crate's error handling, handle management, configuration, shared state, and type definitions.
* Introduced a `patterns` module with `observable`, `lazyobject`, and `visitor` submodules to support common design patterns.
* Added a `utilities` module with `dataformatters`, `null`, `clone`, and `steppingiterator` submodules for shared helper functionality.

**Library and dependency updates:**
* Updated `lib.rs` to declare and expose the new `errors`, `handle`, `patterns`, `settings`, `shared`, `types`, and `utilities` modules.
* Added the `thiserror` dependency to `Cargo.toml` to support ergonomic error definitions.