### PR TITLE
feat(src): add utilities module with helper components

### DIFF
--- a/crates/itofin/src/lib.rs
+++ b/crates/itofin/src/lib.rs
@@ -9,3 +9,4 @@ pub mod patterns;
 pub mod settings;
 pub mod shared;
 pub mod types;
+pub mod utilities;

--- a/crates/itofin/src/utilities/clone.rs
+++ b/crates/itofin/src/utilities/clone.rs
@@ -1,27 +1,29 @@
-//! Cloning proxy to an owned object.
+//! Owning box with deep-copy value semantics.
 //!
 //! Port of `ql/utilities/clone.hpp`. QuantLib's `Clone<T>` is a `unique_ptr`
 //! wrapper that deep-copies its pointee (via the pointee's `clone()`) on copy,
 //! giving value semantics to a polymorphic, heap-owned object.
 //!
 //! In Rust this is largely subsumed by `Box<T>`, whose `Clone` impl already
-//! deep-copies when `T: Clone`. [`Clone`] is kept as a thin owning box so the
-//! C++ call sites translate directly and the intent stays explicit.
+//! deep-copies when `T: Clone`. [`ValueBox`] is kept as a thin owning box so the
+//! C++ call sites translate directly and the intent stays explicit. It is named
+//! `ValueBox` rather than `Clone` (QuantLib's name) to avoid shadowing the
+//! standard `Clone` trait, which it also implements.
 
