### PR TITLE
fix(handle): drop link borrow before notifying on relink

### DIFF
--- a/crates/itofin/src/handle.rs
+++ b/crates/itofin/src/handle.rs
@@ -18,20 +18,23 @@ use crate::shared::{Shared, SharedMut, shared_mut};
 /// observable, through which relinks are broadcast.
 pub struct Link<T> {
     current: Option<Shared<T>>,
-    observable: Observable,
+    observable: Shared<Observable>,
 }
 
 impl<T> Link<T> {
     fn new(pointee: Option<Shared<T>>) -> Self {
         Link {
             current: pointee,
-            observable: Observable::new(),
+            observable: Shared::new(Observable::new()),
         }
     }
 
-    fn link_to(&mut self, pointee: Option<Shared<T>>) {
+    /// Repoints the link and returns its observable so the caller can notify
+    /// *after* dropping the link borrow — observers commonly read or relink the
+    /// handle from `update()`, which would otherwise re-borrow this cell.
+    fn link_to(&mut self, pointee: Option<Shared<T>>) -> Shared<Observable> {
         self.current = pointee;
-        self.observable.notify_observers();
+        self.observable.clone()
     }
 
     fn is_empty(&self) -> bool {
@@ -119,12 +122,14 @@ impl<T> RelinkableHandle<T> {
 
     /// Points the shared link at `pointee`, notifying observers.
     pub fn link_to(&self, pointee: Shared<T>) {
-        self.handle.link.borrow_mut().link_to(Some(pointee));
+        let observable = self.handle.link.borrow_mut().link_to(Some(pointee));
+        observable.notify_observers();
     }
 
     /// Clears the shared link, notifying observers.
     pub fn reset(&self) {
-        self.handle.link.borrow_mut().link_to(None);
+        let observable = self.handle.link.borrow_mut().link_to(None);
+        observable.notify_observers();
     }
 
     /// Borrows this as a plain [`Handle`] (e.g. to hand out non-relinkable copies).
@@ -196,5 +201,35 @@ mod tests {
 
         assert!(flag.borrow().up);
         assert!(observed.is_empty());
+    }
+
+    /// Observer that reads its shared handle while being notified — the common
+    /// "recompute on relink" pattern. This must not hit a `RefCell` borrow panic.
+    struct Reader {
+        handle: Handle<i32>,
+        seen: Option<i32>,
+    }
+
+    impl Observer for Reader {
+        fn update(&mut self) {
+            self.seen = self.handle.current_link().ok().map(|v| *v);
+        }
+    }
+
+    #[test]
+    fn observer_may_read_handle_during_relink() {
+        let rh = RelinkableHandle::new(shared(1_i32));
+        let reader = shared_mut(Reader {
+            handle: rh.handle(),
+            seen: None,
+        });
+        rh.handle()
+            .register_observer(&(reader.clone() as SharedMut<dyn Observer>));
+
+        rh.link_to(shared(2_i32));
+
+        // the relink borrow is released before observers run, so the observer
+        // can dereference the handle and sees the freshly-linked value
+        assert_eq!(reader.borrow().seen, Some(2));
     }
 }


### PR DESCRIPTION
## Problem

`RelinkableHandle::link_to`/`reset` notified observers **while holding a `borrow_mut()`** on the link's `RefCell` — `notify_observers()` ran inside `Link::link_to`, under the method-receiver borrow. Any observer that read or relinked the handle from `update()` then panicked with `RefCell already mutably borrowed`.

That's the standard *recompute-on-relink* pattern (an instrument re-reads its quote handle when notified), so it's a mainline path, not an edge case. In C++ there's no borrow concept, so QuantLib never hits it — the `RefCell` wrapping introduces it, which means the Rust port has to drop the borrow before notifying to preserve QL semantics. Caught by Copilot on the (already-merged) #11.

## Fix

Hold the link's `Observable` behind a `Shared` so `Link::link_to` repoints the link and hands the observable back; the caller notifies **after** the `RefMut` is dropped. ~6 lines. `Handle::register_observer` is unchanged (autoderefs through the `Rc`).

## Test

Adds `observer_may_read_handle_during_relink` — an observer that dereferences its shared handle inside `update()`. It panics on `main` and passes here. Existing handle tests unchanged and green; fmt + clippy clean.

Closes the re-entrancy comments from #11.