### PR TITLE
feat(math): add Halley solver with second-derivative support

### DIFF
--- a/crates/itofin/src/math/solver1d.rs
+++ b/crates/itofin/src/math/solver1d.rs
@@ -361,6 +361,56 @@ where
     Pair { value, derivative }
 }
 
+/// A [`Function1D`] that also exposes its second derivative, for solvers that use
+/// curvature (Halley). Build one from three closures with [`func2d`].
+pub trait Function2D: Function1D {
+    /// `f''(x)`.
+    fn second_derivative(&mut self, x: Real) -> Real;
+}
+
+/// Adapt value, first-derivative and second-derivative closures into a
+/// [`Function2D`].
+pub fn func2d<F, D, S>(value: F, derivative: D, second_derivative: S) -> impl Function2D
+where
+    F: FnMut(Real) -> Real,
+    D: FnMut(Real) -> Real,
+    S: FnMut(Real) -> Real,
+{
+    struct Triple<F, D, S> {
+        value: F,
+        derivative: D,
+        second_derivative: S,
+    }
+    impl<F, D, S> Function1D for Triple<F, D, S>
+    where
+        F: FnMut(Real) -> Real,
+        D: FnMut(Real) -> Real,
+        S: FnMut(Real) -> Real,
+    {
+        fn value(&mut self, x: Real) -> Real {
+            (self.value)(x)
+        }
+        fn derivative(&mut self, x: Real) -> Real {
+            (self.derivative)(x)
+        }
+    }
+    impl<F, D, S> Function2D for Triple<F, D, S>
+    where
+        F: FnMut(Real) -> Real,
+        D: FnMut(Real) -> Real,
+        S: FnMut(Real) -> Real,
+    {
+        fn second_derivative(&mut self, x: Real) -> Real {
+            (self.second_derivative)(x)
+        }
+    }
+    Triple {
+        value,
+        derivative,
+        second_derivative,
+    }
+}
+
 /// A 1-D root finder that uses the function's derivative (Newton and friends).
 ///
 /// A separate contract from [`Solver1D`]: its refinement needs `f'`, so it takes

