### PR TITLE
docs(instructions): replace em dashes with hyphens in doc comments

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-# Copilot Instructions — libitofin
+# Copilot Instructions - libitofin
 
 libitofin is a ground-up, bottom-up port of [QuantLib](https://github.com/lballabio/QuantLib)
 (~470 k LOC of C++) into safe, idiomatic Rust.  Every design decision in this codebase exists to
@@ -9,20 +9,20 @@ serve **one primary goal**: the Rust output must match the QuantLib C++ test-sui
 
 ## 1. The oracle always wins
 
-When reviewing or suggesting code, the QuantLib C++ source is the authoritative reference — not
+When reviewing or suggesting code, the QuantLib C++ source is the authoritative reference - not
 Rust community style guides, Clippy pedantic lints, or general "clean code" advice.
 
 - **Do not** suggest restructuring an algorithm if the restructuring would change numerical
   behaviour or diverge from the C++ control flow.
 - **Do not** flag variable names, loop shapes, branch ordering, or intermediate temporaries as
-  "non-idiomatic" if they mirror the corresponding C++ implementation — the parallel structure is
+  "non-idiomatic" if they mirror the corresponding C++ implementation - the parallel structure is
   intentional and aids auditability.
 - **Do** flag genuine bugs: wrong formula, wrong tolerance, wrong branch, off-by-one index.
 - **Do** flag correctness risks: integer overflow, UB through unsafe, silent precision loss.
 
 ---
 
-## 2. Settled design decisions — do not reopen
+## 2. Settled design decisions - do not reopen
 
 The table below lists cross-cutting decisions that are **fixed for the current phase**.  Do not
 suggest alternatives to these choices; doing so creates noise and stalls reviews.
@@ -31,7 +31,7 @@ suggest alternatives to these choices; doing so creates noise and stalls reviews
 |----------|----------------|
 | **D1** | Observer/Observable uses a push-notification, dirty-flag model with weak-ref observer registry.  Do not suggest pull-based or channel-based alternatives. |
 | **D2** | `Handle<T>` / `RelinkableHandle<T>` are newtypes over `Rc<RefCell<Link<T>>>`.  Do not suggest `Arc` or `Mutex` here. |
-| **D3** | Shared ownership uses `Rc` (not `Arc`).  The codebase exposes three aliases — `Shared<T>`, `SharedMut<T>`, `WeakMut<T>` — that must be used throughout; do not suggest raw `Rc`/`Arc`/`RefCell` at call sites. |
+| **D3** | Shared ownership uses `Rc` (not `Arc`).  The codebase exposes three aliases - `Shared<T>`, `SharedMut<T>`, `WeakMut<T>` - that must be used throughout; do not suggest raw `Rc`/`Arc`/`RefCell` at call sites. |
 | **D4** | Error handling uses `QlResult<T>` (`Result<T, QlError>`) raised via the `fail!`, `require!`, `assert_ql!`, and `ensure!` macros.  Do not suggest `anyhow`, `eyre`, panics, or `unwrap` in library code. |
 | **D5** | `Settings` is an explicit value object passed as `&Context`, not a `thread_local` global or a `lazy_static`. |
 | **D6** | The core is single-threaded-mutable.  No `async`/`tokio` anywhere in `crates/itofin`.  Parallelism is `rayon` snapshot-and-fan-out, added only at L9–L11. |
@@ -49,7 +49,7 @@ QuantLib identifiers are preserved in Rust with only the mechanical transformati
 | `UpperCamelCase` types | keep `UpperCamelCase` |
 | `lowerCamelCase` methods | convert to `snake_case` |
 | `ALL_CAPS` constants | keep `UPPER_SNAKE_CASE` |
-| Type aliases (`Real`, `Rate`, `Time`, …) | keep the QuantLib names — do **not** replace with `f64`, `i32`, etc. |
+| Type aliases (`Real`, `Rate`, `Time`, …) | keep the QuantLib names - do **not** replace with `f64`, `i32`, etc. |
 
 Do not suggest renaming types or methods to "feel more Rustic" if the existing name comes directly
 from QuantLib; the name correspondence is a feature, not a defect.
@@ -82,17 +82,17 @@ WeakMut<T>   // = Weak<RefCell<T>>
 
 Constructor helpers `shared(v)` and `shared_mut(v)` replace `Rc::new` / `Rc::new(RefCell::new(v))`.
 
-Do **not** suggest switching `Shared` / `SharedMut` to `Arc` / `Mutex` — that is a future
+Do **not** suggest switching `Shared` / `SharedMut` to `Arc` / `Mutex` - that is a future
 migration controlled by D3 and touches the entire codebase at once.
 
 ---
 
 ## 6. Error-handling rules
 
-- Use `fail!`, `require!`, `assert_ql!`, `ensure!` — not `panic!`, `unwrap()`, `expect()`, or
+- Use `fail!`, `require!`, `assert_ql!`, `ensure!` - not `panic!`, `unwrap()`, `expect()`, or
   `todo!()` in non-test code.
 - `QlResult<T>` (`Result<T, QlError>`) is the return type for all fallible operations.
-- Do not suggest adding `anyhow::Context` or converting `QlError` to a richer error type — the
+- Do not suggest adding `anyhow::Context` or converting `QlError` to a richer error type - the
   QuantLib error model is intentionally simple.
 
 ---
@@ -112,7 +112,7 @@ migration controlled by D3 and touches the entire codebase at once.
 - Tests port the matching QuantLib `test-suite/*.cpp` cases.  The C++ expected values are the
   ground truth; do not adjust tolerances upward without a documented reason.
 - Test functions are named after the QuantLib test they correspond to where possible.
-- Do not suggest removing or weakening numerical assertions to make tests pass — fix the
+- Do not suggest removing or weakening numerical assertions to make tests pass - fix the
   implementation instead.
 
 ---

--- a/crates/itofin/src/handle.rs
+++ b/crates/itofin/src/handle.rs
@@ -30,7 +30,7 @@ impl<T> Link<T> {
     }
 
     /// Repoints the link and returns its observable so the caller can notify
-    /// *after* dropping the link borrow — observers commonly read or relink the
+    /// *after* dropping the link borrow - observers commonly read or relink the
     /// handle from `update()`, which would otherwise re-borrow this cell.
     fn link_to(&mut self, pointee: Option<Shared<T>>) -> Shared<Observable> {
         self.current = pointee;
@@ -203,7 +203,7 @@ mod tests {
         assert!(observed.is_empty());
     }
 
-    /// Observer that reads its shared handle while being notified — the common
+    /// Observer that reads its shared handle while being notified - the common
     /// "recompute on relink" pattern. This must not hit a `RefCell` borrow panic.
     struct Reader {
         handle: Handle<i32>,

--- a/crates/itofin/src/lib.rs
+++ b/crates/itofin/src/lib.rs
@@ -1,4 +1,4 @@
-//! itofin — a Rust port of QuantLib's quantitative finance core.
+//! itofin - a Rust port of QuantLib's quantitative finance core.
 //!
 //! The core library (`libitofin`). Language bindings (Python via PyO3, a C ABI
 //! via cbindgen) live in sibling crates and depend on this one.


### PR DESCRIPTION
This pull request standardizes punctuation across documentation and doc
comments by replacing em dashes with regular hyphens for consistency.

**Documentation cleanup:**
* Updated `.github/copilot-instructions.md` to use hyphens instead of em
  dashes throughout headings, design decision notes, and naming rules.
* Adjusted doc comments in `crates/itofin/src/handle.rs` for the
  `link_to` method and `Reader` test struct to use hyphens.
* Updated the crate-level doc comment in `crates/itofin/src/lib.rs` to
  use a hyphen in the project description.