### PR TITLE
ci(workflows): bump reusable workflows to 1.0.1

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   pre-commit:
     name: pre-commit checks
-    uses: benbenbang/reusable-workflows/.github/workflows/prek.yml@1.0.0
+    uses: benbenbang/reusable-workflows/.github/workflows/prek.yml@1.0.1
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -16,7 +16,7 @@ jobs:
   semantic-release:
     name: semantic-release
     if: ${{ inputs.prompt == 'true' }}
-    uses: benbenbang/reusable-workflows/.github/workflows/semantic-release.yml@1.0.0
+    uses: benbenbang/reusable-workflows/.github/workflows/semantic-release.yml@1.0.1
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Update the `prek` and `semantic-release` reusable workflow references from version `1.0.0` to `1.0.1` in the pull-request and semantic-release workflows to pick up the latest fixes.