### PR TITLE
ci(.github): use OIDC trusted publishing for crates.io release

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -34,6 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write # mint the OIDC token crates.io trusted publishing verifies
     steps:
       - name: checkout the released tag
         uses: actions/checkout@v4
@@ -46,7 +47,10 @@ jobs:
           VER="${{ needs.semantic-release.outputs.new_release_tag }}"
           sed -i -E "s/^version = \"[0-9]+\.[0-9]+\.[0-9]+\"/version = \"${VER}\"/" Cargo.toml
           grep -E "^version" Cargo.toml
+      - name: authenticate to crates.io via OIDC trusted publishing
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
       - name: publish
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: cargo publish -p libitofin --allow-dirty


### PR DESCRIPTION
This pull request updates the semantic-release workflow to authenticate with crates.io using OIDC trusted publishing instead of a static registry token. The main changes improve credential security by minting short-lived tokens at publish time.

**OIDC trusted publishing integration:**
* Added `id-token: write` permission to the job so the workflow can mint the OIDC token that crates.io trusted publishing verifies.
* Added a new step using `rust-lang/crates-io-auth-action@v1` to authenticate to crates.io via OIDC and expose the minted token as a step output.
* Updated the publish step to source `CARGO_REGISTRY_TOKEN` from the OIDC auth step output instead of the `CARGO_REGISTRY_TOKEN` secret.
