### PR TITLE
refactor(math): provide default solve methods on DerivativeSolver

### DIFF
--- a/crates/itofin/src/math/solver1d.rs
+++ b/crates/itofin/src/math/solver1d.rs
@@ -367,30 +367,73 @@ where
 /// a [`Function1D`] rather than a bare value closure. It still reuses the shared
 /// bracketing helpers for the auto-bracketing and bracket-validation phases.
 pub trait DerivativeSolver {
+    /// The shared configuration (evaluation cap, domain bounds).
+    fn config(&self) -> &SolverConfig;
+
+    /// Refine an already-bracketed root of `g` to the given `accuracy`, with the
+    /// bracket invariants documented on [`Solver1DState`] guaranteed by the driver
+    /// (the derivative-solver analogue of [`Solver1D::solve_impl`]).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the refinement exhausts the evaluation budget or the
+    /// method cannot proceed (e.g. a pure Newton step leaves the bracket).
+    fn refine<G: Function1D>(
+        &self,
+        g: &mut G,
+        accuracy: Real,
+        state: Solver1DState,
+    ) -> QlResult<Real>;
+
     /// Find a zero of `g` near `guess`, auto-bracketing in steps of `step`.
     ///
     /// # Errors
     ///
-    /// Returns an error if `accuracy <= 0`, no bracket is found, the refinement
-    /// exhausts the evaluation budget, or the method leaves the bracket / hits an
-    /// unusable derivative.
-    fn solve<G: Function1D>(&self, g: G, accuracy: Real, guess: Real, step: Real)
-    -> QlResult<Real>;
+    /// Returns an error if `accuracy <= 0`, no bracket is found, or [`refine`](Self::refine) fails.
+    fn solve<G: Function1D>(
+        &self,
+        mut g: G,
+        accuracy: Real,
+        guess: Real,
+        step: Real,
+    ) -> QlResult<Real> {
+        if accuracy <= 0.0 {
+            fail!("accuracy ({accuracy}) must be positive");
+        }
+        let accuracy = accuracy.max(Real::EPSILON);
+        // Bind before matching so the value-closure's borrow of `g` is released
+        // before `refine` takes `&mut g`.
+        let bracketed = bracket_by_stepping(self.config(), &mut |x| g.value(x), guess, step)?;
+        match bracketed {
+            Bracketed::Root(x) => Ok(x),
+            Bracketed::Ready(st) => self.refine(&mut g, accuracy, st),
+        }
+    }
 
     /// Find a zero of `g` in the caller-supplied bracket `[x_min, x_max]`.
     ///
     /// # Errors
     ///
-    /// As for [`solve`](DerivativeSolver::solve), plus the bracket-validation
-    /// errors of the shared driver.
+    /// As for [`solve`](Self::solve), plus the bracket-validation errors of the
+    /// shared driver.
     fn solve_bracketed<G: Function1D>(
         &self,
-        g: G,
+        mut g: G,
         accuracy: Real,
         guess: Real,
         x_min: Real,
         x_max: Real,
-    ) -> QlResult<Real>;
+    ) -> QlResult<Real> {
+        if accuracy <= 0.0 {
+            fail!("accuracy ({accuracy}) must be positive");
+        }
+        let accuracy = accuracy.max(Real::EPSILON);
+        let bracketed = bracket_given(self.config(), &mut |x| g.value(x), guess, x_min, x_max)?;
+        match bracketed {
+            Bracketed::Root(x) => Ok(x),
+            Bracketed::Ready(st) => self.refine(&mut g, accuracy, st),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/itofin/src/math/solvers1d/newton.rs
+++ b/crates/itofin/src/math/solvers1d/newton.rs
@@ -11,10 +11,7 @@
 
 use crate::errors::QlResult;
 use crate::fail;
-use crate::math::solver1d::{
-    Bracketed, DerivativeSolver, Function1D, Solver1DState, SolverConfig, bracket_by_stepping,
-    bracket_given,
-};
+use crate::math::solver1d::{DerivativeSolver, Function1D, Solver1DState, SolverConfig};
 use crate::types::Real;
 
 /// Newton-Raphson root finder.
@@ -48,8 +45,19 @@ impl Newton {
         self.config.upper_bound = Some(upper_bound);
         self
     }
+}
 
-    /// Newton iteration on a prepared bracket.
+impl Default for Newton {
+    fn default() -> Self {
+        Newton::new()
+    }
+}
+
+impl DerivativeSolver for Newton {
+    fn config(&self) -> &SolverConfig {
+        &self.config
+    }
+
     fn refine<G: Function1D>(
         &self,
         g: &mut G,
@@ -93,53 +101,6 @@ impl Newton {
             "maximum number of function evaluations ({}) exceeded",
             self.config.max_evaluations
         )
-    }
-}
-
-impl Default for Newton {
-    fn default() -> Self {
-        Newton::new()
-    }
-}
-
-impl DerivativeSolver for Newton {
-    fn solve<G: Function1D>(
-        &self,
-        mut g: G,
-        accuracy: Real,
-        guess: Real,
-        step: Real,
-    ) -> QlResult<Real> {
-        if accuracy <= 0.0 {
-            fail!("accuracy ({accuracy}) must be positive");
-        }
-        let accuracy = accuracy.max(Real::EPSILON);
-        // Bind before matching so the value-closure's borrow of `g` is released
-        // before `refine` takes `&mut g`.
-        let bracketed = bracket_by_stepping(&self.config, &mut |x| g.value(x), guess, step)?;
-        match bracketed {
-            Bracketed::Root(x) => Ok(x),
-            Bracketed::Ready(st) => self.refine(&mut g, accuracy, st),
-        }
-    }
-
-    fn solve_bracketed<G: Function1D>(
-        &self,
-        mut g: G,
-        accuracy: Real,
-        guess: Real,
-        x_min: Real,
-        x_max: Real,
-    ) -> QlResult<Real> {
-        if accuracy <= 0.0 {
-            fail!("accuracy ({accuracy}) must be positive");
-        }
-        let accuracy = accuracy.max(Real::EPSILON);
-        let bracketed = bracket_given(&self.config, &mut |x| g.value(x), guess, x_min, x_max)?;
-        match bracketed {
-            Bracketed::Root(x) => Ok(x),
-            Bracketed::Ready(st) => self.refine(&mut g, accuracy, st),
-        }
     }
 }
 

--- a/crates/itofin/src/math/solvers1d/newtonsafe.rs
+++ b/crates/itofin/src/math/solvers1d/newtonsafe.rs
@@ -12,10 +12,7 @@
 use crate::errors::QlResult;
 use crate::fail;
 use crate::math::comparison::close;
-use crate::math::solver1d::{
-    Bracketed, DerivativeSolver, Function1D, Solver1DState, SolverConfig, bracket_by_stepping,
-    bracket_given,
-};
+use crate::math::solver1d::{DerivativeSolver, Function1D, Solver1DState, SolverConfig};
 use crate::types::Real;
 
 /// Newton-safe root finder (Newton with a bisection fallback).
@@ -49,8 +46,19 @@ impl NewtonSafe {
         self.config.upper_bound = Some(upper_bound);
         self
     }
+}
 
