### PR TITLE
fix(#59): daycounter review

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,30 @@ oversight) and is documented at the point of divergence in the source.
   lengths QuantLib's inverted bounds make overlapping periods (like `-1 Month`
   vs `-30 Days`) look decidably ordered, whereas this port correctly reports
   them as undecidable. Positive comparisons are unaffected.
+- **`DayCounter` is always valid; there is no empty placeholder.** QuantLib's
+  default-constructed `DayCounter` holds a null `impl_` and `QL_REQUIRE`s a
+  non-null one on every call. This port omits the empty state, so a
+  `DayCounter` always wraps a concrete convention and its accessors never trip
+  that null check. (Individual conventions may still panic on their own
+  preconditions - the Canadian and ISMA counters require a valid reference
+  period - so a call is not unconditionally infallible.) The "not yet set"
+  placeholder used by higher layers (schedules, coupons) will be an
+  `Option<DayCounter>` at those call sites when they are ported.
+- **`Business/252` counts directly instead of via a process-global cache.**
+  QuantLib memoizes per-month and per-year business-day totals in global
+  `std::map`s keyed by calendar name. That hidden mutable state conflicts with
+  the "explicit state, no singletons" decision (D5), so this port counts with
+  `Calendar::business_days_between` directly. With a calendar's built-in
+  schedule the results are identical (QuantLib's month/year decomposition is a
+  pure caching optimization whose segments telescope to a single count); once
+  holidays are overridden they can differ, since QuantLib's name-keyed cache is
+  populated once and goes stale while this port always reflects the current
+  holiday set.
+- **`Actual/Actual (ISMA)` uses the reference-date algorithm only.** QuantLib
+  picks a schedule-driven implementation when a `Schedule` is supplied and a
+  reference-date one otherwise; only the reference-date path is ported, since
+  `Schedule` is not yet available. The schedule-driven overload will follow when
+  `Schedule` lands.
 
 ## License
 

--- a/crates/itofin/src/time/daycounter.rs
+++ b/crates/itofin/src/time/daycounter.rs
@@ -13,7 +13,11 @@
 //! QuantLib's default-constructed `DayCounter` is *empty* (a null `impl_`), and
 //! its accessors `QL_REQUIRE` a non-null implementation. This port omits the
 //! empty state: a [`DayCounter`] always wraps a concrete implementation, so the
-//! accessors cannot fail. The empty placeholder is only used by higher layers
+//! wrapper's accessors never trip the null-implementation check QuantLib guards
+//! against. (This does not make every call infallible: individual conventions
+//! may still panic on their own preconditions - for example the Canadian and
+//! ISMA counters require a valid reference period - as documented in their
+//! `# Panics` sections.) The empty placeholder is only used by higher layers
 //! (schedules, coupons) as a "not yet set" marker; it will be reintroduced as an
 //! `Option<DayCounter>` at those call sites when they are ported, keeping the
 //! counter type itself always-valid.
