### PR TITLE
fix(math): reject non-finite inputs in gamma and beta functions

### DIFF
--- a/crates/itofin/src/math/beta.rs
+++ b/crates/itofin/src/math/beta.rs
@@ -52,13 +52,14 @@ pub fn beta_function(z: Real, w: Real) -> QlResult<Real> {
 /// # Ok::<(), itofin::errors::QlError>(())
 /// ```
 pub fn incomplete_beta(a: Real, b: Real, x: Real) -> QlResult<Real> {
-    // `is_nan()` is required: a bare `<= 0.0` lets NaN through (all NaN
-    // comparisons are false), but QuantLib's QL_REQUIRE(a > 0) rejects it
-    if a <= 0.0 || a.is_nan() {
-        fail!("incomplete_beta requires a > 0, got a={a}");
+    // `is_finite()` is required: a bare `<= 0.0` lets NaN and +infinity through
+    // (all NaN comparisons are false, and +infinity is not <= 0), but
+    // QuantLib's QL_REQUIRE(a > 0) rejects them
+    if !a.is_finite() || a <= 0.0 {
+        fail!("incomplete_beta requires a finite a > 0, got a={a}");
     }
-    if b <= 0.0 || b.is_nan() {
-        fail!("incomplete_beta requires b > 0, got b={b}");
+    if !b.is_finite() || b <= 0.0 {
+        fail!("incomplete_beta requires a finite b > 0, got b={b}");
     }
     // `contains` is false for NaN, so this also rejects NaN
     if !(0.0..=1.0).contains(&x) {
@@ -196,5 +197,9 @@ mod tests {
         assert!(incomplete_beta(1.0, 1.0, Real::NAN).is_err()); // NaN x
         assert!(incomplete_beta(Real::NAN, 1.0, 0.5).is_err()); // NaN a
         assert!(incomplete_beta(1.0, Real::NAN, 0.5).is_err()); // NaN b
+        assert!(incomplete_beta(Real::INFINITY, 1.0, 0.5).is_err()); // +inf a
+        assert!(incomplete_beta(1.0, Real::INFINITY, 0.5).is_err()); // +inf b
+        // beta_function propagates through log_gamma, so infinity errors too
+        assert!(beta_function(Real::INFINITY, 1.0).is_err());
     }
 }

--- a/crates/itofin/src/math/gammafunction.rs
+++ b/crates/itofin/src/math/gammafunction.rs
@@ -50,10 +50,11 @@ const SQRT_TWO_PI: Real = 2.5066282746310005;
 /// # Ok::<(), itofin::errors::QlError>(())
 /// ```
 pub fn log_gamma(x: Real) -> QlResult<Real> {
-    // reject x <= 0 and NaN, matching QuantLib's QL_REQUIRE(x > 0); a bare
-    // `x <= 0.0` would let NaN through (all NaN comparisons are false)
-    if x <= 0.0 || x.is_nan() {
-        fail!("log_gamma requires a positive argument, got {x}");
+    // reject non-finite and x <= 0, matching QuantLib's QL_REQUIRE(x > 0); a
+    // bare `x <= 0.0` would let NaN and +infinity through (all NaN comparisons
+    // are false, and +infinity is not <= 0)
+    if !x.is_finite() || x <= 0.0 {
+        fail!("log_gamma requires a finite positive argument, got {x}");
     }
     let mut temp = x + 5.5;
     temp -= (x + 0.5) * temp.ln();
@@ -87,9 +88,13 @@ pub fn log_gamma(x: Real) -> QlResult<Real> {
 /// assert!((gamma(0.5) - std::f64::consts::PI.sqrt()).abs() < 1e-9);
 /// ```
 pub fn gamma(x: Real) -> Real {
-    // A NaN argument would recurse forever on the reflection branch.
-    if x.is_nan() {
-        return Real::NAN;
+    // Non-finite inputs are handled up front: +inf would hit log_gamma's
+    // finite-only domain and panic the expect below, -inf would recurse into
+    // gamma(+inf) and do the same, and NaN would recurse forever on the
+    // reflection branch. Gamma diverges to +inf at +inf and has no limit at
+    // -inf (NaN), as for NaN input.
+    if !x.is_finite() {
+        return if x > 0.0 { Real::INFINITY } else { Real::NAN };
     }
     if x >= 1.0 {
         // x >= 1 > 0 is always a valid log_gamma argument.
@@ -155,6 +160,9 @@ mod tests {
         assert!(log_gamma(-1.0).is_err());
         // NaN must be rejected too, matching QuantLib's QL_REQUIRE(x > 0)
         assert!(log_gamma(Real::NAN).is_err());
+        // +infinity must be rejected: a bare `x <= 0.0` would let it through
+        assert!(log_gamma(Real::INFINITY).is_err());
+        assert!(log_gamma(Real::NEG_INFINITY).is_err());
     }
 
     #[test]
@@ -215,5 +223,14 @@ mod tests {
         assert!(gamma(-20.0).is_finite());
         // NaN propagates.
         assert!(gamma(Real::NAN).is_nan());
+    }
+
+    #[test]
+    fn value_at_infinities_does_not_panic() {
+        // Regression: log_gamma now rejects non-finite x, so gamma must handle
+        // +-inf before the expect path rather than panic. Gamma diverges to +inf
+        // at +inf and has no limit at -inf.
+        assert_eq!(gamma(Real::INFINITY), Real::INFINITY);
+        assert!(gamma(Real::NEG_INFINITY).is_nan());
     }
 }

--- a/crates/itofin/src/math/incompletegamma.rs
+++ b/crates/itofin/src/math/incompletegamma.rs
@@ -35,13 +35,14 @@ const MAX_ITERATIONS: u32 = 100;
 /// # Ok::<(), itofin::errors::QlError>(())
 /// ```
 pub fn incomplete_gamma(a: Real, x: Real) -> QlResult<Real> {
-    // `is_nan` is explicit: a bare comparison lets NaN through (all NaN
-    // comparisons are false), but QuantLib's QL_REQUIRE rejects it.
-    if a <= 0.0 || a.is_nan() {
-        fail!("incomplete_gamma requires a > 0, got a={a}");
+    // `is_finite` is explicit: a bare comparison lets NaN and ±infinity through
+    // (all NaN comparisons are false, and +infinity is not <= 0 / not < 0), but
+    // QuantLib's QL_REQUIRE rejects them.
+    if !a.is_finite() || a <= 0.0 {
+        fail!("incomplete_gamma requires a finite a > 0, got a={a}");
     }
-    if x < 0.0 || x.is_nan() {
-        fail!("incomplete_gamma requires x >= 0, got x={x}");
+    if !x.is_finite() || x < 0.0 {
+        fail!("incomplete_gamma requires a finite x >= 0, got x={x}");
     }
     if x < a + 1.0 {
         series_repr(a, x)
@@ -178,5 +179,7 @@ mod tests {
         assert!(incomplete_gamma(1.0, -1.0).is_err()); // x < 0
         assert!(incomplete_gamma(Real::NAN, 1.0).is_err()); // NaN a
         assert!(incomplete_gamma(1.0, Real::NAN).is_err()); // NaN x
+        assert!(incomplete_gamma(Real::INFINITY, 1.0).is_err()); // +inf a
+        assert!(incomplete_gamma(1.0, Real::INFINITY).is_err()); // +inf x
     }
 }


### PR DESCRIPTION
This pull request hardens the domain checks of the gamma, beta, and incomplete gamma functions so that infinite inputs are handled explicitly rather than slipping through bare comparisons or panicking. The changes align validation with QuantLib's `QL_REQUIRE` semantics and prevent unexpected panics.

**Domain validation updates:**
* `incomplete_gamma` now rejects non-finite `a` and `x` via `!is_finite()`, since `+infinity` is not caught by `<= 0` / `< 0` comparisons.
* `incomplete_beta` now rejects non-finite `a` and `b`, and `beta_function` propagates infinity errors through `log_gamma`.
* `log_gamma` now rejects all non-finite arguments, matching `QL_REQUIRE(x > 0)`.

**Gamma non-finite handling:**
* `gamma` now returns `+infinity` for `+inf` and `NaN` for `-inf` up front, avoiding a panic from `log_gamma`'s finite-only domain and infinite recursion on the reflection branch.

**Testing improvements:**
* Added assertions covering `+infinity` and `-infinity` inputs across `incomplete_gamma`, `incomplete_beta`, `beta_function`, and `log_gamma`.
* Added a regression test verifying `gamma` returns the correct values at the infinities without panicking.