-/// Owning box with deep-copy value semantics.
-pub struct Clone<T> {
+/// Owning box with deep-copy value semantics (QuantLib's `Clone<T>`).
+pub struct ValueBox<T> {
     ptr: Option<Box<T>>,
 }
 
-impl<T> Clone<T> {
-    /// An empty clone holding nothing.
+impl<T> ValueBox<T> {
+    /// An empty box holding nothing.
     pub fn empty() -> Self {
-        Clone { ptr: None }
+        ValueBox { ptr: None }
     }
 
     /// Wraps an owned value.
     pub fn new(value: T) -> Self {
-        Clone {
+        ValueBox {
             ptr: Some(Box::new(value)),
         }
     }
@@ -41,23 +43,23 @@ impl<T> Clone<T> {
         self.ptr.as_deref_mut()
     }
 
-    /// Swaps the contents of two clones.
-    pub fn swap(&mut self, other: &mut Clone<T>) {
+    /// Swaps the contents of two boxes.
+    pub fn swap(&mut self, other: &mut ValueBox<T>) {
         std::mem::swap(&mut self.ptr, &mut other.ptr);
     }
 }
 
-impl<T: std::clone::Clone> std::clone::Clone for Clone<T> {
+impl<T: Clone> Clone for ValueBox<T> {
     fn clone(&self) -> Self {
-        Clone {
+        ValueBox {
             ptr: self.ptr.clone(),
         }
     }
 }
 
-impl<T> Default for Clone<T> {
+impl<T> Default for ValueBox<T> {
     fn default() -> Self {
-        Clone::empty()
+        ValueBox::empty()
     }
 }
 
@@ -67,18 +69,18 @@ mod tests {
 
     #[test]
     fn empty_and_filled() {
-        let empty: Clone<i32> = Clone::empty();
+        let empty: ValueBox<i32> = ValueBox::empty();
         assert!(empty.is_empty());
         assert!(empty.get().is_none());
 
-        let filled = Clone::new(7_i32);
+        let filled = ValueBox::new(7_i32);
         assert!(!filled.is_empty());
         assert_eq!(filled.get(), Some(&7));
     }
 
     #[test]
     fn clone_is_a_deep_copy() {
-        let original = Clone::new(vec![1, 2, 3]);
+        let original = ValueBox::new(vec![1, 2, 3]);
         let mut copy = original.clone();
         copy.get_mut().unwrap().push(4);
 
@@ -88,8 +90,8 @@ mod tests {
 
     #[test]
     fn swap_exchanges_contents() {
-        let mut a = Clone::new(1_i32);
-        let mut b = Clone::new(2_i32);
+        let mut a = ValueBox::new(1_i32);
+        let mut b = ValueBox::new(2_i32);
         a.swap(&mut b);
         assert_eq!(a.get(), Some(&2));
         assert_eq!(b.get(), Some(&1));

--- a/crates/itofin/src/utilities/clone.rs
+++ b/crates/itofin/src/utilities/clone.rs
@@ -1,0 +1,97 @@
+//! Cloning proxy to an owned object.
+//!
+//! Port of `ql/utilities/clone.hpp`. QuantLib's `Clone<T>` is a `unique_ptr`
+//! wrapper that deep-copies its pointee (via the pointee's `clone()`) on copy,
+//! giving value semantics to a polymorphic, heap-owned object.
+//!
+//! In Rust this is largely subsumed by `Box<T>`, whose `Clone` impl already
+//! deep-copies when `T: Clone`. [`Clone`] is kept as a thin owning box so the
+//! C++ call sites translate directly and the intent stays explicit.
+
+/// Owning box with deep-copy value semantics.
+pub struct Clone<T> {
+    ptr: Option<Box<T>>,
+}
+
+impl<T> Clone<T> {
+    /// An empty clone holding nothing.
+    pub fn empty() -> Self {
+        Clone { ptr: None }
+    }
+
+    /// Wraps an owned value.
+    pub fn new(value: T) -> Self {
+        Clone {
+            ptr: Some(Box::new(value)),
+        }
+    }
+
+    /// Whether there is no underlying object.
+    pub fn is_empty(&self) -> bool {
+        self.ptr.is_none()
+    }
+
+    /// Borrows the underlying object.
+    pub fn get(&self) -> Option<&T> {
+        self.ptr.as_deref()
+    }
+
+    /// Mutably borrows the underlying object.
+    pub fn get_mut(&mut self) -> Option<&mut T> {
+        self.ptr.as_deref_mut()
+    }
+
+    /// Swaps the contents of two clones.
+    pub fn swap(&mut self, other: &mut Clone<T>) {
+        std::mem::swap(&mut self.ptr, &mut other.ptr);
+    }
+}
+
+impl<T: std::clone::Clone> std::clone::Clone for Clone<T> {
+    fn clone(&self) -> Self {
+        Clone {
+            ptr: self.ptr.clone(),
+        }
+    }
+}
+
+impl<T> Default for Clone<T> {
+    fn default() -> Self {
+        Clone::empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_and_filled() {
+        let empty: Clone<i32> = Clone::empty();
+        assert!(empty.is_empty());
+        assert!(empty.get().is_none());
+
+        let filled = Clone::new(7_i32);
+        assert!(!filled.is_empty());
+        assert_eq!(filled.get(), Some(&7));
+    }
+
+    #[test]
+    fn clone_is_a_deep_copy() {
+        let original = Clone::new(vec![1, 2, 3]);
+        let mut copy = original.clone();
+        copy.get_mut().unwrap().push(4);
+
+        assert_eq!(original.get().unwrap().len(), 3);
+        assert_eq!(copy.get().unwrap().len(), 4);
+    }
+
+    #[test]
+    fn swap_exchanges_contents() {
+        let mut a = Clone::new(1_i32);
+        let mut b = Clone::new(2_i32);
+        a.swap(&mut b);
+        assert_eq!(a.get(), Some(&2));
+        assert_eq!(b.get(), Some(&1));
+    }
+}

--- a/crates/itofin/src/utilities/dataformatters.rs
+++ b/crates/itofin/src/utilities/dataformatters.rs
@@ -1,0 +1,78 @@
+//! Output formatters.
+//!
+//! Port of the low-cost subset of `ql/utilities/dataformatters.hpp`. QuantLib's
+//! `io::` manipulators are tied to C++ `std::ostream`; the genuinely useful,
+//! cheap ones are ported here as functions returning `String`. The container
+//! `sequence` / `power_of_two` manipulators are deferred (low value to the
+//! core).
+
+use crate::types::{Rate, Real, Size, Volatility};
+use crate::utilities::null::Null;
+
+/// Formats a value, emitting `"null"` for the type's [`Null`] sentinel.
+pub fn check_null<T: Null + std::fmt::Display>(value: T) -> String {
+    if value.is_null() {
+        "null".to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+/// Formats a count as an English ordinal: `1st`, `2nd`, `3rd`, `4th`, ...
+pub fn ordinal(n: Size) -> String {
+    let suffix = match (n % 10, n % 100) {
+        (1, 11) | (2, 12) | (3, 13) => "th",
+        (1, _) => "st",
+        (2, _) => "nd",
+        (3, _) => "rd",
+        _ => "th",
+    };
+    format!("{n}{suffix}")
+}
+
+/// Formats a real as a percentage, e.g. `0.05` → `"5.000000 %"`.
+pub fn percent(value: Real) -> String {
+    format!("{} %", value * 100.0)
+}
+
+/// Formats a rate as a percentage.
+pub fn rate(r: Rate) -> String {
+    percent(r)
+}
+
+/// Formats a volatility as a percentage.
+pub fn volatility(v: Volatility) -> String {
+    percent(v)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::Integer;
+
+    #[test]
+    fn check_null_emits_null_for_sentinel() {
+        assert_eq!(check_null(Integer::MAX), "null");
+        assert_eq!(check_null(7_i32), "7");
+    }
+
+    #[test]
+    fn ordinals() {
+        assert_eq!(ordinal(1), "1st");
+        assert_eq!(ordinal(2), "2nd");
+        assert_eq!(ordinal(3), "3rd");
+        assert_eq!(ordinal(4), "4th");
+        assert_eq!(ordinal(11), "11th");
+        assert_eq!(ordinal(12), "12th");
+        assert_eq!(ordinal(13), "13th");
+        assert_eq!(ordinal(21), "21st");
+        assert_eq!(ordinal(112), "112th");
+    }
+
+    #[test]
+    fn percentages() {
+        assert_eq!(percent(0.05), "5 %");
+        assert_eq!(rate(0.05), "5 %");
+        assert_eq!(volatility(0.2), "20 %");
+    }
+}

--- a/crates/itofin/src/utilities/dataformatters.rs
+++ b/crates/itofin/src/utilities/dataformatters.rs
@@ -32,7 +32,8 @@ pub fn ordinal(n: Size) -> String {
 
 /// Formats a real as a percentage, e.g. `0.05` → `"5.000000 %"`.
 pub fn percent(value: Real) -> String {
-    format!("{} %", value * 100.0)
+    // QuantLib emits this with `std::fixed` at the default precision of 6.
+    format!("{:.6} %", value * 100.0)
 }
 
 /// Formats a rate as a percentage.
@@ -71,8 +72,8 @@ mod tests {
 
     #[test]
     fn percentages() {
-        assert_eq!(percent(0.05), "5 %");
-        assert_eq!(rate(0.05), "5 %");
-        assert_eq!(volatility(0.2), "20 %");
+        assert_eq!(percent(0.05), "5.000000 %");
+        assert_eq!(rate(0.05), "5.000000 %");
+        assert_eq!(volatility(0.2), "20.000000 %");
     }
 }

--- a/crates/itofin/src/utilities/mod.rs
+++ b/crates/itofin/src/utilities/mod.rs
@@ -1,0 +1,6 @@
+//! Foundational helpers ported from `ql/utilities/`.
+
+pub mod clone;
+pub mod dataformatters;
+pub mod null;
+pub mod steppingiterator;

--- a/crates/itofin/src/utilities/null.rs
+++ b/crates/itofin/src/utilities/null.rs
@@ -1,0 +1,62 @@
+//! Null sentinel values.
+//!
+//! Port of `ql/utilities/null.hpp`. QuantLib's `Null<T>` yields a per-type
+//! sentinel ("not set"): for floating-point types the largest `float`, for
+//! integral types the largest `int`. We expose it as a [`Null`] trait so any
+//! numeric type can provide and recognize its sentinel.
+
+use crate::types::{BigInteger, BigNatural, Integer, Natural, Real, Size};
+
+/// Provides a per-type "null"/unset sentinel value.
+pub trait Null: Sized + PartialEq {
+    /// The sentinel value for this type.
+    fn null() -> Self;
+
+    /// Whether `self` equals the sentinel.
+    fn is_null(&self) -> bool {
+        *self == Self::null()
+    }
+}
+
+impl Null for Real {
+    fn null() -> Self {
+        // a specific, unlikely value that fits into any Real (largest float)
+        f32::MAX as Real
+    }
+}
+
+macro_rules! impl_null_integral {
+    ($($t:ty),*) => {
+        $(
+            impl Null for $t {
+                fn null() -> Self {
+                    // fits into any Integer (largest int)
+                    Integer::MAX as $t
+                }
+            }
+        )*
+    };
+}
+
+impl_null_integral!(Integer, BigInteger, Natural, BigNatural, Size);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn real_null_is_largest_float() {
+        assert_eq!(Real::null(), f32::MAX as Real);
+        assert!(Real::null().is_null());
+        assert!(!(1.0 as Real).is_null());
+    }
+
+    #[test]
+    fn integral_null_is_largest_int() {
+        assert_eq!(Integer::null(), Integer::MAX);
+        assert_eq!(BigInteger::null(), Integer::MAX as BigInteger);
+        assert_eq!(Size::null(), Integer::MAX as Size);
+        assert!(Integer::MAX.is_null());
+        assert!(!0_i32.is_null());
+    }
+}

--- a/crates/itofin/src/utilities/steppingiterator.rs
+++ b/crates/itofin/src/utilities/steppingiterator.rs
@@ -1,0 +1,69 @@
+//! Iterator advancing in constant steps.
+//!
+//! Port of `ql/utilities/steppingiterator.hpp`. QuantLib's `step_iterator`
+//! adapts a random-access iterator so that each increment advances `step`
+//! positions. Over a Rust slice this is naturally an iterator yielding every
+//! `step`-th element; we expose it as [`StepIterator`] (plus the [`step_iter`]
+//! helper) rather than reimplementing C++ iterator arithmetic.
+
+use crate::types::Size;
+
+/// Iterator over a slice that advances by a fixed step.
+pub struct StepIterator<'a, T> {
+    data: &'a [T],
+    pos: Size,
+    step: Size,
+}
+
+impl<'a, T> Iterator for StepIterator<'a, T> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.pos >= self.data.len() {
+            return None;
+        }
+        let item = &self.data[self.pos];
+        self.pos += self.step;
+        Some(item)
+    }
+}
+
+/// Creates a stepping iterator over `data` advancing `step` positions each time.
+///
+/// `step` must be positive, mirroring the C++ pre-condition.
+pub fn step_iter<T>(data: &[T], step: Size) -> StepIterator<'_, T> {
+    assert!(step > 0, "step must be positive");
+    StepIterator { data, pos: 0, step }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn advances_in_constant_steps() {
+        let data = [0, 1, 2, 3, 4, 5, 6];
+        let collected: Vec<i32> = step_iter(&data, 2).copied().collect();
+        assert_eq!(collected, vec![0, 2, 4, 6]);
+    }
+
+    #[test]
+    fn step_of_one_yields_every_element() {
+        let data = [10, 20, 30];
+        let collected: Vec<i32> = step_iter(&data, 1).copied().collect();
+        assert_eq!(collected, vec![10, 20, 30]);
+    }
+
+    #[test]
+    fn step_larger_than_len_yields_first_only() {
+        let data = [10, 20, 30];
+        let collected: Vec<i32> = step_iter(&data, 10).copied().collect();
+        assert_eq!(collected, vec![10]);
+    }
+
+    #[test]
+    #[should_panic(expected = "step must be positive")]
+    fn zero_step_panics() {
+        let _ = step_iter(&[1, 2, 3], 0);
+    }
+}

--- a/crates/itofin/src/utilities/steppingiterator.rs
+++ b/crates/itofin/src/utilities/steppingiterator.rs
@@ -23,7 +23,9 @@ impl<'a, T> Iterator for StepIterator<'a, T> {
             return None;
         }
         let item = &self.data[self.pos];
-        self.pos += self.step;
+        // saturate so a ZST slice near usize::MAX still terminates instead of
+        // wrapping `pos` back below `len`
+        self.pos = self.pos.saturating_add(self.step);
         Some(item)
     }
 }


### PR DESCRIPTION
This pull request introduces a new `utilities` module to the `itofin` crate, providing a set of reusable helper components for common operations.

**New utilities module:**
* Added `utilities/mod.rs` to define the module structure and expose the new helper components.
* Registered the `utilities` module in `lib.rs` to make it available across the crate.

**New helper components:**
* Added `utilities/clone.rs` for cloning-related functionality.
* Added `utilities/dataformatters.rs` for data formatting helpers.
* Added `utilities/null.rs` for null handling utilities.
* Added `utilities/steppingiterator.rs` for a custom stepping iterator implementation.