-    /// Safe Newton iteration on a prepared bracket.
+impl Default for NewtonSafe {
+    fn default() -> Self {
+        NewtonSafe::new()
+    }
+}
+
+impl DerivativeSolver for NewtonSafe {
+    fn config(&self) -> &SolverConfig {
+        &self.config
+    }
+
     fn refine<G: Function1D>(
         &self,
         g: &mut G,
@@ -113,53 +121,6 @@ impl NewtonSafe {
             "maximum number of function evaluations ({}) exceeded",
             self.config.max_evaluations
         )
-    }
-}
-
-impl Default for NewtonSafe {
-    fn default() -> Self {
-        NewtonSafe::new()
-    }
-}
-
-impl DerivativeSolver for NewtonSafe {
-    fn solve<G: Function1D>(
-        &self,
-        mut g: G,
-        accuracy: Real,
-        guess: Real,
-        step: Real,
-    ) -> QlResult<Real> {
-        if accuracy <= 0.0 {
-            fail!("accuracy ({accuracy}) must be positive");
-        }
-        let accuracy = accuracy.max(Real::EPSILON);
-        // Bind before matching so the value-closure's borrow of `g` is released
-        // before `refine` takes `&mut g`.
-        let bracketed = bracket_by_stepping(&self.config, &mut |x| g.value(x), guess, step)?;
-        match bracketed {
-            Bracketed::Root(x) => Ok(x),
-            Bracketed::Ready(st) => self.refine(&mut g, accuracy, st),
-        }
-    }
-
-    fn solve_bracketed<G: Function1D>(
-        &self,
-        mut g: G,
-        accuracy: Real,
-        guess: Real,
-        x_min: Real,
-        x_max: Real,
-    ) -> QlResult<Real> {
-        if accuracy <= 0.0 {
-            fail!("accuracy ({accuracy}) must be positive");
-        }
-        let accuracy = accuracy.max(Real::EPSILON);
-        let bracketed = bracket_given(&self.config, &mut |x| g.value(x), guess, x_min, x_max)?;
-        match bracketed {
-            Bracketed::Root(x) => Ok(x),
-            Bracketed::Ready(st) => self.refine(&mut g, accuracy, st),
-        }
     }
 }
 


### PR DESCRIPTION
This pull request lifts the shared `solve` and `solve_bracketed` logic into the `DerivativeSolver` trait as default methods, removing the duplicated implementations from each concrete solver. Implementors now only need to supply `config` and `refine`.

**Trait changes:**
* Added a `config` method to `DerivativeSolver` so the default `solve`/`solve_bracketed` implementations can access evaluation caps and domain bounds.
* Promoted `refine` to a required trait method, documenting the bracket invariants guaranteed by the driver.
* Moved the accuracy validation, auto-bracketing, and bracket-validation flow into the trait's default `solve` and `solve_bracketed` methods.

**Solver simplification:**
* Updated `Newton` and `NewtonSafe` to implement only `config` and `refine`, dropping their now-redundant `solve` and `solve_bracketed` overrides.
* Trimmed the imports in both solvers to drop the bracketing helpers that are no longer referenced directly.