### PR TITLE
fix(math): scale incomplete gamma iteration cap with a

### DIFF
--- a/crates/itofin/src/math/distributions/chisquare.rs
+++ b/crates/itofin/src/math/distributions/chisquare.rs
@@ -104,6 +104,32 @@ mod tests {
     }
 
     #[test]
+    fn large_df_near_mean_does_not_panic() {
+        // Regression (#92): df above ~190 drove the underlying incomplete_gamma
+        // series past its old 100-iteration cap and the infallible cdf panicked.
+        // At the mean the chi-square CDF is just above 0.5 (right-skewed => mean
+        // above median). Reference value 0.505947 (df = 1000) cross-checked with
+        // the Wilson-Hilferty approximation (0.5059).
+        let d1000 = CumulativeChiSquareDistribution::new(1000.0).unwrap();
+        assert!((d1000.cdf(1000.0) - 0.5059471460854907).abs() < 1e-12);
+        assert!((d1000.cdf(1200.0) - 0.9999877440576714).abs() < 1e-12);
+
+        // Sweep the mean region for several large df: in range and monotone.
+        for df in [400.0, 1000.0, 5000.0] {
+            let dist = CumulativeChiSquareDistribution::new(df).unwrap();
+            let mut prev = 0.0;
+            let mut x = 0.5 * df;
+            while x <= 1.5 * df {
+                let p = dist.cdf(x);
+                assert!((0.0..=1.0).contains(&p), "cdf({x}) = {p} for df={df}");
+                assert!(p >= prev, "not increasing at x={x} for df={df}");
+                prev = p;
+                x += 0.02 * df;
+            }
+        }
+    }
+
+    #[test]
     fn nan_x_is_nan() {
         assert!(
             CumulativeChiSquareDistribution::new(3.0)

--- a/crates/itofin/src/math/incompletegamma.rs
+++ b/crates/itofin/src/math/incompletegamma.rs
@@ -12,7 +12,22 @@ use crate::math::gammafunction::log_gamma;
 use crate::types::Real;
 
 const ACCURACY: Real = 1.0e-13;
-const MAX_ITERATIONS: u32 = 100;
+
+/// Iteration cap for both the series and continued-fraction expansions.
+///
+/// QuantLib hard-codes 100 (Numerical Recipes' `ITMAX`), but near `x ≈ a` both
+/// expansions need on the order of `8·√a` terms to reach `ACCURACY`, so 100 is
+/// exceeded once `a` grows past ~150 (e.g. a central chi-square CDF with `df`
+/// above ~190) and the caller's infallible `.expect()` would panic. The cap
+/// `a + 100` provably dominates that `8·√a` requirement for every `a > 0` (the
+/// minimum of `a + 100 - 8·√a` is ~+84 at `a = 16`) with ample headroom, so a
+/// valid evaluation always converges before the cap; the cap survives only as a
+/// backstop against a non-convergent loop. The `as u32` cast saturates rather
+/// than wrapping, and the `saturating_add` keeps even an unphysically large `a`
+/// (whose cast already hit `u32::MAX`) from overflowing the `+ 100`.
+fn max_iterations(a: Real) -> u32 {
+    100u32.saturating_add(a.ceil() as u32)
+}
 
 /// The regularized lower incomplete gamma function `P(a, x)`.
 ///
@@ -61,7 +76,7 @@ fn series_repr(a: Real, x: Real) -> QlResult<Real> {
     let mut ap = a;
     let mut del = 1.0 / a;
     let mut sum = del;
-    for _ in 1..=MAX_ITERATIONS {
+    for _ in 1..=max_iterations(a) {
         ap += 1.0;
         del *= x / ap;
         sum += del;
@@ -81,7 +96,7 @@ fn continued_fraction_repr(a: Real, x: Real) -> QlResult<Real> {
     let mut c = 1.0 / eps;
     let mut d = 1.0 / b;
     let mut h = d;
-    for i in 1..=MAX_ITERATIONS {
+    for i in 1..=max_iterations(a) {
         let an = -(i as Real) * (i as Real - a);
         b += 2.0;
         d = an * d + b;
@@ -170,6 +185,19 @@ mod tests {
             assert!(cur >= prev, "not increasing at x={x}: {prev} -> {cur}");
             prev = cur;
         }
+    }
+
+    #[test]
+    fn converges_for_large_a() {
+        // Regression: with the old fixed cap of 100, both branches hit the
+        // ~8·√a iteration requirement and failed to converge for a ≳ 150.
+        // Converged values, each cross-checked to ~1e-10 against an independent
+        // high-iteration reference implementation of the same expansions.
+        // Series branch (x < a+1), x = a:
+        assert_close(incomplete_gamma(500.0, 500.0).unwrap(), 0.5059471460854907);
+        assert_close(incomplete_gamma(200.0, 200.0).unwrap(), 0.5094034179355048);
+        // Continued-fraction branch (x >= a+1) with large a near the boundary.
+        assert_close(incomplete_gamma(500.0, 600.0).unwrap(), 0.9999877440576714);
     }
 
     #[test]


### PR DESCRIPTION
The incomplete gamma expansions had a fixed 100-iteration cap, but near `x ≈ a` both the series and continued-fraction branches need on the order of `8·√a` terms to reach the target accuracy. Once `a` grew past ~150 (e.g. a central chi-square CDF with `df` above ~190), the loop hit the cap without converging and the caller's infallible `.expect()` panicked.

**Convergence fix:**
* Replaced the constant `MAX_ITERATIONS` with `max_iterations(a)`, which returns `a + 100` (saturating) so the cap provably dominates the `8·√a` requirement for every `a > 0` while still guarding against non-convergent loops.
* Applied the new cap to both the series and continued-fraction expansions.

**Regression tests:**
* Added `converges_for_large_a` in incompletegamma.rs covering both branches for large `a` near the boundary, cross-checked against a high-iteration reference.
* Added `large_df_near_mean_does_not_panic` in chisquare.rs sweeping the mean region for several large `df`, asserting the CDF stays in range and monotone.

resolve #92