### PR TITLE
feat(solvers1d): add bisection 1D root-finding solver

### DIFF
--- a/crates/itofin/src/math/solvers1d/bisection.rs
+++ b/crates/itofin/src/math/solvers1d/bisection.rs
@@ -1,0 +1,125 @@
+//! Bisection 1-D solver.
+//!
+//! Port of `ql/math/solvers1d/bisection.hpp`: repeated interval halving, keeping
+//! the half that brackets the sign change. Robust and unconditionally convergent
+//! for a valid bracket, following Press et al., "Numerical Recipes in C", 2nd ed.
+
+use crate::errors::QlResult;
+use crate::fail;
+use crate::math::comparison::close;
+use crate::math::solver1d::{Solver1D, Solver1DState, SolverConfig};
+use crate::types::Real;
+
+/// Bisection root finder.
+#[derive(Clone, Copy, Debug)]
+pub struct Bisection {
+    config: SolverConfig,
+}
+
+impl Bisection {
+    /// A bisection solver with the default configuration.
+    pub fn new() -> Self {
+        Bisection {
+            config: SolverConfig::new(),
+        }
+    }
+
+    /// Set the evaluation cap (builder form).
+    pub fn with_max_evaluations(mut self, evaluations: usize) -> Self {
+        self.config.max_evaluations = evaluations;
+        self
+    }
+
+    /// Restrict the search to `x >= lower_bound` (builder form).
+    pub fn with_lower_bound(mut self, lower_bound: Real) -> Self {
+        self.config.lower_bound = Some(lower_bound);
+        self
+    }
+
+    /// Restrict the search to `x <= upper_bound` (builder form).
+    pub fn with_upper_bound(mut self, upper_bound: Real) -> Self {
+        self.config.upper_bound = Some(upper_bound);
+        self
+    }
+}
+
+impl Default for Bisection {
+    fn default() -> Self {
+        Bisection::new()
+    }
+}
+
+impl Solver1D for Bisection {
+    fn config(&self) -> &SolverConfig {
+        &self.config
+    }
+
+    fn config_mut(&mut self) -> &mut SolverConfig {
+        &mut self.config
+    }
+
+    fn solve_impl<F>(
+        &mut self,
+        f: &mut F,
+        x_accuracy: Real,
+        st: &mut Solver1DState,
+    ) -> QlResult<Real>
+    where
+        F: FnMut(Real) -> Real,
+    {
+        // Orient the search so that f > 0 lies at root + dx.
+        let mut dx = if st.fx_min < 0.0 {
+            st.root = st.x_min;
+            st.x_max - st.x_min
+        } else {
+            st.root = st.x_max;
+            st.x_min - st.x_max
+        };
+
+        while st.evaluation_number <= self.max_evaluations() {
+            dx /= 2.0;
+            let x_mid = st.root + dx;
+            let f_mid = f(x_mid);
+            st.evaluation_number += 1;
+            if f_mid <= 0.0 {
+                st.root = x_mid;
+            }
+            if dx.abs() < x_accuracy || close(f_mid, 0.0) {
+                // Final call at the root so a stateful functor records it.
+                let _ = f(st.root);
+                st.evaluation_number += 1;
+                return Ok(st.root);
+            }
+        }
+        fail!(
+            "maximum number of function evaluations ({}) exceeded",
+            self.max_evaluations()
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::math::solvers1d::testkit;
+
+    #[test]
+    fn finds_known_roots() {
+        testkit::check_finds_known_roots(Bisection::new);
+    }
+
+    #[test]
+    fn last_call_is_made_with_the_root() {
+        testkit::check_last_call_with_root(Bisection::new);
+    }
+
+    #[test]
+    fn rejects_invalid_inputs() {
+        testkit::check_rejects_invalid_inputs(Bisection::new);
+    }
+
+    #[test]
+    fn honours_configured_bounds() {
+        testkit::check_honours_bounds(Bisection::new);
+    }
+}

--- a/crates/itofin/src/math/solvers1d/mod.rs
+++ b/crates/itofin/src/math/solvers1d/mod.rs
@@ -3,4 +3,8 @@
 //! Each solver implements [`Solver1D`](crate::math::solver1d::Solver1D) and so
 //! shares the bracketing driver in [`solver1d`](crate::math::solver1d).
 
+pub mod bisection;
 pub mod brent;
+
+#[cfg(test)]
+pub(crate) mod testkit;

--- a/crates/itofin/src/math/solvers1d/testkit.rs
+++ b/crates/itofin/src/math/solvers1d/testkit.rs
@@ -1,0 +1,107 @@
+//! Shared test harness for the concrete 1-D solvers.
+//!
+//! Port of the generic `test_solver` machinery in `test-suite/solvers.cpp`: every
+//! bracketing solver is exercised against the same known-root functions and the
+//! same driver-contract checks, parameterised by a factory that produces a fresh
+//! solver. Each solver's test module just calls these with its own constructor.
+
+use crate::math::solver1d::Solver1D;
+use crate::types::Real;
+use std::cell::Cell;
+
+/// `f1(x) = x^2 - 1`: increasing, single root at `x = 1`.
+pub fn f1(x: Real) -> Real {
+    x * x - 1.0
+}
+/// `f2(x) = 1 - x^2`: decreasing, single root at `x = 1`.
+pub fn f2(x: Real) -> Real {
+    1.0 - x * x
+}
+/// `f3(x) = atan(x - 1)`: single root at `x = 1`.
+pub fn f3(x: Real) -> Real {
+    (x - 1.0).atan()
+}
+
+const ACCURACIES: [Real; 3] = [1.0e-4, 1.0e-6, 1.0e-8];
+
+/// Port of `test_solver`: the solver must find the root at `x = 1` of `f1` and
+/// `f2` (guessing from either side, auto-bracketing and pre-bracketed) and `f3`.
+pub fn check_finds_known_roots<S: Solver1D>(make: impl Fn() -> S) {
+    for f in [f1 as fn(Real) -> Real, f2] {
+        for guess in [0.5, 1.5] {
+            for acc in ACCURACIES {
+                let root = make().solve(f, acc, guess, 0.1).unwrap();
+                assert!(
+                    (root - 1.0).abs() <= acc,
+                    "auto: guess={guess} acc={acc} root={root}"
+                );
+                let root = make().solve_bracketed(f, acc, guess, 0.0, 2.0).unwrap();
+                assert!(
+                    (root - 1.0).abs() <= acc,
+                    "bracketed: guess={guess} acc={acc} root={root}"
+                );
+            }
+        }
+    }
+    for acc in ACCURACIES {
+        let root = make().solve(f3, acc, 1.00001, 0.1).unwrap();
+        assert!((root - 1.0).abs() <= acc, "f3: acc={acc} root={root}");
+    }
+}
+
+/// Port of `test_last_call_with_root`: the solver's final function call must be
+/// made at the value it returns. The stateful `Probe` records the last argument
+/// it saw (exercising the `FnMut` path); the chained offsets give roots 5, 4, 3, 2.
+pub fn check_last_call_with_root<S: Solver1D>(make: impl Fn() -> S) {
+    let mins = [3.0, 2.25, 1.5, 1.0];
+    let maxs = [7.0, 5.75, 4.5, 3.0];
+    let steps = [0.2, 0.2, 0.1, 0.1];
+    let offsets = [25.0, 11.0, 5.0, 1.0];
+    let guesses = [4.5, 4.5, 2.5, 2.5];
+    let accuracy = 1.0e-6;
+
+    for bracketed in [false, true] {
+        let argument = Cell::new(0.0);
+        for i in 0..4 {
+            let previous = argument.get();
+            let probe = |x: Real| {
+                argument.set(x);
+                previous + offsets[i] - x * x
+            };
+            let result = if bracketed {
+                make()
+                    .solve_bracketed(probe, accuracy, guesses[i], mins[i], maxs[i])
+                    .unwrap()
+            } else {
+                make().solve(probe, accuracy, guesses[i], steps[i]).unwrap()
+            };
+            assert!(
+                (result - argument.get()).abs() <= 2.0 * Real::EPSILON,
+                "bracketed={bracketed} i={i}: result={result} last_arg={}",
+                argument.get()
+            );
+        }
+    }
+}
+
+/// The driver rejects malformed inputs: non-positive accuracy, an unbracketed
+/// range, and a guess outside the range.
+pub fn check_rejects_invalid_inputs<S: Solver1D>(make: impl Fn() -> S) {
+    assert!(make().solve(f1, 0.0, 0.5, 0.1).is_err());
+    assert!(make().solve_bracketed(f1, 1e-8, 2.5, 2.0, 3.0).is_err());
+    assert!(make().solve_bracketed(f1, 1e-8, 5.0, 0.0, 2.0).is_err());
+}
+
+/// Configured domain bounds are honoured: a bracket past the upper bound is
+/// rejected, while a bounded auto-bracketing search still finds the root.
+pub fn check_honours_bounds<S: Solver1D>(make: impl Fn() -> S) {
+    let mut solver = make();
+    solver.set_upper_bound(2.0);
+    assert!(solver.solve_bracketed(f1, 1e-8, 1.5, 0.0, 3.0).is_err());
+
+    let mut solver = make();
+    solver.set_lower_bound(0.0);
+    solver.set_upper_bound(5.0);
+    let root = solver.solve(f1, 1e-10, 0.5, 0.1).unwrap();
+    assert!((root - 1.0).abs() <= 1e-9, "root={root}");
+}


### PR DESCRIPTION
Resolves #48

Port ql/math/solvers1d/bisection.hpp: repeated interval halving keeping the sign-changing half, as a Solver1D impl. Also add a shared, solver- generic test harness (testkit) porting solvers.cpp's test_solver machinery
- known-root, last-call-with-root, input-rejection and bound-enforcement checks parameterised by a solver factory - so the remaining solvers reuse it instead of duplicating ~95 lines each. Brent keeps its existing tests.