### PR TITLE
fix(settings): mutate the evaluation date through &self

### DIFF
--- a/crates/libitofin/src/instrument.rs
+++ b/crates/libitofin/src/instrument.rs
@@ -671,7 +671,7 @@ mod tests {
         let (engine, calculations) = mock_engine(true);
         instrument.base_mut().set_pricing_engine(engine);
 
-        let mut settings: Settings<Date> = Settings::new();
+        let settings: Settings<Date> = Settings::new();
         settings.set_evaluation_date(Date::new(7, Month::July, 2026));
         settings.register_eval_date_observer(&instrument.base().observer());
 

--- a/crates/libitofin/src/instruments/oneassetoption.rs
+++ b/crates/libitofin/src/instruments/oneassetoption.rs
@@ -18,9 +18,9 @@
 //! - `isExpired` reads the evaluation date from the `Settings` handle the
 //!   option is constructed with (per D5 there is no singleton). QuantLib's
 //!   singleton always falls back to today's clock date, which the core lacks:
-//!   with no evaluation date set (or the settings locked mid-notification)
-//!   the check fails with an explicit error instead of guessing (D10 -
-//!   silently treating the option as live could price an expired option).
+//!   with no evaluation date set the check fails with an explicit error
+//!   instead of guessing (D10 - silently treating the option as live could
+//!   price an expired option).
 //!   The general `Event`/`simple_event` machinery of `ql/event.hpp` is
 //!   follow-up work; its `hasOccurred` date comparison is ported inline.
 
@@ -33,7 +33,7 @@ use crate::instrument::{Instrument, InstrumentBase, InstrumentResults};
 use crate::instruments::StrikedTypePayoff;
 use crate::pricingengine::{Arguments, GenericEngine, Results};
 use crate::settings::Settings;
-use crate::shared::{Shared, SharedMut};
+use crate::shared::Shared;
 use crate::time::date::Date;
 use crate::types::Real;
 
@@ -127,7 +127,7 @@ pub struct OneAssetOption {
     base: InstrumentBase,
     payoff: Shared<dyn StrikedTypePayoff>,
     exercise: Shared<dyn Exercise>,
-    settings: SharedMut<Settings<Date>>,
+    settings: Shared<Settings<Date>>,
     greeks: Greeks,
     more_greeks: MoreGreeks,
 }
@@ -152,23 +152,18 @@ impl OneAssetOption {
     pub fn new(
         payoff: Shared<dyn StrikedTypePayoff>,
         exercise: Shared<dyn Exercise>,
-        settings: SharedMut<Settings<Date>>,
-    ) -> QlResult<OneAssetOption> {
+        settings: Shared<Settings<Date>>,
+    ) -> OneAssetOption {
         let base = InstrumentBase::new();
-        {
-            let Ok(guard) = settings.try_borrow() else {
-                fail!("evaluation-date settings are locked during notification");
-            };
-            guard.register_eval_date_observer(&base.observer());
-        }
-        Ok(OneAssetOption {
+        settings.register_eval_date_observer(&base.observer());
+        OneAssetOption {
             base,
             payoff,
             exercise,
             settings,
             greeks: Greeks::default(),
             more_greeks: MoreGreeks::default(),
-        })
+        }
     }
 
     /// The payoff the option is written on.
@@ -270,14 +265,11 @@ impl Instrument for OneAssetOption {
     /// Whether the last exercise date has occurred relative to the evaluation
     /// date (`detail::simple_event(exercise_->lastDate()).hasOccurred()`).
     fn is_expired(&self) -> QlResult<bool> {
-        let Ok(settings) = self.settings.try_borrow() else {
-            fail!("evaluation-date settings are locked during notification");
-        };
-        let Some(evaluation_date) = settings.evaluation_date().copied() else {
+        let Some(evaluation_date) = self.settings.evaluation_date() else {
             fail!("evaluation date not set");
         };
         let last_date = self.exercise.last_date();
-        Ok(if settings.include_reference_date_events() {
+        Ok(if self.settings.include_reference_date_events() {
             last_date < evaluation_date
         } else {
             last_date <= evaluation_date
@@ -342,7 +334,7 @@ mod tests {
     use crate::option::OptionType;
     use crate::patterns::observable::{AsObservable, Observable};
     use crate::pricingengine::PricingEngine;
-    use crate::shared::{shared, shared_mut};
+    use crate::shared::{Shared, SharedMut, shared, shared_mut};
     use crate::time::date::Month;
 
     const SPOT: Real = 105.0;
@@ -412,15 +404,15 @@ mod tests {
         (engine, calculations)
     }
 
-    fn european_call(settings: &SharedMut<Settings<Date>>) -> EuropeanOption {
+    fn european_call(settings: &Shared<Settings<Date>>) -> EuropeanOption {
         let payoff = shared(PlainVanillaPayoff::new(OptionType::Call, 100.0));
         let exercise = shared(EuropeanExercise::new(Date::new(7, Month::July, 2027)));
-        EuropeanOption::new(payoff, exercise, SharedMut::clone(settings)).unwrap()
+        EuropeanOption::new(payoff, exercise, Shared::clone(settings))
     }
 
-    fn settings_at(date: Date) -> SharedMut<Settings<Date>> {
-        let settings = shared_mut(Settings::new());
-        settings.borrow_mut().set_evaluation_date(date);
+    fn settings_at(date: Date) -> Shared<Settings<Date>> {
+        let settings = shared(Settings::new());
+        settings.set_evaluation_date(date);
         settings
     }
 
@@ -591,9 +583,7 @@ mod tests {
     #[test]
     fn include_reference_date_events_keeps_expiry_day_alive() {
         let settings = settings_at(Date::new(7, Month::July, 2027));
-        settings
-            .borrow_mut()
-            .set_include_reference_date_events(true);
+        settings.set_include_reference_date_events(true);
         let mut option = european_call(&settings);
         let (engine, calculations) = stub_engine(true);
         option.base_mut().set_pricing_engine(engine);
@@ -608,7 +598,7 @@ mod tests {
     /// calculation with it (D10: explicit error over silently-live).
     #[test]
     fn unset_evaluation_date_fails_the_expiry_check_and_pricing() {
-        let settings = shared_mut(Settings::new());
+        let settings = shared(Settings::new());
         let mut option = european_call(&settings);
         assert_eq!(
             option.is_expired().unwrap_err().message(),
@@ -634,9 +624,7 @@ mod tests {
         option.base_mut().set_pricing_engine(engine);
 
         option.npv().unwrap();
-        settings
-            .borrow_mut()
-            .set_evaluation_date(Date::new(8, Month::July, 2026));
+        settings.set_evaluation_date(Date::new(8, Month::July, 2026));
         assert!(!option.base().is_calculated());
         option.npv().unwrap();
         assert_eq!(calculations.get(), 2);

--- a/crates/libitofin/src/pricingengines/vanilla.rs
+++ b/crates/libitofin/src/pricingengines/vanilla.rs
@@ -197,7 +197,7 @@ pub(crate) mod test_market {
     }
 
     pub(crate) struct Market {
-        pub(crate) settings: SharedMut<Settings<Date>>,
+        pub(crate) settings: Shared<Settings<Date>>,
         pub(crate) spot: Shared<SimpleQuote>,
         pub(crate) q_rate: Shared<SimpleQuote>,
         pub(crate) r_rate: Shared<SimpleQuote>,
@@ -221,8 +221,7 @@ pub(crate) mod test_market {
         ) -> EuropeanOption {
             let payoff = shared(PlainVanillaPayoff::new(option_type, strike));
             let exercise = shared(EuropeanExercise::new(expiry));
-            let mut option =
-                EuropeanOption::new(payoff, exercise, SharedMut::clone(&self.settings)).unwrap();
+            let mut option = EuropeanOption::new(payoff, exercise, Shared::clone(&self.settings));
             let engine = shared_mut(AnalyticEuropeanEngine::new(Shared::clone(&self.process)));
             option
                 .base_mut()
@@ -257,8 +256,8 @@ pub(crate) mod test_market {
     /// Fixed-reference flat market as built by `testValues` and
     /// `testGreekValues`.
     pub(crate) fn market() -> Market {
-        let settings = shared_mut(Settings::new());
-        settings.borrow_mut().set_evaluation_date(today());
+        let settings = shared(Settings::new());
+        settings.set_evaluation_date(today());
         let spot = shared(SimpleQuote::new(0.0));
         let q_rate = shared(SimpleQuote::new(0.0));
         let r_rate = shared(SimpleQuote::new(0.0));
@@ -372,9 +371,8 @@ mod tests {
         let mut american = crate::instruments::OneAssetOption::new(
             payoff,
             exercise,
-            crate::shared::SharedMut::clone(&market.settings),
-        )
-        .unwrap();
+            crate::shared::Shared::clone(&market.settings),
+        );
         american
             .base_mut()
             .set_pricing_engine(option.base().pricing_engine().unwrap().clone());
@@ -415,9 +413,8 @@ mod tests {
         let mut option = crate::instruments::OneAssetOption::new(
             crate::shared::shared(CashOrNothingStub),
             template.exercise().clone(),
-            crate::shared::SharedMut::clone(&market.settings),
-        )
-        .unwrap();
+            crate::shared::Shared::clone(&market.settings),
+        );
         option
             .base_mut()
             .set_pricing_engine(template.base().pricing_engine().unwrap().clone());
@@ -673,8 +670,8 @@ mod mixed_day_counters {
         let t_vol = voldc.year_fraction(today(), expiry);
         assert!(t_rf != t_div && t_div != t_vol && t_rf != t_vol);
 
-        let settings = shared_mut(Settings::new());
-        settings.borrow_mut().set_evaluation_date(today());
+        let settings = shared(Settings::new());
+        settings.set_evaluation_date(today());
         let process = shared(BlackScholesMertonProcess::new(
             Handle::new(shared(SimpleQuote::new(spot)) as Shared<dyn crate::quotes::Quote>),
             Handle::new(shared(FlatForward::with_rate(
@@ -701,9 +698,8 @@ mod mixed_day_counters {
         let mut option = EuropeanOption::new(
             shared(payoff),
             shared(EuropeanExercise::new(expiry)),
-            SharedMut::clone(&settings),
-        )
-        .unwrap();
+            Shared::clone(&settings),
+        );
         let engine = shared_mut(AnalyticEuropeanEngine::new(Shared::clone(&process)));
         option
             .base_mut()
@@ -832,7 +828,7 @@ mod test_greeks {
     const UNDERLYING: Real = 100.0;
 
     struct MovingMarket {
-        settings: SharedMut<Settings<Date>>,
+        settings: Shared<Settings<Date>>,
         spot: Shared<SimpleQuote>,
         q_rate: Shared<SimpleQuote>,
         r_rate: Shared<SimpleQuote>,
@@ -841,40 +837,34 @@ mod test_greeks {
     }
 
     fn moving_market() -> MovingMarket {
-        let settings = shared_mut(Settings::new());
-        settings.borrow_mut().set_evaluation_date(today());
+        let settings = shared(Settings::new());
+        settings.set_evaluation_date(today());
         let spot = shared(SimpleQuote::new(0.0));
         let q_rate = shared(SimpleQuote::new(0.0));
         let r_rate = shared(SimpleQuote::new(0.0));
         let vol = shared(SimpleQuote::new(0.0));
         let flat = |quote: &Shared<SimpleQuote>| {
-            shared(
-                FlatForward::moving(
-                    0,
-                    NullCalendar::new(),
-                    quote_handle(quote),
-                    Actual360::new(),
-                    Compounding::Continuous,
-                    Frequency::Annual,
-                    SharedMut::clone(&settings),
-                )
-                .unwrap(),
-            ) as Shared<dyn YieldTermStructure>
+            shared(FlatForward::moving(
+                0,
+                NullCalendar::new(),
+                quote_handle(quote),
+                Actual360::new(),
+                Compounding::Continuous,
+                Frequency::Annual,
+                Shared::clone(&settings),
+            )) as Shared<dyn YieldTermStructure>
         };
         let process = shared(BlackScholesMertonProcess::new(
             quote_handle(&spot),
             Handle::new(flat(&q_rate)),
             Handle::new(flat(&r_rate)),
-            Handle::new(shared(
-                BlackConstantVol::moving_with_quote(
-                    0,
-                    NullCalendar::new(),
-                    quote_handle(&vol),
-                    Actual360::new(),
-                    SharedMut::clone(&settings),
-                )
-                .unwrap(),
-            )
+            Handle::new(shared(BlackConstantVol::moving_with_quote(
+                0,
+                NullCalendar::new(),
+                quote_handle(&vol),
+                Actual360::new(),
+                Shared::clone(&settings),
+            ))
                 as Shared<
                     dyn crate::termstructures::volatility::BlackVolTermStructure,
                 >),
@@ -915,8 +905,7 @@ mod test_greeks {
                     let payoff = shared(PlainVanillaPayoff::new(option_type, strike));
                     let exercise = shared(EuropeanExercise::new(expiry));
                     let mut option =
-                        EuropeanOption::new(payoff, exercise, SharedMut::clone(&market.settings))
-                            .unwrap();
+                        EuropeanOption::new(payoff, exercise, Shared::clone(&market.settings));
                     let engine =
                         shared_mut(AnalyticEuropeanEngine::new(Shared::clone(&market.process)));
                     option
@@ -980,17 +969,11 @@ mod test_greeks {
                                 let expected_vega = (value_p - value_m) / (2.0 * dv);
 
                                 let dt = day_counter.year_fraction(today() - 1, today() + 1);
-                                market
-                                    .settings
-                                    .borrow_mut()
-                                    .set_evaluation_date(today() - 1);
+                                market.settings.set_evaluation_date(today() - 1);
                                 let value_m = option.npv().unwrap();
-                                market
-                                    .settings
-                                    .borrow_mut()
-                                    .set_evaluation_date(today() + 1);
+                                market.settings.set_evaluation_date(today() + 1);
                                 let value_p = option.npv().unwrap();
-                                market.settings.borrow_mut().set_evaluation_date(today());
+                                market.settings.set_evaluation_date(today());
                                 let expected_theta = (value_p - value_m) / dt;
 
                                 let checks = [

--- a/crates/libitofin/src/settings.rs
+++ b/crates/libitofin/src/settings.rs
@@ -11,6 +11,14 @@
 //! concrete `Date` type belongs to EPIC-2; once `Date` lands, downstream code
 //! uses `Settings<Date>`. Assigning a *different* date notifies observers;
 //! assigning the same date does not, matching `settings.cpp`.
+//!
+//! Mutation goes through `&self` (the state lives in [`Cell`]s), like
+//! [`SimpleQuote`](crate::quotes::SimpleQuote): settings are shared as
+//! [`Shared<Settings<D>>`](crate::shared::Shared) so that an observer may read
+//! the evaluation date while being notified of its change, rather than meeting
+//! a mutable borrow the notifying caller still holds.
+
+use std::cell::Cell;
 
 use crate::patterns::observable::{Observable, Observer};
 use crate::shared::SharedMut;
@@ -19,21 +27,21 @@ use crate::shared::SharedMut;
 ///
 /// `D` is the evaluation-date payload (a `Date` once EPIC-2 is ported).
 pub struct Settings<D> {
-    evaluation_date: Option<D>,
+    evaluation_date: Cell<Option<D>>,
     eval_date_observable: Observable,
-    include_reference_date_events: bool,
-    include_todays_cash_flows: Option<bool>,
-    enforces_todays_historic_fixings: bool,
+    include_reference_date_events: Cell<bool>,
+    include_todays_cash_flows: Cell<Option<bool>>,
+    enforces_todays_historic_fixings: Cell<bool>,
 }
 
 impl<D> Default for Settings<D> {
     fn default() -> Self {
         Settings {
-            evaluation_date: None,
+            evaluation_date: Cell::new(None),
             eval_date_observable: Observable::new(),
-            include_reference_date_events: false,
-            include_todays_cash_flows: None,
-            enforces_todays_historic_fixings: false,
+            include_reference_date_events: Cell::new(false),
+            include_todays_cash_flows: Cell::new(None),
+            enforces_todays_historic_fixings: Cell::new(false),
         }
     }
 }
@@ -49,17 +57,24 @@ impl<D> Settings<D> {
     /// `None` corresponds to QuantLib's "use today's date" default; the
     /// concrete today's-date fallback is resolved by the caller once `Date`
     /// exists.
-    pub fn evaluation_date(&self) -> Option<&D> {
-        self.evaluation_date.as_ref()
+    pub fn evaluation_date(&self) -> Option<D>
+    where
+        D: Copy,
+    {
+        self.evaluation_date.get()
     }
 
     /// Sets the evaluation date, notifying observers only if it actually changed.
-    pub fn set_evaluation_date(&mut self, date: D)
+    ///
+    /// The new date is in place before the notification goes out, so an
+    /// observer reading it back through [`evaluation_date`](Self::evaluation_date)
+    /// sees the value that triggered its update.
+    pub fn set_evaluation_date(&self, date: D)
     where
-        D: PartialEq,
+        D: Copy + PartialEq,
     {
-        if self.evaluation_date.as_ref() != Some(&date) {
-            self.evaluation_date = Some(date);
+        if self.evaluation_date.get() != Some(date) {
+            self.evaluation_date.set(Some(date));
             self.eval_date_observable.notify_observers();
         }
     }
@@ -70,9 +85,8 @@ impl<D> Settings<D> {
     /// Mirrors QuantLib's `resetEvaluationDate()` (which assigns the null
     /// `Date()`). Its companion `anchorEvaluationDate()` is deferred until
     /// EPIC-2 provides a concrete today's-date for the payload type.
-    pub fn reset_evaluation_date(&mut self) {
-        if self.evaluation_date.is_some() {
-            self.evaluation_date = None;
+    pub fn reset_evaluation_date(&self) {
+        if self.evaluation_date.replace(None).is_some() {
             self.eval_date_observable.notify_observers();
         }
     }
@@ -85,39 +99,39 @@ impl<D> Settings<D> {
     /// Whether events on the reference date are, by default, treated as not yet
     /// occurred.
     pub fn include_reference_date_events(&self) -> bool {
-        self.include_reference_date_events
+        self.include_reference_date_events.get()
     }
 
     /// Sets the [`include_reference_date_events`](Self::include_reference_date_events) flag.
-    pub fn set_include_reference_date_events(&mut self, value: bool) {
-        self.include_reference_date_events = value;
+    pub fn set_include_reference_date_events(&self, value: bool) {
+        self.include_reference_date_events.set(value);
     }
 
     /// Whether cash flows on today's date enter the NPV, when set.
     pub fn include_todays_cash_flows(&self) -> Option<bool> {
-        self.include_todays_cash_flows
+        self.include_todays_cash_flows.get()
     }
 
     /// Sets the [`include_todays_cash_flows`](Self::include_todays_cash_flows) flag.
-    pub fn set_include_todays_cash_flows(&mut self, value: Option<bool>) {
-        self.include_todays_cash_flows = value;
+    pub fn set_include_todays_cash_flows(&self, value: Option<bool>) {
+        self.include_todays_cash_flows.set(value);
     }
 
     /// Whether today's historic fixings are enforced.
     pub fn enforces_todays_historic_fixings(&self) -> bool {
-        self.enforces_todays_historic_fixings
+        self.enforces_todays_historic_fixings.get()
     }
 
     /// Sets the [`enforces_todays_historic_fixings`](Self::enforces_todays_historic_fixings) flag.
-    pub fn set_enforces_todays_historic_fixings(&mut self, value: bool) {
-        self.enforces_todays_historic_fixings = value;
+    pub fn set_enforces_todays_historic_fixings(&self, value: bool) {
+        self.enforces_todays_historic_fixings.set(value);
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::shared::{SharedMut, shared_mut};
+    use crate::shared::{Shared, SharedMut, shared, shared_mut};
 
     #[derive(Default)]
     struct Flag {
@@ -134,7 +148,7 @@ mod tests {
     /// serial date in place of the EPIC-2 `Date`.
     #[test]
     fn notifies_only_on_actual_date_change() {
-        let mut settings: Settings<i64> = Settings::new();
+        let settings: Settings<i64> = Settings::new();
         let d1 = 44238_i64; // 11 Feb 2021
         let d2 = 44239_i64; // 12 Feb 2021
 
@@ -150,12 +164,12 @@ mod tests {
         // setting to a different date notifies
         settings.set_evaluation_date(d2);
         assert!(flag.borrow().up);
-        assert_eq!(settings.evaluation_date(), Some(&d2));
+        assert_eq!(settings.evaluation_date(), Some(d2));
     }
 
     #[test]
     fn reset_returns_to_floating_and_notifies_once() {
-        let mut settings: Settings<i64> = Settings::new();
+        let settings: Settings<i64> = Settings::new();
         settings.set_evaluation_date(44238_i64);
 
         let flag = shared_mut(Flag::default());
@@ -174,7 +188,7 @@ mod tests {
 
     #[test]
     fn flags_round_trip() {
-        let mut settings: Settings<i64> = Settings::new();
+        let settings: Settings<i64> = Settings::new();
         assert!(!settings.include_reference_date_events());
         assert_eq!(settings.include_todays_cash_flows(), None);
         assert!(!settings.enforces_todays_historic_fixings());
@@ -186,5 +200,35 @@ mod tests {
         assert!(settings.include_reference_date_events());
         assert_eq!(settings.include_todays_cash_flows(), Some(true));
         assert!(settings.enforces_todays_historic_fixings());
+    }
+
+    /// Observer that reads the settings back while being notified of an
+    /// evaluation-date change, as any structure recomputing off the new date
+    /// does from its `update()`.
+    struct Reader {
+        settings: Shared<Settings<i64>>,
+        seen: Option<i64>,
+    }
+
+    impl Observer for Reader {
+        fn update(&mut self) {
+            self.seen = self.settings.evaluation_date();
+        }
+    }
+
+    #[test]
+    fn observer_may_read_the_evaluation_date_during_notification() {
+        let settings = shared(Settings::<i64>::new());
+        let reader = shared_mut(Reader {
+            settings: Shared::clone(&settings),
+            seen: None,
+        });
+        settings.register_eval_date_observer(&(reader.clone() as SharedMut<dyn Observer>));
+
+        settings.set_evaluation_date(44239_i64);
+        assert_eq!(reader.borrow().seen, Some(44239));
+
+        settings.reset_evaluation_date();
+        assert_eq!(reader.borrow().seen, None);
     }
 }

--- a/crates/libitofin/src/termstructures/mod.rs
+++ b/crates/libitofin/src/termstructures/mod.rs
@@ -13,7 +13,9 @@
 //!
 //! - QuantLib's moving mode reads the global `Settings` singleton; per D5 the
 //!   moving constructor takes the shared [`Settings`] handle explicitly and
-//!   registers with its evaluation-date observable.
+//!   registers with its evaluation-date observable. The date mutates through
+//!   `&self`, so an observer may read the reference date back while the
+//!   evaluation-date notification that invalidated it is still running.
 //! - A base asked for a reference date it does not manage returns an `Err`
 //!   where C++ silently returns the null date.
 //! - C++'s `Extrapolator` base class is folded into the holder as a flag; it
@@ -23,10 +25,6 @@
 //! - No today's-date fallback: C++ resolves an unset evaluation date to
 //!   `Date::todaysDate()`; this port has no system-clock date, so a moving
 //!   structure returns an `Err` until the evaluation date is set explicitly.
-//! - During an evaluation-date notification the settings are mutably
-//!   borrowed, so reading the reference date mid-notification returns an
-//!   `Err` where C++ hands out the fresh date; observers recompute lazily
-//!   after the notification instead.
 //! - The moving recompute reads the constructor-stored calendar and
 //!   settlement days; a curve overriding
 //!   [`calendar`](TermStructure::calendar) or
@@ -88,7 +86,7 @@ pub struct TermStructureBase {
     calendar: Option<Calendar>,
     settlement_days: Option<Natural>,
     day_counter: Option<DayCounter>,
-    settings: Option<SharedMut<Settings<Date>>>,
+    settings: Option<Shared<Settings<Date>>>,
     extrapolation: Cell<bool>,
     reference: Shared<ReferenceState>,
     observable: Shared<Observable>,
@@ -100,7 +98,7 @@ impl TermStructureBase {
         calendar: Option<Calendar>,
         settlement_days: Option<Natural>,
         day_counter: Option<DayCounter>,
-        settings: Option<SharedMut<Settings<Date>>>,
+        settings: Option<Shared<Settings<Date>>>,
         moving: bool,
         reference_date: Option<Date>,
     ) -> TermStructureBase {
@@ -157,22 +155,18 @@ impl TermStructureBase {
         settlement_days: Natural,
         calendar: Calendar,
         day_counter: Option<DayCounter>,
-        settings: SharedMut<Settings<Date>>,
-    ) -> QlResult<TermStructureBase> {
-        let Ok(guard) = settings.try_borrow() else {
-            fail!("evaluation-date settings are locked during notification");
-        };
+        settings: Shared<Settings<Date>>,
+    ) -> TermStructureBase {
         let base = Self::assemble(
             Some(calendar),
             Some(settlement_days),
             day_counter,
-            Some(settings.clone()),
+            Some(Shared::clone(&settings)),
             true,
             None,
         );
-        guard.register_eval_date_observer(&(base.updater.clone() as SharedMut<dyn Observer>));
-        drop(guard);
-        Ok(base)
+        settings.register_eval_date_observer(&(base.updater.clone() as SharedMut<dyn Observer>));
+        base
     }
 
     /// The date at which discount = 1.0 and/or variance = 0.0, recomputing it
@@ -183,10 +177,7 @@ impl TermStructureBase {
                 .settings
                 .as_ref()
                 .expect("a moving term structure holds settings");
-            let Ok(settings) = settings.try_borrow() else {
-                fail!("evaluation-date settings are locked during notification");
-            };
-            let Some(today) = settings.evaluation_date().copied() else {
+            let Some(today) = settings.evaluation_date() else {
                 fail!("no evaluation date set: a moving term structure needs one");
             };
             require!(
@@ -434,18 +425,15 @@ mod tests {
 
     #[test]
     fn moving_reference_date_advances_off_the_evaluation_date() {
-        let settings = shared_mut(Settings::new());
-        settings
-            .borrow_mut()
-            .set_evaluation_date(Date::new(15, Month::January, 2026));
+        let settings = shared(Settings::new());
+        settings.set_evaluation_date(Date::new(15, Month::January, 2026));
         let curve = TestCurve {
             base: TermStructureBase::moving(
                 2,
                 Target::new(),
                 Some(Actual360::new()),
                 settings.clone(),
-            )
-            .unwrap(),
+            ),
             max: Date::new(15, Month::January, 2027),
         };
         assert_eq!(
@@ -457,18 +445,15 @@ mod tests {
 
     #[test]
     fn evaluation_date_change_recomputes_reference_and_notifies() {
-        let settings = shared_mut(Settings::new());
-        settings
-            .borrow_mut()
-            .set_evaluation_date(Date::new(15, Month::January, 2026));
+        let settings = shared(Settings::new());
+        settings.set_evaluation_date(Date::new(15, Month::January, 2026));
         let curve = TestCurve {
             base: TermStructureBase::moving(
                 0,
                 Target::new(),
                 Some(Actual360::new()),
                 settings.clone(),
-            )
-            .unwrap(),
+            ),
             max: Date::new(15, Month::January, 2027),
         };
         assert_eq!(
@@ -478,9 +463,7 @@ mod tests {
 
         let flag = Flag::new();
         curve.observable().register_observer(&as_observer(&flag));
-        settings
-            .borrow_mut()
-            .set_evaluation_date(Date::new(16, Month::January, 2026));
+        settings.set_evaluation_date(Date::new(16, Month::January, 2026));
 
         assert!(Flag::is_up(&flag));
         assert_eq!(
@@ -491,25 +474,23 @@ mod tests {
 
     #[test]
     fn moving_without_evaluation_date_is_an_error() {
-        let settings = shared_mut(Settings::new());
-        let base =
-            TermStructureBase::moving(2, Target::new(), Some(Actual360::new()), settings).unwrap();
+        let settings = shared(Settings::new());
+        let base = TermStructureBase::moving(2, Target::new(), Some(Actual360::new()), settings);
         let err = base.reference_date().unwrap_err();
         assert!(err.message().contains("no evaluation date set"));
     }
 
     #[test]
     fn null_or_near_max_evaluation_dates_are_errors_not_panics() {
-        let settings = shared_mut(Settings::new());
+        let settings = shared(Settings::new());
         let base =
-            TermStructureBase::moving(2, Target::new(), Some(Actual360::new()), settings.clone())
-                .unwrap();
+            TermStructureBase::moving(2, Target::new(), Some(Actual360::new()), settings.clone());
 
-        settings.borrow_mut().set_evaluation_date(Date::null());
+        settings.set_evaluation_date(Date::null());
         let err = base.reference_date().unwrap_err();
         assert!(err.message().contains("null evaluation date"));
 
-        settings.borrow_mut().set_evaluation_date(Date::max_date());
+        settings.set_evaluation_date(Date::max_date());
         let err = base.reference_date().unwrap_err();
         assert!(err.message().contains("too close to the maximum date"));
     }

--- a/crates/libitofin/src/termstructures/volatility/blackconstantvol.rs
+++ b/crates/libitofin/src/termstructures/volatility/blackconstantvol.rs
@@ -17,7 +17,7 @@ use crate::handle::Handle;
 use crate::patterns::observable::{AsObservable, Observable};
 use crate::quotes::{Quote, make_quote_handle};
 use crate::settings::Settings;
-use crate::shared::SharedMut;
+use crate::shared::Shared;
 use crate::termstructures::volatility::VolatilityTermStructure;
 use crate::termstructures::{TermStructure, TermStructureBase};
 use crate::time::businessdayconvention::BusinessDayConvention;
@@ -86,13 +86,13 @@ impl BlackConstantVol {
         calendar: Calendar,
         volatility: Volatility,
         day_counter: DayCounter,
-        settings: SharedMut<Settings<Date>>,
-    ) -> QlResult<BlackConstantVol> {
-        Ok(Self::assemble(
-            TermStructureBase::moving(settlement_days, calendar, Some(day_counter), settings)?,
+        settings: Shared<Settings<Date>>,
+    ) -> BlackConstantVol {
+        Self::assemble(
+            TermStructureBase::moving(settlement_days, calendar, Some(day_counter), settings),
             Self::wrap(volatility),
             false,
-        ))
+        )
     }
 
     /// Quote-backed structure whose reference date moves off the evaluation
@@ -102,13 +102,13 @@ impl BlackConstantVol {
         calendar: Calendar,
         volatility: Handle<dyn Quote>,
         day_counter: DayCounter,
-        settings: SharedMut<Settings<Date>>,
-    ) -> QlResult<BlackConstantVol> {
-        Ok(Self::assemble(
-            TermStructureBase::moving(settlement_days, calendar, Some(day_counter), settings)?,
+        settings: Shared<Settings<Date>>,
+    ) -> BlackConstantVol {
+        Self::assemble(
+            TermStructureBase::moving(settlement_days, calendar, Some(day_counter), settings),
             volatility,
             true,
-        ))
+        )
     }
 }
 
@@ -156,7 +156,7 @@ impl BlackVolTermStructure for BlackConstantVol {
 mod tests {
     use super::*;
     use crate::quotes::SimpleQuote;
-    use crate::shared::{Shared, shared, shared_mut};
+    use crate::shared::{Shared, shared};
     use crate::test_support::{Flag, as_observer};
     use crate::time::calendars::target::Target;
     use crate::time::date::Month;
@@ -247,22 +247,17 @@ mod tests {
 
     #[test]
     fn moving_reference_date_follows_the_evaluation_date() {
-        let settings = shared_mut(Settings::new());
-        settings
-            .borrow_mut()
-            .set_evaluation_date(Date::new(15, Month::January, 2026));
+        let settings = shared(Settings::new());
+        settings.set_evaluation_date(Date::new(15, Month::January, 2026));
         let curve =
-            BlackConstantVol::moving(2, Target::new(), 0.2, Actual360::new(), settings.clone())
-                .unwrap();
+            BlackConstantVol::moving(2, Target::new(), 0.2, Actual360::new(), settings.clone());
         assert_eq!(
             curve.reference_date().unwrap(),
             Date::new(19, Month::January, 2026)
         );
         assert_eq!(curve.black_vol(1.0, 100.0, false).unwrap(), 0.2);
 
-        settings
-            .borrow_mut()
-            .set_evaluation_date(Date::new(16, Month::January, 2026));
+        settings.set_evaluation_date(Date::new(16, Month::January, 2026));
         assert_eq!(
             curve.reference_date().unwrap(),
             Date::new(20, Month::January, 2026)

--- a/crates/libitofin/src/termstructures/volatility/localconstantvol.rs
+++ b/crates/libitofin/src/termstructures/volatility/localconstantvol.rs
@@ -17,7 +17,7 @@ use crate::handle::Handle;
 use crate::patterns::observable::{AsObservable, Observable};
 use crate::quotes::{Quote, make_quote_handle};
 use crate::settings::Settings;
-use crate::shared::SharedMut;
+use crate::shared::Shared;
 use crate::termstructures::volatility::VolatilityTermStructure;
 use crate::termstructures::{TermStructure, TermStructureBase};
 use crate::time::businessdayconvention::BusinessDayConvention;
@@ -84,13 +84,13 @@ impl LocalConstantVol {
         calendar: Calendar,
         volatility: Volatility,
         day_counter: DayCounter,
-        settings: SharedMut<Settings<Date>>,
-    ) -> QlResult<LocalConstantVol> {
-        Ok(Self::assemble(
-            TermStructureBase::moving(settlement_days, calendar, Some(day_counter), settings)?,
+        settings: Shared<Settings<Date>>,
+    ) -> LocalConstantVol {
+        Self::assemble(
+            TermStructureBase::moving(settlement_days, calendar, Some(day_counter), settings),
             Self::wrap(volatility),
             false,
-        ))
+        )
     }
 
     /// Quote-backed structure whose reference date moves off the evaluation
@@ -100,13 +100,13 @@ impl LocalConstantVol {
         calendar: Calendar,
         volatility: Handle<dyn Quote>,
         day_counter: DayCounter,
-        settings: SharedMut<Settings<Date>>,
-    ) -> QlResult<LocalConstantVol> {
-        Ok(Self::assemble(
-            TermStructureBase::moving(settlement_days, calendar, Some(day_counter), settings)?,
+        settings: Shared<Settings<Date>>,
+    ) -> LocalConstantVol {
+        Self::assemble(
+            TermStructureBase::moving(settlement_days, calendar, Some(day_counter), settings),
             volatility,
             true,
-        ))
+        )
     }
 }
 

--- a/crates/libitofin/src/termstructures/yields/flatforward.rs
+++ b/crates/libitofin/src/termstructures/yields/flatforward.rs
@@ -7,11 +7,8 @@
 //! C++'s `LazyObject` half becomes a cached [`InterestRate`] invalidated by
 //! quote notifications: the curve's observer clears the cache *before*
 //! passing the notification on, so observers reading the curve during a
-//! quote-driven notification wave see fresh values. During an
-//! *evaluation-date* wave on a moving curve the settings stay locked (see the
-//! divergence notes in [`crate::termstructures`]), so reads that need the
-//! reference date - including non-extrapolating time-based `discount` calls,
-//! whose range check consults `max_time` - return `Err` until the wave ends.
+//! notification wave see fresh values, whether the wave is quote-driven or
+//! (on a moving curve) evaluation-date-driven.
 //! The value-backed constructors wrap the rate in an unshared [`SimpleQuote`]
 //! like the C++ ones; the subscription they add is inert since nothing else
 //! can change that quote.
@@ -119,11 +116,11 @@ impl FlatForward {
         day_counter: DayCounter,
         compounding: Compounding,
         frequency: Frequency,
-        settings: SharedMut<Settings<Date>>,
-    ) -> QlResult<FlatForward> {
+        settings: Shared<Settings<Date>>,
+    ) -> FlatForward {
         let base =
-            TermStructureBase::moving(settlement_days, calendar, Some(day_counter), settings)?;
-        Ok(Self::assemble(base, forward, compounding, frequency))
+            TermStructureBase::moving(settlement_days, calendar, Some(day_counter), settings);
+        Self::assemble(base, forward, compounding, frequency)
     }
 
     /// Value-backed curve whose reference date moves off the evaluation date.
@@ -134,8 +131,8 @@ impl FlatForward {
         day_counter: DayCounter,
         compounding: Compounding,
         frequency: Frequency,
-        settings: SharedMut<Settings<Date>>,
-    ) -> QlResult<FlatForward> {
+        settings: Shared<Settings<Date>>,
+    ) -> FlatForward {
         Self::moving(
             settlement_days,
             calendar,
@@ -357,10 +354,8 @@ mod tests {
 
     #[test]
     fn moving_curve_follows_the_evaluation_date() {
-        let settings = shared_mut(Settings::new());
-        settings
-            .borrow_mut()
-            .set_evaluation_date(Date::new(15, Month::January, 2026));
+        let settings = shared(Settings::new());
+        settings.set_evaluation_date(Date::new(15, Month::January, 2026));
         let curve = FlatForward::moving_with_rate(
             2,
             Target::new(),
@@ -369,8 +364,7 @@ mod tests {
             Compounding::Continuous,
             Frequency::Annual,
             settings.clone(),
-        )
-        .unwrap();
+        );
         assert_eq!(
             curve.reference_date().unwrap(),
             Date::new(19, Month::January, 2026)
@@ -378,9 +372,7 @@ mod tests {
 
         let flag = Flag::new();
         curve.observable().register_observer(&as_observer(&flag));
-        settings
-            .borrow_mut()
-            .set_evaluation_date(Date::new(16, Month::January, 2026));
+        settings.set_evaluation_date(Date::new(16, Month::January, 2026));
 
         assert!(Flag::is_up(&flag));
         assert_eq!(
@@ -410,10 +402,8 @@ mod tests {
             }
         }
 
-        let settings = shared_mut(Settings::new());
-        settings
-            .borrow_mut()
-            .set_evaluation_date(Date::new(15, Month::January, 2026));
+        let settings = shared(Settings::new());
+        settings.set_evaluation_date(Date::new(15, Month::January, 2026));
         let quote = shared(SimpleQuote::new(0.05));
         let curve = FlatForward::moving(
             2,
@@ -423,8 +413,7 @@ mod tests {
             Compounding::Continuous,
             Frequency::Annual,
             settings.clone(),
-        )
-        .unwrap();
+        );
         curve.discount(1.0, false).unwrap();
 
         let writer = shared_mut(WriteBack {
@@ -436,9 +425,7 @@ mod tests {
             .observable()
             .register_observer(&(writer.clone() as SharedMut<dyn Observer>));
 
-        settings
-            .borrow_mut()
-            .set_evaluation_date(Date::new(16, Month::January, 2026));
+        settings.set_evaluation_date(Date::new(16, Month::January, 2026));
 
         assert_eq!(
             writer.borrow().notifications,


### PR DESCRIPTION
Settings held its state behind plain fields, so every mutation needed a
&mut borrow that stayed alive across notify_observers(). An observer that
read the evaluation date - or anything derived from it, such as a moving
term structure's reference date - during that notification met the live
borrow and could not take a second one.

The state now lives in Cells and the mutators take &self, the pattern
SimpleQuote already uses: the new date is in place before the notification
goes out, and settings are shared as Shared<Settings<D>> rather than
SharedMut. The four `try_borrow` guards that turned the double-borrow into
"evaluation-date settings are locked during notification" are gone with the
condition they guarded, which makes TermStructureBase::moving, FlatForward,
BlackConstantVol, LocalConstantVol and OneAssetOption::new infallible.

The re-entrancy machinery in patterns/observable.rs is untouched: those
guards protect an observer's own RefCell against a re-entrant update, a
separate hazard this change does not dissolve.

Closes #221
