### PR TITLE
feat(#131): tanh-sinh/exp-sinh

### DIFF
--- a/crates/itofin/src/math/integrals/expsinh.rs
+++ b/crates/itofin/src/math/integrals/expsinh.rs
@@ -188,6 +188,24 @@ mod tests {
     }
 
     #[test]
+    fn truncates_dead_tails_before_the_integrand_overflows() {
+        // x^2 * exp(-x^2), the Gaussian second moment: past x ~ 27 the terms
+        // underflow to zero, and past x ~ 1e154 the integrand itself computes
+        // inf * 0 = NaN. The driver must stop walking the dead tail, as Boost
+        // does, instead of erroring on the NaN.
+        let integrator = ExpSinhIntegral::new();
+        let expected = std::f64::consts::PI.sqrt() / 4.0;
+        assert!(
+            (integrator
+                .integrate_semi_infinite(|x| x * x * (-x * x).exp())
+                .unwrap()
+                - expected)
+                .abs()
+                < TOL
+        );
+    }
+
+    #[test]
     fn reports_non_convergence_on_divergent_integrand() {
         let integrator = ExpSinhIntegral::new();
         assert!(

--- a/crates/itofin/src/math/integrals/expsinh.rs
+++ b/crates/itofin/src/math/integrals/expsinh.rs
@@ -7,8 +7,14 @@
 //! over `[0, inf)` into a doubly-exponentially decaying integral over the real
 //! line, evaluated by the trapezoidal rule with successive halving. As in
 //! Boost, the tolerance is used against the error estimate for the L1 norm of
-//! the integral, and a bound at or beyond `Real::MAX` in magnitude counts as
-//! infinite.
+//! the integral.
+//!
+//! The shared [`Integrator::integrate`] driver rejects non-finite bounds, so
+//! an actual `Real::INFINITY` cannot be passed through it: the sentinel for an
+//! infinite bound is `Real::MAX`, exactly as QuantLib calls the Boost
+//! integrator with `QL_MAX_REAL`. Alternatively,
+//! [`ExpSinhIntegral::integrate_semi_infinite`] integrates the native
+//! `[0, inf)` domain with no sentinel at all.
 
 use std::f64::consts::FRAC_PI_2;
 
@@ -23,6 +29,14 @@ use crate::types::{Real, Size};
 const T_MAX: Real = 7.0;
 
 /// Exp-sinh quadrature over `[a, inf)` or `(-inf, b]`.
+///
+/// Through the [`Integrator`] interface the infinite side is spelled
+/// `Real::MAX` (mirroring QuantLib's `QL_MAX_REAL`), since the shared driver
+/// rejects non-finite bounds; `integrate(f, a, Real::MAX)` integrates
+/// `[a, inf)` and `integrate(f, -Real::MAX, b)` integrates `(-inf, b]`. Any
+/// other finite interval is an error - see
+/// [`ExpSinhIntegral::integrate_semi_infinite`] for the native `[0, inf)`
+/// form.
 ///
 /// Tail nodes whose abscissa or weight leaves the positive finite `f64` range
 /// are truncated; their true contribution is below the underflow threshold for
@@ -183,6 +197,13 @@ mod tests {
         assert!(
             integrator
                 .integrate(|_| 0.0, -Real::MAX, Real::MAX)
+                .is_err()
+        );
+        // The documented sentinel for an infinite bound is Real::MAX; an
+        // actual infinity is rejected by the shared driver.
+        assert!(
+            integrator
+                .integrate(|x| (-x).exp(), 0.0, Real::INFINITY)
                 .is_err()
         );
     }

--- a/crates/itofin/src/math/integrals/expsinh.rs
+++ b/crates/itofin/src/math/integrals/expsinh.rs
@@ -1,0 +1,209 @@
+//! Exp-sinh double-exponential integration over semi-infinite domains.
+//!
+//! Port of `ExpSinhIntegral` from `ql/math/integrals/expsinhintegral.hpp`.
+//! QuantLib delegates the work to `boost::math::quadrature::exp_sinh`, which
+//! has no Rust equivalent, so the double-exponential scheme itself is
+//! implemented here: the transform `x = exp(pi/2 sinh t)` turns an integral
+//! over `[0, inf)` into a doubly-exponentially decaying integral over the real
+//! line, evaluated by the trapezoidal rule with successive halving. As in
+//! Boost, the tolerance is used against the error estimate for the L1 norm of
+//! the integral, and a bound at or beyond `Real::MAX` in magnitude counts as
+//! infinite.
+
+use std::f64::consts::FRAC_PI_2;
+
+use crate::errors::QlResult;
+use crate::fail;
+use crate::math::integrals::{Integrator, de_quadrature, require_accuracy};
+use crate::types::{Real, Size};
+
+/// Past this |t| the abscissa `exp(pi/2 sinh t)` falls outside the positive
+/// finite `f64` range on one side or the other, so every node is dropped by
+/// the range clamp anyway.
+const T_MAX: Real = 7.0;
+
+/// Exp-sinh quadrature over `[a, inf)` or `(-inf, b]`.
+///
+/// Tail nodes whose abscissa or weight leaves the positive finite `f64` range
+/// are truncated; their true contribution is below the underflow threshold for
+/// any integrand the scheme converges on.
+pub struct ExpSinhIntegral {
+    rel_tolerance: Real,
+    max_refinements: Size,
+}
+
+impl ExpSinhIntegral {
+    /// QuantLib's defaults: relative tolerance `sqrt(eps)` and at most 9
+    /// refinements.
+    pub fn new() -> Self {
+        ExpSinhIntegral {
+            rel_tolerance: Real::EPSILON.sqrt(),
+            max_refinements: 9,
+        }
+    }
+
+    /// An exp-sinh integrator with explicit parameters.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error unless `rel_tolerance` is finite and above machine
+    /// epsilon.
+    pub fn with_params(rel_tolerance: Real, max_refinements: Size) -> QlResult<Self> {
+        require_accuracy(rel_tolerance)?;
+        Ok(ExpSinhIntegral {
+            rel_tolerance,
+            max_refinements,
+        })
+    }
+
+    /// Integrates `f` over `[0, inf)`, the transform's native domain; ports
+    /// QuantLib's single-argument `integrate` overload.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the integrand yields a non-finite value or the
+    /// refinement budget is exhausted before the tolerance is met (as for a
+    /// divergent integral).
+    pub fn integrate_semi_infinite<F>(&self, mut f: F) -> QlResult<Real>
+    where
+        F: FnMut(Real) -> Real,
+    {
+        self.semi_infinite(&mut f)
+    }
+
+    fn semi_infinite<F>(&self, f: &mut F) -> QlResult<Real>
+    where
+        F: FnMut(Real) -> Real,
+    {
+        let node = |t: Real| {
+            let x = (FRAC_PI_2 * t.sinh()).exp();
+            if x < Real::MIN_POSITIVE {
+                return None;
+            }
+            let w = x * FRAC_PI_2 * t.cosh();
+            if !w.is_finite() {
+                return None;
+            }
+            Some((x, w))
+        };
+        de_quadrature(f, node, T_MAX, self.rel_tolerance, self.max_refinements)
+    }
+}
+
+impl Default for ExpSinhIntegral {
+    fn default() -> Self {
+        ExpSinhIntegral::new()
+    }
+}
+
+impl Integrator for ExpSinhIntegral {
+    fn integrate_impl<F>(&self, f: &mut F, a: Real, b: Real) -> QlResult<Real>
+    where
+        F: FnMut(Real) -> Real,
+    {
+        if a <= -Real::MAX && b >= Real::MAX {
+            fail!(
+                "doubly infinite domains require a sinh-sinh quadrature, which is not ported; got [{a}, {b}]"
+            );
+        }
+        if b >= Real::MAX {
+            self.semi_infinite(&mut |u: Real| f(a + u))
+        } else if a <= -Real::MAX {
+            self.semi_infinite(&mut |u: Real| f(b - u))
+        } else {
+            fail!("exp-sinh quadrature integrates semi-infinite domains only, got [{a}, {b}]");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::math::distributions::normal::NormalDistribution;
+
+    const TOL: Real = 1e-6;
+
+    #[test]
+    fn matches_known_integrals() {
+        // QuantLib's testExpSinh, tolerance 1e-6: the standard normal density
+        // and x * exp(-x) over [0, DBL_MAX].
+        let integrator = ExpSinhIntegral::new();
+        let g = NormalDistribution::standard();
+        assert!(
+            (integrator
+                .integrate(|x| g.value(x), 0.0, Real::MAX)
+                .unwrap()
+                - 0.5)
+                .abs()
+                < TOL
+        );
+        assert!(
+            (integrator
+                .integrate(|x| x * (-x).exp(), 0.0, Real::MAX)
+                .unwrap()
+                - 1.0)
+                .abs()
+                < TOL
+        );
+    }
+
+    #[test]
+    fn native_semi_infinite_overload_matches() {
+        let integrator = ExpSinhIntegral::new();
+        let g = NormalDistribution::standard();
+        assert!((integrator.integrate_semi_infinite(|x| g.value(x)).unwrap() - 0.5).abs() < TOL);
+        assert!(
+            (integrator
+                .integrate_semi_infinite(|x| x * (-x).exp())
+                .unwrap()
+                - 1.0)
+                .abs()
+                < TOL
+        );
+    }
+
+    #[test]
+    fn shifted_and_reflected_domains() {
+        let integrator = ExpSinhIntegral::new();
+        assert!(
+            (integrator
+                .integrate(|x| (-(x - 1.0)).exp(), 1.0, Real::MAX)
+                .unwrap()
+                - 1.0)
+                .abs()
+                < TOL
+        );
+        assert!((integrator.integrate(|x| x.exp(), -Real::MAX, 0.0).unwrap() - 1.0).abs() < TOL);
+    }
+
+    #[test]
+    fn rejects_unsupported_domains() {
+        let integrator = ExpSinhIntegral::new();
+        assert!(integrator.integrate(|x| x, 0.0, 1.0).is_err());
+        assert!(
+            integrator
+                .integrate(|_| 0.0, -Real::MAX, Real::MAX)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn reports_non_convergence_on_divergent_integrand() {
+        let integrator = ExpSinhIntegral::new();
+        assert!(
+            integrator
+                .integrate_semi_infinite(|x| 1.0 / (1.0 + x))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn invalid_configuration_rejected() {
+        for tol in [0.0, -1.0, Real::EPSILON, Real::NAN, Real::INFINITY] {
+            assert!(
+                ExpSinhIntegral::with_params(tol, 9).is_err(),
+                "tolerance {tol}"
+            );
+        }
+    }
+}

--- a/crates/itofin/src/math/integrals/mod.rs
+++ b/crates/itofin/src/math/integrals/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod discrete;
 pub mod exponential_integrals;
+pub mod expsinh;
 pub mod filon;
 pub mod gaussiannoncentralchisquaredpolynomial;
 pub mod gaussianorthogonalpolynomial;

--- a/crates/itofin/src/math/integrals/mod.rs
+++ b/crates/itofin/src/math/integrals/mod.rs
@@ -37,11 +37,19 @@ pub(crate) fn require_accuracy(accuracy: Real) -> QlResult<()> {
 /// shared by the tanh-sinh and exp-sinh integrators.
 ///
 /// Sums `w * f(x)` over the grid `t = k * h` for `|t| <= t_max`, where `node`
-/// maps `t` to the transformed abscissa and weight (`None` drops a tail node
-/// past the transform's usable floating-point range). Each refinement halves
-/// `h`, reusing every previous sample; iteration stops when two consecutive
-/// levels agree to `rel_tolerance` against the L1 norm of the integral, the
-/// termination rule of `boost::math::quadrature`'s DE schemes.
+/// maps `t` to the transformed abscissa and weight. `None` drops a node past
+/// the transform's usable floating-point range and ends that tail, so `node`'s
+/// truncation must be monotone in `|t|` on each side, as it is for both
+/// transforms. Each refinement halves `h`, reusing every previous sample.
+///
+/// Two rules are taken from `boost::math::quadrature`'s DE schemes. A tail
+/// walk stops, for this and all finer levels, once a term no longer changes
+/// the running (nonzero) sum, so the integrand is never evaluated at extreme
+/// abscissas where a decayed-to-zero product could overflow into `inf * 0`;
+/// while the sum is still zero the full range is kept, in case the mass has
+/// simply not been found yet. And iteration stops when two consecutive levels
+/// agree to `rel_tolerance` against the L1 norm of the integral, checked from
+/// the second refinement onward.
 pub(crate) fn de_quadrature<F, N>(
     f: &mut F,
     node: N,
@@ -53,46 +61,77 @@ where
     F: FnMut(Real) -> Real,
     N: Fn(Real) -> Option<(Real, Real)>,
 {
-    fn term<F, N>(f: &mut F, node: &N, t: Real) -> QlResult<(Real, Real)>
+    struct Tally {
+        sum: Real,
+        abs_sum: Real,
+    }
+
+    fn term<F, N>(f: &mut F, node: &N, t: Real) -> QlResult<Option<(Real, Real)>>
     where
         F: FnMut(Real) -> Real,
         N: Fn(Real) -> Option<(Real, Real)>,
     {
         let Some((x, w)) = node(t) else {
-            return Ok((0.0, 0.0));
+            return Ok(None);
         };
         let y = f(x);
         if !y.is_finite() {
             fail!("integrand returned a non-finite value ({y}) at x = {x}");
         }
-        Ok((w * y, (w * y).abs()))
+        Ok(Some((w * y, (w * y).abs())))
     }
 
-    let (mut sum, mut abs_sum) = term(f, &node, 0.0)?;
-    let mut t = 1.0;
-    while t <= t_max {
-        let (plus, abs_plus) = term(f, &node, t)?;
-        let (minus, abs_minus) = term(f, &node, -t)?;
-        sum += plus + minus;
-        abs_sum += abs_plus + abs_minus;
-        t += 1.0;
-    }
-    let mut h = 1.0;
-    let mut value = sum;
-    for _ in 0..max_refinements {
-        h *= 0.5;
-        let mut t = h;
-        while t <= t_max {
-            let (plus, abs_plus) = term(f, &node, t)?;
-            let (minus, abs_minus) = term(f, &node, -t)?;
-            sum += plus + minus;
-            abs_sum += abs_plus + abs_minus;
-            t += 2.0 * h;
+    fn walk_side<F, N>(
+        f: &mut F,
+        node: &N,
+        start: Real,
+        step: Real,
+        cutoff: &mut Real,
+        tally: &mut Tally,
+    ) -> QlResult<()>
+    where
+        F: FnMut(Real) -> Real,
+        N: Fn(Real) -> Option<(Real, Real)>,
+    {
+        let mut t = start;
+        while t.abs() <= *cutoff {
+            let Some((v, av)) = term(f, node, t)? else {
+                break;
+            };
+            let before = tally.sum;
+            tally.sum += v;
+            tally.abs_sum += av;
+            if tally.sum == before && tally.sum != 0.0 {
+                *cutoff = t.abs();
+                break;
+            }
+            t += step;
         }
-        let refined = h * sum;
+        Ok(())
+    }
+
+    let mut tally = Tally {
+        sum: 0.0,
+        abs_sum: 0.0,
+    };
+    if let Some((v, av)) = term(f, &node, 0.0)? {
+        tally.sum += v;
+        tally.abs_sum += av;
+    }
+    let mut pos_cutoff = t_max;
+    let mut neg_cutoff = t_max;
+    walk_side(f, &node, 1.0, 1.0, &mut pos_cutoff, &mut tally)?;
+    walk_side(f, &node, -1.0, -1.0, &mut neg_cutoff, &mut tally)?;
+    let mut h = 1.0;
+    let mut value = tally.sum;
+    for refinement in 0..max_refinements {
+        h *= 0.5;
+        walk_side(f, &node, h, 2.0 * h, &mut pos_cutoff, &mut tally)?;
+        walk_side(f, &node, -h, -2.0 * h, &mut neg_cutoff, &mut tally)?;
+        let refined = h * tally.sum;
         let error = (refined - value).abs();
         value = refined;
-        if error <= rel_tolerance * (h * abs_sum) {
+        if refinement > 0 && error <= rel_tolerance * (h * tally.abs_sum) {
             return Ok(value);
         }
     }

--- a/crates/itofin/src/math/integrals/mod.rs
+++ b/crates/itofin/src/math/integrals/mod.rs
@@ -14,6 +14,7 @@ pub mod piecewise;
 pub mod segment;
 pub mod simpson;
 pub mod tabulatedgausslegendre;
+pub mod tanhsinh;
 pub mod trapezoid;
 pub mod twodimensional;
 
@@ -29,6 +30,74 @@ pub(crate) fn require_accuracy(accuracy: Real) -> QlResult<()> {
         fail!("required accuracy ({accuracy}) must be finite and exceed machine epsilon");
     }
     Ok(())
+}
+
+/// Trapezoidal double-exponential quadrature with successive level refinement,
+/// shared by the tanh-sinh and exp-sinh integrators.
+///
+/// Sums `w * f(x)` over the grid `t = k * h` for `|t| <= t_max`, where `node`
+/// maps `t` to the transformed abscissa and weight (`None` drops a tail node
+/// past the transform's usable floating-point range). Each refinement halves
+/// `h`, reusing every previous sample; iteration stops when two consecutive
+/// levels agree to `rel_tolerance` against the L1 norm of the integral, the
+/// termination rule of `boost::math::quadrature`'s DE schemes.
+pub(crate) fn de_quadrature<F, N>(
+    f: &mut F,
+    node: N,
+    t_max: Real,
+    rel_tolerance: Real,
+    max_refinements: usize,
+) -> QlResult<Real>
+where
+    F: FnMut(Real) -> Real,
+    N: Fn(Real) -> Option<(Real, Real)>,
+{
+    fn term<F, N>(f: &mut F, node: &N, t: Real) -> QlResult<(Real, Real)>
+    where
+        F: FnMut(Real) -> Real,
+        N: Fn(Real) -> Option<(Real, Real)>,
+    {
+        let Some((x, w)) = node(t) else {
+            return Ok((0.0, 0.0));
+        };
+        let y = f(x);
+        if !y.is_finite() {
+            fail!("integrand returned a non-finite value ({y}) at x = {x}");
+        }
+        Ok((w * y, (w * y).abs()))
+    }
+
+    let (mut sum, mut abs_sum) = term(f, &node, 0.0)?;
+    let mut t = 1.0;
+    while t <= t_max {
+        let (plus, abs_plus) = term(f, &node, t)?;
+        let (minus, abs_minus) = term(f, &node, -t)?;
+        sum += plus + minus;
+        abs_sum += abs_plus + abs_minus;
+        t += 1.0;
+    }
+    let mut h = 1.0;
+    let mut value = sum;
+    for _ in 0..max_refinements {
+        h *= 0.5;
+        let mut t = h;
+        while t <= t_max {
+            let (plus, abs_plus) = term(f, &node, t)?;
+            let (minus, abs_minus) = term(f, &node, -t)?;
+            sum += plus + minus;
+            abs_sum += abs_plus + abs_minus;
+            t += 2.0 * h;
+        }
+        let refined = h * sum;
+        let error = (refined - value).abs();
+        value = refined;
+        if error <= rel_tolerance * (h * abs_sum) {
+            return Ok(value);
+        }
+    }
+    fail!(
+        "double-exponential quadrature failed to reach relative tolerance {rel_tolerance} within {max_refinements} refinements"
+    );
 }
 
 /// A one-dimensional numerical integrator over `[a, b]`.

--- a/crates/itofin/src/math/integrals/mod.rs
+++ b/crates/itofin/src/math/integrals/mod.rs
@@ -129,6 +129,11 @@ where
         walk_side(f, &node, h, 2.0 * h, &mut pos_cutoff, &mut tally)?;
         walk_side(f, &node, -h, -2.0 * h, &mut neg_cutoff, &mut tally)?;
         let refined = h * tally.sum;
+        if !refined.is_finite() {
+            fail!(
+                "double-exponential quadrature overflowed accumulating an integral near the top of the f64 range"
+            );
+        }
         let error = (refined - value).abs();
         value = refined;
         if refinement > 0 && error <= rel_tolerance * (h * tally.abs_sum) {

--- a/crates/itofin/src/math/integrals/tanhsinh.rs
+++ b/crates/itofin/src/math/integrals/tanhsinh.rs
@@ -22,7 +22,11 @@ use crate::types::{Real, Size};
 /// Nodes whose distance to an endpoint of the unit interval falls below the
 /// minimum complement, or whose mapped abscissa rounds onto an endpoint of
 /// `[a, b]`, are truncated, so the integrand is never evaluated at `a` or `b`
-/// themselves.
+/// themselves. When the interval is so narrow that no abscissa survives the
+/// truncation (the midpoint itself rounds onto an endpoint), the integral
+/// degenerates to a one-point midpoint rule, `f(mid) * (b - a)`, evaluated at
+/// the rounded midpoint - the vanishing-width limit of the scheme, matching
+/// Boost, which evaluates such rounded points directly.
 pub struct TanhSinhIntegral {
     rel_tolerance: Real,
     max_refinements: Size,
@@ -77,8 +81,17 @@ impl Integrator for TanhSinhIntegral {
     where
         F: FnMut(Real) -> Real,
     {
-        let center = 0.5 * (a + b);
-        let half_width = 0.5 * (b - a);
+        // Halved before combining: 0.5 * (a + b) overflows for large
+        // same-sign bounds, and an infinite center truncates every node.
+        let center = 0.5 * a + 0.5 * b;
+        let half_width = 0.5 * b - 0.5 * a;
+        if !(a < center && center < b) {
+            let y = f(center);
+            if !y.is_finite() {
+                fail!("integrand returned a non-finite value ({y}) at x = {center}");
+            }
+            return Ok(y * (b - a));
+        }
         let min_complement = self.min_complement;
         // With e = exp(-2|u|), the unit-interval complement 1 - |x| equals
         // 2e / (1 + e) and sech^2(u) equals 4e / (1 + e)^2, both stable where
@@ -166,6 +179,36 @@ mod tests {
     fn rejects_non_finite_integrand_values() {
         let ts = TanhSinhIntegral::new();
         assert!(ts.integrate(|x| (x - 0.5).recip(), 0.0, 1.0).is_err());
+    }
+
+    #[test]
+    fn ultra_narrow_intervals_fall_back_to_the_midpoint_rule() {
+        // One ULP wide: every node rounds onto an endpoint, so without the
+        // fallback the truncation leaves a spurious Ok(0.0).
+        let ts = TanhSinhIntegral::new();
+        let a: Real = 1.0;
+        let b = a.next_up();
+        let v = ts.integrate(|_| 3.0, a, b).unwrap();
+        assert!(v > 0.0);
+        assert!((v - 3.0 * (b - a)).abs() <= Real::EPSILON * v);
+        // Large same-sign bounds overflow a naive 0.5 * (a + b) midpoint into
+        // the same all-nodes-truncated spurious zero.
+        let wide = ts.integrate(|_| 1.0, 1.0e307, 1.6e307).unwrap();
+        assert!((wide - 0.6e307).abs() < TOL * 0.6e307);
+        // Near the top of the f64 range the level sums themselves overflow;
+        // that must surface as an error, not a spurious Ok(0.0) or Ok(inf).
+        assert!(ts.integrate(|_| 1.0, 1.0e308, 1.6e308).is_err());
+    }
+
+    #[test]
+    fn narrow_interval_fallback_keeps_singularities_honest() {
+        // The rounded midpoint of [0, next_up(0)] is 0.0 itself, where the
+        // integrand diverges: an Err, never a silent zero.
+        let ts = TanhSinhIntegral::new();
+        assert!(
+            ts.integrate(|x| 1.0 / x.sqrt(), 0.0, Real::from_bits(1))
+                .is_err()
+        );
     }
 
     #[test]

--- a/crates/itofin/src/math/integrals/tanhsinh.rs
+++ b/crates/itofin/src/math/integrals/tanhsinh.rs
@@ -1,0 +1,186 @@
+//! Tanh-sinh double-exponential integration.
+//!
+//! Port of `TanhSinhIntegral` from `ql/math/integrals/tanhsinhintegral.hpp`.
+//! QuantLib delegates the work to `boost::math::quadrature::tanh_sinh`, which
+//! has no Rust equivalent, so the double-exponential scheme itself is
+//! implemented here: the Takahasi-Mori transform `x = tanh(pi/2 sinh t)` turns
+//! the integral over `[-1, 1]` into a doubly-exponentially decaying integral
+//! over the real line, which the trapezoidal rule with successive halving
+//! evaluates to rapidly increasing accuracy for holomorphic integrands, and
+//! robustly for integrable endpoint singularities. As in Boost, the tolerance
+//! is used against the error estimate for the L1 norm of the integral.
+
+use std::f64::consts::{FRAC_PI_2, PI};
+
+use crate::errors::QlResult;
+use crate::fail;
+use crate::math::integrals::{Integrator, de_quadrature, require_accuracy};
+use crate::types::{Real, Size};
+
+/// Tanh-sinh quadrature over finite intervals.
+///
+/// Nodes whose distance to an endpoint of the unit interval falls below the
+/// minimum complement, or whose mapped abscissa rounds onto an endpoint of
+/// `[a, b]`, are truncated, so the integrand is never evaluated at `a` or `b`
+/// themselves.
+pub struct TanhSinhIntegral {
+    rel_tolerance: Real,
+    max_refinements: Size,
+    min_complement: Real,
+}
+
+impl TanhSinhIntegral {
+    /// QuantLib's defaults: relative tolerance `sqrt(eps)`, at most 15
+    /// refinements, and a minimum endpoint complement of four times the
+    /// smallest positive normal.
+    pub fn new() -> Self {
+        TanhSinhIntegral {
+            rel_tolerance: Real::EPSILON.sqrt(),
+            max_refinements: 15,
+            min_complement: 4.0 * Real::MIN_POSITIVE,
+        }
+    }
+
+    /// A tanh-sinh integrator with explicit parameters.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error unless `rel_tolerance` is finite and above machine
+    /// epsilon and `min_complement` lies in `[minimum normal, 1)`.
+    pub fn with_params(
+        rel_tolerance: Real,
+        max_refinements: Size,
+        min_complement: Real,
+    ) -> QlResult<Self> {
+        require_accuracy(rel_tolerance)?;
+        if !min_complement.is_finite() || !(Real::MIN_POSITIVE..1.0).contains(&min_complement) {
+            fail!(
+                "minimum complement ({min_complement}) must lie between the smallest positive normal and 1"
+            );
+        }
+        Ok(TanhSinhIntegral {
+            rel_tolerance,
+            max_refinements,
+            min_complement,
+        })
+    }
+}
+
+impl Default for TanhSinhIntegral {
+    fn default() -> Self {
+        TanhSinhIntegral::new()
+    }
+}
+
+impl Integrator for TanhSinhIntegral {
+    fn integrate_impl<F>(&self, f: &mut F, a: Real, b: Real) -> QlResult<Real>
+    where
+        F: FnMut(Real) -> Real,
+    {
+        let center = 0.5 * (a + b);
+        let half_width = 0.5 * (b - a);
+        let min_complement = self.min_complement;
+        // With e = exp(-2|u|), the unit-interval complement 1 - |x| equals
+        // 2e / (1 + e) and sech^2(u) equals 4e / (1 + e)^2, both stable where
+        // cosh^2(u) itself would overflow.
+        let node = move |t: Real| {
+            let u = FRAC_PI_2 * t.sinh();
+            let e = (-2.0 * u.abs()).exp();
+            if 2.0 * e < min_complement * (1.0 + e) {
+                return None;
+            }
+            let x = center + half_width * u.tanh();
+            if x <= a || x >= b {
+                return None;
+            }
+            let w = FRAC_PI_2 * t.cosh() * 4.0 * e / ((1.0 + e) * (1.0 + e));
+            Some((x, half_width * w))
+        };
+        let t_max = ((2.0 / min_complement).ln() / PI).asinh();
+        de_quadrature(f, node, t_max, self.rel_tolerance, self.max_refinements)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::math::distributions::normal::NormalDistribution;
+
+    const TOL: Real = 1e-6;
+
+    #[test]
+    fn matches_known_integrals() {
+        // QuantLib's testTanhSinh runs testSeveral (Abcd case omitted, not yet
+        // ported), tolerance 1e-6.
+        let ts = TanhSinhIntegral::new();
+        assert!((ts.integrate(|_| 0.0, 0.0, 1.0).unwrap() - 0.0).abs() < TOL);
+        assert!((ts.integrate(|_| 1.0, 0.0, 1.0).unwrap() - 1.0).abs() < TOL);
+        assert!((ts.integrate(|x| x, 0.0, 1.0).unwrap() - 0.5).abs() < TOL);
+        assert!((ts.integrate(|x| x * x, 0.0, 1.0).unwrap() - 1.0 / 3.0).abs() < TOL);
+        assert!(
+            (ts.integrate(|x| x.sin(), 0.0, std::f64::consts::PI)
+                .unwrap()
+                - 2.0)
+                .abs()
+                < TOL
+        );
+        assert!(
+            (ts.integrate(|x| x.cos(), 0.0, std::f64::consts::PI)
+                .unwrap()
+                - 0.0)
+                .abs()
+                < TOL
+        );
+        let g = NormalDistribution::standard();
+        assert!((ts.integrate(|x| g.value(x), -10.0, 10.0).unwrap() - 1.0).abs() < TOL);
+    }
+
+    #[test]
+    fn handles_endpoint_singularities() {
+        // The double-exponential transform's signature strength: integrable
+        // singularities at the endpoints, which the integrand never sees.
+        let ts = TanhSinhIntegral::new();
+        assert!((ts.integrate(|x| 1.0 / x.sqrt(), 0.0, 1.0).unwrap() - 2.0).abs() < TOL);
+        assert!((ts.integrate(|x| x.ln(), 0.0, 1.0).unwrap() - (-1.0)).abs() < TOL);
+    }
+
+    #[test]
+    fn reversed_limits_negate() {
+        let ts = TanhSinhIntegral::new();
+        assert!((ts.integrate(|x| x, 1.0, 0.0).unwrap() - (-0.5)).abs() < TOL);
+    }
+
+    #[test]
+    fn reports_non_convergence() {
+        // A discontinuity in the interior defeats the DE error model; with the
+        // refinement budget cut to two levels the driver must report failure
+        // rather than return the stalled estimate.
+        let ts = TanhSinhIntegral::with_params(1e-12, 2, 4.0 * Real::MIN_POSITIVE).unwrap();
+        assert!(
+            ts.integrate(|x| if x < 1.0 / 3.0 { 0.0 } else { 1.0 }, 0.0, 1.0)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn rejects_non_finite_integrand_values() {
+        let ts = TanhSinhIntegral::new();
+        assert!(ts.integrate(|x| (x - 0.5).recip(), 0.0, 1.0).is_err());
+    }
+
+    #[test]
+    fn invalid_configuration_rejected() {
+        for tol in [0.0, -1.0, Real::EPSILON, Real::NAN, Real::INFINITY] {
+            assert!(
+                TanhSinhIntegral::with_params(tol, 15, 4.0 * Real::MIN_POSITIVE).is_err(),
+                "tolerance {tol}"
+            );
+        }
+        for mc in [0.0, -1.0, Real::MIN_POSITIVE / 2.0, 1.0, Real::NAN] {
+            assert!(
+                TanhSinhIntegral::with_params(1e-8, 15, mc).is_err(),
+                "complement {mc}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
- **feat(integrals): add double-exponential quadrature driver**
- **feat(integrals): add exp-sinh integration module**
- **fix(integrals): stop DE tail walks once terms stop contributing**
- **fix(integrals): midpoint fallback for ultra-narrow tanh-sinh intervals**
- **docs(integrals): state the Real::MAX sentinel contract for exp-sinh bounds**

close #131
