### PR TITLE
feat(#247)!: imple SimpleCashFlow & Redemption & Dividend

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,16 @@ oversight) and is documented at the point of divergence in the source.
   provided method on `CashFlow` would be ambiguous rather than overriding. Each
   implementor therefore forwards explicitly to `event_has_occurred` or
   `cash_flow_has_occurred`, turning a silent wrong answer into a compile error.
+- **`CashFlow::ex_coupon_date` is required, and a coupon holds the date twice.**
+  C++ answers both `Coupon::accruedPeriod`'s ex-coupon test and
+  `CashFlow::exCouponDate()` from one member (`coupon.hpp:57`). In Rust a
+  `Coupon` cannot override a provided method on its `CashFlow` supertrait, so
+  the accrual reads the date off `CouponBase` while `trading_ex_coupon` reads
+  it off the trait method. Defaulting the trait method to `None` would let an
+  implementor accrue ex-coupon while reporting `trading_ex_coupon` as `false`;
+  it is therefore required, so omission is a compile error. The two readers
+  remain distinct, and a concrete coupon must forward `ex_coupon_date` to its
+  `CouponBase` for them to agree.
 
 ## License
 

--- a/crates/libitofin/src/cashflow.rs
+++ b/crates/libitofin/src/cashflow.rs
@@ -31,9 +31,12 @@ pub trait CashFlow: Event {
     fn amount(&self) -> QlResult<Real>;
 
     /// The date from which the flow trades ex-coupon, when it has one.
-    fn ex_coupon_date(&self) -> Option<Date> {
-        None
-    }
+    ///
+    /// Required rather than defaulted to `None`: a `Coupon` stores this date on
+    /// its base and cannot override a provided method here, so a default would
+    /// let an implementor accrue ex-coupon while reporting
+    /// [`trading_ex_coupon`](CashFlow::trading_ex_coupon) as `false`.
+    fn ex_coupon_date(&self) -> Option<Date>;
 
     /// Whether the flow trades ex-coupon as of `ref_date` (the evaluation date
     /// when `None`).

--- a/crates/libitofin/src/cashflows/dividend.rs
+++ b/crates/libitofin/src/cashflows/dividend.rs
@@ -68,6 +68,10 @@ impl CashFlow for FixedDividend {
     fn amount(&self) -> QlResult<Real> {
         Ok(self.amount)
     }
+
+    fn ex_coupon_date(&self) -> Option<Date> {
+        None
+    }
 }
 
 impl Dividend for FixedDividend {
@@ -138,6 +142,10 @@ impl CashFlow for FractionalDividend {
             Some(nominal) => Ok(self.rate * nominal),
             None => fail!("no nominal given"),
         }
+    }
+
+    fn ex_coupon_date(&self) -> Option<Date> {
+        None
     }
 }
 

