### PR TITLE
refactor(patterns): unify the reset-then-notify observers

### DIFF
--- a/crates/libitofin/src/handle.rs
+++ b/crates/libitofin/src/handle.rs
@@ -13,7 +13,7 @@
 
 use crate::errors::QlResult;
 pub use crate::patterns::observable::AsObservable;
-use crate::patterns::observable::{Forwarder, Observable, Observer};
+use crate::patterns::observable::{Observable, Observer, ResetThenNotify};
 use crate::require;
 use crate::shared::{Shared, SharedMut, shared_mut};
 
@@ -22,7 +22,7 @@ use crate::shared::{Shared, SharedMut, shared_mut};
 pub struct Link<T: ?Sized> {
     current: Option<Shared<T>>,
     observable: Shared<Observable>,
-    forwarder: SharedMut<Forwarder>,
+    forwarder: SharedMut<ResetThenNotify>,
 }
 
 impl<T: ?Sized> Link<T> {
@@ -38,9 +38,7 @@ impl<T: AsObservable + ?Sized> Link<T> {
     /// dropped unnotified.
     fn new(pointee: Option<Shared<T>>) -> Self {
         let observable = Shared::new(Observable::new());
-        let forwarder = shared_mut(Forwarder {
-            observable: Shared::clone(&observable),
-        });
+        let forwarder = ResetThenNotify::forwarding(Shared::clone(&observable));
         let mut link = Link {
             current: None,
             observable,

--- a/crates/libitofin/src/patterns/observable.rs
+++ b/crates/libitofin/src/patterns/observable.rs
@@ -147,31 +147,73 @@ pub trait AsObservable {
     fn observable(&self) -> &Observable;
 }
 
-/// Observer that forwards every notification to another observable (the
-/// C++ `update()` of `Link`, `DeltaVolQuote` and friends).
-///
-/// The forwarding target embeds this in front of its own [`Observable`]: the
-/// forwarder registers with the source and passes each notification on to the
-/// target's observers.
-pub(crate) struct Forwarder {
-    pub(crate) observable: Shared<Observable>,
+/// Where a [`ResetThenNotify`] sends the notification once its reset has run.
+enum Target {
+    /// Broadcast to an observable's own observers.
+    Broadcast(Shared<Observable>),
+    /// Hand on to a single observer, with [`deliver`]'s re-entrancy discipline.
+    Deliver(SharedMut<dyn Observer>),
 }
 
-impl Forwarder {
+/// The observer half every cache-holding type embeds: drop the stale state,
+/// then pass the notification on (the C++ `update()` overrides of `Link`,
+/// `DeltaVolQuote`, `FlatForward`, `TermStructure`, the derived quotes and the
+/// Black-Scholes process, which all reset something and call the base
+/// `update()`).
+///
+/// The reset runs *before* the notification, so an observer reading the type
+/// while being notified sees fresh state rather than the value the
+/// notification invalidates.
+pub(crate) struct ResetThenNotify {
+    reset: Box<dyn Fn()>,
+    target: Target,
+}
+
+impl ResetThenNotify {
+    /// Resets, then broadcasts through `observable`.
+    pub(crate) fn broadcasting(
+        observable: Shared<Observable>,
+        reset: impl Fn() + 'static,
+    ) -> SharedMut<ResetThenNotify> {
+        shared_mut(ResetThenNotify {
+            reset: Box::new(reset),
+            target: Target::Broadcast(observable),
+        })
+    }
+
+    /// Resets, then delivers to `observer` - the shape of a type layered on
+    /// another observer half (a curve in front of its term-structure base).
+    pub(crate) fn delivering(
+        observer: SharedMut<dyn Observer>,
+        reset: impl Fn() + 'static,
+    ) -> SharedMut<ResetThenNotify> {
+        shared_mut(ResetThenNotify {
+            reset: Box::new(reset),
+            target: Target::Deliver(observer),
+        })
+    }
+
+    /// Pure forwarding: no state to reset, broadcast through `observable`.
+    pub(crate) fn forwarding(observable: Shared<Observable>) -> SharedMut<ResetThenNotify> {
+        Self::broadcasting(observable, || {})
+    }
+
     /// Builds a fresh observable and the forwarder wired to it, the shared
     /// construction step of every forwarding type.
-    pub(crate) fn new() -> (Shared<Observable>, SharedMut<Forwarder>) {
+    pub(crate) fn forwarder() -> (Shared<Observable>, SharedMut<ResetThenNotify>) {
         let observable = shared(Observable::new());
-        let forwarder = shared_mut(Forwarder {
-            observable: Shared::clone(&observable),
-        });
+        let forwarder = Self::forwarding(Shared::clone(&observable));
         (observable, forwarder)
     }
 }
 
-impl Observer for Forwarder {
+impl Observer for ResetThenNotify {
     fn update(&mut self) {
-        self.observable.notify_observers();
+        (self.reset)();
+        match &self.target {
+            Target::Broadcast(observable) => observable.notify_observers(),
+            Target::Deliver(observer) => deliver(observer),
+        }
     }
 }
 

--- a/crates/libitofin/src/pricingengine.rs
+++ b/crates/libitofin/src/pricingengine.rs
@@ -14,7 +14,7 @@
 use std::any::Any;
 
 use crate::errors::QlResult;
-use crate::patterns::observable::{AsObservable, Forwarder, Observable, Observer};
+use crate::patterns::observable::{AsObservable, Observable, Observer, ResetThenNotify};
 use crate::shared::{Shared, SharedMut};
 
 /// Input bundle of a pricing engine (the C++ `PricingEngine::arguments`).
@@ -72,13 +72,13 @@ pub struct GenericEngine<A, R> {
     arguments: A,
     results: R,
     observable: Shared<Observable>,
-    forwarder: SharedMut<Forwarder>,
+    forwarder: SharedMut<ResetThenNotify>,
 }
 
 impl<A: Arguments, R: Results> GenericEngine<A, R> {
     /// Creates the engine base around its argument and result bundles.
     pub fn new(arguments: A, results: R) -> Self {
-        let (observable, forwarder) = Forwarder::new();
+        let (observable, forwarder) = ResetThenNotify::forwarder();
         GenericEngine {
             arguments,
             results,

--- a/crates/libitofin/src/processes/blackscholesprocess.rs
+++ b/crates/libitofin/src/processes/blackscholesprocess.rs
@@ -32,10 +32,10 @@ use crate::errors::QlResult;
 use crate::fail;
 use crate::handle::{Handle, RelinkableHandle};
 use crate::interestrate::Compounding;
-use crate::patterns::observable::{AsObservable, Observable, Observer};
+use crate::patterns::observable::{AsObservable, Observable, Observer, ResetThenNotify};
 use crate::quotes::Quote;
 use crate::require;
-use crate::shared::{Shared, SharedMut, shared, shared_mut};
+use crate::shared::{Shared, SharedMut, shared};
 use crate::stochasticprocess::StochasticProcess1D;
 use crate::termstructures::TermStructure;
 use crate::termstructures::volatility::{
@@ -45,21 +45,6 @@ use crate::termstructures::yieldtermstructure::YieldTermStructure;
 use crate::time::date::Date;
 use crate::time::frequency::Frequency;
 use crate::types::{Rate, Real, Time};
-
-/// Observer half of the process (the C++
-/// `GeneralizedBlackScholesProcess::update()`): drops the cached local
-/// volatility, then forwards the notification to the process observers.
-struct CacheInvalidator {
-    updated: Shared<Cell<bool>>,
-    observable: Shared<Observable>,
-}
-
-impl Observer for CacheInvalidator {
-    fn update(&mut self) {
-        self.updated.set(false);
-        self.observable.notify_observers();
-    }
-}
 
 /// Generalized Black-Scholes stochastic process.
 pub struct GeneralizedBlackScholesProcess {
@@ -72,7 +57,7 @@ pub struct GeneralizedBlackScholesProcess {
     updated: Shared<Cell<bool>>,
     is_strike_independent: Cell<bool>,
     observable: Shared<Observable>,
-    _listener: SharedMut<CacheInvalidator>,
+    _listener: SharedMut<ResetThenNotify>,
 }
 
 /// Merton (1973) extension to the Black-Scholes stochastic process: a stock
@@ -90,9 +75,9 @@ impl GeneralizedBlackScholesProcess {
     ) -> GeneralizedBlackScholesProcess {
         let updated = shared(Cell::new(false));
         let observable = shared(Observable::new());
-        let listener = shared_mut(CacheInvalidator {
-            updated: Shared::clone(&updated),
-            observable: Shared::clone(&observable),
+        let listener = ResetThenNotify::broadcasting(Shared::clone(&observable), {
+            let updated = Shared::clone(&updated);
+            move || updated.set(false)
         });
         let observer = listener.clone() as SharedMut<dyn Observer>;
         x0.register_observer(&observer);

--- a/crates/libitofin/src/quotes/compositequote.rs
+++ b/crates/libitofin/src/quotes/compositequote.rs
@@ -10,11 +10,11 @@ use std::cell::Cell;
 use crate::ensure;
 use crate::errors::QlResult;
 use crate::handle::{AsObservable, Handle};
-use crate::patterns::observable::{Observable, Observer};
+use crate::patterns::observable::{Observable, Observer, ResetThenNotify};
 use crate::shared::{Shared, SharedMut};
 use crate::types::Real;
 
-use super::{Invalidator, Quote};
+use super::{Quote, invalidator};
 
 /// Market element whose value depends on two other market elements.
 ///
@@ -27,7 +27,7 @@ pub struct CompositeQuote<F> {
     cache: Shared<Cell<Option<Real>>>,
     observable: Shared<Observable>,
     f: F,
-    _listener: SharedMut<Invalidator>,
+    _listener: SharedMut<ResetThenNotify>,
 }
 
 impl<F: Fn(Real, Real) -> Real> CompositeQuote<F> {
@@ -35,7 +35,7 @@ impl<F: Fn(Real, Real) -> Real> CompositeQuote<F> {
     /// registering with both handles like the C++ constructor's
     /// `registerWith` calls.
     pub fn new(element1: Handle<dyn Quote>, element2: Handle<dyn Quote>, f: F) -> Self {
-        let (cache, observable, listener) = Invalidator::new();
+        let (cache, observable, listener) = invalidator();
         let observer = listener.clone() as SharedMut<dyn Observer>;
         element1.register_observer(&observer);
         element2.register_observer(&observer);

--- a/crates/libitofin/src/quotes/deltavolquote.rs
+++ b/crates/libitofin/src/quotes/deltavolquote.rs
@@ -7,8 +7,8 @@
 
 use crate::errors::QlResult;
 use crate::handle::{AsObservable, Handle};
-use crate::patterns::observable::{Forwarder, Observable, Observer};
-use crate::shared::{Shared, SharedMut, shared, shared_mut};
+use crate::patterns::observable::{Observable, Observer, ResetThenNotify};
+use crate::shared::{Shared, SharedMut, shared};
 use crate::types::{Real, Time};
 
 use super::Quote;
@@ -57,7 +57,7 @@ pub struct DeltaVolQuote {
     maturity: Time,
     atm_type: AtmType,
     observable: Shared<Observable>,
-    _listener: SharedMut<Forwarder>,
+    _listener: SharedMut<ResetThenNotify>,
 }
 
 impl DeltaVolQuote {
@@ -87,9 +87,7 @@ impl DeltaVolQuote {
         atm_type: AtmType,
     ) -> Self {
         let observable = shared(Observable::new());
-        let listener = shared_mut(Forwarder {
-            observable: Shared::clone(&observable),
-        });
+        let listener = ResetThenNotify::forwarding(Shared::clone(&observable));
         vol.register_observer(&(listener.clone() as SharedMut<dyn Observer>));
         DeltaVolQuote {
             delta,

--- a/crates/libitofin/src/quotes/derivedquote.rs
+++ b/crates/libitofin/src/quotes/derivedquote.rs
@@ -10,11 +10,11 @@ use std::cell::Cell;
 use crate::ensure;
 use crate::errors::QlResult;
 use crate::handle::{AsObservable, Handle};
-use crate::patterns::observable::{Observable, Observer};
+use crate::patterns::observable::{Observable, Observer, ResetThenNotify};
 use crate::shared::{Shared, SharedMut};
 use crate::types::Real;
 
-use super::{Invalidator, Quote};
+use super::{Quote, invalidator};
 
 /// Market quote whose value depends on another quote.
 ///
@@ -26,14 +26,14 @@ pub struct DerivedQuote<F> {
     cache: Shared<Cell<Option<Real>>>,
     observable: Shared<Observable>,
     f: F,
-    _listener: SharedMut<Invalidator>,
+    _listener: SharedMut<ResetThenNotify>,
 }
 
 impl<F: Fn(Real) -> Real> DerivedQuote<F> {
     /// Creates a quote deriving its value from `element` through `f`,
     /// registering with the handle like the C++ constructor's `registerWith`.
     pub fn new(element: Handle<dyn Quote>, f: F) -> Self {
-        let (cache, observable, listener) = Invalidator::new();
+        let (cache, observable, listener) = invalidator();
         element.register_observer(&(listener.clone() as SharedMut<dyn Observer>));
         DerivedQuote {
             element,

--- a/crates/libitofin/src/quotes/mod.rs
+++ b/crates/libitofin/src/quotes/mod.rs
@@ -32,8 +32,8 @@ pub use simplequote::{SimpleQuote, make_quote_handle};
 use std::cell::Cell;
 
 use crate::errors::QlResult;
-use crate::patterns::observable::{AsObservable, Observable, Observer};
-use crate::shared::{Shared, SharedMut, shared, shared_mut};
+use crate::patterns::observable::{AsObservable, Observable, ResetThenNotify};
+use crate::shared::{Shared, SharedMut, shared};
 use crate::types::Real;
 
 /// Purely virtual base class for market observables.
@@ -50,39 +50,23 @@ pub trait Quote: AsObservable {
     fn is_valid(&self) -> bool;
 }
 
-/// Observer half of a derived quote (the C++ `update()` of `DerivedQuote` and
-/// friends): drops the cached value and passes the notification on to the
-/// quote's own observers.
+/// Builds the empty cache, the quote's observable and the invalidating
+/// listener wired to both - the shared construction step of every derived
+/// quote (the C++ `update()` of `DerivedQuote` and friends drops the cached
+/// value and passes the notification on).
 ///
-/// Derived quotes register one of these with their source handle(s) and hold
+/// Derived quotes register the listener with their source handle(s) and hold
 /// the strong reference; the observer registry keeps only a weak one.
-struct Invalidator {
-    cache: Shared<Cell<Option<Real>>>,
-    observable: Shared<Observable>,
-}
-
-impl Invalidator {
-    /// Builds the empty cache, the quote's observable and the invalidating
-    /// listener wired to both - the shared construction step of every derived
-    /// quote.
-    fn new() -> (
-        Shared<Cell<Option<Real>>>,
-        Shared<Observable>,
-        SharedMut<Invalidator>,
-    ) {
-        let cache = shared(Cell::new(None));
-        let observable = shared(Observable::new());
-        let listener = shared_mut(Invalidator {
-            cache: Shared::clone(&cache),
-            observable: Shared::clone(&observable),
-        });
-        (cache, observable, listener)
-    }
-}
-
-impl Observer for Invalidator {
-    fn update(&mut self) {
-        self.cache.set(None);
-        self.observable.notify_observers();
-    }
+fn invalidator() -> (
+    Shared<Cell<Option<Real>>>,
+    Shared<Observable>,
+    SharedMut<ResetThenNotify>,
+) {
+    let cache = shared(Cell::new(None));
+    let observable = shared(Observable::new());
+    let listener = ResetThenNotify::broadcasting(Shared::clone(&observable), {
+        let cache = Shared::clone(&cache);
+        move || cache.set(None)
+    });
+    (cache, observable, listener)
 }

--- a/crates/libitofin/src/quotes/multicompositequote.rs
+++ b/crates/libitofin/src/quotes/multicompositequote.rs
@@ -11,12 +11,12 @@ use crate::ensure;
 use crate::errors::QlResult;
 use crate::handle::{AsObservable, Handle};
 use crate::math::array::Array;
-use crate::patterns::observable::{Observable, Observer};
+use crate::patterns::observable::{Observable, Observer, ResetThenNotify};
 use crate::require;
 use crate::shared::{Shared, SharedMut};
 use crate::types::{Real, Size};
 
-use super::{Invalidator, Quote};
+use super::{Quote, invalidator};
 
 /// Market element whose value depends on any number of other market elements.
 ///
@@ -28,14 +28,14 @@ pub struct MultiCompositeQuote<F> {
     cache: Shared<Cell<Option<Real>>>,
     observable: Shared<Observable>,
     f: F,
-    _listener: SharedMut<Invalidator>,
+    _listener: SharedMut<ResetThenNotify>,
 }
 
 impl<F: Fn(&Array) -> Real> MultiCompositeQuote<F> {
     /// Creates a quote combining `elements` through `f`, registering with
     /// every handle like the C++ constructor's `registerWith` loop.
     pub fn new(elements: Vec<Handle<dyn Quote>>, f: F) -> Self {
-        let (cache, observable, listener) = Invalidator::new();
+        let (cache, observable, listener) = invalidator();
         let observer = listener.clone() as SharedMut<dyn Observer>;
         for element in &elements {
             element.register_observer(&observer);

--- a/crates/libitofin/src/stochasticprocess.rs
+++ b/crates/libitofin/src/stochasticprocess.rs
@@ -18,7 +18,8 @@
 //! construction, registers with each of its inputs an
 //! [`Observer`](crate::patterns::observable::Observer) whose `update`
 //! forwards the notification to that embedded observable. Processes inside
-//! this crate reuse the crate-internal `Forwarder` for that observer, as
+//! this crate reuse the crate-internal `ResetThenNotify` (via its
+//! `forwarding` constructor) for that observer, as
 //! [`Handle`](crate::handle::Handle) and `DeltaVolQuote` already do.
 
 use crate::errors::QlResult;
@@ -96,9 +97,9 @@ pub trait StochasticProcess1D: AsObservable {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::patterns::observable::{Forwarder, Observable, Observer};
+    use crate::patterns::observable::{Observable, Observer, ResetThenNotify};
     use crate::quotes::{Quote, SimpleQuote};
-    use crate::shared::{Shared, SharedMut, shared, shared_mut};
+    use crate::shared::{Shared, SharedMut, shared};
     use crate::test_support::{Flag, as_observer};
     use crate::time::date::Month;
 
@@ -107,16 +108,14 @@ mod tests {
         sigma: Real,
         quote: Shared<SimpleQuote>,
         observable: Shared<Observable>,
-        _listener: SharedMut<Forwarder>,
+        _listener: SharedMut<ResetThenNotify>,
     }
 
     impl ConstantProcess {
         fn new(initial: Real, mu: Real, sigma: Real) -> Self {
             let quote = shared(SimpleQuote::new(initial));
             let observable = shared(Observable::new());
-            let listener = shared_mut(Forwarder {
-                observable: Shared::clone(&observable),
-            });
+            let listener = ResetThenNotify::forwarding(Shared::clone(&observable));
             quote
                 .observable()
                 .register_observer(&(listener.clone() as SharedMut<dyn Observer>));

--- a/crates/libitofin/src/termstructures/mod.rs
+++ b/crates/libitofin/src/termstructures/mod.rs
@@ -41,9 +41,9 @@ use std::cell::Cell;
 
 use crate::errors::QlResult;
 use crate::math::comparison::close_enough;
-use crate::patterns::observable::{AsObservable, Observable, Observer};
+use crate::patterns::observable::{AsObservable, Observable, Observer, ResetThenNotify};
 use crate::settings::Settings;
-use crate::shared::{Shared, SharedMut, shared, shared_mut};
+use crate::shared::{Shared, SharedMut, shared};
 use crate::time::businessdayconvention::BusinessDayConvention;
 use crate::time::calendar::Calendar;
 use crate::time::date::Date;
@@ -60,23 +60,6 @@ struct ReferenceState {
     moving: bool,
 }
 
-/// Observer half of a term structure (the C++ `TermStructure::update()`):
-/// drops the cached reference date when the structure is moving and passes
-/// the notification on to the structure's own observers.
-struct Updater {
-    reference: Shared<ReferenceState>,
-    observable: Shared<Observable>,
-}
-
-impl Observer for Updater {
-    fn update(&mut self) {
-        if self.reference.moving {
-            self.reference.date.set(None);
-        }
-        self.observable.notify_observers();
-    }
-}
-
 /// Shared base holder for term structures.
 ///
 /// Concrete curves embed one, delegate the [`TermStructure`] trait's
@@ -90,7 +73,7 @@ pub struct TermStructureBase {
     extrapolation: Cell<bool>,
     reference: Shared<ReferenceState>,
     observable: Shared<Observable>,
-    updater: SharedMut<Updater>,
+    updater: SharedMut<ResetThenNotify>,
 }
 
 impl TermStructureBase {
@@ -107,9 +90,13 @@ impl TermStructureBase {
             moving,
         });
         let observable = shared(Observable::new());
-        let updater = shared_mut(Updater {
-            reference: Shared::clone(&reference),
-            observable: Shared::clone(&observable),
+        let updater = ResetThenNotify::broadcasting(Shared::clone(&observable), {
+            let reference = Shared::clone(&reference);
+            move || {
+                if reference.moving {
+                    reference.date.set(None);
+                }
+            }
         });
         TermStructureBase {
             calendar,

--- a/crates/libitofin/src/termstructures/yields/flatforward.rs
+++ b/crates/libitofin/src/termstructures/yields/flatforward.rs
@@ -16,7 +16,7 @@
 use crate::errors::QlResult;
 use crate::handle::Handle;
 use crate::interestrate::{Compounding, InterestRate};
-use crate::patterns::observable::{AsObservable, Observable, Observer, deliver};
+use crate::patterns::observable::{AsObservable, Observable, Observer, ResetThenNotify};
 use crate::quotes::{Quote, SimpleQuote};
 use crate::settings::Settings;
 use crate::shared::{Shared, SharedMut, shared, shared_mut};
@@ -28,20 +28,6 @@ use crate::time::daycounter::DayCounter;
 use crate::time::frequency::Frequency;
 use crate::types::{DiscountFactor, Natural, Rate, Time};
 
-/// Observer half of a flat curve (the C++ `FlatForward::update()`): drops the
-/// cached rate, then behaves like the term-structure base updater.
-struct RateInvalidator {
-    rate: SharedMut<Option<InterestRate>>,
-    updater: SharedMut<dyn Observer>,
-}
-
-impl Observer for RateInvalidator {
-    fn update(&mut self) {
-        self.rate.borrow_mut().take();
-        deliver(&self.updater);
-    }
-}
-
 /// Flat interest-rate curve.
 pub struct FlatForward {
     base: TermStructureBase,
@@ -49,7 +35,7 @@ pub struct FlatForward {
     compounding: Compounding,
     frequency: Frequency,
     rate: SharedMut<Option<InterestRate>>,
-    _listener: SharedMut<RateInvalidator>,
+    _listener: SharedMut<ResetThenNotify>,
 }
 
 impl FlatForward {
@@ -60,9 +46,11 @@ impl FlatForward {
         frequency: Frequency,
     ) -> FlatForward {
         let rate = shared_mut(None);
-        let listener = shared_mut(RateInvalidator {
-            rate: SharedMut::clone(&rate),
-            updater: base.updater(),
+        let listener = ResetThenNotify::delivering(base.updater(), {
+            let rate = SharedMut::clone(&rate);
+            move || {
+                rate.borrow_mut().take();
+            }
         });
         forward.register_observer(&(listener.clone() as SharedMut<dyn Observer>));
         FlatForward {

--- a/crates/libitofin/src/termstructures/yields/forwardspreadedtermstructure.rs
+++ b/crates/libitofin/src/termstructures/yields/forwardspreadedtermstructure.rs
@@ -20,13 +20,11 @@
 use crate::errors::QlResult;
 use crate::handle::Handle;
 use crate::interestrate::Compounding;
-use crate::patterns::observable::{AsObservable, Observable};
+use crate::patterns::observable::{AsObservable, Observable, ResetThenNotify};
 use crate::quotes::Quote;
 use crate::shared::{Shared, SharedMut, shared};
 use crate::termstructures::yields::ZeroYieldStructure;
-use crate::termstructures::yields::zerospreadedtermstructure::{
-    ExtrapolationSync, spawn_extrapolation_sync,
-};
+use crate::termstructures::yields::zerospreadedtermstructure::spawn_extrapolation_sync;
 use crate::termstructures::yieldtermstructure::YieldTermStructure;
 use crate::termstructures::{TermStructure, TermStructureBase};
 use crate::time::calendar::Calendar;
@@ -40,7 +38,7 @@ pub struct ForwardSpreadedTermStructure {
     base: Shared<TermStructureBase>,
     original: Handle<dyn YieldTermStructure>,
     spread: Handle<dyn Quote>,
-    _listener: SharedMut<ExtrapolationSync>,
+    _listener: SharedMut<ResetThenNotify>,
 }
 
 impl ForwardSpreadedTermStructure {

--- a/crates/libitofin/src/termstructures/yields/impliedtermstructure.rs
+++ b/crates/libitofin/src/termstructures/yields/impliedtermstructure.rs
@@ -19,7 +19,7 @@
 use super::sync_extrapolation;
 use crate::errors::QlResult;
 use crate::handle::Handle;
-use crate::patterns::observable::{AsObservable, Observable, Observer, deliver};
+use crate::patterns::observable::{AsObservable, Observable, Observer, ResetThenNotify};
 use crate::shared::{Shared, SharedMut, shared, shared_mut};
 use crate::termstructures::yieldtermstructure::YieldTermStructure;
 use crate::termstructures::{TermStructure, TermStructureBase};
@@ -27,24 +27,6 @@ use crate::time::calendar::Calendar;
 use crate::time::date::Date;
 use crate::time::daycounter::DayCounter;
 use crate::types::{DiscountFactor, Natural, Time};
-
-/// Observer half of an implied curve (the C++ `ImpliedTermStructure::update()`):
-/// drops the cached re-basing factors, re-syncs the extrapolation flag to the
-/// underlying curve, then behaves like the term-structure base updater.
-struct CacheInvalidator {
-    cache: SharedMut<Option<(Time, DiscountFactor)>>,
-    base: Shared<TermStructureBase>,
-    original: Handle<dyn YieldTermStructure>,
-    updater: SharedMut<dyn Observer>,
-}
-
-impl Observer for CacheInvalidator {
-    fn update(&mut self) {
-        self.cache.borrow_mut().take();
-        sync_extrapolation(&self.base, &self.original);
-        deliver(&self.updater);
-    }
-}
 
 /// Implied term structure at a given date in the future.
 ///
@@ -54,7 +36,7 @@ pub struct ImpliedTermStructure {
     base: Shared<TermStructureBase>,
     original: Handle<dyn YieldTermStructure>,
     cache: SharedMut<Option<(Time, DiscountFactor)>>,
-    _listener: SharedMut<CacheInvalidator>,
+    _listener: SharedMut<ResetThenNotify>,
 }
 
 impl ImpliedTermStructure {
@@ -71,11 +53,14 @@ impl ImpliedTermStructure {
         ));
         sync_extrapolation(&base, &original);
         let cache = shared_mut(None);
-        let listener = shared_mut(CacheInvalidator {
-            cache: SharedMut::clone(&cache),
-            base: Shared::clone(&base),
-            original: original.clone(),
-            updater: base.updater(),
+        let listener = ResetThenNotify::delivering(base.updater(), {
+            let cache = SharedMut::clone(&cache);
+            let base = Shared::clone(&base);
+            let original = original.clone();
+            move || {
+                cache.borrow_mut().take();
+                sync_extrapolation(&base, &original);
+            }
         });
         original.register_observer(&(listener.clone() as SharedMut<dyn Observer>));
         ImpliedTermStructure {

--- a/crates/libitofin/src/termstructures/yields/zerospreadedtermstructure.rs
+++ b/crates/libitofin/src/termstructures/yields/zerospreadedtermstructure.rs
@@ -21,9 +21,9 @@ use super::sync_extrapolation;
 use crate::errors::QlResult;
 use crate::handle::Handle;
 use crate::interestrate::{Compounding, InterestRate};
-use crate::patterns::observable::{AsObservable, Observable, Observer, deliver};
+use crate::patterns::observable::{AsObservable, Observable, Observer, ResetThenNotify};
 use crate::quotes::Quote;
-use crate::shared::{Shared, SharedMut, shared, shared_mut};
+use crate::shared::{Shared, SharedMut, shared};
 use crate::termstructures::yields::ZeroYieldStructure;
 use crate::termstructures::yieldtermstructure::YieldTermStructure;
 use crate::termstructures::{TermStructure, TermStructureBase};
@@ -33,32 +33,19 @@ use crate::time::daycounter::DayCounter;
 use crate::time::frequency::Frequency;
 use crate::types::{DiscountFactor, Natural, Rate, Time};
 
-/// Observer half of a spreaded curve (the C++ `update()` override): re-syncs
-/// the extrapolation flag to the underlying curve, then behaves like the
-/// term-structure base updater.
-pub(super) struct ExtrapolationSync {
-    base: Shared<TermStructureBase>,
-    original: Handle<dyn YieldTermStructure>,
-    updater: SharedMut<dyn Observer>,
-}
-
-impl Observer for ExtrapolationSync {
-    fn update(&mut self) {
-        sync_extrapolation(&self.base, &self.original);
-        deliver(&self.updater);
-    }
-}
-
+/// Builds the observer half of a spreaded curve (the C++ `update()` override):
+/// re-syncs the extrapolation flag to the underlying curve, then behaves like
+/// the term-structure base updater.
 pub(super) fn spawn_extrapolation_sync(
     base: &Shared<TermStructureBase>,
     original: &Handle<dyn YieldTermStructure>,
     spread: &Handle<dyn Quote>,
-) -> SharedMut<ExtrapolationSync> {
+) -> SharedMut<ResetThenNotify> {
     sync_extrapolation(base, original);
-    let listener = shared_mut(ExtrapolationSync {
-        base: Shared::clone(base),
-        original: original.clone(),
-        updater: base.updater(),
+    let listener = ResetThenNotify::delivering(base.updater(), {
+        let base = Shared::clone(base);
+        let original = original.clone();
+        move || sync_extrapolation(&base, &original)
     });
     original.register_observer(&(listener.clone() as SharedMut<dyn Observer>));
     spread.register_observer(&(listener.clone() as SharedMut<dyn Observer>));
@@ -72,7 +59,7 @@ pub struct ZeroSpreadedTermStructure {
     spread: Handle<dyn Quote>,
     compounding: Compounding,
     frequency: Frequency,
-    _listener: SharedMut<ExtrapolationSync>,
+    _listener: SharedMut<ResetThenNotify>,
 }
 
 impl ZeroSpreadedTermStructure {


### PR DESCRIPTION
Seven observer halves repeated the same shape - drop some cached state,
then pass the notification on - each with its own struct, its own Observer
impl and its own wiring: Forwarder, quotes::Invalidator, RateInvalidator,
ExtrapolationSync, the two CacheInvalidators and TermStructureBase's
Updater.

They collapse into one ResetThenNotify in patterns::observable, holding a
boxed reset closure and a target that either broadcasts through an
Observable or delivers to another observer. Each site now names its reset
inline at construction; the reset still runs before the notification, so an
observer reading the type mid-wave sees fresh state.

instrument::Updater keeps its own impl: it notifies conditionally on the
lazy core's deferred_update, which is not this shape.

No functional change; 148 insertions against 198 deletions.

Closes #222
