### PR TITLE
chore(gitignore): ignore generated fable text files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,4 @@ QuantLib
 # Added by cargo
 /target
 .zed
+fable*.txt


### PR DESCRIPTION
Add `fable*.txt` to `.gitignore` to prevent generated fable output files from being tracked in version control.
