### PR TITLE
feat(#155): imple handle forwarding

### DIFF
--- a/crates/itofin/src/handle.rs
+++ b/crates/itofin/src/handle.rs
@@ -4,41 +4,88 @@
 //! share one inner `Link`; relinking through a [`RelinkableHandle`] swaps the
 //! pointee for every copy and notifies the link's observers.
 //!
-//! QuantLib's `Link` also registers as an *observer of its pointee* so that
-//! changes inside the pointee propagate through the handle. That wiring needs an
-//! observable pointee type (e.g. `Quote`, EPIC-3) and is added once such types
-//! exist; the EPIC-0 port covers the shared-link relink-and-notify behavior.
+//! QuantLib's `Link` is an *observer of its pointee* as well as an observable:
+//! changes inside the pointee propagate to observers of the handle, and
+//! relinking moves that registration to the new pointee. The port mirrors the
+//! `handle.hpp` precondition "class T must inherit from Observable" with the
+//! [`AsObservable`] bound on handle pointees and forwards every pointee
+//! notification to the link's own observers.
 
 use crate::errors::QlResult;
 use crate::patterns::observable::{Observable, Observer};
 use crate::require;
 use crate::shared::{Shared, SharedMut, shared_mut};
 
-/// Inner shared cell of a [`Handle`]: the current pointee plus the link's own
-/// observable, through which relinks are broadcast.
-pub struct Link<T: ?Sized> {
-    current: Option<Shared<T>>,
+/// Pointee contract for [`Handle`]: access to the embedded [`Observable`]
+/// through which the pointee broadcasts its changes.
+///
+/// Mirrors the `handle.hpp` precondition that a handle target "must inherit
+/// from `Observable`". The handle's link registers with this observable, so a
+/// pointee change reaches every observer of the handle.
+pub trait AsObservable {
+    /// Access to the embedded observable for registering observers.
+    fn observable(&self) -> &Observable;
+}
+
+/// Observer half of the link (QuantLib's `Link::update`): forwards every
+/// notification of the current pointee to the link's own observers.
+struct Forwarder {
     observable: Shared<Observable>,
 }
 
+impl Observer for Forwarder {
+    fn update(&mut self) {
+        self.observable.notify_observers();
+    }
+}
+
+/// Inner shared cell of a [`Handle`]: the current pointee plus the link's own
+/// observable, through which relinks and pointee changes are broadcast.
+pub struct Link<T: ?Sized> {
+    current: Option<Shared<T>>,
+    observable: Shared<Observable>,
+    forwarder: SharedMut<Forwarder>,
+}
+
 impl<T: ?Sized> Link<T> {
+    fn is_empty(&self) -> bool {
+        self.current.is_none()
+    }
+}
+
+impl<T: AsObservable + ?Sized> Link<T> {
     fn new(pointee: Option<Shared<T>>) -> Self {
+        let observable = Shared::new(Observable::new());
+        let forwarder = shared_mut(Forwarder {
+            observable: Shared::clone(&observable),
+        });
+        if let Some(pointee) = &pointee {
+            pointee
+                .observable()
+                .register_observer(&(forwarder.clone() as SharedMut<dyn Observer>));
+        }
         Link {
             current: pointee,
-            observable: Shared::new(Observable::new()),
+            observable,
+            forwarder,
         }
     }
 
-    /// Repoints the link and returns its observable so the caller can notify
-    /// *after* dropping the link borrow - observers commonly read or relink the
-    /// handle from `update()`, which would otherwise re-borrow this cell.
+    /// Repoints the link, moving the pointee subscription from the old pointee
+    /// to the new one, and returns the link's observable so the caller can
+    /// notify *after* dropping the link borrow - observers commonly read or
+    /// relink the handle from `update()`, which would otherwise re-borrow this
+    /// cell.
     fn link_to(&mut self, pointee: Option<Shared<T>>) -> Shared<Observable> {
+        let forwarder = self.forwarder.clone() as SharedMut<dyn Observer>;
+        if let Some(old) = &self.current {
+            old.observable().unregister_observer(&forwarder);
+        }
+        if let Some(new) = &pointee {
+            new.observable().register_observer(&forwarder);
+        }
         self.current = pointee;
         self.observable.clone()
-    }
-
-    fn is_empty(&self) -> bool {
-        self.current.is_none()
     }
 }
 
@@ -50,7 +97,7 @@ pub struct Handle<T: ?Sized> {
     link: SharedMut<Link<T>>,
 }
 
-impl<T: ?Sized> Handle<T> {
+impl<T: AsObservable + ?Sized> Handle<T> {
     /// Creates an empty handle.
     pub fn empty() -> Self {
         Handle {
@@ -58,13 +105,15 @@ impl<T: ?Sized> Handle<T> {
         }
     }
 
-    /// Creates a handle pointing at `pointee`.
+    /// Creates a handle pointing at `pointee`, registering with its observable.
     pub fn new(pointee: Shared<T>) -> Self {
         Handle {
             link: shared_mut(Link::new(Some(pointee))),
         }
     }
+}
 
+impl<T: ?Sized> Handle<T> {
     /// Returns the current pointee, or an error if the handle is empty.
     ///
     /// Mirrors QuantLib's `currentLink`/`operator*`, which require a non-empty
@@ -81,7 +130,8 @@ impl<T: ?Sized> Handle<T> {
 
     /// Registers an observer with the underlying link.
     ///
-    /// The observer is notified whenever the handle is relinked.
+    /// The observer is notified whenever the handle is relinked and whenever
+    /// the current pointee notifies a change.
     pub fn register_observer(&self, observer: &SharedMut<dyn Observer>) -> bool {
         self.link.borrow().observable.register_observer(observer)
     }
@@ -105,7 +155,7 @@ pub struct RelinkableHandle<T: ?Sized> {
     handle: Handle<T>,
 }
 
-impl<T: ?Sized> RelinkableHandle<T> {
+impl<T: AsObservable + ?Sized> RelinkableHandle<T> {
     /// Creates an empty relinkable handle.
     pub fn empty() -> Self {
         RelinkableHandle {
@@ -120,18 +170,22 @@ impl<T: ?Sized> RelinkableHandle<T> {
         }
     }
 
-    /// Points the shared link at `pointee`, notifying observers.
+    /// Points the shared link at `pointee`, moving the pointee subscription
+    /// and notifying observers.
     pub fn link_to(&self, pointee: Shared<T>) {
         let observable = self.handle.link.borrow_mut().link_to(Some(pointee));
         observable.notify_observers();
     }
 
-    /// Clears the shared link, notifying observers.
+    /// Clears the shared link, dropping the pointee subscription and notifying
+    /// observers.
     pub fn reset(&self) {
         let observable = self.handle.link.borrow_mut().link_to(None);
         observable.notify_observers();
     }
+}
 
+impl<T: ?Sized> RelinkableHandle<T> {
     /// Borrows this as a plain [`Handle`] (e.g. to hand out non-relinkable copies).
     pub fn handle(&self) -> Handle<T> {
         self.handle.clone()
@@ -141,6 +195,7 @@ impl<T: ?Sized> RelinkableHandle<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::quotes::{Quote, SimpleQuote};
     use crate::shared::{shared, shared_mut};
 
     #[derive(Default)]
@@ -154,45 +209,67 @@ mod tests {
         }
     }
 
+    /// Minimal observable pointee for the link-sharing tests, standing in for
+    /// the `handle.hpp` precondition that pointees derive from `Observable`.
+    struct Pointee {
+        value: i32,
+        observable: Observable,
+    }
+
+    impl Pointee {
+        fn new(value: i32) -> Shared<Pointee> {
+            shared(Pointee {
+                value,
+                observable: Observable::new(),
+            })
+        }
+    }
+
+    impl AsObservable for Pointee {
+        fn observable(&self) -> &Observable {
+            &self.observable
+        }
+    }
+
     #[test]
     fn empty_handle_cannot_be_dereferenced() {
-        let h: Handle<i32> = Handle::empty();
+        let h: Handle<Pointee> = Handle::empty();
         assert!(h.is_empty());
         assert!(h.current_link().is_err());
     }
 
     #[test]
     fn handle_dereferences_to_pointee() {
-        let h = Handle::new(shared(42_i32));
+        let h = Handle::new(Pointee::new(42));
         assert!(!h.is_empty());
-        assert_eq!(*h.current_link().unwrap(), 42);
+        assert_eq!(h.current_link().unwrap().value, 42);
     }
 
     #[test]
     fn copies_share_one_link() {
-        let h = Handle::new(shared(1_i32));
+        let h = Handle::new(Pointee::new(1));
         let copy = h.clone();
         assert!(h.points_to_same_link(&copy));
     }
 
     #[test]
     fn relink_propagates_notification_to_observers() {
-        let rh = RelinkableHandle::new(shared(1_i32));
+        let rh = RelinkableHandle::new(Pointee::new(1));
         let observed = rh.handle();
 
         let flag = shared_mut(Flag::default());
         observed.register_observer(&(flag.clone() as SharedMut<dyn Observer>));
 
-        rh.link_to(shared(2_i32));
+        rh.link_to(Pointee::new(2));
 
         assert!(flag.borrow().up, "relink should notify observers");
         // the change is visible through the copy that shares the link
-        assert_eq!(*observed.current_link().unwrap(), 2);
+        assert_eq!(observed.current_link().unwrap().value, 2);
     }
 
     #[test]
     fn reset_empties_and_notifies() {
-        let rh = RelinkableHandle::new(shared(1_i32));
+        let rh = RelinkableHandle::new(Pointee::new(1));
         let observed = rh.handle();
         let flag = shared_mut(Flag::default());
         observed.register_observer(&(flag.clone() as SharedMut<dyn Observer>));
@@ -206,19 +283,19 @@ mod tests {
     /// Observer that reads its shared handle while being notified - the common
     /// "recompute on relink" pattern. This must not hit a `RefCell` borrow panic.
     struct Reader {
-        handle: Handle<i32>,
+        handle: Handle<Pointee>,
         seen: Option<i32>,
     }
 
     impl Observer for Reader {
         fn update(&mut self) {
-            self.seen = self.handle.current_link().ok().map(|v| *v);
+            self.seen = self.handle.current_link().ok().map(|p| p.value);
         }
     }
 
     #[test]
     fn observer_may_read_handle_during_relink() {
-        let rh = RelinkableHandle::new(shared(1_i32));
+        let rh = RelinkableHandle::new(Pointee::new(1));
         let reader = shared_mut(Reader {
             handle: rh.handle(),
             seen: None,
@@ -226,10 +303,109 @@ mod tests {
         rh.handle()
             .register_observer(&(reader.clone() as SharedMut<dyn Observer>));
 
-        rh.link_to(shared(2_i32));
+        rh.link_to(Pointee::new(2));
 
         // the relink borrow is released before observers run, so the observer
         // can dereference the handle and sees the freshly-linked value
         assert_eq!(reader.borrow().seen, Some(2));
+    }
+
+    /// The deferred half of the ticket's oracle: an observer of a plain
+    /// `Handle<SimpleQuote>` is notified when the underlying quote changes.
+    #[test]
+    #[allow(clippy::approx_constant)]
+    fn pointee_change_notifies_handle_observers() {
+        let quote = shared(SimpleQuote::new(0.0));
+        let h: Handle<SimpleQuote> = Handle::new(quote.clone());
+        let flag = shared_mut(Flag::default());
+        h.register_observer(&(flag.clone() as SharedMut<dyn Observer>));
+
+        quote.set_value(3.14);
+
+        assert!(
+            flag.borrow().up,
+            "observer was not notified of quote change"
+        );
+    }
+
+    /// Port of `testObservableHandle` (test-suite/quotes.cpp), extended with
+    /// the subscription-move asserts: the detached pointee must stop notifying
+    /// and the newly linked one must start.
+    #[test]
+    #[allow(clippy::approx_constant)]
+    fn observable_handle_forwards_pointee_changes_and_relinks() {
+        let me1 = shared(SimpleQuote::new(0.0));
+        let h: RelinkableHandle<dyn Quote> = RelinkableHandle::new(me1.clone());
+        let f = shared_mut(Flag::default());
+        h.handle()
+            .register_observer(&(f.clone() as SharedMut<dyn Observer>));
+
+        me1.set_value(3.14);
+        assert!(f.borrow().up, "observer was not notified of quote change");
+
+        f.borrow_mut().up = false;
+        let me2 = shared(SimpleQuote::new(0.0));
+        h.link_to(me2.clone());
+        assert!(f.borrow().up, "observer was not notified of relink");
+
+        f.borrow_mut().up = false;
+        me1.set_value(1.0);
+        assert!(
+            !f.borrow().up,
+            "detached pointee must no longer notify handle observers"
+        );
+
+        me2.set_value(2.0);
+        assert!(
+            f.borrow().up,
+            "new pointee change must notify handle observers"
+        );
+    }
+
+    #[test]
+    fn reset_unhooks_the_old_pointee() {
+        let quote = shared(SimpleQuote::new(1.0));
+        let rh: RelinkableHandle<dyn Quote> = RelinkableHandle::new(quote.clone());
+        let flag = shared_mut(Flag::default());
+        rh.handle()
+            .register_observer(&(flag.clone() as SharedMut<dyn Observer>));
+
+        rh.reset();
+        flag.borrow_mut().up = false;
+
+        quote.set_value(2.0);
+        assert!(
+            !flag.borrow().up,
+            "reset must drop the pointee subscription"
+        );
+    }
+
+    #[test]
+    fn linking_an_empty_handle_starts_forwarding() {
+        let rh: RelinkableHandle<dyn Quote> = RelinkableHandle::empty();
+        let flag = shared_mut(Flag::default());
+        rh.handle()
+            .register_observer(&(flag.clone() as SharedMut<dyn Observer>));
+
+        let quote = shared(SimpleQuote::new(0.0));
+        rh.link_to(quote.clone());
+        flag.borrow_mut().up = false;
+
+        quote.set_value(1.0);
+        assert!(
+            flag.borrow().up,
+            "pointee linked after construction must forward"
+        );
+    }
+
+    /// Dropping every handle drops the forwarder; the quote must keep working
+    /// and silently prune the dead registration on its next notification.
+    #[test]
+    fn dropped_handle_stops_forwarding() {
+        let quote = shared(SimpleQuote::new(0.0));
+        {
+            let _h: Handle<SimpleQuote> = Handle::new(quote.clone());
+        }
+        assert_eq!(quote.set_value(1.0), Some(1.0));
     }
 }

--- a/crates/itofin/src/handle.rs
+++ b/crates/itofin/src/handle.rs
@@ -398,6 +398,62 @@ mod tests {
         );
     }
 
+    /// Caches the quote value it sees at notification time.
+    struct Cacher {
+        handle: Handle<SimpleQuote>,
+        seen: Option<f64>,
+    }
+
+    impl Observer for Cacher {
+        fn update(&mut self) {
+            self.seen = self.handle.current_link().ok().and_then(|q| q.value().ok());
+        }
+    }
+
+    /// Caps the quote at 1.0, writing back into it from inside `update`.
+    struct Normalizer {
+        quote: Shared<SimpleQuote>,
+    }
+
+    impl Observer for Normalizer {
+        fn update(&mut self) {
+            if let Ok(v) = self.quote.value() {
+                if v > 1.0 {
+                    self.quote.set_value(1.0);
+                }
+            }
+        }
+    }
+
+    /// A handle observer that writes back into the pointee mid-notification
+    /// re-notifies through the forwarder once the in-flight round finishes, so
+    /// every handle observer ends up with the final value - the state
+    /// QuantLib's recursive `Link::update` reaches directly.
+    #[test]
+    fn write_back_during_forwarded_notification_reaches_handle_observers() {
+        let quote = shared(SimpleQuote::new(0.5));
+        let h: Handle<SimpleQuote> = Handle::new(quote.clone());
+
+        let cacher = shared_mut(Cacher {
+            handle: h.clone(),
+            seen: None,
+        });
+        h.register_observer(&(cacher.clone() as SharedMut<dyn Observer>));
+        let normalizer = shared_mut(Normalizer {
+            quote: quote.clone(),
+        });
+        h.register_observer(&(normalizer.clone() as SharedMut<dyn Observer>));
+
+        quote.set_value(2.0);
+
+        assert_eq!(quote.value().unwrap(), 1.0);
+        assert_eq!(
+            cacher.borrow().seen,
+            Some(1.0),
+            "handle observers must see the written-back value, not the stale one"
+        );
+    }
+
     /// Dropping every handle drops the forwarder; the quote must keep working
     /// and silently prune the dead registration on its next notification.
     #[test]

--- a/crates/itofin/src/handle.rs
+++ b/crates/itofin/src/handle.rs
@@ -12,20 +12,10 @@
 //! notification to the link's own observers.
 
 use crate::errors::QlResult;
+pub use crate::patterns::observable::AsObservable;
 use crate::patterns::observable::{Observable, Observer};
 use crate::require;
 use crate::shared::{Shared, SharedMut, shared_mut};
-
-/// Pointee contract for [`Handle`]: access to the embedded [`Observable`]
-/// through which the pointee broadcasts its changes.
-///
-/// Mirrors the `handle.hpp` precondition that a handle target "must inherit
-/// from `Observable`". The handle's link registers with this observable, so a
-/// pointee change reaches every observer of the handle.
-pub trait AsObservable {
-    /// Access to the embedded observable for registering observers.
-    fn observable(&self) -> &Observable;
-}
 
 /// Observer half of the link (QuantLib's `Link::update`): forwards every
 /// notification of the current pointee to the link's own observers.
@@ -54,21 +44,22 @@ impl<T: ?Sized> Link<T> {
 }
 
 impl<T: AsObservable + ?Sized> Link<T> {
+    /// Builds the link and delegates the initial subscription to
+    /// [`link_to`](Link::link_to), as the C++ constructor delegates to
+    /// `linkTo`; no observers can exist yet, so the returned observable is
+    /// dropped unnotified.
     fn new(pointee: Option<Shared<T>>) -> Self {
         let observable = Shared::new(Observable::new());
         let forwarder = shared_mut(Forwarder {
             observable: Shared::clone(&observable),
         });
-        if let Some(pointee) = &pointee {
-            pointee
-                .observable()
-                .register_observer(&(forwarder.clone() as SharedMut<dyn Observer>));
-        }
-        Link {
-            current: pointee,
+        let mut link = Link {
+            current: None,
             observable,
             forwarder,
-        }
+        };
+        link.link_to(pointee);
+        link
     }
 
     /// Repoints the link, moving the pointee subscription from the old pointee
@@ -417,10 +408,10 @@ mod tests {
 
     impl Observer for Normalizer {
         fn update(&mut self) {
-            if let Ok(v) = self.quote.value() {
-                if v > 1.0 {
-                    self.quote.set_value(1.0);
-                }
+            if let Ok(v) = self.quote.value()
+                && v > 1.0
+            {
+                self.quote.set_value(1.0);
             }
         }
     }

--- a/crates/itofin/src/patterns/observable.rs
+++ b/crates/itofin/src/patterns/observable.rs
@@ -9,10 +9,112 @@
 //! graph cannot form an `Rc` cycle. [`Observable::notify_observers`] snapshots the
 //! live observers and drops every borrow before calling `update`, so an observer
 //! may freely register, unregister or mutate the graph while being notified.
+//!
+//! A notification that cannot be delivered immediately - the observer is
+//! already mid-`update` when a re-entrant notification reaches it, through any
+//! observable - is queued on a thread-local pending list and re-delivered by
+//! the outermost notification on the thread once the borrow releases, so no
+//! notification is dropped; see [`Observable::notify_observers`].
 
 use std::cell::{Cell, RefCell};
 
 use crate::shared::{SharedMut, WeakMut};
+
+thread_local! {
+    /// Nesting depth of [`Observable::notify_observers`] across all
+    /// observables on this thread; the invocation returning to depth zero
+    /// drains [`PENDING`].
+    static DEPTH: Cell<usize> = const { Cell::new(0) };
+    /// Re-entrancy latch so a drained observer re-notifying does not start a
+    /// nested drain; the running drain loop picks its deferrals up instead.
+    static DRAINING: Cell<bool> = const { Cell::new(false) };
+    /// Observers a notification round could not borrow, shared by all
+    /// observables so a miss is re-delivered no matter which observable's
+    /// round it happened in.
+    static PENDING: RefCell<Vec<WeakMut<dyn Observer>>> = const { RefCell::new(Vec::new()) };
+}
+
+/// RAII depth counter for [`DEPTH`], panic-safe like `LazyObject`'s guard.
+struct DepthGuard;
+
+impl DepthGuard {
+    fn enter() -> Self {
+        DEPTH.with(|depth| depth.set(depth.get() + 1));
+        DepthGuard
+    }
+}
+
+impl Drop for DepthGuard {
+    fn drop(&mut self) {
+        DEPTH.with(|depth| depth.set(depth.get() - 1));
+    }
+}
+
+/// RAII latch for [`DRAINING`]; `try_enter` yields `None` when already set.
+struct DrainGuard;
+
+impl DrainGuard {
+    fn try_enter() -> Option<Self> {
+        if DRAINING.with(Cell::get) {
+            return None;
+        }
+        DRAINING.with(|flag| flag.set(true));
+        Some(DrainGuard)
+    }
+}
+
+impl Drop for DrainGuard {
+    fn drop(&mut self) {
+        DRAINING.with(|flag| flag.set(false));
+    }
+}
+
+/// Queues an undeliverable observer for the outermost round, once.
+fn defer(observer: &SharedMut<dyn Observer>) {
+    let weak = SharedMut::downgrade(observer);
+    PENDING.with(|pending| {
+        let mut pending = pending.borrow_mut();
+        if !pending.iter().any(|queued| queued.ptr_eq(&weak)) {
+            pending.push(weak);
+        }
+    });
+}
+
+/// Delivers every queued miss; runs only at depth zero and never nests.
+///
+/// A drained `update` may notify further observables; their fresh misses land
+/// in [`PENDING`] and are picked up by the next pass of the loop. An observer
+/// still borrowed here is held by code outside any notification; it stays
+/// queued for the next outermost notification rather than spinning.
+fn drain_pending() {
+    let Some(_draining) = DrainGuard::try_enter() else {
+        return;
+    };
+    let mut stalled: Vec<WeakMut<dyn Observer>> = Vec::new();
+    loop {
+        let batch: Vec<WeakMut<dyn Observer>> =
+            PENDING.with(|pending| pending.borrow_mut().drain(..).collect());
+        if batch.is_empty() {
+            break;
+        }
+        for weak in batch {
+            let Some(observer) = weak.upgrade() else {
+                continue;
+            };
+            match observer.try_borrow_mut() {
+                Ok(mut observer) => observer.update(),
+                Err(_) => {
+                    if !stalled.iter().any(|queued| queued.ptr_eq(&weak)) {
+                        stalled.push(weak);
+                    }
+                }
+            }
+        }
+    }
+    if !stalled.is_empty() {
+        PENDING.with(|pending| pending.borrow_mut().append(&mut stalled));
+    }
+}
 
 /// Object that gets notified when an [`Observable`] it registered with changes.
 ///
@@ -45,7 +147,6 @@ pub trait AsObservable {
 #[derive(Default)]
 pub struct Observable {
     observers: RefCell<Vec<WeakMut<dyn Observer>>>,
-    missed: Cell<bool>,
 }
 
 impl Observable {
@@ -91,45 +192,40 @@ impl Observable {
     /// registration/unregistration during `update` is safe and does not affect
     /// this round of notification. Dropped observers are pruned.
     ///
-    /// An observer whose `update` is already running when a re-entrant
-    /// notification fires (e.g. it wrote a new value back into the notifying
-    /// observable) cannot take the unsatisfiable second `&mut`; QuantLib runs
-    /// the nested `update` recursively and relies on the recursion
-    /// terminating. Here the nested round skips the in-flight observer and
-    /// flags the miss, and the outer round on the same observable re-notifies
-    /// once that observer's `update` has returned, so every observer still
-    /// converges on the final state. The deferral matters for pass-through
-    /// observers like the handle forwarder, whose skip would otherwise cut
-    /// off every observer downstream of it. A miss can only be re-delivered
-    /// by an outer round on this observable; if the in-flight borrow belongs
-    /// to another observable's notification, the miss is dropped exactly as
-    /// before.
+    /// An observer whose `RefCell` is already mutably borrowed when the round
+    /// reaches it - typically its own `update` is on the stack and re-entrantly
+    /// triggered this notification, the case QuantLib runs as direct recursion -
+    /// cannot take the unsatisfiable second `&mut`. Instead of dropping the
+    /// notification, the round queues it on a pending list shared by every
+    /// observable on the thread, and the outermost notification re-delivers it
+    /// once the borrow has been released. Delivery is thus guaranteed no matter
+    /// which observable the re-entrant notification arrived through, and every
+    /// observer converges on the final state - the fixed point of QuantLib's
+    /// recursion. Updates are idempotent invalidations, so a re-delivered
+    /// observer may hear one extra round; and as in C++, a graph whose
+    /// observers keep writing back forever does not terminate.
+    ///
+    /// The one case deferred past the current notification is an observer kept
+    /// borrowed by code outside any `update` (a caller holding a borrow across
+    /// the notification): it stays queued and is delivered at the end of the
+    /// next outermost notification on the thread.
     pub fn notify_observers(&self) {
-        loop {
-            self.missed.set(false);
-            let snapshot: Vec<SharedMut<dyn Observer>> = {
-                let mut observers = self.observers.borrow_mut();
-                observers.retain(|w| w.strong_count() > 0);
-                observers.iter().filter_map(WeakMut::upgrade).collect()
-            };
-            let mut skipped = false;
+        let snapshot: Vec<SharedMut<dyn Observer>> = {
+            let mut observers = self.observers.borrow_mut();
+            observers.retain(|w| w.strong_count() > 0);
+            observers.iter().filter_map(WeakMut::upgrade).collect()
+        };
+        {
+            let _depth = DepthGuard::enter();
             for observer in snapshot {
-                if let Ok(mut observer) = observer.try_borrow_mut() {
-                    observer.update();
-                } else {
-                    skipped = true;
+                match observer.try_borrow_mut() {
+                    Ok(mut observer) => observer.update(),
+                    Err(_) => defer(&observer),
                 }
             }
-            if self.missed.get() {
-                // a nested round on this observable skipped an observer whose
-                // update was running in this round; it has returned, so
-                // re-deliver the (now final) state
-                continue;
-            }
-            if skipped {
-                self.missed.set(true);
-            }
-            return;
+        }
+        if DEPTH.with(Cell::get) == 0 {
+            drain_pending();
         }
     }
 }
@@ -308,6 +404,69 @@ mod tests {
         }
     }
 
+    /// Listener registered with two observables, mirroring a composite
+    /// quote's invalidator: handling observable A's notification triggers
+    /// observable B, whose round finds the listener still mid-`update`.
+    struct CrossNotifier {
+        updates: usize,
+        other: Shared<Observable>,
+        fired: bool,
+    }
+
+    impl Observer for CrossNotifier {
+        fn update(&mut self) {
+            self.updates += 1;
+            if !self.fired {
+                self.fired = true;
+                self.other.notify_observers();
+            }
+        }
+    }
+
+    #[test]
+    fn cross_observable_reentrant_notification_is_redelivered() {
+        let a = Shared::new(Observable::new());
+        let b = Shared::new(Observable::new());
+
+        let listener = shared_mut(CrossNotifier {
+            updates: 0,
+            other: b.clone(),
+            fired: false,
+        });
+        a.register_observer(&(listener.clone() as SharedMut<dyn Observer>));
+        b.register_observer(&(listener.clone() as SharedMut<dyn Observer>));
+
+        let bystander = UpdateCounter::new();
+        b.register_observer(&as_observer(&bystander));
+
+        a.notify_observers();
+
+        // b's round ran while the listener was in-flight from a's round: the
+        // miss must be re-delivered once a's round unwinds, not dropped
+        assert_eq!(listener.borrow().updates, 2);
+        assert_eq!(bystander.borrow().counter, 1);
+    }
+
+    #[test]
+    fn notification_blocked_by_an_outside_borrow_is_delivered_later() {
+        let observable = Observable::new();
+        let counter = UpdateCounter::new();
+        observable.register_observer(&as_observer(&counter));
+
+        {
+            let held = counter.borrow();
+            observable.notify_observers();
+            // the observer cannot be updated while the caller holds it...
+            assert_eq!(held.counter, 0);
+        }
+
+        // ...so it stays queued and the next outermost notification delivers
+        // both its own round and the queued re-delivery (updates are
+        // idempotent invalidations)
+        observable.notify_observers();
+        assert_eq!(counter.borrow().counter, 2);
+    }
+
     #[test]
     fn reentrant_notification_defers_the_in_flight_observer() {
         let observable = Shared::new(Observable::new());
@@ -323,11 +482,11 @@ mod tests {
         observable.notify_observers();
 
         // instead of panicking on a second mutable borrow, the nested round
-        // skips the in-flight observer and the outer round re-delivers to it,
-        // matching the two updates C++ delivers through recursion...
+        // queues the in-flight observer and the outermost round drains the
+        // queue, matching the two updates C++ delivers through recursion...
         assert_eq!(renotifier.borrow().updates, 2);
-        // ...while the other observer hears the outer, nested and re-delivery
-        // rounds (one idempotent update more than the C++ recursion)
-        assert_eq!(plain.borrow().counter, 3);
+        // ...and the other observer hears the outer and nested rounds, the
+        // exact counts of the C++ recursion
+        assert_eq!(plain.borrow().counter, 2);
     }
 }

--- a/crates/itofin/src/patterns/observable.rs
+++ b/crates/itofin/src/patterns/observable.rs
@@ -23,6 +23,16 @@ pub trait Observer {
     fn update(&mut self);
 }
 
+/// Contract for types that embed an [`Observable`] and broadcast through it.
+///
+/// Mirrors QuantLib's "inherits from `Observable`" preconditions (e.g. the
+/// `handle.hpp` requirement on handle pointees): observers register with the
+/// embedded observable this accessor exposes.
+pub trait AsObservable {
+    /// Access to the embedded observable for registering observers.
+    fn observable(&self) -> &Observable;
+}
+
 /// Object that notifies its changes to a set of observers.
 ///
 /// Mirrors QuantLib's `Observable`. Embed one in any type that needs to notify;

--- a/crates/itofin/src/patterns/observable.rs
+++ b/crates/itofin/src/patterns/observable.rs
@@ -10,7 +10,7 @@
 //! live observers and drops every borrow before calling `update`, so an observer
 //! may freely register, unregister or mutate the graph while being notified.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 
 use crate::shared::{SharedMut, WeakMut};
 
@@ -35,14 +35,13 @@ pub trait Observer {
 #[derive(Default)]
 pub struct Observable {
     observers: RefCell<Vec<WeakMut<dyn Observer>>>,
+    missed: Cell<bool>,
 }
 
 impl Observable {
     /// Creates an observable with no registered observers.
     pub fn new() -> Self {
-        Observable {
-            observers: RefCell::new(Vec::new()),
-        }
+        Observable::default()
     }
 
     /// Registers an observer, returning `true` if it was newly added.
@@ -84,20 +83,43 @@ impl Observable {
     ///
     /// An observer whose `update` is already running when a re-entrant
     /// notification fires (e.g. it wrote a new value back into the notifying
-    /// observable) is skipped by the nested round: it is mid-reaction and can
-    /// read the latest state directly. QuantLib runs the nested `update` and
-    /// relies on the recursion terminating; skipping the in-flight observer
-    /// reaches the same final state without the unsatisfiable second `&mut`.
+    /// observable) cannot take the unsatisfiable second `&mut`; QuantLib runs
+    /// the nested `update` recursively and relies on the recursion
+    /// terminating. Here the nested round skips the in-flight observer and
+    /// flags the miss, and the outer round on the same observable re-notifies
+    /// once that observer's `update` has returned, so every observer still
+    /// converges on the final state. The deferral matters for pass-through
+    /// observers like the handle forwarder, whose skip would otherwise cut
+    /// off every observer downstream of it. A miss can only be re-delivered
+    /// by an outer round on this observable; if the in-flight borrow belongs
+    /// to another observable's notification, the miss is dropped exactly as
+    /// before.
     pub fn notify_observers(&self) {
-        let snapshot: Vec<SharedMut<dyn Observer>> = {
-            let mut observers = self.observers.borrow_mut();
-            observers.retain(|w| w.strong_count() > 0);
-            observers.iter().filter_map(WeakMut::upgrade).collect()
-        };
-        for observer in snapshot {
-            if let Ok(mut observer) = observer.try_borrow_mut() {
-                observer.update();
+        loop {
+            self.missed.set(false);
+            let snapshot: Vec<SharedMut<dyn Observer>> = {
+                let mut observers = self.observers.borrow_mut();
+                observers.retain(|w| w.strong_count() > 0);
+                observers.iter().filter_map(WeakMut::upgrade).collect()
+            };
+            let mut skipped = false;
+            for observer in snapshot {
+                if let Ok(mut observer) = observer.try_borrow_mut() {
+                    observer.update();
+                } else {
+                    skipped = true;
+                }
             }
+            if self.missed.get() {
+                // a nested round on this observable skipped an observer whose
+                // update was running in this round; it has returned, so
+                // re-deliver the (now final) state
+                continue;
+            }
+            if skipped {
+                self.missed.set(true);
+            }
+            return;
         }
     }
 }
@@ -277,7 +299,7 @@ mod tests {
     }
 
     #[test]
-    fn reentrant_notification_skips_the_in_flight_observer() {
+    fn reentrant_notification_defers_the_in_flight_observer() {
         let observable = Shared::new(Observable::new());
         let plain = UpdateCounter::new();
         observable.register_observer(&as_observer(&plain));
@@ -290,10 +312,12 @@ mod tests {
 
         observable.notify_observers();
 
-        // the re-entrant round skipped the in-flight observer instead of
-        // panicking on a second mutable borrow...
-        assert_eq!(renotifier.borrow().updates, 1);
-        // ...while other observers received both the outer and nested rounds
-        assert_eq!(plain.borrow().counter, 2);
+        // instead of panicking on a second mutable borrow, the nested round
+        // skips the in-flight observer and the outer round re-delivers to it,
+        // matching the two updates C++ delivers through recursion...
+        assert_eq!(renotifier.borrow().updates, 2);
+        // ...while the other observer hears the outer, nested and re-delivery
+        // rounds (one idempotent update more than the C++ recursion)
+        assert_eq!(plain.borrow().counter, 3);
     }
 }

--- a/crates/itofin/src/quotes/mod.rs
+++ b/crates/itofin/src/quotes/mod.rs
@@ -16,7 +16,7 @@ mod simplequote;
 pub use simplequote::{SimpleQuote, make_quote_handle};
 
 use crate::errors::QlResult;
-use crate::handle::AsObservable;
+use crate::patterns::observable::AsObservable;
 use crate::types::Real;
 
 /// Purely virtual base class for market observables.

--- a/crates/itofin/src/quotes/mod.rs
+++ b/crates/itofin/src/quotes/mod.rs
@@ -2,9 +2,10 @@
 //!
 //! Port of `ql/quote.hpp`: the [`Quote`] trait is the purely virtual base
 //! class for market observables. QuantLib's `Quote` inherits `Observable`;
-//! here the trait exposes the embedded [`Observable`] through
-//! [`observable`](Quote::observable), following the crate's embedding
-//! convention (see `patterns::lazyobject`).
+//! here the trait exposes the embedded observable through its
+//! [`AsObservable`] supertrait, which is also what lets a
+//! [`Handle`](crate::handle::Handle) forward pointee changes to its
+//! observers.
 //!
 //! `handleFromVariant` (a `std::variant<Real, Handle<Quote>>` convenience for
 //! C++ term-structure constructors) has no caller in the core yet and is not
@@ -15,18 +16,16 @@ mod simplequote;
 pub use simplequote::{SimpleQuote, make_quote_handle};
 
 use crate::errors::QlResult;
-use crate::patterns::observable::Observable;
+use crate::handle::AsObservable;
 use crate::types::Real;
 
 /// Purely virtual base class for market observables.
 ///
-/// Mirrors QuantLib's `Quote`. Implementors embed an [`Observable`] and
-/// notify it when their value changes; observers of a quote register through
-/// [`observable`](Quote::observable).
-pub trait Quote {
-    /// Access to the embedded observable for registering observers.
-    fn observable(&self) -> &Observable;
-
+/// Mirrors QuantLib's `Quote`. Implementors embed an
+/// [`Observable`](crate::patterns::observable::Observable) and notify it when
+/// their value changes; observers of a quote register through
+/// [`observable`](AsObservable::observable).
+pub trait Quote: AsObservable {
     /// Returns the current value, or an error if the quote holds none.
     fn value(&self) -> QlResult<Real>;
 

--- a/crates/itofin/src/quotes/simplequote.rs
+++ b/crates/itofin/src/quotes/simplequote.rs
@@ -13,7 +13,7 @@ use std::cell::Cell;
 
 use crate::errors::QlResult;
 use crate::fail;
-use crate::handle::RelinkableHandle;
+use crate::handle::{AsObservable, RelinkableHandle};
 use crate::patterns::observable::Observable;
 use crate::shared::shared;
 use crate::types::Real;
@@ -65,11 +65,13 @@ impl SimpleQuote {
     }
 }
 
-impl Quote for SimpleQuote {
+impl AsObservable for SimpleQuote {
     fn observable(&self) -> &Observable {
         &self.observable
     }
+}
 
+impl Quote for SimpleQuote {
     fn value(&self) -> QlResult<Real> {
         match self.value.get() {
             Some(value) => Ok(value),

--- a/crates/itofin/src/quotes/simplequote.rs
+++ b/crates/itofin/src/quotes/simplequote.rs
@@ -13,8 +13,8 @@ use std::cell::Cell;
 
 use crate::errors::QlResult;
 use crate::fail;
-use crate::handle::{AsObservable, RelinkableHandle};
-use crate::patterns::observable::Observable;
+use crate::handle::RelinkableHandle;
+use crate::patterns::observable::{AsObservable, Observable};
 use crate::shared::shared;
 use crate::types::Real;
 


### PR DESCRIPTION
- **refactor(itofin): support unsized types in Handle and Link**
- **feat(quotes): add quotes module with simple quote support**
- **fix(observable): skip in-flight observers on re-entrant notification**
- **refactor(quotes): simplify SimpleQuote and share the Flag test helper**
- **feat(handle): forward pointee changes to handle observers**
- **fix(observable): re-deliver notifications missed by in-flight observers**
- **refactor(handle): delegate Link::new to link_to and home AsObservable with the observer pattern**
- **fix(observable): guarantee delivery of re-entrant notifications across observables**

close #155 