### PR TITLE
chore(workspace): exclude crates/worktrees from the member glob

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,9 @@
 [workspace]
 resolver = "3"
 members = ["crates/*"]
+# `crates/worktrees` is a tooling-created directory for git worktrees, not a
+# crate; exclude it so the `crates/*` glob does not try to load it as a member.
+exclude = ["crates/worktrees"]
 
 [workspace.package]
 version = "0.1.0"


### PR DESCRIPTION
A git-worktree directory created under crates/ is matched by the members = ["crates/*"] glob but has no Cargo.toml, so cargo metadata fails to load the workspace. Exclude it.