### PR TITLE
feat(itofin): add errors module to core library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,3 +5,61 @@ version = 4
 [[package]]
 name = "itofin"
 version = "0.1.0"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"

--- a/crates/itofin/Cargo.toml
+++ b/crates/itofin/Cargo.toml
@@ -7,3 +7,4 @@ edition.workspace = true
 name = "itofin"
 
 [dependencies]
+thiserror = "2.0.12"

--- a/crates/itofin/src/errors.rs
+++ b/crates/itofin/src/errors.rs
@@ -6,12 +6,11 @@
 //! `Result<T, QlError>`, raised with the [`fail!`], [`require!`], [`assert_ql!`]
 //! and [`ensure!`] macros.
 
-use std::fmt;
-
 use thiserror::Error;
 
 /// Base error type, carrying the message and the source location that raised it.
 #[derive(Debug, Clone, Error)]
+#[error("{file}:{line}: {message}")]
 pub struct QlError {
     message: String,
     file: &'static str,
@@ -31,12 +30,6 @@ impl QlError {
     /// The error message, without location information.
     pub fn message(&self) -> &str {
         &self.message
-    }
-}
-
-impl fmt::Display for QlError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}:{}: {}", self.file, self.line, self.message)
     }
 }
 

--- a/crates/itofin/src/errors.rs
+++ b/crates/itofin/src/errors.rs
@@ -1,0 +1,141 @@
+//! Error handling.
+//!
+//! Port of `ql/errors.{hpp,cpp}` (design decision D4). QuantLib throws
+//! `QuantLib::Error` via the `QL_FAIL`, `QL_REQUIRE`, `QL_ASSERT` and
+//! `QL_ENSURE` macros; we model failures as a [`QlError`] returned through
+//! `Result<T, QlError>`, raised with the [`fail!`], [`require!`], [`assert_ql!`]
+//! and [`ensure!`] macros.
+
+use std::fmt;
+
+use thiserror::Error;
+
+/// Base error type, carrying the message and the source location that raised it.
+#[derive(Debug, Clone, Error)]
+pub struct QlError {
+    message: String,
+    file: &'static str,
+    line: u32,
+}
+
+impl QlError {
+    /// Builds an error from a message and the location it was raised at.
+    pub fn new(message: impl Into<String>, file: &'static str, line: u32) -> Self {
+        QlError {
+            message: message.into(),
+            file,
+            line,
+        }
+    }
+
+    /// The error message, without location information.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl fmt::Display for QlError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}: {}", self.file, self.line, self.message)
+    }
+}
+
+/// Convenience alias for fallible core operations.
+pub type QlResult<T> = Result<T, QlError>;
+
+/// Raises a [`QlError`] by returning `Err`, capturing the call site.
+///
+/// Mirrors `QL_FAIL`. Accepts `format!`-style arguments.
+#[macro_export]
+macro_rules! fail {
+    ($($arg:tt)*) => {
+        return ::core::result::Result::Err($crate::errors::QlError::new(
+            ::std::format!($($arg)*),
+            ::core::file!(),
+            ::core::line!(),
+        ))
+    };
+}
+
+/// Returns `Err` with a [`QlError`] if a pre-condition does not hold.
+///
+/// Mirrors `QL_REQUIRE`.
+#[macro_export]
+macro_rules! require {
+    ($cond:expr, $($arg:tt)*) => {
+        if !($cond) {
+            $crate::fail!($($arg)*);
+        }
+    };
+}
+
+/// Returns `Err` with a [`QlError`] if a post-condition does not hold.
+///
+/// Mirrors `QL_ENSURE`.
+#[macro_export]
+macro_rules! ensure {
+    ($cond:expr, $($arg:tt)*) => {
+        if !($cond) {
+            $crate::fail!($($arg)*);
+        }
+    };
+}
+
+/// Returns `Err` with a [`QlError`] if an invariant does not hold.
+///
+/// Mirrors `QL_ASSERT`. Named `assert_ql!` to avoid clashing with the
+/// std `assert!` macro.
+#[macro_export]
+macro_rules! assert_ql {
+    ($cond:expr, $($arg:tt)*) => {
+        if !($cond) {
+            $crate::fail!($($arg)*);
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fails_with(value: i32) -> QlResult<i32> {
+        fail!("bad value {value}");
+    }
+
+    fn requires_positive(value: i32) -> QlResult<i32> {
+        require!(value > 0, "value must be positive, got {value}");
+        Ok(value)
+    }
+
+    fn ensures_positive(value: i32) -> QlResult<i32> {
+        ensure!(value > 0, "post-condition violated: {value}");
+        Ok(value)
+    }
+
+    #[test]
+    fn fail_returns_err_with_message() {
+        let err = fails_with(7).unwrap_err();
+        assert_eq!(err.message(), "bad value 7");
+    }
+
+    #[test]
+    fn require_passes_and_fails() {
+        assert_eq!(requires_positive(3).unwrap(), 3);
+        let err = requires_positive(-1).unwrap_err();
+        assert_eq!(err.message(), "value must be positive, got -1");
+    }
+
+    #[test]
+    fn ensure_returns_err_on_violation() {
+        assert!(ensures_positive(1).is_ok());
+        assert!(ensures_positive(0).is_err());
+    }
+
+    #[test]
+    fn display_includes_location() {
+        let err = requires_positive(-1).unwrap_err();
+        let text = err.to_string();
+        assert!(text.contains("errors.rs"));
+        assert!(text.contains("value must be positive"));
+    }
+}

--- a/crates/itofin/src/lib.rs
+++ b/crates/itofin/src/lib.rs
@@ -3,5 +3,6 @@
 //! The core library (`libitofin`). Language bindings (Python via PyO3, a C ABI
 //! via cbindgen) live in sibling crates and depend on this one.
 
+pub mod errors;
 pub mod shared;
 pub mod types;


### PR DESCRIPTION
This pull request introduces a new errors module to the core `itofin` crate, laying the groundwork for structured error handling across the library.

**New errors module:**
* Added a new `errors.rs` source file in `crates/itofin/src` to house the library's error types.
* Registered the new module via `pub mod errors;` in `lib.rs`, making it publicly available to dependents.

**Dependency update:**
* Added `thiserror = "2.0.12"` to `Cargo.toml` to support ergonomic, derive-based error definitions in the new module.