### PR TITLE
feat(crates): add gamma function to gammafunction module

### DIFF
--- a/crates/itofin/src/math/gammafunction.rs
+++ b/crates/itofin/src/math/gammafunction.rs
@@ -1,15 +1,18 @@
-//! Logarithm of the gamma function.
+//! Gamma function.
 //!
-//! Port of `GammaFunction::logValue` from
-//! `ql/math/distributions/gammadistribution.{hpp,cpp}` - the Lanczos
-//! approximation (Numerical Recipes `gammln`). It underpins the Student-t and
-//! gamma-family distributions. Exposed as a free function, like [`erf`].
+//! Port of `GammaFunction::{logValue, value}` from
+//! `ql/math/distributions/gammadistribution.{hpp,cpp}`: [`log_gamma`] (the
+//! Lanczos / Numerical Recipes `gammln` approximation) and [`gamma`] itself
+//! (`Γ(x)` via recurrence and reflection). They underpin the Student-t and
+//! gamma-family distributions. Exposed as free functions, like [`erf`].
 //!
 //! [`erf`]: crate::math::errorfunction::erf
 
 // Coefficients are transcribed verbatim from QuantLib; their precision exceeds
 // f64 but rounds to the intended bit pattern.
 #![allow(clippy::excessive_precision)]
+
+use std::f64::consts::PI;
 
 use crate::errors::QlResult;
 use crate::fail;
@@ -59,6 +62,45 @@ pub fn log_gamma(x: Real) -> QlResult<Real> {
         ser += c / (x + (i as Real + 1.0));
     }
     Ok(-temp + (SQRT_TWO_PI * ser / x).ln())
+}
+
+/// The gamma function `Γ(x)`.
+///
+/// Port of `GammaFunction::value`. For `x >= 1` it exponentiates [`log_gamma`];
+/// for `-20 < x < 1` it applies the recurrence `Γ(x) = Γ(x+1) / x`; for
+/// `x <= -20` it applies the reflection formula
+/// `Γ(x) = -π / (Γ(-x)·x·sin(πx))`.
+///
+/// At the non-positive integer poles `Γ` is undefined. Poles in `-20 < x <= 0`
+/// surface as `±∞` (the recurrence divides by zero), but poles `x <= -20` reach
+/// the reflection branch, where `sin(πx)` is only approximately zero in floating
+/// point, so they return a finite (meaningless) value rather than `±∞` - this
+/// matches QuantLib. A `NaN` argument returns `NaN`.
+///
+/// # Examples
+///
+/// ```
+/// use itofin::math::gammafunction::gamma;
+/// // Γ(5) = 4! = 24
+/// assert!((gamma(5.0) - 24.0).abs() < 1e-6);
+/// // Γ(1/2) = √π
+/// assert!((gamma(0.5) - std::f64::consts::PI.sqrt()).abs() < 1e-9);
+/// ```
+pub fn gamma(x: Real) -> Real {
+    // A NaN argument would recurse forever on the reflection branch.
+    if x.is_nan() {
+        return Real::NAN;
+    }
+    if x >= 1.0 {
+        // x >= 1 > 0 is always a valid log_gamma argument.
+        log_gamma(x).expect("log_gamma is valid for x >= 1").exp()
+    } else if x > -20.0 {
+        // recurrence: Γ(x) = Γ(x+1) / x
+        gamma(x + 1.0) / x
+    } else {
+        // reflection: Γ(x) = -π / (Γ(-x)·x·sin(πx))
+        -PI / (gamma(-x) * x * (PI * x).sin())
+    }
 }
 
 #[cfg(test)]
@@ -131,5 +173,47 @@ mod tests {
                 (calculated - expected).abs() / expected
             );
         }
+    }
+
+    #[test]
+    fn value_matches_reference_table() {
+        // Faithful port of QuantLib's testGammaValues: (x, Γ(x) from R, tol
+        // multiplier), checked to `multiplier * EPSILON * |expected|`.
+        let tasks: [(Real, Real, Real); 10] = [
+            (0.0001, 9999.422883231624, 1e3),
+            (1.2, 0.9181687423997607, 1e3),
+            (7.3, 1271.4236336639089586, 1e3),
+            (-1.1, 9.7148063829028946, 1e3),
+            (-4.001, -41.6040228304425312, 1e3),
+            (-4.999, -8.347576090315059, 1e3),
+            (-19.000001, 8.220610833201313e-12, 1e8),
+            (-19.5, 5.811045977502255e-18, 1e3),
+            (-21.000001, 1.957288098276488e-14, 1e8),
+            (-21.5, 1.318444918321553e-20, 1e6),
+        ];
+        for (x, expected, multiplier) in tasks {
+            let calculated = gamma(x);
+            let tol = multiplier * Real::EPSILON * expected.abs();
+            assert!(
+                (calculated - expected).abs() <= tol,
+                "Γ({x}): got {calculated}, expected {expected}, diff {}, tol {tol}",
+                (calculated - expected).abs()
+            );
+        }
+    }
+
+    #[test]
+    fn value_handles_poles_and_nan() {
+        // Poles in -20 < x <= 0 hit an exact divide-by-zero in the recurrence,
+        // so they surface as ±∞.
+        assert!(gamma(0.0).is_infinite());
+        assert!(gamma(-1.0).is_infinite());
+        assert!(gamma(-19.0).is_infinite());
+        // A pole x <= -20 goes through the reflection branch, where sin(πx) is
+        // only approximately zero, so it returns a finite (non-Γ) value, not
+        // ±∞. This matches QuantLib; we pin it so the doc claim cannot drift.
+        assert!(gamma(-20.0).is_finite());
+        // NaN propagates.
+        assert!(gamma(Real::NAN).is_nan());
     }
 }


### PR DESCRIPTION
This pull request extends the gamma function module with a full implementation of `Γ(x)`, ported from QuantLib's `GammaFunction::value`, alongside the existing `log_gamma`. The new function underpins the Student-t and gamma-family distributions.

**New gamma function implementation:**
* Added a `gamma` free function in `crates/itofin/src/math/gammafunction.rs` that exponentiates `log_gamma` for `x >= 1`, applies the recurrence `Γ(x) = Γ(x+1) / x` for `-20 < x < 1`, and uses the reflection formula `Γ(x) = -π / (Γ(-x)·x·sin(πx))` for `x <= -20`.
* Handled edge cases: `NaN` arguments propagate as `NaN`, poles in `-20 < x <= 0` surface as `±∞`, and poles `x <= -20` return finite (meaningless) values via the reflection branch, matching QuantLib behavior.

**Documentation update:**
* Updated the module-level docs to describe both `log_gamma` and `gamma`, including pole behavior and usage examples.

**Testing improvements:**
* Added `value_matches_reference_table` to validate `gamma` against a reference table of values computed in R.
* Added `value_handles_poles_and_nan` to pin the documented pole and `NaN` handling so the doc claims cannot drift.