### PR TITLE
feat(src): add shared and types modules to itofin core

### DIFF
--- a/crates/itofin/src/lib.rs
+++ b/crates/itofin/src/lib.rs
@@ -2,3 +2,6 @@
 //!
 //! The core library (`libitofin`). Language bindings (Python via PyO3, a C ABI
 //! via cbindgen) live in sibling crates and depend on this one.
+
+pub mod shared;
+pub mod types;

--- a/crates/itofin/src/shared.rs
+++ b/crates/itofin/src/shared.rs
@@ -1,0 +1,58 @@
+//! Centralized smart-pointer aliases for the core.
+//!
+//! QuantLib uses `ext::shared_ptr<T>` pervasively. Per design decision D3 the
+//! core is single-threaded-mutable, so we map it to [`Rc`] now; a future switch
+//! to `Arc` (for `rayon`/PyO3) is a localized change to this module rather than
+//! a scattered rewrite. Everything downstream must go through these aliases.
+
+use std::cell::RefCell;
+use std::rc::{Rc, Weak};
+
+/// Shared ownership of an immutable pointee (`ext::shared_ptr<T>`).
+pub type Shared<T> = Rc<T>;
+
+/// Shared ownership of a mutable pointee (`ext::shared_ptr<T>` over mutable state).
+pub type SharedMut<T> = Rc<RefCell<T>>;
+
+/// Non-owning back-reference used to break reference cycles (observer graph).
+pub type WeakMut<T> = Weak<RefCell<T>>;
+
+/// Constructs a [`Shared`] from a value.
+pub fn shared<T>(value: T) -> Shared<T> {
+    Rc::new(value)
+}
+
+/// Constructs a [`SharedMut`] from a value.
+pub fn shared_mut<T>(value: T) -> SharedMut<T> {
+    Rc::new(RefCell::new(value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shared_clones_share_one_pointee() {
+        let a = shared(7_i32);
+        let b = Shared::clone(&a);
+        assert!(Shared::ptr_eq(&a, &b));
+        assert_eq!(Shared::strong_count(&a), 2);
+    }
+
+    #[test]
+    fn shared_mut_mutation_is_visible_through_clones() {
+        let a = shared_mut(1_i32);
+        let b = SharedMut::clone(&a);
+        *b.borrow_mut() = 42;
+        assert_eq!(*a.borrow(), 42);
+    }
+
+    #[test]
+    fn weak_does_not_keep_pointee_alive() {
+        let weak: WeakMut<i32> = {
+            let strong = shared_mut(3_i32);
+            SharedMut::downgrade(&strong)
+        };
+        assert!(weak.upgrade().is_none());
+    }
+}

--- a/crates/itofin/src/types.rs
+++ b/crates/itofin/src/types.rs
@@ -1,0 +1,71 @@
+//! Custom numeric types.
+//!
+//! Port of `ql/types.hpp`. QuantLib defines these as `typedef`s over the
+//! configurable macros `QL_REAL` (default `double`), `QL_INTEGER` (default
+//! `int`) and `QL_BIG_INTEGER` (default `long`); we pin them to their default
+//! widths.
+
+/// Integer number (`QL_INTEGER`, default `int`).
+pub type Integer = i32;
+
+/// Large integer number (`QL_BIG_INTEGER`, default `long`).
+pub type BigInteger = i64;
+
+/// Positive integer (`unsigned QL_INTEGER`).
+pub type Natural = u32;
+
+/// Large positive integer (`unsigned QL_BIG_INTEGER`).
+pub type BigNatural = u64;
+
+/// Real number (`QL_REAL`, default `double`).
+pub type Real = f64;
+
+/// Decimal number.
+pub type Decimal = Real;
+
+/// Size of a container (`std::size_t`).
+pub type Size = usize;
+
+/// Continuous quantity with 1-year units.
+pub type Time = Real;
+
+/// Discount factor between dates.
+pub type DiscountFactor = Real;
+
+/// Interest rate.
+pub type Rate = Real;
+
+/// Spread on an interest rate.
+pub type Spread = Real;
+
+/// Volatility.
+pub type Volatility = Real;
+
+/// Probability.
+pub type Probability = Real;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn type_widths_match_quantlib_defaults() {
+        assert_eq!(size_of::<Real>(), 8);
+        assert_eq!(size_of::<Integer>(), 4);
+        assert_eq!(size_of::<BigInteger>(), 8);
+        assert_eq!(size_of::<Natural>(), 4);
+        assert_eq!(size_of::<BigNatural>(), 8);
+        assert_eq!(size_of::<Size>(), size_of::<usize>());
+    }
+
+    #[test]
+    fn semantic_aliases_are_real() {
+        let _t: Time = 1.0;
+        let _r: Rate = 0.05;
+        let _s: Spread = 0.01;
+        let _v: Volatility = 0.2;
+        let _d: Decimal = 2.5;
+        let _df: DiscountFactor = 0.99;
+        let _p: Probability = 0.5;
+    }
+}


### PR DESCRIPTION
This change introduces two new modules to the core `libitofin` library, laying the groundwork for shared utilities and type definitions used across the crate.

**Module additions:**
* Added a new `shared` module (`crates/itofin/src/shared.rs`) for common functionality intended to be reused throughout the library.
* Added a new `types` module (`crates/itofin/src/types.rs`) to house type definitions for the core library.

**Library exports:**
* Updated `crates/itofin/src/lib.rs` to publicly export the new `shared` and `types` modules, making them available to dependent crates and language bindings.