### PR TITLE
docs(errors): add intra-doc links for error macros

### DIFF
--- a/crates/itofin/src/errors.rs
+++ b/crates/itofin/src/errors.rs
@@ -3,8 +3,9 @@
 //! Port of `ql/errors.{hpp,cpp}` (design decision D4). QuantLib throws
 //! `QuantLib::Error` via the `QL_FAIL`, `QL_REQUIRE`, `QL_ASSERT` and
 //! `QL_ENSURE` macros; we model failures as a [`QlError`] returned through
-//! `Result<T, QlError>`, raised with the [`fail!`], [`require!`], [`assert_ql!`]
-//! and [`ensure!`] macros.
+//! `Result<T, QlError>`, raised with the [`fail!`](crate::fail),
+//! [`require!`](crate::require), [`assert_ql!`](crate::assert_ql) and
+//! [`ensure!`](crate::ensure) macros.
 
 use thiserror::Error;
 


### PR DESCRIPTION
Update the module-level documentation in `crates/itofin/src/errors.rs` to reference the `fail!`, `require!`, `assert_ql!`, and `ensure!` macros using intra-doc links (`crate::fail`, `crate::require`, etc.), improving navigation in the generated documentation.
