### PR TITLE
feat(#208): port payoffs and exercise

### DIFF
--- a/crates/itofin/src/exercise.rs
+++ b/crates/itofin/src/exercise.rs
@@ -1,0 +1,86 @@
+//! Option exercise classes.
+//!
+//! Port of the European subset of `ql/exercise.{hpp,cpp}`: the [`Exercise`]
+//! trait is the base exercise contract and [`EuropeanExercise`] its
+//! single-date implementation. `EarlyExercise`, `AmericanExercise` and
+//! `BermudanExercise` are follow-up work.
+
+use crate::time::date::Date;
+
+/// Exercise style of an option (QuantLib's `Exercise::Type`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ExerciseType {
+    /// Exercisable at any time between two predefined dates.
+    American,
+    /// Exercisable only at a set of fixed dates.
+    Bermudan,
+    /// Exercisable only at one (expiry) date.
+    European,
+}
+
+/// Base exercise contract.
+///
+/// Implementors guarantee at least one exercise date (their constructors
+/// enforce it), so [`last_date`](Exercise::last_date) is infallible where
+/// QuantLib's `lastDate()` throws on an empty date vector.
+pub trait Exercise {
+    /// The exercise style.
+    fn exercise_type(&self) -> ExerciseType;
+
+    /// All exercise dates, in ascending order.
+    fn dates(&self) -> &[Date];
+
+    /// The last exercise date.
+    fn last_date(&self) -> Date {
+        *self
+            .dates()
+            .last()
+            .expect("no exercise date given (implementors guarantee at least one)")
+    }
+}
+
+/// European exercise: the option can only be exercised at one (expiry) date.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct EuropeanExercise {
+    dates: [Date; 1],
+}
+
+impl EuropeanExercise {
+    /// Builds a European exercise at the given expiry date.
+    pub fn new(date: Date) -> EuropeanExercise {
+        EuropeanExercise { dates: [date] }
+    }
+}
+
+impl Exercise for EuropeanExercise {
+    fn exercise_type(&self) -> ExerciseType {
+        ExerciseType::European
+    }
+
+    fn dates(&self) -> &[Date] {
+        &self.dates
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::time::date::Month;
+
+    #[test]
+    fn european_exercise_holds_the_single_expiry() {
+        let expiry = Date::new(17, Month::May, 2027);
+        let exercise = EuropeanExercise::new(expiry);
+        assert_eq!(exercise.exercise_type(), ExerciseType::European);
+        assert_eq!(exercise.dates(), &[expiry]);
+        assert_eq!(exercise.last_date(), expiry);
+    }
+
+    #[test]
+    fn usable_as_trait_object() {
+        let expiry = Date::new(31, Month::December, 2030);
+        let exercise: &dyn Exercise = &EuropeanExercise::new(expiry);
+        assert_eq!(exercise.last_date(), expiry);
+        assert_eq!(exercise.dates().len(), 1);
+    }
+}

--- a/crates/itofin/src/instruments/mod.rs
+++ b/crates/itofin/src/instruments/mod.rs
@@ -1,0 +1,10 @@
+//! Financial instruments.
+//!
+//! Port of `ql/instruments/`: currently the payoff subset needed by the
+//! European-option slice. The instrument classes (`OneAssetOption`,
+//! `VanillaOption`, `EuropeanOption`) follow with the instrument and
+//! pricing-engine framework.
+
+mod payoffs;
+
+pub use payoffs::{PlainVanillaPayoff, StrikedTypePayoff, TypePayoff};

--- a/crates/itofin/src/instruments/payoffs.rs
+++ b/crates/itofin/src/instruments/payoffs.rs
@@ -57,10 +57,11 @@ impl Payoff for PlainVanillaPayoff {
     }
 
     fn value(&self, price: Real) -> Real {
-        match self.option_type {
-            OptionType::Call => (price - self.strike).max(0.0),
-            OptionType::Put => (self.strike - price).max(0.0),
-        }
+        let intrinsic = match self.option_type {
+            OptionType::Call => price - self.strike,
+            OptionType::Put => self.strike - price,
+        };
+        if intrinsic < 0.0 { 0.0 } else { intrinsic }
     }
 }
 
