### PR TITLE
feat(math): add Newton 1D solver and derivative-solver API (QL-1.5)

### DIFF
--- a/crates/itofin/src/math/solver1d.rs
+++ b/crates/itofin/src/math/solver1d.rs
@@ -323,6 +323,76 @@ where
     Ok(Bracketed::Ready(st))
 }
 
+/// A function paired with its first derivative, the input to derivative-based
+/// solvers (mirroring QuantLib's functor with an `operator()` and a
+/// `derivative()`). Build one from a pair of closures with [`func1d`].
+///
+/// The methods take `&mut self` so a stateful functor can be used, matching the
+/// `FnMut` value closures the [`Solver1D`] drivers accept.
+pub trait Function1D {
+    /// `f(x)`.
+    fn value(&mut self, x: Real) -> Real;
+    /// `f'(x)`.
+    fn derivative(&mut self, x: Real) -> Real;
+}
+
+/// Adapt a value closure and a derivative closure into a [`Function1D`].
+pub fn func1d<F, D>(value: F, derivative: D) -> impl Function1D
+where
+    F: FnMut(Real) -> Real,
+    D: FnMut(Real) -> Real,
+{
+    struct Pair<F, D> {
+        value: F,
+        derivative: D,
+    }
+    impl<F, D> Function1D for Pair<F, D>
+    where
+        F: FnMut(Real) -> Real,
+        D: FnMut(Real) -> Real,
+    {
+        fn value(&mut self, x: Real) -> Real {
+            (self.value)(x)
+        }
+        fn derivative(&mut self, x: Real) -> Real {
+            (self.derivative)(x)
+        }
+    }
+    Pair { value, derivative }
+}
+
+/// A 1-D root finder that uses the function's derivative (Newton and friends).
+///
+/// A separate contract from [`Solver1D`]: its refinement needs `f'`, so it takes
+/// a [`Function1D`] rather than a bare value closure. It still reuses the shared
+/// bracketing helpers for the auto-bracketing and bracket-validation phases.
+pub trait DerivativeSolver {
+    /// Find a zero of `g` near `guess`, auto-bracketing in steps of `step`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `accuracy <= 0`, no bracket is found, the refinement
+    /// exhausts the evaluation budget, or the method leaves the bracket / hits an
+    /// unusable derivative.
+    fn solve<G: Function1D>(&self, g: G, accuracy: Real, guess: Real, step: Real)
+    -> QlResult<Real>;
+
+    /// Find a zero of `g` in the caller-supplied bracket `[x_min, x_max]`.
+    ///
+    /// # Errors
+    ///
+    /// As for [`solve`](DerivativeSolver::solve), plus the bracket-validation
+    /// errors of the shared driver.
+    fn solve_bracketed<G: Function1D>(
+        &self,
+        g: G,
+        accuracy: Real,
+        guess: Real,
+        x_min: Real,
+        x_max: Real,
+    ) -> QlResult<Real>;
+}
+
 #[cfg(test)]
 mod tests {
     use std::cell::Cell;

--- a/crates/itofin/src/math/solvers1d/mod.rs
+++ b/crates/itofin/src/math/solvers1d/mod.rs
@@ -6,6 +6,7 @@
 pub mod bisection;
 pub mod brent;
 pub mod falseposition;
+pub mod newton;
 pub mod ridder;
 pub mod secant;
 

--- a/crates/itofin/src/math/solvers1d/newton.rs
+++ b/crates/itofin/src/math/solvers1d/newton.rs
@@ -1,0 +1,228 @@
+//! Newton 1-D solver.
+//!
+//! Port of `ql/math/solvers1d/newton.hpp`: Newton-Raphson stepping
+//! `x -= f(x)/f'(x)` from the bracket midpoint. QuantLib hands off to NewtonSafe
+//! when a step leaves the bracket; here - keeping Newton conceptually pure - we
+//! instead return an explicit error, leaving safe bracketing to [`NewtonSafe`].
+//! Following Press et al., "Numerical Recipes in C", 2nd ed.
+//!
+//! [`NewtonSafe`]: super
+// (NewtonSafe is a later ticket; the link target is the module for now.)
+
+use crate::errors::QlResult;
+use crate::fail;
+use crate::math::solver1d::{
+    Bracketed, DerivativeSolver, Function1D, Solver1DState, SolverConfig, bracket_by_stepping,
+    bracket_given,
+};
+use crate::types::Real;
+
+/// Newton-Raphson root finder.
+#[derive(Clone, Copy, Debug)]
+pub struct Newton {
+    config: SolverConfig,
+}
+
+impl Newton {
+    /// A Newton solver with the default configuration.
+    pub fn new() -> Self {
+        Newton {
+            config: SolverConfig::new(),
+        }
+    }
+
+    /// Set the evaluation cap (builder form).
+    pub fn with_max_evaluations(mut self, evaluations: usize) -> Self {
+        self.config.max_evaluations = evaluations;
+        self
+    }
+
+    /// Restrict the search to `x >= lower_bound` (builder form).
+    pub fn with_lower_bound(mut self, lower_bound: Real) -> Self {
+        self.config.lower_bound = Some(lower_bound);
+        self
+    }
+
+    /// Restrict the search to `x <= upper_bound` (builder form).
+    pub fn with_upper_bound(mut self, upper_bound: Real) -> Self {
+        self.config.upper_bound = Some(upper_bound);
+        self
+    }
+
+    /// Newton iteration on a prepared bracket.
+    fn refine<G: Function1D>(
+        &self,
+        g: &mut G,
+        x_accuracy: Real,
+        mut st: Solver1DState,
+    ) -> QlResult<Real> {
+        let mut froot = g.value(st.root);
+        let mut dfroot = g.derivative(st.root);
+        st.evaluation_number += 1;
+
+        while st.evaluation_number <= self.config.max_evaluations {
+            if dfroot == 0.0 || !dfroot.is_finite() {
+                fail!(
+                    "Newton solver hit an unusable derivative ({dfroot}) at x = {}",
+                    st.root
+                );
+            }
+            let dx = froot / dfroot;
+            st.root -= dx;
+            // Pure Newton: a step out of the bracket is an error (QuantLib would
+            // hand off to NewtonSafe here).
+            if (st.x_min - st.root) * (st.root - st.x_max) < 0.0 {
+                fail!(
+                    "Newton solver left the bracket: root ({}) not in [{}, {}]",
+                    st.root,
+                    st.x_min,
+                    st.x_max
+                );
+            }
+            if dx.abs() < x_accuracy {
+                // Final call at the root so a stateful functor records it.
+                let _ = g.value(st.root);
+                st.evaluation_number += 1;
+                return Ok(st.root);
+            }
+            froot = g.value(st.root);
+            dfroot = g.derivative(st.root);
+            st.evaluation_number += 1;
+        }
+        fail!(
+            "maximum number of function evaluations ({}) exceeded",
+            self.config.max_evaluations
+        )
+    }
+}
+
+impl Default for Newton {
+    fn default() -> Self {
+        Newton::new()
+    }
+}
+
+impl DerivativeSolver for Newton {
+    fn solve<G: Function1D>(
+        &self,
+        mut g: G,
+        accuracy: Real,
+        guess: Real,
+        step: Real,
+    ) -> QlResult<Real> {
+        if accuracy <= 0.0 {
+            fail!("accuracy ({accuracy}) must be positive");
+        }
+        let accuracy = accuracy.max(Real::EPSILON);
+        // Bind before matching so the value-closure's borrow of `g` is released
+        // before `refine` takes `&mut g`.
+        let bracketed = bracket_by_stepping(&self.config, &mut |x| g.value(x), guess, step)?;
+        match bracketed {
+            Bracketed::Root(x) => Ok(x),
+            Bracketed::Ready(st) => self.refine(&mut g, accuracy, st),
+        }
+    }
+
+    fn solve_bracketed<G: Function1D>(
+        &self,
+        mut g: G,
+        accuracy: Real,
+        guess: Real,
+        x_min: Real,
+        x_max: Real,
+    ) -> QlResult<Real> {
+        if accuracy <= 0.0 {
+            fail!("accuracy ({accuracy}) must be positive");
+        }
+        let accuracy = accuracy.max(Real::EPSILON);
+        let bracketed = bracket_given(&self.config, &mut |x| g.value(x), guess, x_min, x_max)?;
+        match bracketed {
+            Bracketed::Root(x) => Ok(x),
+            Bracketed::Ready(st) => self.refine(&mut g, accuracy, st),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::math::solver1d::func1d;
+    use crate::math::solvers1d::testkit;
+
+    #[test]
+    fn finds_known_roots() {
+        testkit::check_derivative_solver_finds_roots(Newton::new);
+    }
+
+    #[test]
+    fn last_call_is_made_with_the_root() {
+        testkit::check_derivative_last_call(Newton::new);
+    }
+
+    #[test]
+    fn rejects_invalid_inputs() {
+        testkit::check_derivative_rejects(Newton::new);
+    }
+
+    #[test]
+    fn honours_configured_bounds() {
+        // A bracket past the upper bound is rejected by the shared driver.
+        let solver = Newton::new().with_upper_bound(2.0);
+        assert!(
+            solver
+                .solve_bracketed(func1d(testkit::f1, testkit::d1), 1e-8, 1.5, 0.0, 3.0)
+                .is_err()
+        );
+    }
+
+    // Pure Newton: a step that leaves the bracket is an explicit error, not a
+    // silent fallback. atan diverges under Newton from |x| > ~1.39, so guessing
+    // 1.5 inside [-2, 2] forces a step outside.
+    #[test]
+    fn errors_explicitly_when_a_step_leaves_the_bracket() {
+        let atan = func1d(|x: Real| x.atan(), |x: Real| 1.0 / (1.0 + x * x));
+        let err = Newton::new()
+            .solve_bracketed(atan, 1e-12, 1.5, -2.0, 2.0)
+            .unwrap_err();
+        assert!(
+            err.message().contains("left the bracket"),
+            "unexpected error: {}",
+            err.message()
+        );
+    }
+
+    // A genuinely FnMut functor (mutating captured state directly, not via a
+    // Cell) must be accepted - the reason Function1D takes &mut self. This would
+    // not compile if func1d required Fn.
+    #[test]
+    fn accepts_a_stateful_fnmut_functor() {
+        let mut calls = 0_usize;
+        let g = func1d(
+            |x: Real| {
+                calls += 1;
+                x * x - 1.0
+            },
+            |x: Real| 2.0 * x,
+        );
+        let root = Newton::new()
+            .solve_bracketed(g, 1e-10, 0.5, 0.0, 2.0)
+            .unwrap();
+        assert!((root - 1.0).abs() <= 1e-9, "root={root}");
+        assert!(calls > 0, "the functor was never called");
+    }
+
+    // A zero (or non-finite) derivative makes the Newton step undefined; report it
+    // explicitly rather than dividing by zero into an escape.
+    #[test]
+    fn errors_on_unusable_derivative() {
+        let g = func1d(|x: Real| x * x - 1.0, |_: Real| 0.0);
+        let err = Newton::new()
+            .solve_bracketed(g, 1e-8, 0.5, 0.0, 2.0)
+            .unwrap_err();
+        assert!(
+            err.message().contains("unusable derivative"),
+            "unexpected error: {}",
+            err.message()
+        );
+    }
+}

--- a/crates/itofin/src/math/solvers1d/testkit.rs
+++ b/crates/itofin/src/math/solvers1d/testkit.rs
@@ -5,7 +5,7 @@
 //! same driver-contract checks, parameterised by a factory that produces a fresh
 //! solver. Each solver's test module just calls these with its own constructor.
 
-use crate::math::solver1d::Solver1D;
+use crate::math::solver1d::{DerivativeSolver, Solver1D, func1d};
 use crate::types::Real;
 use std::cell::Cell;
 
@@ -20,6 +20,14 @@ pub fn f2(x: Real) -> Real {
 /// `f3(x) = atan(x - 1)`: single root at `x = 1`.
 pub fn f3(x: Real) -> Real {
     (x - 1.0).atan()
+}
+/// `f1'(x) = 2x`.
+pub fn d1(x: Real) -> Real {
+    2.0 * x
+}
+/// `f2'(x) = -2x`.
+pub fn d2(x: Real) -> Real {
+    -2.0 * x
 }
 
 const ACCURACIES: [Real; 3] = [1.0e-4, 1.0e-6, 1.0e-8];
@@ -104,4 +112,84 @@ pub fn check_honours_bounds<S: Solver1D>(make: impl Fn() -> S) {
     solver.set_upper_bound(5.0);
     let root = solver.solve(f1, 1e-10, 0.5, 0.1).unwrap();
     assert!((root - 1.0).abs() <= 1e-9, "root={root}");
+}
+
+// --- Derivative-based solvers (Newton, NewtonSafe, ...) ---
+
+/// Port of `test_solver` for a [`DerivativeSolver`]: the well-behaved known roots
+/// of `f1` and `f2`, paired with their derivatives, that every derivative solver
+/// must find. (The `f3 = atan(x - 1)`, `guess = 1.00001` case forces a step out
+/// of the bracket and so belongs to the safe-stepping solvers - see NewtonSafe.)
+pub fn check_derivative_solver_finds_roots<S: DerivativeSolver>(make: impl Fn() -> S) {
+    let cases = [(f1 as fn(Real) -> Real, d1 as fn(Real) -> Real), (f2, d2)];
+    for (f, d) in cases {
+        for guess in [0.5, 1.5] {
+            for acc in ACCURACIES {
+                let root = make().solve(func1d(f, d), acc, guess, 0.1).unwrap();
+                assert!(
+                    (root - 1.0).abs() <= acc,
+                    "auto: guess={guess} acc={acc} root={root}"
+                );
+                let root = make()
+                    .solve_bracketed(func1d(f, d), acc, guess, 0.0, 2.0)
+                    .unwrap();
+                assert!(
+                    (root - 1.0).abs() <= acc,
+                    "bracketed: guess={guess} acc={acc} root={root}"
+                );
+            }
+        }
+    }
+}
+
+/// Port of `test_last_call_with_root` for a [`DerivativeSolver`]. The Probe gets
+/// its CORRECT derivative `-2x` (QuantLib's fixture declares `2x` and relies on
+/// the NewtonSafe fallback to absorb it; pure Newton needs the true derivative).
+pub fn check_derivative_last_call<S: DerivativeSolver>(make: impl Fn() -> S) {
+    let mins = [3.0, 2.25, 1.5, 1.0];
+    let maxs = [7.0, 5.75, 4.5, 3.0];
+    let steps = [0.2, 0.2, 0.1, 0.1];
+    let offsets = [25.0, 11.0, 5.0, 1.0];
+    let guesses = [4.5, 4.5, 2.5, 2.5];
+    let accuracy = 1.0e-6;
+
+    for bracketed in [false, true] {
+        let argument = Cell::new(0.0);
+        for i in 0..4 {
+            let previous = argument.get();
+            let value = |x: Real| {
+                argument.set(x);
+                previous + offsets[i] - x * x
+            };
+            let derivative = |x: Real| -2.0 * x;
+            let g = func1d(value, derivative);
+            let result = if bracketed {
+                make()
+                    .solve_bracketed(g, accuracy, guesses[i], mins[i], maxs[i])
+                    .unwrap()
+            } else {
+                make().solve(g, accuracy, guesses[i], steps[i]).unwrap()
+            };
+            assert!(
+                (result - argument.get()).abs() <= 2.0 * Real::EPSILON,
+                "bracketed={bracketed} i={i}: result={result} last_arg={}",
+                argument.get()
+            );
+        }
+    }
+}
+
+/// The shared driver rejects malformed inputs for a [`DerivativeSolver`] too.
+pub fn check_derivative_rejects<S: DerivativeSolver>(make: impl Fn() -> S) {
+    assert!(make().solve(func1d(f1, d1), 0.0, 0.5, 0.1).is_err());
+    assert!(
+        make()
+            .solve_bracketed(func1d(f1, d1), 1e-8, 2.5, 2.0, 3.0)
+            .is_err()
+    );
+    assert!(
+        make()
+            .solve_bracketed(func1d(f1, d1), 1e-8, 5.0, 0.0, 2.0)
+            .is_err()
+    );
 }


### PR DESCRIPTION
Settle the function-plus-derivative contract and add the first derivative-based solver, on top of the extracted bracketing helpers:

- Function1D trait (value + derivative, both &mut self to match the FnMut value closures the Solver1D drivers accept) with a func1d(f, df) closure adapter.
- DerivativeSolver trait: a separate contract from Solver1D whose refinement takes a Function1D, reusing the shared bracketing.
- Newton: pure Newton-Raphson from the bracket midpoint. Per the intended Newton/NewtonSafe split it stays sharp - a step that leaves the bracket or an unusable derivative is an explicit error, not a silent fallback (QuantLib delegates to NewtonSafe there).
- testkit: derivative-aware checks reusing f1/f2; the atan(x-1), guess=1.00001 escape-stress case is deferred to NewtonSafe.

Refs #48