--- a/crates/libitofin/src/cashflows/dividend.rs
+++ b/crates/libitofin/src/cashflows/dividend.rs
@@ -1,0 +1,239 @@
+//! Stock dividends.
+//!
+//! Port of `ql/cashflows/dividend.{hpp,cpp}`. A [`Dividend`] is a cash flow
+//! whose amount may depend on the underlying's value, which is what
+//! [`FractionalDividend`] uses it for.
+//!
+//! QuantLib marks a fractional dividend's missing nominal with the
+//! `Null<Real>` sentinel and fails on it in `amount()`; the port stores
+//! `Option<Real>` and returns the same failure as an `Err`, following the
+//! [`SimpleQuote`](crate::quotes::SimpleQuote) precedent.
+
+use crate::cashflow::{CashFlow, cash_flow_has_occurred};
+use crate::errors::QlResult;
+use crate::event::Event;
+use crate::patterns::observable::{AsObservable, Observable};
+use crate::settings::Settings;
+use crate::shared::{Shared, shared};
+use crate::time::date::Date;
+use crate::types::Real;
+use crate::{fail, require};
+
+/// A cash flow paid on a stock, whose amount may be read off the underlying.
+pub trait Dividend: CashFlow {
+    /// The amount paid when the underlying is worth `underlying`.
+    fn amount_with_underlying(&self, underlying: Real) -> Real;
+}
+
+/// A dividend paying a predetermined amount, whatever the underlying is worth.
+pub struct FixedDividend {
+    amount: Real,
+    date: Date,
+    observable: Observable,
+}
+
+impl FixedDividend {
+    /// Creates a dividend paying `amount` on `date`.
+    pub fn new(amount: Real, date: Date) -> Self {
+        FixedDividend {
+            amount,
+            date,
+            observable: Observable::new(),
+        }
+    }
+}
+
+impl AsObservable for FixedDividend {
+    fn observable(&self) -> &Observable {
+        &self.observable
+    }
+}
+
+impl Event for FixedDividend {
+    fn date(&self) -> Date {
+        self.date
+    }
+
+    fn has_occurred(
+        &self,
+        settings: &Settings<Date>,
+        ref_date: Option<Date>,
+        include_ref_date: Option<bool>,
+    ) -> QlResult<bool> {
+        cash_flow_has_occurred(self.date, settings, ref_date, include_ref_date)
+    }
+}
+
+impl CashFlow for FixedDividend {
+    fn amount(&self) -> QlResult<Real> {
+        Ok(self.amount)
+    }
+}
+
+impl Dividend for FixedDividend {
+    fn amount_with_underlying(&self, _underlying: Real) -> Real {
+        self.amount
+    }
+}
+
+/// A dividend paying a fixed fraction of the underlying.
+///
+/// The nominal is optional: without one, [`CashFlow::amount`] has no underlying
+/// to apply the rate to and fails, while
+/// [`amount_with_underlying`](Dividend::amount_with_underlying) still works.
+pub struct FractionalDividend {
+    rate: Real,
+    nominal: Option<Real>,
+    date: Date,
+    observable: Observable,
+}
+
+impl FractionalDividend {
+    /// Creates a dividend paying `rate` times `nominal` on `date`; pass `None`
+    /// for the nominal-less C++ two-argument constructor.
+    pub fn new(rate: Real, nominal: impl Into<Option<Real>>, date: Date) -> Self {
+        FractionalDividend {
+            rate,
+            nominal: nominal.into(),
+            date,
+            observable: Observable::new(),
+        }
+    }
+
+    /// The fraction of the underlying that is paid.
+    pub fn rate(&self) -> Real {
+        self.rate
+    }
+
+    /// The nominal the rate applies to, when one was given.
+    pub fn nominal(&self) -> Option<Real> {
+        self.nominal
+    }
+}
+
+impl AsObservable for FractionalDividend {
+    fn observable(&self) -> &Observable {
+        &self.observable
+    }
+}
+
+impl Event for FractionalDividend {
+    fn date(&self) -> Date {
+        self.date
+    }
+
+    fn has_occurred(
+        &self,
+        settings: &Settings<Date>,
+        ref_date: Option<Date>,
+        include_ref_date: Option<bool>,
+    ) -> QlResult<bool> {
+        cash_flow_has_occurred(self.date, settings, ref_date, include_ref_date)
+    }
+}
+
+impl CashFlow for FractionalDividend {
+    fn amount(&self) -> QlResult<Real> {
+        match self.nominal {
+            Some(nominal) => Ok(self.rate * nominal),
+            None => fail!("no nominal given"),
+        }
+    }
+}
+
+impl Dividend for FractionalDividend {
+    fn amount_with_underlying(&self, underlying: Real) -> Real {
+        self.rate * underlying
+    }
+}
+
+/// Builds a sequence of [`FixedDividend`]s, one per date.
+///
+/// Mirrors `DividendVector`; the size mismatch it throws on is an `Err` here.
+pub fn dividend_vector(dates: &[Date], amounts: &[Real]) -> QlResult<Vec<Shared<dyn Dividend>>> {
+    require!(
+        dates.len() == amounts.len(),
+        "size mismatch between dividend dates and amounts"
+    );
+    Ok(dates
+        .iter()
+        .zip(amounts)
+        .map(|(&date, &amount)| shared(FixedDividend::new(amount, date)) as Shared<dyn Dividend>)
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::time::date::Month;
+
+    fn today() -> Date {
+        Date::new(7, Month::July, 2026)
+    }
+
+    /// No test-suite case pins the dividends numerically; the header is the
+    /// only oracle, and it makes a fixed dividend ignore the underlying.
+    #[test]
+    fn a_fixed_dividend_pays_its_amount_whatever_the_underlying() {
+        let dividend = FixedDividend::new(3.5, today());
+
+        assert_eq!(dividend.date(), today());
+        assert_eq!(dividend.amount().unwrap(), 3.5);
+        assert_eq!(dividend.amount_with_underlying(0.0), 3.5);
+        assert_eq!(dividend.amount_with_underlying(100.0), 3.5);
+    }
+
+    #[test]
+    fn a_fractional_dividend_pays_its_rate_times_the_underlying() {
+        let dividend = FractionalDividend::new(0.02, None, today());
+
+        assert_eq!(dividend.rate(), 0.02);
+        assert_eq!(dividend.nominal(), None);
+        assert_eq!(dividend.amount_with_underlying(150.0), 3.0);
+    }
+
+    /// The `QL_REQUIRE(nominal_ != Null<Real>(), "no nominal given")` of the
+    /// header, as an `Err`.
+    #[test]
+    fn a_fractional_dividend_without_a_nominal_has_no_amount() {
+        let without = FractionalDividend::new(0.02, None, today());
+        let with = FractionalDividend::new(0.02, 150.0, today());
+
+        assert!(without.amount().is_err());
+        assert_eq!(with.nominal(), Some(150.0));
+        assert_eq!(with.amount().unwrap(), 3.0);
+    }
+
+    #[test]
+    fn a_dividend_uses_the_cash_flow_occurrence_rule() {
+        let settings = Settings::new();
+        settings.set_evaluation_date(today());
+        settings.set_include_reference_date_events(true);
+        settings.set_include_todays_cash_flows(Some(false));
+
+        let fixed = FixedDividend::new(3.5, today());
+        let fractional = FractionalDividend::new(0.02, 150.0, today());
+
+        assert!(fixed.has_occurred(&settings, None, None).unwrap());
+        assert!(fractional.has_occurred(&settings, None, None).unwrap());
+    }
+
+    #[test]
+    fn a_dividend_vector_pairs_each_date_with_its_amount() {
+        let dates = [today(), today() + 90];
+        let amounts = [1.0, 2.0];
+
+        let dividends = dividend_vector(&dates, &amounts).unwrap();
+
+        assert_eq!(dividends.len(), 2);
+        assert_eq!(dividends[0].date(), today());
+        assert_eq!(dividends[0].amount().unwrap(), 1.0);
+        assert_eq!(dividends[1].date(), today() + 90);
+        assert_eq!(dividends[1].amount_with_underlying(50.0), 2.0);
+    }
+
+    #[test]
+    fn a_dividend_vector_rejects_a_size_mismatch() {
+        assert!(dividend_vector(&[today()], &[1.0, 2.0]).is_err());
+    }
+}

--- a/crates/libitofin/src/cashflows/mod.rs
+++ b/crates/libitofin/src/cashflows/mod.rs
@@ -4,6 +4,8 @@
 //! implementors, re-exported flat. The coupons follow; this module starts with
 //! the flows that pay a predetermined amount.
 
+mod dividend;
 mod simplecashflow;
 
+pub use dividend::{Dividend, FixedDividend, FractionalDividend, dividend_vector};
 pub use simplecashflow::{AmortizingPayment, Redemption, SimpleCashFlow};

--- a/crates/libitofin/src/cashflows/mod.rs
+++ b/crates/libitofin/src/cashflows/mod.rs
@@ -1,0 +1,9 @@
+//! Concrete cash flows.
+//!
+//! Port of `ql/cashflows/`: the [`CashFlow`](crate::cashflow::CashFlow)
+//! implementors, re-exported flat. The coupons follow; this module starts with
+//! the flows that pay a predetermined amount.
+
+mod simplecashflow;
+
+pub use simplecashflow::{AmortizingPayment, Redemption, SimpleCashFlow};

--- a/crates/libitofin/src/cashflows/simplecashflow.rs
+++ b/crates/libitofin/src/cashflows/simplecashflow.rs
@@ -57,6 +57,10 @@ impl CashFlow for SimpleCashFlow {
     fn amount(&self) -> QlResult<Real> {
         Ok(self.amount)
     }
+
+    fn ex_coupon_date(&self) -> Option<Date> {
+        None
+    }
 }
 
 macro_rules! simple_cash_flow_alias {
@@ -95,6 +99,10 @@ macro_rules! simple_cash_flow_alias {
         impl CashFlow for $name {
             fn amount(&self) -> QlResult<Real> {
                 self.0.amount()
+            }
+
+            fn ex_coupon_date(&self) -> Option<Date> {
+                self.0.ex_coupon_date()
             }
         }
     };

--- a/crates/libitofin/src/cashflows/simplecashflow.rs
+++ b/crates/libitofin/src/cashflows/simplecashflow.rs
@@ -1,0 +1,233 @@
+//! Predetermined cash flows.
+//!
+//! Port of `ql/cashflows/simplecashflow.hpp`. [`Redemption`] and
+//! [`AmortizingPayment`] add no state or behaviour to [`SimpleCashFlow`] in
+//! C++: they exist so that an `AcyclicVisitor` can tell them apart. The port
+//! has no visitor, so they wrap a `SimpleCashFlow` and keep the type identity
+//! that gives them their meaning.
+
+use crate::cashflow::{CashFlow, cash_flow_has_occurred};
+use crate::errors::QlResult;
+use crate::event::Event;
+use crate::patterns::observable::{AsObservable, Observable};
+use crate::settings::Settings;
+use crate::time::date::Date;
+use crate::types::Real;
+
+/// A payment of a predetermined amount on a given date.
+pub struct SimpleCashFlow {
+    amount: Real,
+    date: Date,
+    observable: Observable,
+}
+
+impl SimpleCashFlow {
+    /// Creates a flow paying `amount` on `date`.
+    pub fn new(amount: Real, date: Date) -> Self {
+        SimpleCashFlow {
+            amount,
+            date,
+            observable: Observable::new(),
+        }
+    }
+}
+
+impl AsObservable for SimpleCashFlow {
+    fn observable(&self) -> &Observable {
+        &self.observable
+    }
+}
+
+impl Event for SimpleCashFlow {
+    fn date(&self) -> Date {
+        self.date
+    }
+
+    fn has_occurred(
+        &self,
+        settings: &Settings<Date>,
+        ref_date: Option<Date>,
+        include_ref_date: Option<bool>,
+    ) -> QlResult<bool> {
+        cash_flow_has_occurred(self.date, settings, ref_date, include_ref_date)
+    }
+}
+
+impl CashFlow for SimpleCashFlow {
+    fn amount(&self) -> QlResult<Real> {
+        Ok(self.amount)
+    }
+}
+
+macro_rules! simple_cash_flow_alias {
+    ($(#[$meta:meta])* $name:ident) => {
+        $(#[$meta])*
+        pub struct $name(SimpleCashFlow);
+
+        impl $name {
+            /// Creates a flow paying `amount` on `date`.
+            pub fn new(amount: Real, date: Date) -> Self {
+                $name(SimpleCashFlow::new(amount, date))
+            }
+        }
+
+        impl AsObservable for $name {
+            fn observable(&self) -> &Observable {
+                self.0.observable()
+            }
+        }
+
+        impl Event for $name {
+            fn date(&self) -> Date {
+                self.0.date()
+            }
+
+            fn has_occurred(
+                &self,
+                settings: &Settings<Date>,
+                ref_date: Option<Date>,
+                include_ref_date: Option<bool>,
+            ) -> QlResult<bool> {
+                self.0.has_occurred(settings, ref_date, include_ref_date)
+            }
+        }
+
+        impl CashFlow for $name {
+            fn amount(&self) -> QlResult<Real> {
+                self.0.amount()
+            }
+        }
+    };
+}
+
+simple_cash_flow_alias! {
+    /// The redemption of a bond's notional: a [`SimpleCashFlow`] that cash-flow
+    /// analysis can single out.
+    Redemption
+}
+
+simple_cash_flow_alias! {
+    /// A repayment of principal: a [`SimpleCashFlow`] that cash-flow analysis
+    /// can single out.
+    AmortizingPayment
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cashflow::Leg;
+    use crate::shared::{Shared, shared};
+    use crate::time::date::Month;
+
+    fn today() -> Date {
+        Date::new(7, Month::July, 2026)
+    }
+
+    /// The `leg` of `cashflows.cpp::testSettings`: unit flows at T+0, T+1, T+2.
+    fn leg(settings: &Settings<Date>) -> Leg {
+        settings.set_evaluation_date(today());
+        (0..3)
+            .map(|i| shared(SimpleCashFlow::new(1.0, today() + i)) as Shared<dyn CashFlow>)
+            .collect()
+    }
+
+    /// `CHECK_INCLUSION`: flow `n` is included at `T+days` when it has not occurred.
+    fn included(leg: &Leg, settings: &Settings<Date>, n: usize, days: i32) -> bool {
+        !leg[n]
+            .has_occurred(settings, Some(today() + days), None)
+            .unwrap()
+    }
+
+    #[test]
+    fn a_simple_cash_flow_pays_its_amount_on_its_date() {
+        let flow = SimpleCashFlow::new(105.0, today());
+
+        assert_eq!(flow.date(), today());
+        assert_eq!(flow.amount().unwrap(), 105.0);
+        assert_eq!(flow.ex_coupon_date(), None);
+    }
+
+    /// `cashflows.cpp::testSettings`, cases 1 and 2: reference-date payments
+    /// excluded, with and without an explicit override at today's date.
+    #[test]
+    fn reference_date_payments_are_excluded() {
+        for todays_flows in [None, Some(false)] {
+            let settings = Settings::new();
+            let leg = leg(&settings);
+            settings.set_include_reference_date_events(false);
+            settings.set_include_todays_cash_flows(todays_flows);
+
+            assert!(!included(&leg, &settings, 0, 0));
+            assert!(!included(&leg, &settings, 0, 1));
+            assert!(included(&leg, &settings, 1, 0));
+            assert!(!included(&leg, &settings, 1, 1));
+            assert!(!included(&leg, &settings, 1, 2));
+            assert!(included(&leg, &settings, 2, 1));
+            assert!(!included(&leg, &settings, 2, 2));
+            assert!(!included(&leg, &settings, 2, 3));
+        }
+    }
+
+    /// `cashflows.cpp::testSettings`, cases 3 and 4: reference-date payments
+    /// included, with and without an explicit override at today's date.
+    #[test]
+    fn reference_date_payments_are_included() {
+        for todays_flows in [None, Some(true)] {
+            let settings = Settings::new();
+            let leg = leg(&settings);
+            settings.set_include_reference_date_events(true);
+            settings.set_include_todays_cash_flows(todays_flows);
+
+            assert!(included(&leg, &settings, 0, 0));
+            assert!(!included(&leg, &settings, 0, 1));
+            assert!(included(&leg, &settings, 1, 0));
+            assert!(included(&leg, &settings, 1, 1));
+            assert!(!included(&leg, &settings, 1, 2));
+            assert!(included(&leg, &settings, 2, 1));
+            assert!(included(&leg, &settings, 2, 2));
+            assert!(!included(&leg, &settings, 2, 3));
+        }
+    }
+
+    /// `cashflows.cpp::testSettings`, case 5: today's flows override the
+    /// reference-date rule, which is what forbids
+    /// [`event_has_occurred`](crate::event::event_has_occurred) here.
+    #[test]
+    fn todays_cash_flows_override_the_reference_date_rule() {
+        let settings = Settings::new();
+        let leg = leg(&settings);
+        settings.set_include_reference_date_events(true);
+        settings.set_include_todays_cash_flows(Some(false));
+
+        assert!(!included(&leg, &settings, 0, 0));
+        assert!(!included(&leg, &settings, 0, 1));
+        assert!(included(&leg, &settings, 1, 0));
+        assert!(included(&leg, &settings, 1, 1));
+        assert!(!included(&leg, &settings, 1, 2));
+        assert!(included(&leg, &settings, 2, 1));
+        assert!(included(&leg, &settings, 2, 2));
+        assert!(!included(&leg, &settings, 2, 3));
+    }
+
+    /// No test-suite case covers `Redemption` or `AmortizingPayment`; the
+    /// header makes them pass-through `SimpleCashFlow`s, including the
+    /// today's-cash-flows rule they inherit with it.
+    #[test]
+    fn a_redemption_and_an_amortizing_payment_behave_as_simple_cash_flows() {
+        let settings = Settings::new();
+        settings.set_evaluation_date(today());
+        settings.set_include_reference_date_events(true);
+        settings.set_include_todays_cash_flows(Some(false));
+
+        let redemption = Redemption::new(100.0, today());
+        let amortizing = AmortizingPayment::new(2.5, today());
+
+        assert_eq!(redemption.date(), today());
+        assert_eq!(redemption.amount().unwrap(), 100.0);
+        assert!(redemption.has_occurred(&settings, None, None).unwrap());
+
+        assert_eq!(amortizing.date(), today());
+        assert_eq!(amortizing.amount().unwrap(), 2.5);
+        assert!(amortizing.has_occurred(&settings, None, None).unwrap());
+    }
+}

--- a/crates/libitofin/src/lib.rs
+++ b/crates/libitofin/src/lib.rs
@@ -4,6 +4,7 @@
 //! via cbindgen) live in sibling crates and depend on this one.
 
 pub mod cashflow;
+pub mod cashflows;
 pub mod errors;
 pub mod event;
 pub mod exercise;


### PR DESCRIPTION
close #247

BREAKING CHANGE: CashFlow::ex_coupon_date is now a required trait method
(previously had a provided default). Downstream implementors of CashFlow
must add an ex_coupon_date; forward it to the CouponBase for coupons.
That gets it into the 0.3.0 notes under Breaking Changes.

