### PR TITLE
docs(crates): fix intra-doc link for ProblemAdapter in LM solver

### DIFF
--- a/crates/itofin/src/math/optimization/levenbergmarquardt.rs
+++ b/crates/itofin/src/math/optimization/levenbergmarquardt.rs
@@ -7,7 +7,7 @@
 //! (a central difference by default, order 2 but costlier) is used instead.
 //!
 //! Several deviations guard against silent false convergence, all stemming
-//! from the penalty fallbacks that [`ProblemAdapter`] returns for a bad
+//! from the penalty fallbacks that `ProblemAdapter` returns for a bad
 //! evaluation (which yield a zero/flat Jacobian and let lmdif report
 //! convergence). The starting point is validated against the constraint -
 //! QuantLib accepts an infeasible start and converges there - and the


### PR DESCRIPTION
Changed the `ProblemAdapter` reference in the Levenberg-Marquardt module documentation from an intra-doc link to plain code formatting, avoiding a broken or unintended doc link.
