### PR TITLE
feat(#177): implement reset of the datcounter

### DIFF
--- a/crates/itofin/src/time/daycounters/actual364.rs
+++ b/crates/itofin/src/time/daycounters/actual364.rs
@@ -1,0 +1,57 @@
+//! Actual/364 day count convention.
+//!
+//! Port of `ql/time/daycounters/actual364.hpp`.
+
+use crate::shared::shared;
+use crate::time::date::Date;
+use crate::time::daycounter::{DayCounter, DayCounterImpl};
+use crate::types::Time;
+
+/// The Actual/364 day count convention.
+pub struct Actual364;
+
+impl Actual364 {
+    /// Builds an Actual/364 counter.
+    pub fn new() -> DayCounter {
+        DayCounter::from_impl(shared(Impl))
+    }
+}
+
+struct Impl;
+
+impl DayCounterImpl for Impl {
+    fn name(&self) -> String {
+        "Actual/364".to_string()
+    }
+
+    fn year_fraction(&self, d1: Date, d2: Date, _ref_start: Date, _ref_end: Date) -> Time {
+        Time::from(d2 - d1) / 364.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::time::date::Month;
+
+    #[test]
+    fn name_is_actual_364() {
+        assert_eq!(Actual364::new().name(), "Actual/364");
+    }
+
+    #[test]
+    fn day_count_is_plain_difference() {
+        let dc = Actual364::new();
+        let d1 = Date::new(1, Month::January, 2020);
+        let d2 = Date::new(31, Month::January, 2020);
+        assert_eq!(dc.day_count(d1, d2), 30);
+    }
+
+    #[test]
+    fn year_fraction_divides_by_364() {
+        let dc = Actual364::new();
+        let d1 = Date::new(1, Month::January, 2020);
+        let d2 = Date::new(1, Month::July, 2020);
+        assert!((dc.year_fraction(d1, d2) - 182.0 / 364.0).abs() < 1e-12);
+    }
+}

--- a/crates/itofin/src/time/daycounters/actual36525.rs
+++ b/crates/itofin/src/time/daycounters/actual36525.rs
@@ -1,0 +1,119 @@
+//! Actual/365.25 day count convention.
+//!
+//! Port of `ql/time/daycounters/actual36525.hpp`. Also known as "Act/365.25"
+//! or "A/365.25". An optional flag counts the last day as well, giving the
+//! "(inc)" variant.
+
+use crate::shared::shared;
+use crate::time::date::{Date, SerialNumber};
+use crate::time::daycounter::{DayCounter, DayCounterImpl};
+use crate::types::Time;
+
+/// The Actual/365.25 day count convention.
+pub struct Actual36525;
+
+impl Actual36525 {
+    /// Builds an Actual/365.25 counter that excludes the last day.
+    pub fn new() -> DayCounter {
+        Self::with_last_day(false)
+    }
+
+    /// Builds an Actual/365.25 counter, optionally including the last day (the
+    /// "(inc)" variant), matching QuantLib's `includeLastDay` constructor flag.
+    pub fn with_last_day(include_last_day: bool) -> DayCounter {
+        DayCounter::from_impl(shared(Impl { include_last_day }))
+    }
+}
+
+struct Impl {
+    include_last_day: bool,
+}
+
+impl DayCounterImpl for Impl {
+    fn name(&self) -> String {
+        if self.include_last_day {
+            "Actual/365.25 (inc)".to_string()
+        } else {
+            "Actual/365.25".to_string()
+        }
+    }
+
+    fn day_count(&self, d1: Date, d2: Date) -> SerialNumber {
+        (d2 - d1) + SerialNumber::from(self.include_last_day)
+    }
+
+    fn year_fraction(&self, d1: Date, d2: Date, _ref_start: Date, _ref_end: Date) -> Time {
+        Time::from(self.day_count(d1, d2)) / 365.25
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::time::date::Month;
+
+    #[test]
+    fn name_reflects_include_last_day() {
+        assert_eq!(Actual36525::new().name(), "Actual/365.25");
+        assert_eq!(
+            Actual36525::with_last_day(true).name(),
+            "Actual/365.25 (inc)"
+        );
+    }
+
+    #[test]
+    fn include_last_day_adds_one() {
+        let d1 = Date::new(1, Month::January, 2020);
+        let d2 = Date::new(31, Month::January, 2020);
+        assert_eq!(Actual36525::with_last_day(true).day_count(d1, d2), 31);
+    }
+
+    #[test]
+    fn matches_quantlib_year_fractions() {
+        let dates = [
+            Date::new(1, Month::February, 2002),
+            Date::new(4, Month::February, 2002),
+            Date::new(16, Month::May, 2003),
+            Date::new(17, Month::December, 2003),
+            Date::new(17, Month::December, 2004),
+            Date::new(19, Month::December, 2005),
+            Date::new(2, Month::January, 2006),
+            Date::new(13, Month::March, 2006),
+            Date::new(15, Month::May, 2006),
+            Date::new(17, Month::March, 2006),
+            Date::new(15, Month::May, 2006),
+            Date::new(26, Month::July, 2006),
+            Date::new(28, Month::June, 2007),
+            Date::new(16, Month::September, 2009),
+            Date::new(26, Month::July, 2016),
+        ];
+        let expected = [
+            0.0082135523613963,
+            1.27583846680356,
+            0.588637919233402,
+            1.00205338809035,
+            1.00479123887748,
+            0.0383299110198494,
+            0.191649555099247,
+            0.172484599589322,
+            -0.161533196440794,
+            0.161533196440794,
+            0.197125256673511,
+            0.922655715263518,
+            2.22039698836413,
+            6.85831622176591,
+        ];
+
+        let dc = Actual36525::new();
+        for i in 1..dates.len() {
+            let calculated = dc.year_fraction(dates[i - 1], dates[i]);
+            assert!(
+                (calculated - expected[i - 1]).abs() <= 1.0e-12,
+                "from {} to {}: calculated {calculated}, expected {}",
+                dates[i - 1],
+                dates[i],
+                expected[i - 1]
+            );
+        }
+    }
+}

--- a/crates/itofin/src/time/daycounters/actual366.rs
+++ b/crates/itofin/src/time/daycounters/actual366.rs
@@ -1,0 +1,115 @@
+//! Actual/366 day count convention.
+//!
+//! Port of `ql/time/daycounters/actual366.hpp`. Also known as "Act/366". An
+//! optional flag counts the last day as well, giving the "(inc)" variant.
+
+use crate::shared::shared;
+use crate::time::date::{Date, SerialNumber};
+use crate::time::daycounter::{DayCounter, DayCounterImpl};
+use crate::types::Time;
+
+/// The Actual/366 day count convention.
+pub struct Actual366;
+
+impl Actual366 {
+    /// Builds an Actual/366 counter that excludes the last day.
+    pub fn new() -> DayCounter {
+        Self::with_last_day(false)
+    }
+
+    /// Builds an Actual/366 counter, optionally including the last day (the
+    /// "(inc)" variant), matching QuantLib's `includeLastDay` constructor flag.
+    pub fn with_last_day(include_last_day: bool) -> DayCounter {
+        DayCounter::from_impl(shared(Impl { include_last_day }))
+    }
+}
+
+struct Impl {
+    include_last_day: bool,
+}
+
+impl DayCounterImpl for Impl {
+    fn name(&self) -> String {
+        if self.include_last_day {
+            "Actual/366 (inc)".to_string()
+        } else {
+            "Actual/366".to_string()
+        }
+    }
+
+    fn day_count(&self, d1: Date, d2: Date) -> SerialNumber {
+        (d2 - d1) + SerialNumber::from(self.include_last_day)
+    }
+
+    fn year_fraction(&self, d1: Date, d2: Date, _ref_start: Date, _ref_end: Date) -> Time {
+        Time::from(self.day_count(d1, d2)) / 366.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::time::date::Month;
+
+    #[test]
+    fn name_reflects_include_last_day() {
+        assert_eq!(Actual366::new().name(), "Actual/366");
+        assert_eq!(Actual366::with_last_day(true).name(), "Actual/366 (inc)");
+    }
+
+    #[test]
+    fn include_last_day_adds_one() {
+        let d1 = Date::new(1, Month::January, 2020);
+        let d2 = Date::new(31, Month::January, 2020);
+        assert_eq!(Actual366::with_last_day(true).day_count(d1, d2), 31);
+    }
+
+    #[test]
+    fn matches_quantlib_year_fractions() {
+        let dates = [
+            Date::new(1, Month::February, 2002),
+            Date::new(4, Month::February, 2002),
+            Date::new(16, Month::May, 2003),
+            Date::new(17, Month::December, 2003),
+            Date::new(17, Month::December, 2004),
+            Date::new(19, Month::December, 2005),
+            Date::new(2, Month::January, 2006),
+            Date::new(13, Month::March, 2006),
+            Date::new(15, Month::May, 2006),
+            Date::new(17, Month::March, 2006),
+            Date::new(15, Month::May, 2006),
+            Date::new(26, Month::July, 2006),
+            Date::new(28, Month::June, 2007),
+            Date::new(16, Month::September, 2009),
+            Date::new(26, Month::July, 2016),
+        ];
+        let expected = [
+            0.00819672131147541,
+            1.27322404371585,
+            0.587431693989071,
+            1.0000000000000,
+            1.00273224043716,
+            0.0382513661202186,
+            0.191256830601093,
+            0.172131147540984,
+            -0.16120218579235,
+            0.16120218579235,
+            0.19672131147541,
+            0.920765027322404,
+            2.21584699453552,
+            6.84426229508197,
+        ];
+
+        let dc = Actual366::new();
+        for i in 1..dates.len() {
+            let calculated = dc.year_fraction(dates[i - 1], dates[i]);
+            assert!(
+                (calculated - expected[i - 1]).abs() <= 1.0e-12,
+                "from {} to {}: calculated {calculated}, expected {}",
+                dates[i - 1],
+                dates[i],
+                expected[i - 1]
+            );
+        }
+    }
+}

--- a/crates/itofin/src/time/daycounters/mod.rs
+++ b/crates/itofin/src/time/daycounters/mod.rs
@@ -17,5 +17,6 @@ pub mod actual366;
 pub mod actualactual;
 pub mod business252;
 pub mod one;
+pub mod simpledaycounter;
 pub mod thirty360;
 pub mod thirty365;

--- a/crates/itofin/src/time/daycounters/mod.rs
+++ b/crates/itofin/src/time/daycounters/mod.rs
@@ -10,7 +10,10 @@
 #![allow(clippy::new_ret_no_self)]
 
 pub mod actual360;
+pub mod actual364;
 pub mod actual365fixed;
 pub mod actualactual;
 pub mod business252;
+pub mod one;
 pub mod thirty360;
+pub mod thirty365;

--- a/crates/itofin/src/time/daycounters/mod.rs
+++ b/crates/itofin/src/time/daycounters/mod.rs
@@ -20,3 +20,4 @@ pub mod one;
 pub mod simpledaycounter;
 pub mod thirty360;
 pub mod thirty365;
+pub mod yearfractiontodate;

--- a/crates/itofin/src/time/daycounters/mod.rs
+++ b/crates/itofin/src/time/daycounters/mod.rs
@@ -11,7 +11,9 @@
 
 pub mod actual360;
 pub mod actual364;
+pub mod actual36525;
 pub mod actual365fixed;
+pub mod actual366;
 pub mod actualactual;
 pub mod business252;
 pub mod one;

--- a/crates/itofin/src/time/daycounters/one.rs
+++ b/crates/itofin/src/time/daycounters/one.rs
@@ -1,0 +1,81 @@
+//! 1/1 day count convention.
+//!
+//! Port of `ql/time/daycounters/one.hpp`. Every period counts as one year
+//! (one day), carrying only the sign of the interval.
+
+use crate::shared::shared;
+use crate::time::date::{Date, SerialNumber};
+use crate::time::daycounter::{DayCounter, DayCounterImpl};
+use crate::types::Time;
+
+/// The 1/1 day count convention.
+pub struct OneDayCounter;
+
+impl OneDayCounter {
+    /// Builds a 1/1 counter.
+    pub fn new() -> DayCounter {
+        DayCounter::from_impl(shared(Impl))
+    }
+}
+
+struct Impl;
+
+impl DayCounterImpl for Impl {
+    fn name(&self) -> String {
+        "1/1".to_string()
+    }
+
+    fn day_count(&self, d1: Date, d2: Date) -> SerialNumber {
+        if d2 >= d1 { 1 } else { -1 }
+    }
+
+    fn year_fraction(&self, d1: Date, d2: Date, _ref_start: Date, _ref_end: Date) -> Time {
+        Time::from(self.day_count(d1, d2))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::time::date::Month;
+    use crate::time::period::Period;
+    use crate::time::timeunit::TimeUnit;
+
+    #[test]
+    fn name_is_one_over_one() {
+        assert_eq!(OneDayCounter::new().name(), "1/1");
+    }
+
+    #[test]
+    fn day_count_carries_only_the_sign() {
+        let dc = OneDayCounter::new();
+        let d1 = Date::new(1, Month::January, 2004);
+        let d2 = Date::new(1, Month::July, 2004);
+        assert_eq!(dc.day_count(d1, d2), 1);
+        assert_eq!(dc.day_count(d1, d1), 1);
+        assert_eq!(dc.day_count(d2, d1), -1);
+    }
+
+    #[test]
+    fn year_fraction_is_one_for_any_period() {
+        let periods = [
+            Period::new(3, TimeUnit::Months),
+            Period::new(6, TimeUnit::Months),
+            Period::new(1, TimeUnit::Years),
+        ];
+        let dc = OneDayCounter::new();
+        let first = Date::new(1, Month::January, 2004);
+        let last = Date::new(31, Month::December, 2004);
+        let mut start = first;
+        while start <= last {
+            for p in periods {
+                let end = start + p;
+                assert!(
+                    (dc.year_fraction(start, end) - 1.0).abs() <= 1.0e-12,
+                    "from {start} to {end}"
+                );
+            }
+            start += 1;
+        }
+    }
+}

--- a/crates/itofin/src/time/daycounters/simpledaycounter.rs
+++ b/crates/itofin/src/time/daycounters/simpledaycounter.rs
@@ -1,0 +1,104 @@
+//! Simple day counter for reproducing theoretical calculations.
+//!
+//! Port of `ql/time/daycounters/simpledaycounter.{hpp,cpp}`. Whole-month
+//! distances come out as simple fractions (1 year = 1.0, 6 months = 0.5,
+//! 3 months = 0.25 and so forth); other periods fall back to 30/360
+//! (Bond Basis).
+//!
+//! As in QuantLib, this counter should be used together with a null calendar,
+//! which keeps dates at whole-month distances on the same day of month; it is
+//! not guaranteed to work with any other calendar.
+
+use crate::shared::shared;
+use crate::time::date::{Date, SerialNumber};
+use crate::time::daycounter::{DayCounter, DayCounterImpl};
+use crate::time::daycounters::thirty360::{Convention, Thirty360};
+use crate::types::Time;
+
+/// The simple day count convention.
+pub struct SimpleDayCounter;
+
+impl SimpleDayCounter {
+    /// Builds a simple day counter.
+    pub fn new() -> DayCounter {
+        DayCounter::from_impl(shared(Impl {
+            fallback: Thirty360::with_convention(Convention::BondBasis),
+        }))
+    }
+}
+
+struct Impl {
+    fallback: DayCounter,
+}
+
+impl DayCounterImpl for Impl {
+    fn name(&self) -> String {
+        "Simple".to_string()
+    }
+
+    fn day_count(&self, d1: Date, d2: Date) -> SerialNumber {
+        self.fallback.day_count(d1, d2)
+    }
+
+    fn year_fraction(&self, d1: Date, d2: Date, _ref_start: Date, _ref_end: Date) -> Time {
+        let dm1 = d1.day_of_month();
+        let dm2 = d2.day_of_month();
+
+        if dm1 == dm2
+            || (dm1 > dm2 && Date::is_end_of_month(d2))
+            || (dm1 < dm2 && Date::is_end_of_month(d1))
+        {
+            Time::from(d2.year() - d1.year())
+                + Time::from(d2.month().ordinal() - d1.month().ordinal()) / 12.0
+        } else {
+            self.fallback.year_fraction(d1, d2)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::time::date::Month;
+    use crate::time::period::Period;
+    use crate::time::timeunit::TimeUnit;
+
+    #[test]
+    fn name_is_simple() {
+        assert_eq!(SimpleDayCounter::new().name(), "Simple");
+    }
+
+    #[test]
+    fn whole_month_distances_are_simple_fractions() {
+        let cases = [
+            (Period::new(3, TimeUnit::Months), 0.25),
+            (Period::new(6, TimeUnit::Months), 0.5),
+            (Period::new(1, TimeUnit::Years), 1.0),
+        ];
+        let dc = SimpleDayCounter::new();
+        let first = Date::new(1, Month::January, 2002);
+        let last = Date::new(31, Month::December, 2005);
+        let mut start = first;
+        while start <= last {
+            for (p, expected) in cases {
+                let end = start + p;
+                let calculated = dc.year_fraction(start, end);
+                assert!(
+                    (calculated - expected).abs() <= 1.0e-12,
+                    "from {start} to {end}: calculated {calculated}, expected {expected}"
+                );
+            }
+            start += 1;
+        }
+    }
+
+    #[test]
+    fn broken_periods_fall_back_to_thirty360() {
+        let dc = SimpleDayCounter::new();
+        let fallback = Thirty360::with_convention(Convention::BondBasis);
+        let d1 = Date::new(3, Month::February, 2002);
+        let d2 = Date::new(17, Month::June, 2002);
+        assert_eq!(dc.year_fraction(d1, d2), fallback.year_fraction(d1, d2));
+        assert_eq!(dc.day_count(d1, d2), fallback.day_count(d1, d2));
+    }
+}

--- a/crates/itofin/src/time/daycounters/thirty365.rs
+++ b/crates/itofin/src/time/daycounters/thirty365.rs
@@ -1,0 +1,94 @@
+//! 30/365 day count convention.
+//!
+//! Port of `ql/time/daycounters/thirty365.{hpp,cpp}`. Days are counted with
+//! the ISO 20022 30/360-style adjustment (day 31 becomes 30) but the year
+//! fraction divides by 365.
+
+use crate::shared::shared;
+use crate::time::date::{Date, SerialNumber};
+use crate::time::daycounter::{DayCounter, DayCounterImpl};
+use crate::types::Time;
+
+/// The 30/365 day count convention.
+pub struct Thirty365;
+
+impl Thirty365 {
+    /// Builds a 30/365 counter.
+    pub fn new() -> DayCounter {
+        DayCounter::from_impl(shared(Impl))
+    }
+}
+
+struct Impl;
+
+impl DayCounterImpl for Impl {
+    fn name(&self) -> String {
+        "30/365".to_string()
+    }
+
+    fn day_count(&self, d1: Date, d2: Date) -> SerialNumber {
+        let (mut dd1, mut dd2) = (d1.day_of_month(), d2.day_of_month());
+        let (mm1, mm2) = (d1.month().ordinal(), d2.month().ordinal());
+        let (yy1, yy2) = (d1.year(), d2.year());
+
+        if dd1 == 31 {
+            dd1 = 30;
+        }
+        if dd2 == 31 {
+            dd2 = 30;
+        }
+
+        360 * (yy2 - yy1) + 30 * (mm2 - mm1) + (dd2 - dd1)
+    }
+
+    fn year_fraction(&self, d1: Date, d2: Date, _ref_start: Date, _ref_end: Date) -> Time {
+        Time::from(self.day_count(d1, d2)) / 365.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::time::date::Month;
+
+    #[test]
+    fn name_is_thirty_over_365() {
+        assert_eq!(Thirty365::new().name(), "30/365");
+    }
+
+    #[test]
+    fn matches_quantlib_day_counts_and_year_fractions() {
+        let cases = [
+            (
+                Date::new(17, Month::June, 2011),
+                Date::new(30, Month::December, 2012),
+                553,
+            ),
+            (
+                Date::new(31, Month::March, 2025),
+                Date::new(30, Month::April, 2025),
+                30,
+            ),
+            (
+                Date::new(30, Month::September, 2024),
+                Date::new(31, Month::March, 2025),
+                180,
+            ),
+            (
+                Date::new(30, Month::March, 2025),
+                Date::new(31, Month::March, 2025),
+                0,
+            ),
+        ];
+
+        let dc = Thirty365::new();
+        for (d1, d2, expected) in cases {
+            assert_eq!(dc.day_count(d1, d2), expected, "from {d1} to {d2}");
+            let expected_time = Time::from(expected) / 365.0;
+            assert!(
+                (dc.year_fraction(d1, d2) - expected_time).abs() <= 1.0e-12,
+                "from {d1} to {d2}"
+            );
+        }
+    }
+}

--- a/crates/itofin/src/time/daycounters/yearfractiontodate.rs
+++ b/crates/itofin/src/time/daycounters/yearfractiontodate.rs
@@ -1,0 +1,152 @@
+//! "Inverse" of a day counter: mapping a year fraction back to a date.
+//!
+//! Port of `ql/time/daycounters/yearfractiontodate.{hpp,cpp}`. Starting from a
+//! calendar-time guess, the search refines by whole years, then months, then
+//! days, and finally rounds to whichever neighbouring date reproduces the
+//! target fraction more closely.
+
+use crate::math::comparison::close_enough;
+use crate::time::date::Date;
+use crate::time::daycounter::DayCounter;
+use crate::time::period::Period;
+use crate::time::timeunit::TimeUnit;
+use crate::types::{Integer, Time};
+
+/// The date `d` such that `day_counter.year_fraction(reference_date, d)` is
+/// closest to `t`, QuantLib's `yearFractionToDate`.
+pub fn year_fraction_to_date(day_counter: &DayCounter, reference_date: Date, t: Time) -> Date {
+    let mut guess_date =
+        reference_date + Period::new((t * 365.25).round() as Integer, TimeUnit::Days);
+    let mut guess_time = day_counter.year_fraction(reference_date, guess_date);
+
+    guess_date = guess_date
+        + Period::new(
+            ((t - guess_time) * 365.25).round() as Integer,
+            TimeUnit::Days,
+        );
+    guess_time = day_counter.year_fraction(reference_date, guess_date);
+
+    if close_enough(guess_time, t) {
+        return guess_date;
+    }
+
+    let search_direction = 1.0f64.copysign(t - guess_time) as Integer;
+
+    let t = t + Time::from(search_direction) * 100.0 * f64::EPSILON;
+
+    for u in [TimeUnit::Years, TimeUnit::Months, TimeUnit::Days] {
+        loop {
+            let next_date = guess_date + Period::new(search_direction, u);
+            if Time::from(search_direction)
+                * (day_counter.year_fraction(reference_date, next_date) - t)
+                < 0.0
+            {
+                guess_date = next_date;
+            } else {
+                break;
+            }
+        }
+    }
+
+    let guess_time = day_counter.year_fraction(reference_date, guess_date);
+    let next_date = guess_date + Period::new(search_direction, TimeUnit::Days);
+    if close_enough(guess_time, t)
+        || (day_counter.year_fraction(reference_date, next_date) - t).abs() > (guess_time - t).abs()
+    {
+        guess_date
+    } else {
+        next_date
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::time::date::Month;
+    use crate::time::daycounters::actual360::Actual360;
+    use crate::time::daycounters::actual364::Actual364;
+    use crate::time::daycounters::actual365fixed::{
+        Actual365Fixed, Convention as Act365Convention,
+    };
+    use crate::time::daycounters::actual366::Actual366;
+    use crate::time::daycounters::actual36525::Actual36525;
+    use crate::time::daycounters::actualactual::{ActualActual, Convention as ActActConvention};
+    use crate::time::daycounters::business252::Business252;
+    use crate::time::daycounters::simpledaycounter::SimpleDayCounter;
+    use crate::time::daycounters::thirty360::{Convention as Thirty360Convention, Thirty360};
+    use crate::time::daycounters::thirty365::Thirty365;
+
+    #[test]
+    fn round_trips_bulk_dates_for_every_day_counter() {
+        let day_counters = [
+            Actual365Fixed::new(),
+            Actual365Fixed::with_convention(Act365Convention::NoLeap),
+            Actual360::new(),
+            Actual360::with_last_day(true),
+            Actual36525::new(),
+            Actual36525::with_last_day(true),
+            Actual364::new(),
+            Actual366::new(),
+            Actual366::with_last_day(true),
+            ActualActual::with_convention(ActActConvention::ISDA),
+            ActualActual::with_convention(ActActConvention::ISMA),
+            ActualActual::with_convention(ActActConvention::Bond),
+            ActualActual::with_convention(ActActConvention::Historical),
+            ActualActual::with_convention(ActActConvention::Actual365),
+            ActualActual::with_convention(ActActConvention::AFB),
+            ActualActual::with_convention(ActActConvention::Euro),
+            Business252::new(),
+            Thirty360::with_convention(Thirty360Convention::USA),
+            Thirty360::with_convention(Thirty360Convention::BondBasis),
+            Thirty360::with_convention(Thirty360Convention::European),
+            Thirty360::with_convention(Thirty360Convention::EurobondBasis),
+            Thirty360::with_convention(Thirty360Convention::Italian),
+            Thirty360::with_convention(Thirty360Convention::German),
+            Thirty360::with_convention(Thirty360Convention::ISMA),
+            Thirty360::with_convention(Thirty360Convention::ISDA),
+            Thirty360::with_convention(Thirty360Convention::NASD),
+            Thirty365::new(),
+            SimpleDayCounter::new(),
+        ];
+
+        for dc in &day_counters {
+            for i in -360..730 {
+                let today = Date::new(1, Month::January, 2020) + Period::new(i, TimeUnit::Days);
+                let target = today + Period::new(i, TimeUnit::Days);
+
+                let t = dc.year_fraction(today, target);
+                let time_to_date = year_fraction_to_date(dc, today, t);
+                let t_new = dc.year_fraction(today, time_to_date);
+
+                assert!(
+                    close_enough(t, t_new),
+                    "today {today}, target {target}, inverse {time_to_date}, \
+                     time diff {}, day counter {}",
+                    t - t_new,
+                    dc.name()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn rounds_to_the_closer_date() {
+        let day_counters = [
+            Thirty360::with_convention(Thirty360Convention::USA),
+            Actual360::new(),
+        ];
+        let d1 = Date::new(1, Month::February, 2023);
+        let d2 = Date::new(17, Month::February, 2124);
+
+        for dc in &day_counters {
+            let t = dc.year_fraction(d1, d2);
+            let mut offset: Time = 0.0;
+            while offset < 1.0 + 1e-10 {
+                let inv = year_fraction_to_date(dc, d1, t + offset / 360.0);
+                let expected = if offset < 0.4999 { d2 } else { d2 + 1 };
+                assert_eq!(inv, expected, "offset {offset}, day counter {}", dc.name());
+                offset += 0.05;
+            }
+        }
+    }
+}

--- a/crates/itofin/src/time/daycounters/yearfractiontodate.rs
+++ b/crates/itofin/src/time/daycounters/yearfractiontodate.rs
@@ -5,29 +5,44 @@
 //! days, and finally rounds to whichever neighbouring date reproduces the
 //! target fraction more closely.
 
+use crate::errors::QlResult;
 use crate::math::comparison::close_enough;
+use crate::require;
 use crate::time::date::Date;
 use crate::time::daycounter::DayCounter;
 use crate::time::period::Period;
 use crate::time::timeunit::TimeUnit;
 use crate::types::{Integer, Time};
 
+fn day_offset(x: Time) -> QlResult<Integer> {
+    let days = x.round();
+    require!(
+        days >= Time::from(Integer::MIN) && days <= Time::from(Integer::MAX),
+        "time {x} is out of range for a day offset"
+    );
+    Ok(days as Integer)
+}
+
 /// The date `d` such that `day_counter.year_fraction(reference_date, d)` is
 /// closest to `t`, QuantLib's `yearFractionToDate`.
-pub fn year_fraction_to_date(day_counter: &DayCounter, reference_date: Date, t: Time) -> Date {
-    let mut guess_date =
-        reference_date + Period::new((t * 365.25).round() as Integer, TimeUnit::Days);
+///
+/// # Errors
+///
+/// Returns an error if `t` is not finite or lies outside the representable
+/// day-offset range, where QuantLib's `boost::numeric_cast` throws.
+pub fn year_fraction_to_date(
+    day_counter: &DayCounter,
+    reference_date: Date,
+    t: Time,
+) -> QlResult<Date> {
+    let mut guess_date = reference_date + Period::new(day_offset(t * 365.25)?, TimeUnit::Days);
     let mut guess_time = day_counter.year_fraction(reference_date, guess_date);
 
-    guess_date = guess_date
-        + Period::new(
-            ((t - guess_time) * 365.25).round() as Integer,
-            TimeUnit::Days,
-        );
+    guess_date = guess_date + Period::new(day_offset((t - guess_time) * 365.25)?, TimeUnit::Days);
     guess_time = day_counter.year_fraction(reference_date, guess_date);
 
     if close_enough(guess_time, t) {
-        return guess_date;
+        return Ok(guess_date);
     }
 
     let search_direction = 1.0f64.copysign(t - guess_time) as Integer;
@@ -53,9 +68,9 @@ pub fn year_fraction_to_date(day_counter: &DayCounter, reference_date: Date, t: 
     if close_enough(guess_time, t)
         || (day_counter.year_fraction(reference_date, next_date) - t).abs() > (guess_time - t).abs()
     {
-        guess_date
+        Ok(guess_date)
     } else {
-        next_date
+        Ok(next_date)
     }
 }
 
@@ -115,7 +130,7 @@ mod tests {
                 let target = today + Period::new(i, TimeUnit::Days);
 
                 let t = dc.year_fraction(today, target);
-                let time_to_date = year_fraction_to_date(dc, today, t);
+                let time_to_date = year_fraction_to_date(dc, today, t).unwrap();
                 let t_new = dc.year_fraction(today, time_to_date);
 
                 assert!(
@@ -142,11 +157,23 @@ mod tests {
             let t = dc.year_fraction(d1, d2);
             let mut offset: Time = 0.0;
             while offset < 1.0 + 1e-10 {
-                let inv = year_fraction_to_date(dc, d1, t + offset / 360.0);
+                let inv = year_fraction_to_date(dc, d1, t + offset / 360.0).unwrap();
                 let expected = if offset < 0.4999 { d2 } else { d2 + 1 };
                 assert_eq!(inv, expected, "offset {offset}, day counter {}", dc.name());
                 offset += 0.05;
             }
         }
+    }
+
+    #[test]
+    fn rejects_non_finite_or_out_of_range_times() {
+        let dc = Actual360::new();
+        let reference = Date::new(1, Month::January, 2020);
+
+        assert!(year_fraction_to_date(&dc, reference, Time::NAN).is_err());
+        assert!(year_fraction_to_date(&dc, reference, Time::INFINITY).is_err());
+        assert!(year_fraction_to_date(&dc, reference, Time::NEG_INFINITY).is_err());
+        assert!(year_fraction_to_date(&dc, reference, 1e10).is_err());
+        assert!(year_fraction_to_date(&dc, reference, -1e10).is_err());
     }
 }

--- a/crates/itofin/src/time/daycounters/yearfractiontodate.rs
+++ b/crates/itofin/src/time/daycounters/yearfractiontodate.rs
@@ -23,22 +23,43 @@ fn day_offset(x: Time) -> QlResult<Integer> {
     Ok(days as Integer)
 }
 
+fn shifted_within_bounds(d: Date, days: Integer) -> Date {
+    let serial = (i64::from(d.serial_number()) + i64::from(days)).clamp(
+        i64::from(Date::min_date().serial_number()),
+        i64::from(Date::max_date().serial_number()),
+    );
+    Date::from_serial(serial as Integer)
+}
+
+fn step_within_bounds(d: Date, direction: Integer, u: TimeUnit) -> Option<Date> {
+    let worst_case_days = match u {
+        TimeUnit::Years => 366,
+        TimeUnit::Months => 31,
+        _ => 1,
+    };
+    let serial = i64::from(d.serial_number()) + i64::from(direction) * worst_case_days;
+    let in_bounds = serial >= i64::from(Date::min_date().serial_number())
+        && serial <= i64::from(Date::max_date().serial_number());
+    in_bounds.then(|| d + Period::new(direction, u))
+}
+
 /// The date `d` such that `day_counter.year_fraction(reference_date, d)` is
 /// closest to `t`, QuantLib's `yearFractionToDate`.
 ///
 /// # Errors
 ///
-/// Returns an error if `t` is not finite or lies outside the representable
-/// day-offset range, where QuantLib's `boost::numeric_cast` throws.
+/// Returns an error if `t` is not finite, lies outside the representable
+/// day-offset range where QuantLib's `boost::numeric_cast` throws, or maps to
+/// a date outside the supported range (where QuantLib's `Date` throws).
 pub fn year_fraction_to_date(
     day_counter: &DayCounter,
     reference_date: Date,
     t: Time,
 ) -> QlResult<Date> {
-    let mut guess_date = reference_date + Period::new(day_offset(t * 365.25)?, TimeUnit::Days);
+    let mut guess_date = shifted_within_bounds(reference_date, day_offset(t * 365.25)?);
     let mut guess_time = day_counter.year_fraction(reference_date, guess_date);
 
-    guess_date = guess_date + Period::new(day_offset((t - guess_time) * 365.25)?, TimeUnit::Days);
+    guess_date = shifted_within_bounds(guess_date, day_offset((t - guess_time) * 365.25)?);
     guess_time = day_counter.year_fraction(reference_date, guess_date);
 
     if close_enough(guess_time, t) {
@@ -50,8 +71,7 @@ pub fn year_fraction_to_date(
     let t = t + Time::from(search_direction) * 100.0 * f64::EPSILON;
 
     for u in [TimeUnit::Years, TimeUnit::Months, TimeUnit::Days] {
-        loop {
-            let next_date = guess_date + Period::new(search_direction, u);
+        while let Some(next_date) = step_within_bounds(guess_date, search_direction, u) {
             if Time::from(search_direction)
                 * (day_counter.year_fraction(reference_date, next_date) - t)
                 < 0.0
@@ -64,7 +84,13 @@ pub fn year_fraction_to_date(
     }
 
     let guess_time = day_counter.year_fraction(reference_date, guess_date);
-    let next_date = guess_date + Period::new(search_direction, TimeUnit::Days);
+    let Some(next_date) = step_within_bounds(guess_date, search_direction, TimeUnit::Days) else {
+        require!(
+            close_enough(guess_time, t) || Time::from(search_direction) * (guess_time - t) >= 0.0,
+            "time {t} maps to a date outside the supported date range from {reference_date}"
+        );
+        return Ok(guess_date);
+    };
     if close_enough(guess_time, t)
         || (day_counter.year_fraction(reference_date, next_date) - t).abs() > (guess_time - t).abs()
     {
@@ -175,5 +201,40 @@ mod tests {
         assert!(year_fraction_to_date(&dc, reference, Time::NEG_INFINITY).is_err());
         assert!(year_fraction_to_date(&dc, reference, 1e10).is_err());
         assert!(year_fraction_to_date(&dc, reference, -1e10).is_err());
+    }
+
+    #[test]
+    fn errs_instead_of_panicking_past_the_date_bounds() {
+        let dc = Actual360::new();
+        let reference = Date::new(1, Month::January, 2020);
+
+        assert!(year_fraction_to_date(&dc, reference, 500.0).is_err());
+        assert!(year_fraction_to_date(&dc, reference, -500.0).is_err());
+
+        let just_past_max = dc.year_fraction(reference, Date::max_date()) + 0.01;
+        assert!(year_fraction_to_date(&dc, reference, just_past_max).is_err());
+        let just_past_min = dc.year_fraction(reference, Date::min_date()) - 0.01;
+        assert!(year_fraction_to_date(&dc, reference, just_past_min).is_err());
+    }
+
+    #[test]
+    fn resolves_times_near_the_date_bounds() {
+        let dc = Actual360::new();
+        let reference = Date::new(1, Month::January, 2020);
+
+        let latest = dc.year_fraction(reference, Date::max_date());
+        assert_eq!(
+            year_fraction_to_date(&dc, reference, latest).unwrap(),
+            Date::max_date()
+        );
+        let earliest = dc.year_fraction(reference, Date::min_date());
+        assert_eq!(
+            year_fraction_to_date(&dc, reference, earliest).unwrap(),
+            Date::min_date()
+        );
+
+        let t = 182.0;
+        let inverse = year_fraction_to_date(&dc, reference, t).unwrap();
+        assert!(close_enough(dc.year_fraction(reference, inverse), t));
     }
 }


### PR DESCRIPTION
- **feat(daycounters): add actual364, one, and thirty365 day counters**
- **feat(daycounters): add Actual/365.25 and Actual/366 day counters**
- **feat(daycounters): add simple day counter implementation**
- **feat(daycounters): add year fraction to date day counter**
- **fix(daycounters): reject non-finite and out-of-range year fractions**
- **fix(daycounters): return Err instead of panicking at Date bounds**
