### PR TITLE
docs(tickets): add D8 logging/observability decision (deferred)

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -64,10 +64,11 @@ FFI shape constraints (design the core API around these, don't compromise the co
 ### D8 — Logging / observability (deferred; does not block any ticket)
 
 QuantLib has no logging — it's a numeric library, not a service. The core stays **dep-free and IO-free**, so
-logging is opt-in and must impose **zero cost when unused**:
+logging is opt-in and must impose **minimal overhead when disabled**:
 
-- Use the **`log` facade** (not `tracing`): a `log::debug!` with no installed logger compiles to a near-noop and
-  pulls in no runtime. `tracing`'s spans/subscribers are heavier and belong to a service layer, not the core.
+- Use the **`log` facade** (not `tracing`): with no installed logger a `log::debug!` does only a cheap level
+  check (a relaxed atomic load against the max level — not literally free, but negligible) and pulls in no
+  runtime. `tracing`'s spans/subscribers are heavier and belong to a service layer, not the core.
 - **Coarse boundaries only.** Log at calibration/bootstrap entry-exit or solver non-convergence — *never* inside
   hot paths like `Observable::notify_observers`, relinks, or per-path/per-scenario loops (D6), which would emit
   millions of lines and distort timing.

--- a/TICKETS.md
+++ b/TICKETS.md
@@ -64,11 +64,10 @@ FFI shape constraints (design the core API around these, don't compromise the co
 ### D8 — Logging / observability (deferred; does not block any ticket)
 
 QuantLib has no logging — it's a numeric library, not a service. The core stays **dep-free and IO-free**, so
-logging is opt-in and must impose **minimal overhead when disabled**:
+logging is opt-in and should impose **minimal overhead when disabled**:
 
-- Use the **`log` facade** (not `tracing`): with no installed logger a `log::debug!` does only a cheap level
-  check (a relaxed atomic load against the max level — not literally free, but negligible) and pulls in no
-  runtime. `tracing`'s spans/subscribers are heavier and belong to a service layer, not the core.
+- Use the **`log` facade** (not `tracing`): a `log::debug!` with no installed logger is a near-noop and
+  avoids formatting work. `tracing`'s spans/subscribers are heavier and belong to a service layer, not the core.
 - **Coarse boundaries only.** Log at calibration/bootstrap entry-exit or solver non-convergence — *never* inside
   hot paths like `Observable::notify_observers`, relinks, or per-path/per-scenario loops (D6), which would emit
   millions of lines and distort timing.

--- a/TICKETS.md
+++ b/TICKETS.md
@@ -24,8 +24,9 @@ written. Proposed defaults below are **single-threaded first** — revisit `Arc`
 | D5 | `Settings` singleton (global eval date) | explicit `&Context` (NOT `thread_local` — invisible to compute threads, see D6) | ⬜ needs sign-off |
 | D6 | runtime concurrency model | `rayon` **snapshot-and-fan-out**; no `async` in the core | ⬜ needs sign-off |
 | D7 | language bindings | PyO3 + maturin (Python); `extern "C"` + cbindgen (C ABI) in sibling crates | ⬜ needs sign-off |
+| D8 | logging / observability | `log` facade (zero-cost without a subscriber), coarse boundaries only — **deferred, non-blocking** | ⬜ deferred |
 
-**D1–D5 are the QL-0.x foundation tickets — see Epic L0. D6/D7 shape the core API and couple back to D3.**
+**D1–D5 are the QL-0.x foundation tickets — see Epic L0. D6/D7 shape the core API and couple back to D3. D8 is deferred — it touches no existing ticket and can land any time.**
 
 ### D6 — Concurrency model (`rayon` only; the core does no IO)
 
@@ -59,6 +60,21 @@ crates/itofin-py    PyO3 + maturin → pip-installable wheel
 FFI shape constraints (design the core API around these, don't compromise the core):
 - generics/trait objects don't cross FFI → expose concrete/enum facades in the binding layer, keep the core generic.
 - ownership across the boundary → opaque handles; PyO3 manages it, the raw C ABI needs explicit `free` fns.
+
+### D8 — Logging / observability (deferred; does not block any ticket)
+
+QuantLib has no logging — it's a numeric library, not a service. The core stays **dep-free and IO-free**, so
+logging is opt-in and must impose **zero cost when unused**:
+
+- Use the **`log` facade** (not `tracing`): a `log::debug!` with no installed logger compiles to a near-noop and
+  pulls in no runtime. `tracing`'s spans/subscribers are heavier and belong to a service layer, not the core.
+- **Coarse boundaries only.** Log at calibration/bootstrap entry-exit or solver non-convergence — *never* inside
+  hot paths like `Observable::notify_observers`, relinks, or per-path/per-scenario loops (D6), which would emit
+  millions of lines and distort timing.
+- Bindings choose the sink: the PyO3 crate (D7) can bridge `log` → Python `logging`; the C ABI exposes a callback.
+
+**Status: deferred.** No existing ticket depends on it; it can be added in any later PR without reworking the
+core. Revisit when a real diagnostic need appears (e.g. debugging curve bootstrap non-convergence in L4).
 
 ---
 


### PR DESCRIPTION
Captures the logging stance that came out of the handle re-entrancy review (#12 discussion).

Adds **D8** to the cross-cutting decisions table and a detail section:
- `log` facade (not `tracing`) — **minimal overhead when disabled** (a cheap level check, not literally zero), no runtime pulled into the dep-free core. The sink is a *logger* (`log`'s term; `tracing` calls it a subscriber).
- **Coarse boundaries only** — calibration/bootstrap entry-exit, solver non-convergence. Never inside `notify_observers`, relinks, or per-path/per-scenario loops (D6).
- Bindings choose the sink (PyO3 → Python `logging`; C ABI → callback).
- **Marked deferred** — depends on no existing ticket, can land in any later PR. Revisit when a real diagnostic need shows up (e.g. L4 curve bootstrap).

Docs-only; no code change.