@@ -127,6 +131,11 @@ impl fmt::Display for DayCounter {
 impl PartialEq for DayCounter {
     /// Two day counters are equal iff they share the same name, matching
     /// QuantLib's `operator==` (which compares the derived-class name).
+    ///
+    /// Because equality is purely by name, a custom [`DayCounterImpl`] must
+    /// return a name distinct from the built-in conventions (and from other
+    /// customs) or it will compare equal to them despite different behaviour -
+    /// the same caveat applies to user-defined day counters in QuantLib.
     fn eq(&self, other: &DayCounter) -> bool {
         self.name() == other.name()
     }

--- a/crates/itofin/src/time/daycounters/actual365fixed.rs
+++ b/crates/itofin/src/time/daycounters/actual365fixed.rs
@@ -65,9 +65,12 @@ impl DayCounterImpl for CanadianImpl {
 
     /// # Panics
     ///
-    /// Panics (mirroring QuantLib's `QL_REQUIRE`) if the reference period is
-    /// absent, shorter than a month, or longer than a year - the Canadian bond
-    /// convention cannot infer a coupon frequency without a valid one.
+    /// Panics if the reference period is absent, inverted (`ref_end` not after
+    /// `ref_start`), shorter than a month, or longer than a year - the Canadian
+    /// bond convention cannot infer a coupon frequency without a valid one. The
+    /// absent/short/long checks mirror QuantLib's `QL_REQUIRE`s; rejecting an
+    /// inverted period is a deliberate hardening - QuantLib omits that check and
+    /// would derive a negative frequency and return a nonsensical fraction.
     fn year_fraction(&self, d1: Date, d2: Date, ref_start: Date, ref_end: Date) -> Time {
         if d1 == d2 {
             return 0.0;
@@ -76,6 +79,10 @@ impl DayCounterImpl for CanadianImpl {
         // The reference period is needed to recover the coupon frequency.
         assert!(ref_start != Date::null(), "invalid refPeriodStart");
         assert!(ref_end != Date::null(), "invalid refPeriodEnd");
+        assert!(
+            ref_end > ref_start,
+            "invalid reference period for Act/365 Canadian; end must be after start"
+        );
 
         let dcs = Time::from(d2 - d1);
         let dcc = Time::from(ref_end - ref_start);
@@ -194,6 +201,20 @@ mod tests {
             d(8, Month::January, 2027),
             d(8, Month::January, 2025),
             d(8, Month::January, 2027),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "end must be after start")]
+    fn canadian_inverted_reference_panics() {
+        // An inverted reference period would otherwise yield a negative
+        // frequency and a nonsensical fraction; reject it up front.
+        let dc = Actual365Fixed::with_convention(Convention::Canadian);
+        dc.year_fraction_ref(
+            d(10, Month::September, 2018),
+            d(10, Month::October, 2018),
+            d(10, Month::March, 2019),
+            d(10, Month::September, 2018),
         );
     }
 

--- a/crates/itofin/src/time/daycounters/actualactual.rs
+++ b/crates/itofin/src/time/daycounters/actualactual.rs
@@ -118,6 +118,15 @@ impl DayCounterImpl for IsmaImpl {
         // Estimate roughly the length in months of a period.
         let mut months = (12.0 * days_between(ref_start, ref_end) / 365.0).round() as Integer;
         if months == 0 {
+            // A short stub with no usable reference period is treated as a
+            // fraction of the year following d1. Building d1 + 1*Years overflows
+            // the supported date range when d1 is in the last representable
+            // year; there d2 is necessarily within that same year, so the result
+            // reduces to the stub over the year's length (365 - neither the last
+            // supported year nor the next one is a leap year).
+            if d1.year() == Date::max_date().year() {
+                return days_between(d1, d2) / 365.0;
+            }
             // ...take the reference period as 1 year from d1.
             ref_start = d1;
             ref_end = d1 + 1 * TimeUnit::Years;
@@ -289,6 +298,15 @@ mod tests {
         // A same-year period in 2199 must not reach for Jan 1st 2200, which
         // is outside the supported date range.
         let dc = ActualActual::with_convention(Convention::ISDA);
+        let t = dc.year_fraction(d(1, Month::January, 2199), d(2, Month::January, 2199));
+        assert!((t - 1.0 / 365.0).abs() < TOL, "got {t}");
+    }
+
+    #[test]
+    fn isma_handles_the_last_supported_year() {
+        // A short stub in the last supported year rounds to 0 months and would
+        // otherwise fall back to d1 + 1 year (Jan 1st 2200), outside the range.
+        let dc = ActualActual::with_convention(Convention::ISMA);
         let t = dc.year_fraction(d(1, Month::January, 2199), d(2, Month::January, 2199));
         assert!((t - 1.0 / 365.0).abs() < TOL, "got {t}");
     }

--- a/crates/itofin/src/time/daycounters/business252.rs
+++ b/crates/itofin/src/time/daycounters/business252.rs
@@ -12,11 +12,16 @@
 //! this port's "explicit state, no hidden singletons" decision (D5), the same
 //! reason [`Calendar`] holiday overrides are
 //! per-value here. This port drops the cache and counts directly with
-//! [`Calendar::business_days_between`] (first day included, last excluded). The
-//! two are numerically identical:
-//! QuantLib's month/year decomposition is a pure caching optimization whose
-//! contiguous `[include-first, exclude-last]` segments telescope back to a
-//! single `businessDaysBetween(d1, d2)`.
+//! [`Calendar::business_days_between`] (first day included, last excluded).
+//!
+//! For a calendar with its built-in schedule the two agree exactly: QuantLib's
+//! month/year decomposition is a pure caching optimization whose contiguous
+//! `[include-first, exclude-last]` segments telescope back to a single
+//! `businessDaysBetween(d1, d2)`. They can diverge once holidays are
+//! *overridden*, though: QuantLib populates each cached figure once and keys it
+//! only by calendar name, so an `addHoliday`/`removeHoliday` after the first
+//! query leaves the cache stale, while this port always reflects the current
+//! holiday set. In that case the direct count is the more correct of the two.
 
 use crate::shared::shared;
 use crate::time::calendar::Calendar;


### PR DESCRIPTION
- **fix(daycounters): handle short stub in last supported year for ActualActual**
- **fix(daycounters): reject inverted reference period in Act/365 Canadian**
- **docs(daycounter): clarify divergences from QuantLib's caching and null state**
