### PR TITLE
feat(#65): implement derived quotes

### DIFF
--- a/crates/itofin/src/handle.rs
+++ b/crates/itofin/src/handle.rs
@@ -13,21 +13,9 @@
 
 use crate::errors::QlResult;
 pub use crate::patterns::observable::AsObservable;
-use crate::patterns::observable::{Observable, Observer};
+use crate::patterns::observable::{Forwarder, Observable, Observer};
 use crate::require;
 use crate::shared::{Shared, SharedMut, shared_mut};
-
-/// Observer half of the link (QuantLib's `Link::update`): forwards every
-/// notification of the current pointee to the link's own observers.
-struct Forwarder {
-    observable: Shared<Observable>,
-}
-
-impl Observer for Forwarder {
-    fn update(&mut self) {
-        self.observable.notify_observers();
-    }
-}
 
 /// Inner shared cell of a [`Handle`]: the current pointee plus the link's own
 /// observable, through which relinks and pointee changes are broadcast.

--- a/crates/itofin/src/patterns/observable.rs
+++ b/crates/itofin/src/patterns/observable.rs
@@ -18,7 +18,7 @@
 
 use std::cell::{Cell, RefCell};
 
-use crate::shared::{SharedMut, WeakMut};
+use crate::shared::{Shared, SharedMut, WeakMut};
 
 thread_local! {
     /// Nesting depth of [`Observable::notify_observers`] across all
@@ -133,6 +133,22 @@ pub trait Observer {
 pub trait AsObservable {
     /// Access to the embedded observable for registering observers.
     fn observable(&self) -> &Observable;
+}
+
+/// Observer that forwards every notification to another observable (the
+/// C++ `update()` of `Link`, `DeltaVolQuote` and friends).
+///
+/// The forwarding target embeds this in front of its own [`Observable`]: the
+/// forwarder registers with the source and passes each notification on to the
+/// target's observers.
+pub(crate) struct Forwarder {
+    pub(crate) observable: Shared<Observable>,
+}
+
+impl Observer for Forwarder {
+    fn update(&mut self) {
+        self.observable.notify_observers();
+    }
 }
 
 /// Object that notifies its changes to a set of observers.

--- a/crates/itofin/src/quotes/compositequote.rs
+++ b/crates/itofin/src/quotes/compositequote.rs
@@ -11,7 +11,7 @@ use crate::ensure;
 use crate::errors::QlResult;
 use crate::handle::{AsObservable, Handle};
 use crate::patterns::observable::{Observable, Observer};
-use crate::shared::{Shared, SharedMut, shared, shared_mut};
+use crate::shared::{Shared, SharedMut};
 use crate::types::Real;
 
 use super::{Invalidator, Quote};
@@ -35,12 +35,7 @@ impl<F: Fn(Real, Real) -> Real> CompositeQuote<F> {
     /// registering with both handles like the C++ constructor's
     /// `registerWith` calls.
     pub fn new(element1: Handle<dyn Quote>, element2: Handle<dyn Quote>, f: F) -> Self {
-        let cache = shared(Cell::new(None));
-        let observable = shared(Observable::new());
-        let listener = shared_mut(Invalidator {
-            cache: Shared::clone(&cache),
-            observable: Shared::clone(&observable),
-        });
+        let (cache, observable, listener) = Invalidator::new();
         let observer = listener.clone() as SharedMut<dyn Observer>;
         element1.register_observer(&observer);
         element2.register_observer(&observer);
@@ -93,17 +88,7 @@ mod tests {
     use super::*;
     use crate::quotes::SimpleQuote;
     use crate::shared::shared;
-
-    #[derive(Default)]
-    struct Flag {
-        up: bool,
-    }
-
-    impl Observer for Flag {
-        fn update(&mut self) {
-            self.up = true;
-        }
-    }
+    use crate::test_support::{Flag, as_observer};
 
     /// Port of `testComposite` (test-suite/quotes.cpp): the composite value
     /// tracks `f(source1, source2)` across source changes for several
@@ -146,18 +131,18 @@ mod tests {
         assert_eq!(composite.value1().unwrap(), 1.0);
         assert_eq!(composite.value2().unwrap(), 2.0);
 
-        let flag = shared_mut(Flag::default());
+        let flag = Flag::new();
         composite
             .observable()
-            .register_observer(&(flag.clone() as SharedMut<dyn Observer>));
+            .register_observer(&as_observer(&flag));
 
         me1.set_value(10.0);
-        assert!(flag.borrow().up, "first source change must notify");
+        assert!(Flag::is_up(&flag), "first source change must notify");
         assert_eq!(composite.value().unwrap(), 12.0);
 
-        flag.borrow_mut().up = false;
+        Flag::lower(&flag);
         me2.set_value(20.0);
-        assert!(flag.borrow().up, "second source change must notify");
+        assert!(Flag::is_up(&flag), "second source change must notify");
         assert_eq!(composite.value().unwrap(), 30.0);
     }
 

--- a/crates/itofin/src/quotes/compositequote.rs
+++ b/crates/itofin/src/quotes/compositequote.rs
@@ -87,8 +87,79 @@ impl<F: Fn(Real, Real) -> Real> Quote for CompositeQuote<F> {
 mod tests {
     use super::*;
     use crate::quotes::SimpleQuote;
-    use crate::shared::shared;
+    use crate::shared::{shared, shared_mut};
     use crate::test_support::{Flag, as_observer};
+
+    type SumQuote = CompositeQuote<fn(Real, Real) -> Real>;
+
+    /// Recomputes and records the composite value at notification time.
+    struct Recomputer {
+        composite: Shared<SumQuote>,
+        seen: Option<Real>,
+    }
+
+    impl Observer for Recomputer {
+        fn update(&mut self) {
+            self.seen = self.composite.value().ok();
+        }
+    }
+
+    /// Writes a value into another source quote from inside `update`.
+    struct Rebalancer {
+        other: Shared<SimpleQuote>,
+        target: Real,
+    }
+
+    impl Observer for Rebalancer {
+        fn update(&mut self) {
+            self.other.set_value(self.target);
+        }
+    }
+
+    /// A composite observer writing into source B while source A's
+    /// notification is in flight must not leave the cache stale: the shared
+    /// invalidator receives B's cross-observable notification once the
+    /// in-flight round ends, so every observer converges on `f(new1, new2)`.
+    #[test]
+    fn cross_source_write_back_does_not_leave_the_cache_stale() {
+        let me1 = shared(SimpleQuote::new(1.0));
+        let me2 = shared(SimpleQuote::new(2.0));
+        let h1: Handle<dyn Quote> = Handle::new(me1.clone());
+        let h2: Handle<dyn Quote> = Handle::new(me2.clone());
+        let composite = shared(CompositeQuote::new(
+            h1,
+            h2,
+            (|x, y| x + y) as fn(Real, Real) -> Real,
+        ));
+
+        let recomputer = shared_mut(Recomputer {
+            composite: composite.clone(),
+            seen: None,
+        });
+        composite
+            .observable()
+            .register_observer(&(recomputer.clone() as SharedMut<dyn Observer>));
+        let rebalancer = shared_mut(Rebalancer {
+            other: me2.clone(),
+            target: 20.0,
+        });
+        composite
+            .observable()
+            .register_observer(&(rebalancer.clone() as SharedMut<dyn Observer>));
+
+        me1.set_value(10.0);
+
+        assert_eq!(
+            composite.value().unwrap(),
+            30.0,
+            "cache must reflect the written-back source, not the stale one"
+        );
+        assert_eq!(
+            recomputer.borrow().seen,
+            Some(30.0),
+            "composite observers must converge on the final value"
+        );
+    }
 
     /// Port of `testComposite` (test-suite/quotes.cpp): the composite value
     /// tracks `f(source1, source2)` across source changes for several

--- a/crates/itofin/src/quotes/compositequote.rs
+++ b/crates/itofin/src/quotes/compositequote.rs
@@ -1,0 +1,174 @@
+//! Market element whose value depends on two other market elements.
+//!
+//! Port of `ql/quotes/compositequote.hpp`. The C++ class template is generic
+//! over any binary function object; here the function is a
+//! `Fn(Real, Real) -> Real` type parameter. `makeCompositeQuote` exists only
+//! for C++ template-argument deduction and is not ported.
+
+use std::cell::Cell;
+
+use crate::ensure;
+use crate::errors::QlResult;
+use crate::handle::{AsObservable, Handle};
+use crate::patterns::observable::{Observable, Observer};
+use crate::shared::{Shared, SharedMut, shared, shared_mut};
+use crate::types::Real;
+
+use super::{Invalidator, Quote};
+
+/// Market element whose value depends on two other market elements.
+///
+/// Mirrors QuantLib's `CompositeQuote`: `f(source1, source2)` is computed
+/// lazily and cached; any notification from either source handle (a pointee
+/// change or a relink) drops the cache and reaches this quote's observers.
+pub struct CompositeQuote<F> {
+    element1: Handle<dyn Quote>,
+    element2: Handle<dyn Quote>,
+    cache: Shared<Cell<Option<Real>>>,
+    observable: Shared<Observable>,
+    f: F,
+    _listener: SharedMut<Invalidator>,
+}
+
+impl<F: Fn(Real, Real) -> Real> CompositeQuote<F> {
+    /// Creates a quote combining `element1` and `element2` through `f`,
+    /// registering with both handles like the C++ constructor's
+    /// `registerWith` calls.
+    pub fn new(element1: Handle<dyn Quote>, element2: Handle<dyn Quote>, f: F) -> Self {
+        let cache = shared(Cell::new(None));
+        let observable = shared(Observable::new());
+        let listener = shared_mut(Invalidator {
+            cache: Shared::clone(&cache),
+            observable: Shared::clone(&observable),
+        });
+        let observer = listener.clone() as SharedMut<dyn Observer>;
+        element1.register_observer(&observer);
+        element2.register_observer(&observer);
+        CompositeQuote {
+            element1,
+            element2,
+            cache,
+            observable,
+            f,
+            _listener: listener,
+        }
+    }
+
+    /// The current value of the first source quote.
+    pub fn value1(&self) -> QlResult<Real> {
+        self.element1.current_link()?.value()
+    }
+
+    /// The current value of the second source quote.
+    pub fn value2(&self) -> QlResult<Real> {
+        self.element2.current_link()?.value()
+    }
+}
+
+impl<F> AsObservable for CompositeQuote<F> {
+    fn observable(&self) -> &Observable {
+        &self.observable
+    }
+}
+
+impl<F: Fn(Real, Real) -> Real> Quote for CompositeQuote<F> {
+    fn value(&self) -> QlResult<Real> {
+        if let Some(cached) = self.cache.get() {
+            return Ok(cached);
+        }
+        ensure!(self.is_valid(), "invalid CompositeQuote");
+        let value = (self.f)(self.value1()?, self.value2()?);
+        self.cache.set(Some(value));
+        Ok(value)
+    }
+
+    fn is_valid(&self) -> bool {
+        self.element1.current_link().is_ok_and(|q| q.is_valid())
+            && self.element2.current_link().is_ok_and(|q| q.is_valid())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::quotes::SimpleQuote;
+    use crate::shared::shared;
+
+    #[derive(Default)]
+    struct Flag {
+        up: bool,
+    }
+
+    impl Observer for Flag {
+        fn update(&mut self) {
+            self.up = true;
+        }
+    }
+
+    /// Port of `testComposite` (test-suite/quotes.cpp): the composite value
+    /// tracks `f(source1, source2)` across source changes for several
+    /// functions.
+    #[test]
+    fn composite_quote_tracks_function_of_sources() {
+        let funcs: [fn(Real, Real) -> Real; 3] = [|x, y| x + y, |x, y| x * y, |x, y| x - y];
+        let values = [12.0, 23.0, 34.0];
+
+        let me1 = shared(SimpleQuote::default());
+        let me2 = shared(SimpleQuote::default());
+        let h1: Handle<dyn Quote> = Handle::new(me1.clone());
+        let h2: Handle<dyn Quote> = Handle::new(me2.clone());
+
+        for f in funcs {
+            let composite = CompositeQuote::new(h1.clone(), h2.clone(), f);
+            for value in values {
+                me1.set_value(value);
+                me2.set_value(value + 1.0);
+                let x = composite.value().unwrap();
+                let y = f(value, value + 1.0);
+                assert!(
+                    (x - y).abs() <= 1.0e-10,
+                    "composite quote yields {x}, function result is {y}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn either_source_change_notifies_observers_and_recomputes() {
+        let me1 = shared(SimpleQuote::new(1.0));
+        let me2 = shared(SimpleQuote::new(2.0));
+        let composite = CompositeQuote::new(
+            Handle::new(me1.clone()),
+            Handle::new(me2.clone()),
+            |x, y| x + y,
+        );
+        assert_eq!(composite.value().unwrap(), 3.0);
+        assert_eq!(composite.value1().unwrap(), 1.0);
+        assert_eq!(composite.value2().unwrap(), 2.0);
+
+        let flag = shared_mut(Flag::default());
+        composite
+            .observable()
+            .register_observer(&(flag.clone() as SharedMut<dyn Observer>));
+
+        me1.set_value(10.0);
+        assert!(flag.borrow().up, "first source change must notify");
+        assert_eq!(composite.value().unwrap(), 12.0);
+
+        flag.borrow_mut().up = false;
+        me2.set_value(20.0);
+        assert!(flag.borrow().up, "second source change must notify");
+        assert_eq!(composite.value().unwrap(), 30.0);
+    }
+
+    #[test]
+    fn composite_is_invalid_unless_both_sources_are_valid() {
+        let me1 = shared(SimpleQuote::new(1.0));
+        let composite = CompositeQuote::new(Handle::new(me1), Handle::empty(), |x, y| x + y);
+        assert!(!composite.is_valid());
+        assert_eq!(
+            composite.value().unwrap_err().message(),
+            "invalid CompositeQuote"
+        );
+    }
+}

--- a/crates/itofin/src/quotes/deltavolquote.rs
+++ b/crates/itofin/src/quotes/deltavolquote.rs
@@ -1,0 +1,222 @@
+//! Quote for the delta of an option and its volatility.
+//!
+//! Port of `ql/quotes/deltavolquote.hpp+cpp`. The C++ nested enums
+//! `DeltaVolQuote::DeltaType`/`AtmType` become module-level enums; the `Atm`
+//! prefix on the C++ `AtmType` values is a name-leakage artifact and is
+//! dropped (`DeltaVolQuote::AtmSpot` reads `AtmType::Spot` here).
+
+use crate::errors::QlResult;
+use crate::handle::{AsObservable, Handle};
+use crate::patterns::observable::{Observable, Observer};
+use crate::shared::{Shared, SharedMut, shared, shared_mut};
+use crate::types::{Real, Time};
+
+use super::Quote;
+
+/// Delta convention of a [`DeltaVolQuote`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum DeltaType {
+    /// Spot delta, e.g. the usual Black-Scholes delta.
+    Spot,
+    /// Forward delta.
+    Fwd,
+    /// Premium-adjusted spot delta.
+    PaSpot,
+    /// Premium-adjusted forward delta.
+    PaFwd,
+}
+
+/// At-the-money convention of a [`DeltaVolQuote`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum AtmType {
+    /// Default, if not an ATM quote.
+    Null,
+    /// K = S_0.
+    Spot,
+    /// K = F.
+    Fwd,
+    /// Call delta = put delta.
+    DeltaNeutral,
+    /// K such that vega is maximal.
+    VegaMax,
+    /// K such that gamma is maximal.
+    GammaMax,
+    /// K such that call delta = 0.50 (only for forward delta).
+    PutCall50,
+}
+
+/// Observer half of the quote (the C++ `update()`): passes every notification
+/// from the volatility handle on to the quote's own observers.
+struct Forwarder {
+    observable: Shared<Observable>,
+}
+
+impl Observer for Forwarder {
+    fn update(&mut self) {
+        self.observable.notify_observers();
+    }
+}
+
+/// Quote for the delta of an option and its volatility.
+///
+/// Mirrors QuantLib's `DeltaVolQuote`: a volatility quote tagged with the
+/// delta and maturity it belongs to, forwarding every notification of the
+/// underlying volatility handle.
+pub struct DeltaVolQuote {
+    delta: Option<Real>,
+    vol: Handle<dyn Quote>,
+    delta_type: DeltaType,
+    maturity: Time,
+    atm_type: AtmType,
+    observable: Shared<Observable>,
+    _listener: SharedMut<Forwarder>,
+}
+
+impl DeltaVolQuote {
+    /// Standard constructor: delta versus volatility.
+    pub fn new(delta: Real, vol: Handle<dyn Quote>, maturity: Time, delta_type: DeltaType) -> Self {
+        Self::build(Some(delta), vol, delta_type, maturity, AtmType::Null)
+    }
+
+    /// Additional constructor for a special ATM quote.
+    ///
+    /// The C++ constructor leaves `delta_` uninitialized here (reading it is
+    /// undefined behavior); the port stores `None` instead.
+    pub fn new_atm(
+        vol: Handle<dyn Quote>,
+        delta_type: DeltaType,
+        maturity: Time,
+        atm_type: AtmType,
+    ) -> Self {
+        Self::build(None, vol, delta_type, maturity, atm_type)
+    }
+
+    fn build(
+        delta: Option<Real>,
+        vol: Handle<dyn Quote>,
+        delta_type: DeltaType,
+        maturity: Time,
+        atm_type: AtmType,
+    ) -> Self {
+        let observable = shared(Observable::new());
+        let listener = shared_mut(Forwarder {
+            observable: Shared::clone(&observable),
+        });
+        vol.register_observer(&(listener.clone() as SharedMut<dyn Observer>));
+        DeltaVolQuote {
+            delta,
+            vol,
+            delta_type,
+            maturity,
+            atm_type,
+            observable,
+            _listener: listener,
+        }
+    }
+
+    /// The delta this volatility belongs to; `None` for the ATM constructor,
+    /// where C++ leaves it uninitialized.
+    pub fn delta(&self) -> Option<Real> {
+        self.delta
+    }
+
+    /// The maturity this volatility belongs to.
+    pub fn maturity(&self) -> Time {
+        self.maturity
+    }
+
+    /// The ATM convention of the quote.
+    pub fn atm_type(&self) -> AtmType {
+        self.atm_type
+    }
+
+    /// The delta convention of the quote.
+    pub fn delta_type(&self) -> DeltaType {
+        self.delta_type
+    }
+}
+
+impl AsObservable for DeltaVolQuote {
+    fn observable(&self) -> &Observable {
+        &self.observable
+    }
+}
+
+impl Quote for DeltaVolQuote {
+    fn value(&self) -> QlResult<Real> {
+        self.vol.current_link()?.value()
+    }
+
+    fn is_valid(&self) -> bool {
+        self.vol.current_link().is_ok_and(|q| q.is_valid())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::quotes::{SimpleQuote, make_quote_handle};
+    use crate::shared::shared;
+
+    #[derive(Default)]
+    struct Flag {
+        up: bool,
+    }
+
+    impl Observer for Flag {
+        fn update(&mut self) {
+            self.up = true;
+        }
+    }
+
+    #[test]
+    fn value_and_inspectors_mirror_the_construction() {
+        let vol = shared(SimpleQuote::new(0.2));
+        let quote = DeltaVolQuote::new(0.25, Handle::new(vol), 1.5, DeltaType::Spot);
+
+        assert!(quote.is_valid());
+        assert_eq!(quote.value().unwrap(), 0.2);
+        assert_eq!(quote.delta(), Some(0.25));
+        assert_eq!(quote.maturity(), 1.5);
+        assert_eq!(quote.delta_type(), DeltaType::Spot);
+        assert_eq!(quote.atm_type(), AtmType::Null);
+    }
+
+    #[test]
+    fn atm_constructor_has_no_delta() {
+        let vol = shared(SimpleQuote::new(0.1));
+        let quote = DeltaVolQuote::new_atm(Handle::new(vol), DeltaType::Fwd, 0.5, AtmType::Spot);
+
+        assert_eq!(quote.delta(), None);
+        assert_eq!(quote.atm_type(), AtmType::Spot);
+        assert_eq!(quote.delta_type(), DeltaType::Fwd);
+    }
+
+    #[test]
+    fn vol_change_and_relink_notify_observers() {
+        let rh = make_quote_handle(0.2);
+        let quote = DeltaVolQuote::new(0.25, rh.handle(), 1.0, DeltaType::PaSpot);
+
+        let flag = shared_mut(Flag::default());
+        quote
+            .observable()
+            .register_observer(&(flag.clone() as SharedMut<dyn Observer>));
+
+        let vol = shared(SimpleQuote::new(0.3));
+        rh.link_to(vol.clone());
+        assert!(flag.borrow().up, "relink must reach quote observers");
+        assert_eq!(quote.value().unwrap(), 0.3);
+
+        flag.borrow_mut().up = false;
+        vol.set_value(0.4);
+        assert!(flag.borrow().up, "vol change must reach quote observers");
+        assert_eq!(quote.value().unwrap(), 0.4);
+    }
+
+    #[test]
+    fn empty_or_invalid_vol_is_invalid() {
+        let quote = DeltaVolQuote::new(0.25, Handle::empty(), 1.0, DeltaType::Spot);
+        assert!(!quote.is_valid());
+        assert!(quote.value().is_err());
+    }
+}

--- a/crates/itofin/src/quotes/deltavolquote.rs
+++ b/crates/itofin/src/quotes/deltavolquote.rs
@@ -7,7 +7,7 @@
 
 use crate::errors::QlResult;
 use crate::handle::{AsObservable, Handle};
-use crate::patterns::observable::{Observable, Observer};
+use crate::patterns::observable::{Forwarder, Observable, Observer};
 use crate::shared::{Shared, SharedMut, shared, shared_mut};
 use crate::types::{Real, Time};
 
@@ -43,18 +43,6 @@ pub enum AtmType {
     GammaMax,
     /// K such that call delta = 0.50 (only for forward delta).
     PutCall50,
-}
-
-/// Observer half of the quote (the C++ `update()`): passes every notification
-/// from the volatility handle on to the quote's own observers.
-struct Forwarder {
-    observable: Shared<Observable>,
-}
-
-impl Observer for Forwarder {
-    fn update(&mut self) {
-        self.observable.notify_observers();
-    }
 }
 
 /// Quote for the delta of an option and its volatility.
@@ -157,17 +145,7 @@ mod tests {
     use super::*;
     use crate::quotes::{SimpleQuote, make_quote_handle};
     use crate::shared::shared;
-
-    #[derive(Default)]
-    struct Flag {
-        up: bool,
-    }
-
-    impl Observer for Flag {
-        fn update(&mut self) {
-            self.up = true;
-        }
-    }
+    use crate::test_support::{Flag, as_observer};
 
     #[test]
     fn value_and_inspectors_mirror_the_construction() {
@@ -197,19 +175,17 @@ mod tests {
         let rh = make_quote_handle(0.2);
         let quote = DeltaVolQuote::new(0.25, rh.handle(), 1.0, DeltaType::PaSpot);
 
-        let flag = shared_mut(Flag::default());
-        quote
-            .observable()
-            .register_observer(&(flag.clone() as SharedMut<dyn Observer>));
+        let flag = Flag::new();
+        quote.observable().register_observer(&as_observer(&flag));
 
         let vol = shared(SimpleQuote::new(0.3));
         rh.link_to(vol.clone());
-        assert!(flag.borrow().up, "relink must reach quote observers");
+        assert!(Flag::is_up(&flag), "relink must reach quote observers");
         assert_eq!(quote.value().unwrap(), 0.3);
 
-        flag.borrow_mut().up = false;
+        Flag::lower(&flag);
         vol.set_value(0.4);
-        assert!(flag.borrow().up, "vol change must reach quote observers");
+        assert!(Flag::is_up(&flag), "vol change must reach quote observers");
         assert_eq!(quote.value().unwrap(), 0.4);
     }
 

--- a/crates/itofin/src/quotes/derivedquote.rs
+++ b/crates/itofin/src/quotes/derivedquote.rs
@@ -1,0 +1,161 @@
+//! Market quote whose value depends on another quote.
+//!
+//! Port of `ql/quotes/derivedquote.hpp`. The C++ class template is generic
+//! over any unary function object; here the function is a `Fn(Real) -> Real`
+//! type parameter. `makeDerivedQuote` exists only for C++ template-argument
+//! deduction and is not ported.
+
+use std::cell::Cell;
+
+use crate::ensure;
+use crate::errors::QlResult;
+use crate::handle::{AsObservable, Handle};
+use crate::patterns::observable::{Observable, Observer};
+use crate::shared::{Shared, SharedMut, shared, shared_mut};
+use crate::types::Real;
+
+use super::{Invalidator, Quote};
+
+/// Market quote whose value depends on another quote.
+///
+/// Mirrors QuantLib's `DerivedQuote`: `f(source)` is computed lazily and
+/// cached; any notification from the source handle (a pointee change or a
+/// relink) drops the cache and reaches this quote's observers.
+pub struct DerivedQuote<F> {
+    element: Handle<dyn Quote>,
+    cache: Shared<Cell<Option<Real>>>,
+    observable: Shared<Observable>,
+    f: F,
+    _listener: SharedMut<Invalidator>,
+}
+
+impl<F: Fn(Real) -> Real> DerivedQuote<F> {
+    /// Creates a quote deriving its value from `element` through `f`,
+    /// registering with the handle like the C++ constructor's `registerWith`.
+    pub fn new(element: Handle<dyn Quote>, f: F) -> Self {
+        let cache = shared(Cell::new(None));
+        let observable = shared(Observable::new());
+        let listener = shared_mut(Invalidator {
+            cache: Shared::clone(&cache),
+            observable: Shared::clone(&observable),
+        });
+        element.register_observer(&(listener.clone() as SharedMut<dyn Observer>));
+        DerivedQuote {
+            element,
+            cache,
+            observable,
+            f,
+            _listener: listener,
+        }
+    }
+}
+
+impl<F> AsObservable for DerivedQuote<F> {
+    fn observable(&self) -> &Observable {
+        &self.observable
+    }
+}
+
+impl<F: Fn(Real) -> Real> Quote for DerivedQuote<F> {
+    fn value(&self) -> QlResult<Real> {
+        if let Some(cached) = self.cache.get() {
+            return Ok(cached);
+        }
+        ensure!(self.is_valid(), "invalid DerivedQuote");
+        let value = (self.f)(self.element.current_link()?.value()?);
+        self.cache.set(Some(value));
+        Ok(value)
+    }
+
+    fn is_valid(&self) -> bool {
+        self.element.current_link().is_ok_and(|q| q.is_valid())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::quotes::SimpleQuote;
+    use crate::shared::shared;
+
+    #[derive(Default)]
+    struct Flag {
+        up: bool,
+    }
+
+    impl Observer for Flag {
+        fn update(&mut self) {
+            self.up = true;
+        }
+    }
+
+    /// Port of `testDerived` (test-suite/quotes.cpp): the derived value tracks
+    /// `f(source)` across source changes for several functions.
+    #[test]
+    fn derived_quote_tracks_function_of_source() {
+        let funcs: [fn(Real) -> Real; 3] = [|x| x + 10.0, |x| x * 10.0, |x| x - 10.0];
+        let values = [12.0, 23.0, 34.0];
+
+        let me = shared(SimpleQuote::default());
+        let h: Handle<dyn Quote> = Handle::new(me.clone());
+
+        for f in funcs {
+            let derived = DerivedQuote::new(h.clone(), f);
+            for value in values {
+                me.set_value(value);
+                let x = derived.value().unwrap();
+                let y = f(value);
+                assert!(
+                    (x - y).abs() <= 1.0e-10,
+                    "derived quote yields {x}, function result is {y}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn source_change_notifies_observers_and_recomputes() {
+        let me = shared(SimpleQuote::new(1.0));
+        let derived = DerivedQuote::new(Handle::new(me.clone()), |x| 2.0 * x);
+        assert_eq!(derived.value().unwrap(), 2.0);
+
+        let flag = shared_mut(Flag::default());
+        derived
+            .observable()
+            .register_observer(&(flag.clone() as SharedMut<dyn Observer>));
+
+        me.set_value(3.0);
+
+        assert!(flag.borrow().up, "source change must reach quote observers");
+        assert_eq!(derived.value().unwrap(), 6.0);
+    }
+
+    #[test]
+    fn relink_notifies_observers_and_recomputes() {
+        let rh = crate::quotes::make_quote_handle(1.0);
+        let derived = DerivedQuote::new(rh.handle(), |x| x + 1.0);
+        assert_eq!(derived.value().unwrap(), 2.0);
+
+        let flag = shared_mut(Flag::default());
+        derived
+            .observable()
+            .register_observer(&(flag.clone() as SharedMut<dyn Observer>));
+
+        rh.link_to(shared(SimpleQuote::new(5.0)));
+
+        assert!(flag.borrow().up, "relink must reach quote observers");
+        assert_eq!(derived.value().unwrap(), 6.0);
+    }
+
+    #[test]
+    fn empty_or_invalid_source_is_invalid() {
+        let empty = DerivedQuote::new(Handle::empty(), |x| x);
+        assert!(!empty.is_valid());
+        assert_eq!(empty.value().unwrap_err().message(), "invalid DerivedQuote");
+
+        let me = shared(SimpleQuote::default());
+        let derived = DerivedQuote::new(Handle::new(me), |x| x);
+        assert!(!derived.is_valid());
+        assert!(derived.value().is_err());
+    }
+}

--- a/crates/itofin/src/quotes/derivedquote.rs
+++ b/crates/itofin/src/quotes/derivedquote.rs
@@ -11,7 +11,7 @@ use crate::ensure;
 use crate::errors::QlResult;
 use crate::handle::{AsObservable, Handle};
 use crate::patterns::observable::{Observable, Observer};
-use crate::shared::{Shared, SharedMut, shared, shared_mut};
+use crate::shared::{Shared, SharedMut};
 use crate::types::Real;
 
 use super::{Invalidator, Quote};
@@ -33,12 +33,7 @@ impl<F: Fn(Real) -> Real> DerivedQuote<F> {
     /// Creates a quote deriving its value from `element` through `f`,
     /// registering with the handle like the C++ constructor's `registerWith`.
     pub fn new(element: Handle<dyn Quote>, f: F) -> Self {
-        let cache = shared(Cell::new(None));
-        let observable = shared(Observable::new());
-        let listener = shared_mut(Invalidator {
-            cache: Shared::clone(&cache),
-            observable: Shared::clone(&observable),
-        });
+        let (cache, observable, listener) = Invalidator::new();
         element.register_observer(&(listener.clone() as SharedMut<dyn Observer>));
         DerivedQuote {
             element,
@@ -77,17 +72,7 @@ mod tests {
     use super::*;
     use crate::quotes::SimpleQuote;
     use crate::shared::shared;
-
-    #[derive(Default)]
-    struct Flag {
-        up: bool,
-    }
-
-    impl Observer for Flag {
-        fn update(&mut self) {
-            self.up = true;
-        }
-    }
+    use crate::test_support::{Flag, as_observer};
 
     /// Port of `testDerived` (test-suite/quotes.cpp): the derived value tracks
     /// `f(source)` across source changes for several functions.
@@ -119,14 +104,15 @@ mod tests {
         let derived = DerivedQuote::new(Handle::new(me.clone()), |x| 2.0 * x);
         assert_eq!(derived.value().unwrap(), 2.0);
 
-        let flag = shared_mut(Flag::default());
-        derived
-            .observable()
-            .register_observer(&(flag.clone() as SharedMut<dyn Observer>));
+        let flag = Flag::new();
+        derived.observable().register_observer(&as_observer(&flag));
 
         me.set_value(3.0);
 
-        assert!(flag.borrow().up, "source change must reach quote observers");
+        assert!(
+            Flag::is_up(&flag),
+            "source change must reach quote observers"
+        );
         assert_eq!(derived.value().unwrap(), 6.0);
     }
 
@@ -136,14 +122,12 @@ mod tests {
         let derived = DerivedQuote::new(rh.handle(), |x| x + 1.0);
         assert_eq!(derived.value().unwrap(), 2.0);
 
-        let flag = shared_mut(Flag::default());
-        derived
-            .observable()
-            .register_observer(&(flag.clone() as SharedMut<dyn Observer>));
+        let flag = Flag::new();
+        derived.observable().register_observer(&as_observer(&flag));
 
         rh.link_to(shared(SimpleQuote::new(5.0)));
 
-        assert!(flag.borrow().up, "relink must reach quote observers");
+        assert!(Flag::is_up(&flag), "relink must reach quote observers");
         assert_eq!(derived.value().unwrap(), 6.0);
     }
 

--- a/crates/itofin/src/quotes/mod.rs
+++ b/crates/itofin/src/quotes/mod.rs
@@ -11,12 +11,17 @@
 //! C++ term-structure constructors) has no caller in the core yet and is not
 //! ported.
 
+mod derivedquote;
 mod simplequote;
 
+pub use derivedquote::DerivedQuote;
 pub use simplequote::{SimpleQuote, make_quote_handle};
 
+use std::cell::Cell;
+
 use crate::errors::QlResult;
-use crate::patterns::observable::AsObservable;
+use crate::patterns::observable::{AsObservable, Observable, Observer};
+use crate::shared::Shared;
 use crate::types::Real;
 
 /// Purely virtual base class for market observables.
@@ -31,4 +36,22 @@ pub trait Quote: AsObservable {
 
     /// Whether the quote holds a valid value.
     fn is_valid(&self) -> bool;
+}
+
+/// Observer half of a derived quote (the C++ `update()` of `DerivedQuote` and
+/// friends): drops the cached value and passes the notification on to the
+/// quote's own observers.
+///
+/// Derived quotes register one of these with their source handle(s) and hold
+/// the strong reference; the observer registry keeps only a weak one.
+struct Invalidator {
+    cache: Shared<Cell<Option<Real>>>,
+    observable: Shared<Observable>,
+}
+
+impl Observer for Invalidator {
+    fn update(&mut self) {
+        self.cache.set(None);
+        self.observable.notify_observers();
+    }
 }

--- a/crates/itofin/src/quotes/mod.rs
+++ b/crates/itofin/src/quotes/mod.rs
@@ -33,7 +33,7 @@ use std::cell::Cell;
 
 use crate::errors::QlResult;
 use crate::patterns::observable::{AsObservable, Observable, Observer};
-use crate::shared::Shared;
+use crate::shared::{Shared, SharedMut, shared, shared_mut};
 use crate::types::Real;
 
 /// Purely virtual base class for market observables.
@@ -59,6 +59,25 @@ pub trait Quote: AsObservable {
 struct Invalidator {
     cache: Shared<Cell<Option<Real>>>,
     observable: Shared<Observable>,
+}
+
+impl Invalidator {
+    /// Builds the empty cache, the quote's observable and the invalidating
+    /// listener wired to both - the shared construction step of every derived
+    /// quote.
+    fn new() -> (
+        Shared<Cell<Option<Real>>>,
+        Shared<Observable>,
+        SharedMut<Invalidator>,
+    ) {
+        let cache = shared(Cell::new(None));
+        let observable = shared(Observable::new());
+        let listener = shared_mut(Invalidator {
+            cache: Shared::clone(&cache),
+            observable: Shared::clone(&observable),
+        });
+        (cache, observable, listener)
+    }
 }
 
 impl Observer for Invalidator {

--- a/crates/itofin/src/quotes/mod.rs
+++ b/crates/itofin/src/quotes/mod.rs
@@ -13,10 +13,12 @@
 
 mod compositequote;
 mod derivedquote;
+mod multicompositequote;
 mod simplequote;
 
 pub use compositequote::CompositeQuote;
 pub use derivedquote::DerivedQuote;
+pub use multicompositequote::MultiCompositeQuote;
 pub use simplequote::{SimpleQuote, make_quote_handle};
 
 use std::cell::Cell;

--- a/crates/itofin/src/quotes/mod.rs
+++ b/crates/itofin/src/quotes/mod.rs
@@ -11,9 +11,11 @@
 //! C++ term-structure constructors) has no caller in the core yet and is not
 //! ported.
 
+mod compositequote;
 mod derivedquote;
 mod simplequote;
 
+pub use compositequote::CompositeQuote;
 pub use derivedquote::DerivedQuote;
 pub use simplequote::{SimpleQuote, make_quote_handle};
 

--- a/crates/itofin/src/quotes/mod.rs
+++ b/crates/itofin/src/quotes/mod.rs
@@ -10,13 +10,21 @@
 //! `handleFromVariant` (a `std::variant<Real, Handle<Quote>>` convenience for
 //! C++ term-structure constructors) has no caller in the core yet and is not
 //! ported.
+//!
+//! The remaining `ql/quotes/` classes depend on layers not yet ported and
+//! follow with them: `ForwardValueQuote` and `LastFixingQuote` (Index),
+//! `ForwardSwapQuote` (SwapIndex/VanillaSwap), `FuturesConvAdjustmentQuote`
+//! (IborIndex), `ImpliedStdDevQuote` and
+//! `EurodollarFuturesImpliedStdDevQuote` (`blackFormulaImpliedStdDev`).
 
 mod compositequote;
+mod deltavolquote;
 mod derivedquote;
 mod multicompositequote;
 mod simplequote;
 
 pub use compositequote::CompositeQuote;
+pub use deltavolquote::{AtmType, DeltaType, DeltaVolQuote};
 pub use derivedquote::DerivedQuote;
 pub use multicompositequote::MultiCompositeQuote;
 pub use simplequote::{SimpleQuote, make_quote_handle};

--- a/crates/itofin/src/quotes/multicompositequote.rs
+++ b/crates/itofin/src/quotes/multicompositequote.rs
@@ -1,0 +1,182 @@
+//! Market element whose value depends on any number of other market elements.
+//!
+//! Port of `ql/quotes/multicompositequote.hpp`. The C++ class template is
+//! generic over any function object taking an `Array`; here the function is a
+//! `Fn(&Array) -> Real` type parameter, borrowing the argument array instead
+//! of consuming it.
+
+use std::cell::Cell;
+
+use crate::ensure;
+use crate::errors::QlResult;
+use crate::handle::{AsObservable, Handle};
+use crate::math::array::Array;
+use crate::patterns::observable::{Observable, Observer};
+use crate::require;
+use crate::shared::{Shared, SharedMut, shared, shared_mut};
+use crate::types::{Real, Size};
+
+use super::{Invalidator, Quote};
+
+/// Market element whose value depends on any number of other market elements.
+///
+/// Mirrors QuantLib's `MultiCompositeQuote`: `f(sources)` is computed lazily
+/// and cached; any notification from any source handle (a pointee change or a
+/// relink) drops the cache and reaches this quote's observers.
+pub struct MultiCompositeQuote<F> {
+    elements: Vec<Handle<dyn Quote>>,
+    cache: Shared<Cell<Option<Real>>>,
+    observable: Shared<Observable>,
+    f: F,
+    _listener: SharedMut<Invalidator>,
+}
+
+impl<F: Fn(&Array) -> Real> MultiCompositeQuote<F> {
+    /// Creates a quote combining `elements` through `f`, registering with
+    /// every handle like the C++ constructor's `registerWith` loop.
+    pub fn new(elements: Vec<Handle<dyn Quote>>, f: F) -> Self {
+        let cache = shared(Cell::new(None));
+        let observable = shared(Observable::new());
+        let listener = shared_mut(Invalidator {
+            cache: Shared::clone(&cache),
+            observable: Shared::clone(&observable),
+        });
+        let observer = listener.clone() as SharedMut<dyn Observer>;
+        for element in &elements {
+            element.register_observer(&observer);
+        }
+        MultiCompositeQuote {
+            elements,
+            cache,
+            observable,
+            f,
+            _listener: listener,
+        }
+    }
+
+    /// The current value of the `i`-th source quote.
+    ///
+    /// Mirrors the C++ `inputValue`, whose `at(i)` throws on an out-of-range
+    /// index.
+    pub fn input_value(&self, i: Size) -> QlResult<Real> {
+        require!(
+            i < self.elements.len(),
+            "index {i} out of range for {} quotes",
+            self.elements.len()
+        );
+        self.elements[i].current_link()?.value()
+    }
+}
+
+impl<F> AsObservable for MultiCompositeQuote<F> {
+    fn observable(&self) -> &Observable {
+        &self.observable
+    }
+}
+
+impl<F: Fn(&Array) -> Real> Quote for MultiCompositeQuote<F> {
+    fn value(&self) -> QlResult<Real> {
+        if let Some(cached) = self.cache.get() {
+            return Ok(cached);
+        }
+        ensure!(self.is_valid(), "invalid MultiCompositeQuote");
+        let args = self
+            .elements
+            .iter()
+            .map(|element| element.current_link()?.value())
+            .collect::<QlResult<Array>>()?;
+        let value = (self.f)(&args);
+        self.cache.set(Some(value));
+        Ok(value)
+    }
+
+    fn is_valid(&self) -> bool {
+        self.elements
+            .iter()
+            .all(|element| element.current_link().is_ok_and(|q| q.is_valid()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::quotes::SimpleQuote;
+    use crate::shared::shared;
+
+    #[derive(Default)]
+    struct Flag {
+        up: bool,
+    }
+
+    impl Observer for Flag {
+        fn update(&mut self) {
+            self.up = true;
+        }
+    }
+
+    /// Port of `testMultiComposite` (test-suite/quotes.cpp): the composite
+    /// value tracks `f(sources)` for growing source sets and several array
+    /// functions, and `input_value` mirrors each source.
+    #[test]
+    fn multi_composite_quote_tracks_function_of_sources() {
+        let funcs: [fn(&Array) -> Real; 3] =
+            [|a| a.iter().sum(), |a| a.iter().product(), |a| a.norm2()];
+
+        for f in funcs {
+            let mut mes: Vec<Shared<SimpleQuote>> = Vec::new();
+            let mut handles: Vec<Handle<dyn Quote>> = Vec::new();
+            for i in 0..3usize {
+                mes.push(shared(SimpleQuote::new((i + 1) as Real)));
+                handles.push(Handle::new(mes[i].clone()));
+                let composite = MultiCompositeQuote::new(handles.clone(), f);
+                for j in 0..=i {
+                    mes[j].set_value((j * 10 + 1) as Real);
+                    let args: Array = mes.iter().map(|me| me.value().unwrap()).collect();
+                    let x = composite.value().unwrap();
+                    let y = f(&args);
+                    assert!(
+                        (x - y).abs() <= 1.0e-10,
+                        "composite quote yields {x}, function result is {y}"
+                    );
+                    for k in 0..mes.len() {
+                        assert_eq!(composite.input_value(k).unwrap(), mes[k].value().unwrap());
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn any_source_change_notifies_observers_and_recomputes() {
+        let me1 = shared(SimpleQuote::new(1.0));
+        let me2 = shared(SimpleQuote::new(2.0));
+        let me3 = shared(SimpleQuote::new(3.0));
+        let handles: Vec<Handle<dyn Quote>> =
+            vec![Handle::new(me1), Handle::new(me2), Handle::new(me3.clone())];
+        let composite = MultiCompositeQuote::new(handles, |a| a.iter().sum());
+        assert_eq!(composite.value().unwrap(), 6.0);
+
+        let flag = shared_mut(Flag::default());
+        composite
+            .observable()
+            .register_observer(&(flag.clone() as SharedMut<dyn Observer>));
+
+        me3.set_value(30.0);
+
+        assert!(flag.borrow().up, "any source change must notify");
+        assert_eq!(composite.value().unwrap(), 33.0);
+    }
+
+    #[test]
+    fn invalid_source_and_bad_index_error() {
+        let me1 = shared(SimpleQuote::new(1.0));
+        let handles: Vec<Handle<dyn Quote>> = vec![Handle::new(me1), Handle::empty()];
+        let composite = MultiCompositeQuote::new(handles, |a| a.iter().sum());
+        assert!(!composite.is_valid());
+        assert_eq!(
+            composite.value().unwrap_err().message(),
+            "invalid MultiCompositeQuote"
+        );
+        assert!(composite.input_value(2).is_err());
+    }
+}

--- a/crates/itofin/src/quotes/multicompositequote.rs
+++ b/crates/itofin/src/quotes/multicompositequote.rs
@@ -138,8 +138,8 @@ mod tests {
                         (x - y).abs() <= 1.0e-10,
                         "composite quote yields {x}, function result is {y}"
                     );
-                    for k in 0..mes.len() {
-                        assert_eq!(composite.input_value(k).unwrap(), mes[k].value().unwrap());
+                    for (k, me) in mes.iter().enumerate() {
+                        assert_eq!(composite.input_value(k).unwrap(), me.value().unwrap());
                     }
                 }
             }

--- a/crates/itofin/src/quotes/multicompositequote.rs
+++ b/crates/itofin/src/quotes/multicompositequote.rs
@@ -96,7 +96,7 @@ impl<F: Fn(&Array) -> Real> Quote for MultiCompositeQuote<F> {
 mod tests {
     use super::*;
     use crate::quotes::SimpleQuote;
-    use crate::shared::shared;
+    use crate::shared::{shared, shared_mut};
     use crate::test_support::{Flag, as_observer};
 
     /// Port of `testMultiComposite` (test-suite/quotes.cpp): the composite
@@ -150,6 +150,75 @@ mod tests {
 
         assert!(Flag::is_up(&flag), "any source change must notify");
         assert_eq!(composite.value().unwrap(), 33.0);
+    }
+
+    type SumMultiQuote = MultiCompositeQuote<fn(&Array) -> Real>;
+
+    /// Recomputes and records the composite value at notification time.
+    struct Recomputer {
+        composite: Shared<SumMultiQuote>,
+        seen: Option<Real>,
+    }
+
+    impl Observer for Recomputer {
+        fn update(&mut self) {
+            self.seen = self.composite.value().ok();
+        }
+    }
+
+    /// Writes a value into another source quote from inside `update`.
+    struct Rebalancer {
+        other: Shared<SimpleQuote>,
+        target: Real,
+    }
+
+    impl Observer for Rebalancer {
+        fn update(&mut self) {
+            self.other.set_value(self.target);
+        }
+    }
+
+    /// Same cross-source write-back convergence guarantee as CompositeQuote:
+    /// a notification from source B while the shared invalidator is in flight
+    /// on source A must still drop the cache and re-notify.
+    #[test]
+    fn cross_source_write_back_does_not_leave_the_cache_stale() {
+        let me1 = shared(SimpleQuote::new(1.0));
+        let me2 = shared(SimpleQuote::new(2.0));
+        let handles: Vec<Handle<dyn Quote>> =
+            vec![Handle::new(me1.clone()), Handle::new(me2.clone())];
+        let composite = shared(MultiCompositeQuote::new(
+            handles,
+            (|a: &Array| a.iter().sum()) as fn(&Array) -> Real,
+        ));
+
+        let recomputer = shared_mut(Recomputer {
+            composite: composite.clone(),
+            seen: None,
+        });
+        composite
+            .observable()
+            .register_observer(&(recomputer.clone() as SharedMut<dyn Observer>));
+        let rebalancer = shared_mut(Rebalancer {
+            other: me2.clone(),
+            target: 20.0,
+        });
+        composite
+            .observable()
+            .register_observer(&(rebalancer.clone() as SharedMut<dyn Observer>));
+
+        me1.set_value(10.0);
+
+        assert_eq!(
+            composite.value().unwrap(),
+            30.0,
+            "cache must reflect the written-back source, not the stale one"
+        );
+        assert_eq!(
+            recomputer.borrow().seen,
+            Some(30.0),
+            "composite observers must converge on the final value"
+        );
     }
 
     #[test]

--- a/crates/itofin/src/quotes/multicompositequote.rs
+++ b/crates/itofin/src/quotes/multicompositequote.rs
@@ -13,7 +13,7 @@ use crate::handle::{AsObservable, Handle};
 use crate::math::array::Array;
 use crate::patterns::observable::{Observable, Observer};
 use crate::require;
-use crate::shared::{Shared, SharedMut, shared, shared_mut};
+use crate::shared::{Shared, SharedMut};
 use crate::types::{Real, Size};
 
 use super::{Invalidator, Quote};
@@ -35,12 +35,7 @@ impl<F: Fn(&Array) -> Real> MultiCompositeQuote<F> {
     /// Creates a quote combining `elements` through `f`, registering with
     /// every handle like the C++ constructor's `registerWith` loop.
     pub fn new(elements: Vec<Handle<dyn Quote>>, f: F) -> Self {
-        let cache = shared(Cell::new(None));
-        let observable = shared(Observable::new());
-        let listener = shared_mut(Invalidator {
-            cache: Shared::clone(&cache),
-            observable: Shared::clone(&observable),
-        });
+        let (cache, observable, listener) = Invalidator::new();
         let observer = listener.clone() as SharedMut<dyn Observer>;
         for element in &elements {
             element.register_observer(&observer);
@@ -102,17 +97,7 @@ mod tests {
     use super::*;
     use crate::quotes::SimpleQuote;
     use crate::shared::shared;
-
-    #[derive(Default)]
-    struct Flag {
-        up: bool,
-    }
-
-    impl Observer for Flag {
-        fn update(&mut self) {
-            self.up = true;
-        }
-    }
+    use crate::test_support::{Flag, as_observer};
 
     /// Port of `testMultiComposite` (test-suite/quotes.cpp): the composite
     /// value tracks `f(sources)` for growing source sets and several array
@@ -156,14 +141,14 @@ mod tests {
         let composite = MultiCompositeQuote::new(handles, |a| a.iter().sum());
         assert_eq!(composite.value().unwrap(), 6.0);
 
-        let flag = shared_mut(Flag::default());
+        let flag = Flag::new();
         composite
             .observable()
-            .register_observer(&(flag.clone() as SharedMut<dyn Observer>));
+            .register_observer(&as_observer(&flag));
 
         me3.set_value(30.0);
 
-        assert!(flag.borrow().up, "any source change must notify");
+        assert!(Flag::is_up(&flag), "any source change must notify");
         assert_eq!(composite.value().unwrap(), 33.0);
     }
 


### PR DESCRIPTION
- **refactor(itofin): support unsized types in Handle and Link**
- **feat(quotes): add quotes module with simple quote support**
- **fix(observable): skip in-flight observers on re-entrant notification**
- **refactor(quotes): simplify SimpleQuote and share the Flag test helper**
- **feat(handle): forward pointee changes to handle observers**
- **fix(observable): re-deliver notifications missed by in-flight observers**
- **refactor(handle): delegate Link::new to link_to and home AsObservable with the observer pattern**
- **fix(observable): guarantee delivery of re-entrant notifications across observables**
- **feat(quotes): add DerivedQuote with cache-invalidating observer**
- **feat(quotes): add CompositeQuote implementation**
- **feat(quotes): add MultiCompositeQuote implementation**
- **feat(quotes): add DeltaVolQuote for delta-based vol quoting**
- **refactor(quotes): dedupe forwarder, invalidator wiring and test flags**
- **test(quotes): lock cross-source write-back convergence for composite quotes**

close #65 
