### PR TITLE
fix(randomnumbers): apply review findings for RNG generators

### DIFF
--- a/crates/itofin/src/math/randomnumbers/mod.rs
+++ b/crates/itofin/src/math/randomnumbers/mod.rs
@@ -3,7 +3,8 @@
 //! QuantLib couples its generators through class templates whose `next()`
 //! returns a weighted `Sample<Real>`; for the pseudo-random generators the
 //! weight is always `1.0`, so we drop the wrapper and express the coupling
-//! with traits instead: [`UniformRng`] for uniform deviates in `(0, 1)`,
+//! with traits instead: [`UniformRng`] for uniform deviates in the unit
+//! interval,
 //! [`Uint64Rng`] for the generators that also expose their raw 64-bit output
 //! (what the Ziggurat transform consumes), and [`GaussianRng`] for normal
 //! deviates. Generators take `&mut self` where QuantLib mutates through
@@ -28,10 +29,12 @@ pub use ranluxuniformrng::{Ranlux3UniformRng, Ranlux4UniformRng, Ranlux64Uniform
 pub use xoshiro256starstaruniformrng::Xoshiro256StarStarUniformRng;
 pub use zigguratgaussianrng::ZigguratGaussianRng;
 
-/// A generator of uniform pseudo-random deviates in the open `(0, 1)`
-/// interval.
+/// A generator of uniform pseudo-random deviates in the unit interval.
+///
+/// Endpoint behavior is generator-specific (e.g. Ranlux can return exactly
+/// `0.0`); see each implementation's documentation.
 pub trait UniformRng {
-    /// The next uniform deviate in `(0, 1)`.
+    /// The next uniform deviate in the unit interval.
     fn next_real(&mut self) -> Real;
 }
 

--- a/crates/itofin/src/math/randomnumbers/ranluxuniformrng.rs
+++ b/crates/itofin/src/math/randomnumbers/ranluxuniformrng.rs
@@ -28,6 +28,7 @@ struct SubtractWithCarry48 {
 
 impl SubtractWithCarry48 {
     fn new(seed: u64) -> Self {
+        let seed = if seed == 0 { 19_780_503 } else { seed };
         let mut lcg = (seed % 2_147_483_563).max(1);
         let mut next_lcg = || {
             lcg = (40014 * lcg) % 2_147_483_563;
@@ -79,8 +80,9 @@ pub type Ranlux3UniformRng = Ranlux64UniformRng<223, 24>;
 pub type Ranlux4UniformRng = Ranlux64UniformRng<389, 24>;
 
 impl<const P: usize, const R: usize> Ranlux64UniformRng<P, R> {
-    /// A generator initialized from the given seed (QuantLib's default seed
-    /// is `19780503`).
+    /// A generator initialized from the given seed. Seed `0` selects the
+    /// standard engine's default seed `19780503` (also QuantLib's default),
+    /// per the C++ standard's seeding scheme.
     pub fn new(seed: u64) -> Self {
         Ranlux64UniformRng {
             base: SubtractWithCarry48::new(seed),
@@ -159,6 +161,19 @@ mod tests {
             assert!(
                 close_enough(ranlux4.next_real(), ranlux4_expected[i]),
                 "ranlux4 mismatch at index {i}"
+            );
+        }
+    }
+
+    #[test]
+    fn seed_zero_selects_default_seed() {
+        let mut from_zero = Ranlux3UniformRng::new(0);
+        let mut from_default = Ranlux3UniformRng::new(19_780_503);
+        for i in 0..100 {
+            assert_eq!(
+                from_zero.next_u48(),
+                from_default.next_u48(),
+                "seed-0 sequence diverged from default seed at index {i}"
             );
         }
     }


### PR DESCRIPTION
- Ranlux: seed 0 now selects the standard engine's default seed 19780503,
  matching std::subtract_with_carry_engine seeding that QuantLib proxies
- soften UniformRng docs: unit interval with generator-specific endpoints

Claude-Session: https://claude.ai/code/session_01JzUEe427tQ4LJdEEwseV9m