--- a/crates/itofin/src/math/solvers1d/halley.rs
+++ b/crates/itofin/src/math/solvers1d/halley.rs
@@ -1,0 +1,269 @@
+//! Halley 1-D solver.
+//!
+//! Port of `ql/math/solvers1d/halley.hpp`: Halley's method, a cubically-convergent
+//! step using the value, first and second derivatives. Like QuantLib's Newton it
+//! hands the rest of the search to [`NewtonSafe`] if a step leaves the bracket
+//! (and `NewtonSafe` needs only the value and first derivative, which a
+//! [`Function2D`] also provides).
+//!
+//! [`NewtonSafe`]: super::newtonsafe::NewtonSafe
+
+use crate::errors::QlResult;
+use crate::fail;
+use crate::math::solver1d::{
+    Bracketed, DerivativeSolver, Function2D, Solver1DState, SolverConfig, bracket_by_stepping,
+    bracket_given,
+};
+use crate::math::solvers1d::newtonsafe::NewtonSafe;
+use crate::types::Real;
+
+/// Halley's method root finder.
+#[derive(Clone, Copy, Debug)]
+pub struct Halley {
+    config: SolverConfig,
+}
+
+impl Halley {
+    /// A Halley solver with the default configuration.
+    pub fn new() -> Self {
+        Halley {
+            config: SolverConfig::new(),
+        }
+    }
+
+    /// Set the evaluation cap (builder form).
+    pub fn with_max_evaluations(mut self, evaluations: usize) -> Self {
+        self.config.max_evaluations = evaluations;
+        self
+    }
+
+    /// Restrict the search to `x >= lower_bound` (builder form).
+    pub fn with_lower_bound(mut self, lower_bound: Real) -> Self {
+        self.config.lower_bound = Some(lower_bound);
+        self
+    }
+
+    /// Restrict the search to `x <= upper_bound` (builder form).
+    pub fn with_upper_bound(mut self, upper_bound: Real) -> Self {
+        self.config.upper_bound = Some(upper_bound);
+        self
+    }
+
+    /// Find a zero of `g` near `guess`, auto-bracketing in steps of `step`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `accuracy <= 0`, no bracket is found, or the refinement
+    /// (including any NewtonSafe handoff) exhausts the evaluation budget.
+    pub fn solve<G: Function2D>(
+        &self,
+        mut g: G,
+        accuracy: Real,
+        guess: Real,
+        step: Real,
+    ) -> QlResult<Real> {
+        if accuracy <= 0.0 {
+            fail!("accuracy ({accuracy}) must be positive");
+        }
+        let accuracy = accuracy.max(Real::EPSILON);
+        // Bind before matching so the value-closure's borrow of `g` is released
+        // before `refine` takes ownership.
+        let bracketed = bracket_by_stepping(&self.config, &mut |x| g.value(x), guess, step)?;
+        match bracketed {
+            Bracketed::Root(x) => Ok(x),
+            Bracketed::Ready(st) => self.refine(g, accuracy, st),
+        }
+    }
+
+    /// Find a zero of `g` in the caller-supplied bracket `[x_min, x_max]`.
+    ///
+    /// # Errors
+    ///
+    /// As for [`solve`](Self::solve), plus the bracket-validation errors of the
+    /// shared driver.
+    pub fn solve_bracketed<G: Function2D>(
+        &self,
+        mut g: G,
+        accuracy: Real,
+        guess: Real,
+        x_min: Real,
+        x_max: Real,
+    ) -> QlResult<Real> {
+        if accuracy <= 0.0 {
+            fail!("accuracy ({accuracy}) must be positive");
+        }
+        let accuracy = accuracy.max(Real::EPSILON);
+        let bracketed = bracket_given(&self.config, &mut |x| g.value(x), guess, x_min, x_max)?;
+        match bracketed {
+            Bracketed::Root(x) => Ok(x),
+            Bracketed::Ready(st) => self.refine(g, accuracy, st),
+        }
+    }
+
+    /// Halley iteration on a prepared bracket. Takes `g` by value so it can be
+    /// handed to [`NewtonSafe`] on a bracket escape.
+    fn refine<G: Function2D>(
+        &self,
+        mut g: G,
+        x_accuracy: Real,
+        mut st: Solver1DState,
+    ) -> QlResult<Real> {
+        loop {
+            st.evaluation_number += 1;
+            if st.evaluation_number > self.config.max_evaluations {
+                break;
+            }
+            let fx = g.value(st.root);
+            let f_prime = g.derivative(st.root);
+            let lf = fx * g.second_derivative(st.root) / (f_prime * f_prime);
+            let step = 1.0 / (1.0 - 0.5 * lf) * fx / f_prime;
+            st.root -= step;
+
+            // Jumped out of the bracket: hand the rest to NewtonSafe (which needs
+            // only value + first derivative, both carried by a Function2D).
+            if (st.x_min - st.root) * (st.root - st.x_max) < 0.0 {
+                let remaining = self.config.max_evaluations - st.evaluation_number;
+                return NewtonSafe::new()
+                    .with_max_evaluations(remaining)
+                    .solve_bracketed(g, x_accuracy, st.root + step, st.x_min, st.x_max);
+            }
+            if step.abs() < x_accuracy {
+                // Final call at the root so a stateful functor records it.
+                let _ = g.value(st.root);
+                st.evaluation_number += 1;
+                return Ok(st.root);
+            }
+        }
+        fail!(
+            "maximum number of function evaluations ({}) exceeded",
+            self.config.max_evaluations
+        )
+    }
+}
+
+impl Default for Halley {
+    fn default() -> Self {
+        Halley::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::math::solver1d::func2d;
+    use crate::math::solvers1d::testkit::{d1, d2, d3, dd1, dd2, dd3, f1, f2, f3};
+    use std::cell::Cell;
+
+    const ACCURACIES: [Real; 3] = [1.0e-4, 1.0e-6, 1.0e-8];
+
+    // Port of test_solver for Halley: roots of f1, f2 (both sides, auto + pre-
+    // bracketed), and the f3 = atan(x-1), guess=1.00001 stress case where a Halley
+    // step leaves the bracket and the search is handed to NewtonSafe.
+    #[test]
+    fn finds_known_roots() {
+        let cases = [
+            (
+                f1 as fn(Real) -> Real,
+                d1 as fn(Real) -> Real,
+                dd1 as fn(Real) -> Real,
+            ),
+            (f2, d2, dd2),
+        ];
+        for (f, d, dd) in cases {
+            for guess in [0.5, 1.5] {
+                for acc in ACCURACIES {
+                    let root = Halley::new()
+                        .solve(func2d(f, d, dd), acc, guess, 0.1)
+                        .unwrap();
+                    assert!(
+                        (root - 1.0).abs() <= acc,
+                        "auto: guess={guess} acc={acc} root={root}"
+                    );
+                    let root = Halley::new()
+                        .solve_bracketed(func2d(f, d, dd), acc, guess, 0.0, 2.0)
+                        .unwrap();
+                    assert!(
+                        (root - 1.0).abs() <= acc,
+                        "bracketed: guess={guess} acc={acc} root={root}"
+                    );
+                }
+            }
+        }
+        for acc in ACCURACIES {
+            let root = Halley::new()
+                .solve(func2d(f3, d3, dd3), acc, 1.00001, 0.1)
+                .unwrap();
+            assert!((root - 1.0).abs() <= acc, "f3: acc={acc} root={root}");
+        }
+    }
+
+    // Port of test_last_call_with_root: the final function call is made at the
+    // returned root (Probe with its true derivatives, f' = -2x, f'' = -2).
+    #[test]
+    fn last_call_is_made_with_the_root() {
+        let mins = [3.0, 2.25, 1.5, 1.0];
+        let maxs = [7.0, 5.75, 4.5, 3.0];
+        let steps = [0.2, 0.2, 0.1, 0.1];
+        let offsets = [25.0, 11.0, 5.0, 1.0];
+        let guesses = [4.5, 4.5, 2.5, 2.5];
+        let accuracy = 1.0e-6;
+
+        for bracketed in [false, true] {
+            let argument = Cell::new(0.0);
+            for i in 0..4 {
+                let previous = argument.get();
+                let g = func2d(
+                    |x: Real| {
+                        argument.set(x);
+                        previous + offsets[i] - x * x
+                    },
+                    |x: Real| -2.0 * x,
+                    |_: Real| -2.0,
+                );
+                let result = if bracketed {
+                    Halley::new()
+                        .solve_bracketed(g, accuracy, guesses[i], mins[i], maxs[i])
+                        .unwrap()
+                } else {
+                    Halley::new()
+                        .solve(g, accuracy, guesses[i], steps[i])
+                        .unwrap()
+                };
+                assert!(
+                    (result - argument.get()).abs() <= 2.0 * Real::EPSILON,
+                    "bracketed={bracketed} i={i}: result={result} last_arg={}",
+                    argument.get()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_inputs() {
+        assert!(
+            Halley::new()
+                .solve(func2d(f1, d1, dd1), 0.0, 0.5, 0.1)
+                .is_err()
+        );
+        assert!(
+            Halley::new()
+                .solve_bracketed(func2d(f1, d1, dd1), 1e-8, 2.5, 2.0, 3.0)
+                .is_err()
+        );
+        assert!(
+            Halley::new()
+                .solve_bracketed(func2d(f1, d1, dd1), 1e-8, 5.0, 0.0, 2.0)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn honours_configured_bounds() {
+        let solver = Halley::new().with_upper_bound(2.0);
+        assert!(
+            solver
+                .solve_bracketed(func2d(f1, d1, dd1), 1e-8, 1.5, 0.0, 3.0)
+                .is_err()
+        );
+    }
+}

--- a/crates/itofin/src/math/solvers1d/mod.rs
+++ b/crates/itofin/src/math/solvers1d/mod.rs
@@ -7,6 +7,7 @@ pub mod bisection;
 pub mod brent;
 pub mod falseposition;
 pub mod finitedifferencenewtonsafe;
+pub mod halley;
 pub mod newton;
 pub mod newtonsafe;
 pub mod ridder;

--- a/crates/itofin/src/math/solvers1d/testkit.rs
+++ b/crates/itofin/src/math/solvers1d/testkit.rs
@@ -34,6 +34,20 @@ pub fn d3(x: Real) -> Real {
     let u = x - 1.0;
     1.0 / (1.0 + u * u)
 }
+/// `f1''(x) = 2`.
+pub fn dd1(_x: Real) -> Real {
+    2.0
+}
+/// `f2''(x) = -2`.
+pub fn dd2(_x: Real) -> Real {
+    -2.0
+}
+/// `f3''(x) = -2(x - 1) / (1 + (x - 1)^2)^2`.
+pub fn dd3(x: Real) -> Real {
+    let u = x - 1.0;
+    let d = 1.0 + u * u;
+    -2.0 * u / (d * d)
+}
 
 const ACCURACIES: [Real; 3] = [1.0e-4, 1.0e-6, 1.0e-8];
 


### PR DESCRIPTION
This change introduces support for curvature-aware 1-D root finding via Halley's method, extending the solver framework to provide and consume second derivatives.

**Second-derivative function abstraction:**
* Added a new `Function2D` trait in `math/solver1d.rs` that extends `Function1D` with a `second_derivative` method, intended for solvers that exploit curvature.
* Added the `func2d` helper that adapts value, first-derivative, and second-derivative closures into a `Function2D` implementation.

**Halley solver:**
* Added a new `math/solvers1d/halley.rs` module implementing the Halley root-finding method.
* Registered the new `halley` module in `math/solvers1d/mod.rs`.

**Testing support:**
* Added second-derivative test functions `dd1`, `dd2`, and `dd3` to `math/solvers1d/testkit.rs` to exercise the new curvature-based solver against the existing test functions.