### PR TITLE
fix(interpolations): reject non-finite x and y nodes in linear interpolation

### DIFF
--- a/crates/itofin/src/math/interpolations/linear.rs
+++ b/crates/itofin/src/math/interpolations/linear.rs
@@ -35,6 +35,16 @@ impl LinearInterpolation {
                 x.len()
             );
         }
+        for &xi in &x {
+            if !xi.is_finite() {
+                fail!("x values must be finite, got {xi}");
+            }
+        }
+        for &yi in &y {
+            if !yi.is_finite() {
+                fail!("y values must be finite, got {yi}");
+            }
+        }
         for w in x.windows(2) {
             if w[1] <= w[0] {
                 fail!("x values must be strictly increasing");
@@ -206,5 +216,14 @@ mod tests {
         assert!(LinearInterpolation::new(vec![0.0, 1.0], vec![0.0]).is_err());
         assert!(LinearInterpolation::new(vec![0.0], vec![0.0]).is_err());
         assert!(LinearInterpolation::new(vec![0.0, 0.0], vec![1.0, 2.0]).is_err());
+    }
+
+    #[test]
+    fn non_finite_nodes_rejected() {
+        // A NaN x-node slips past the strictly-increasing check (all NaN
+        // comparisons are false) and must be rejected explicitly.
+        assert!(LinearInterpolation::new(vec![0.0, Real::NAN], vec![0.0, 1.0]).is_err());
+        assert!(LinearInterpolation::new(vec![0.0, Real::INFINITY], vec![0.0, 1.0]).is_err());
+        assert!(LinearInterpolation::new(vec![0.0, 1.0], vec![0.0, Real::NAN]).is_err());
     }
 }


### PR DESCRIPTION
This pull request adds explicit validation for non-finite values in the `LinearInterpolation` constructor, closing a gap where invalid nodes could pass existing checks.

**Validation improvements:**
* Added checks in `crates/itofin/src/math/interpolations/linear.rs` to reject any `x` or `y` value that is not finite, returning an error with the offending value.
* This guards against NaN x-nodes, which silently slipped past the strictly-increasing check since all NaN comparisons evaluate to false.

**Testing improvements:**
* Added a new test `non_finite_nodes_rejected` that verifies the constructor rejects NaN and infinite values in both the `x` and `y` inputs.