@@ -94,6 +95,14 @@ mod tests {
         assert_eq!(payoff.value(90.0), 10.0);
         assert_eq!(payoff.value(100.0), 0.0);
         assert_eq!(payoff.value(110.0), 0.0);
+    }
+
+    #[test]
+    fn nan_price_propagates_like_cpp_std_max() {
+        let call = PlainVanillaPayoff::new(OptionType::Call, 100.0);
+        assert!(call.value(Real::NAN).is_nan());
+        let put = PlainVanillaPayoff::new(OptionType::Put, 100.0);
+        assert!(put.value(Real::NAN).is_nan());
     }
 
     #[test]

--- a/crates/itofin/src/instruments/payoffs.rs
+++ b/crates/itofin/src/instruments/payoffs.rs
@@ -1,0 +1,124 @@
+//! Payoffs for various options.
+//!
+//! Port of the plain-vanilla subset of `ql/instruments/payoffs.{hpp,cpp}`:
+//! the [`TypePayoff`] and [`StrikedTypePayoff`] intermediate contracts and
+//! the [`PlainVanillaPayoff`]. The remaining payoffs (`NullPayoff`,
+//! `FloatingTypePayoff`, `PercentageStrikePayoff`, `AssetOrNothingPayoff`,
+//! `CashOrNothingPayoff`, `GapPayoff`, `SuperFundPayoff`,
+//! `SuperSharePayoff`) are follow-up work.
+
+use crate::option::OptionType;
+use crate::payoff::Payoff;
+use crate::types::Real;
+
+/// Intermediate contract for put/call payoffs (QuantLib's `TypePayoff`).
+pub trait TypePayoff: Payoff {
+    /// The option type the payoff is written on.
+    fn option_type(&self) -> OptionType;
+}
+
+/// Intermediate contract for payoffs based on a fixed strike (QuantLib's
+/// `StrikedTypePayoff`).
+pub trait StrikedTypePayoff: TypePayoff {
+    /// The strike the payoff is based on.
+    fn strike(&self) -> Real;
+}
+
+/// Plain-vanilla payoff: `max(price - strike, 0)` for a call,
+/// `max(strike - price, 0)` for a put.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct PlainVanillaPayoff {
+    option_type: OptionType,
+    strike: Real,
+}
+
+impl PlainVanillaPayoff {
+    /// Builds a plain-vanilla payoff of the given type and strike.
+    pub fn new(option_type: OptionType, strike: Real) -> PlainVanillaPayoff {
+        PlainVanillaPayoff {
+            option_type,
+            strike,
+        }
+    }
+}
+
+impl Payoff for PlainVanillaPayoff {
+    fn name(&self) -> String {
+        "Vanilla".to_string()
+    }
+
+    fn description(&self) -> String {
+        format!(
+            "{} {}, {} strike",
+            self.name(),
+            self.option_type,
+            self.strike
+        )
+    }
+
+    fn value(&self, price: Real) -> Real {
+        match self.option_type {
+            OptionType::Call => (price - self.strike).max(0.0),
+            OptionType::Put => (self.strike - price).max(0.0),
+        }
+    }
+}
+
+impl TypePayoff for PlainVanillaPayoff {
+    fn option_type(&self) -> OptionType {
+        self.option_type
+    }
+}
+
+impl StrikedTypePayoff for PlainVanillaPayoff {
+    fn strike(&self) -> Real {
+        self.strike
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn call_pays_excess_over_strike() {
+        let payoff = PlainVanillaPayoff::new(OptionType::Call, 100.0);
+        assert_eq!(payoff.value(110.0), 10.0);
+        assert_eq!(payoff.value(100.0), 0.0);
+        assert_eq!(payoff.value(90.0), 0.0);
+    }
+
+    #[test]
+    fn put_pays_shortfall_under_strike() {
+        let payoff = PlainVanillaPayoff::new(OptionType::Put, 100.0);
+        assert_eq!(payoff.value(90.0), 10.0);
+        assert_eq!(payoff.value(100.0), 0.0);
+        assert_eq!(payoff.value(110.0), 0.0);
+    }
+
+    #[test]
+    fn accessors_expose_type_and_strike() {
+        let payoff = PlainVanillaPayoff::new(OptionType::Put, 32.5);
+        assert_eq!(payoff.option_type(), OptionType::Put);
+        assert_eq!(payoff.strike(), 32.5);
+    }
+
+    #[test]
+    fn name_and_description_match_quantlib() {
+        let call = PlainVanillaPayoff::new(OptionType::Call, 100.0);
+        assert_eq!(call.name(), "Vanilla");
+        assert_eq!(call.description(), "Vanilla Call, 100 strike");
+
+        let put = PlainVanillaPayoff::new(OptionType::Put, 32.5);
+        assert_eq!(put.description(), "Vanilla Put, 32.5 strike");
+    }
+
+    #[test]
+    fn usable_as_trait_object() {
+        let payoff = PlainVanillaPayoff::new(OptionType::Call, 100.0);
+        let dynamic: &dyn StrikedTypePayoff = &payoff;
+        assert_eq!(dynamic.value(107.0), 7.0);
+        assert_eq!(dynamic.option_type(), OptionType::Call);
+        assert_eq!(dynamic.strike(), 100.0);
+    }
+}

--- a/crates/itofin/src/lib.rs
+++ b/crates/itofin/src/lib.rs
@@ -6,9 +6,12 @@
 pub mod errors;
 pub mod handle;
 pub mod instrument;
+pub mod instruments;
 pub mod interestrate;
 pub mod math;
+pub mod option;
 pub mod patterns;
+pub mod payoff;
 pub mod pricingengine;
 pub mod quotes;
 pub mod settings;

--- a/crates/itofin/src/lib.rs
+++ b/crates/itofin/src/lib.rs
@@ -4,6 +4,7 @@
 //! via cbindgen) live in sibling crates and depend on this one.
 
 pub mod errors;
+pub mod exercise;
 pub mod handle;
 pub mod instrument;
 pub mod instruments;

--- a/crates/itofin/src/option.rs
+++ b/crates/itofin/src/option.rs
@@ -1,0 +1,46 @@
+//! Base option definitions.
+//!
+//! Port of the `Option::Type` subset of `ql/option.hpp`. The `Option`
+//! instrument base class, its `arguments` and the `Greeks`/`MoreGreeks`
+//! results follow with the instrument and pricing-engine framework.
+
+use std::fmt;
+
+/// Call/put flag of an option.
+///
+/// The integer discriminants match QuantLib's `Option::Type` enum
+/// (`Put = -1`, `Call = 1`), whose sign some pricing formulas rely on.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[repr(i32)]
+pub enum OptionType {
+    /// Right to sell at the strike.
+    Put = -1,
+    /// Right to buy at the strike.
+    Call = 1,
+}
+
+impl fmt::Display for OptionType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            OptionType::Call => f.write_str("Call"),
+            OptionType::Put => f.write_str("Put"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn discriminants_match_quantlib() {
+        assert_eq!(OptionType::Put as i32, -1);
+        assert_eq!(OptionType::Call as i32, 1);
+    }
+
+    #[test]
+    fn display_matches_quantlib_output() {
+        assert_eq!(OptionType::Call.to_string(), "Call");
+        assert_eq!(OptionType::Put.to_string(), "Put");
+    }
+}

--- a/crates/itofin/src/payoff.rs
+++ b/crates/itofin/src/payoff.rs
@@ -1,0 +1,28 @@
+//! Option payoff contract.
+//!
+//! Port of `ql/payoff.hpp`: the [`Payoff`] trait is the abstract base class
+//! for option payoffs. The concrete payoff hierarchy lives in
+//! [`instruments`](crate::instruments).
+//!
+//! QuantLib's `accept(AcyclicVisitor&)` hook is not ported: Rust callers
+//! dispatch on the payoff traits (e.g.
+//! [`StrikedTypePayoff`](crate::instruments::StrikedTypePayoff)) instead of
+//! visiting by dynamic type.
+
+use crate::types::Real;
+
+/// Abstract base class for option payoffs.
+pub trait Payoff {
+    /// A name describing the payoff type.
+    ///
+    /// Used for output and comparison between payoffs; not meant for writing
+    /// switch-on-type code.
+    fn name(&self) -> String;
+
+    /// A description of the payoff, including its parameters.
+    fn description(&self) -> String;
+
+    /// The payoff value at the given underlying price
+    /// (`operator()(Real price)` in QuantLib).
+    fn value(&self, price: Real) -> Real;
+}


### PR DESCRIPTION
- **feat(payoffs): add option type, payoff contract and plain-vanilla payoff**
- **feat(exercise): add exercise contract and European exercise**
- **fix(payoffs): propagate NaN through plain-vanilla payoff value**

close #208 