### PR TITLE
feat(#258)!: make cashflow::as_coupon a required trait method

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,22 @@ oversight) and is documented at the point of divergence in the source.
   preserved: `Coupon::trades_ex_coupon_on` goes through `ex_coupon_date`, which
   a concrete coupon forwards to its `CouponBase`, and both `accrued_period` and
   `accrued_amount` test the ex-coupon branch through that one helper.
+- **`CashFlow::as_coupon` is a required trait method.**
+  The `isCoupon`/`coupon_cast` pair (`cashflow.hpp:79`, `coupon.hpp:96`), which
+  the `CashFlows` analytics use to tell an accruing flow from a plain payment.
+  C++ needs no default here: its `Coupon` base class overrides `isCoupon()` to
+  `true`, so no coupon can forget. A Rust `Coupon` is a trait and cannot supply
+  its supertrait's method on its implementors' behalf, which is the same
+  no-specialization argument as `ex_coupon_date` above. A coupon answering
+  `None` contributes nothing to `bps`, has its amount subtracted from
+  `atm_rate`'s target, and reports its payment date to `maturity_date` in place
+  of its accrual end: beside coupons that answer correctly this skews the rate,
+  and alone in a leg it drives the rate to `0.0`. The method is therefore
+  required, so omission is a compile error. A deliberate `None` from a `Coupon`
+  remains possible, and the analytics cannot detect it. A blanket
+  `impl<T: Coupon> CashFlow for T` would make that lie a compile error too, at
+  the cost of moving every `CashFlow` body a coupon overrides onto `Coupon`;
+  it is tracked separately.
 
 ## License
 

--- a/crates/libitofin/src/cashflow.rs
+++ b/crates/libitofin/src/cashflow.rs
@@ -44,12 +44,24 @@ pub trait CashFlow: Event {
     ///
     /// The `isCoupon`/`coupon_cast` pair of `cashflow.hpp` and `coupon.hpp`,
     /// which the [`CashFlows`](crate::cashflows::CashFlows) analytics use to
-    /// tell an accruing flow from a plain payment. Defaulted to `None`, so
-    /// every [`Coupon`] implementor must override it with `Some(self)` or it
-    /// contributes nothing to a basis-point sensitivity.
-    fn as_coupon(&self) -> Option<&dyn Coupon> {
-        None
-    }
+    /// tell an accruing flow from a plain payment. Required rather than
+    /// defaulted to `None`, like [`ex_coupon_date`](CashFlow::ex_coupon_date):
+    /// a [`Coupon`] answering `None` contributes nothing to
+    /// [`bps`](crate::cashflows::CashFlows::bps), has its amount subtracted
+    /// from the target of [`atm_rate`](crate::cashflows::CashFlows::atm_rate),
+    /// and reports its payment date to
+    /// [`maturity_date`](crate::cashflows::CashFlows::maturity_date) in place
+    /// of its accrual end. Beside coupons that answer correctly it skews the
+    /// rate; alone in a leg it drives the rate to `0.0`. Neither is an obvious
+    /// failure, so the answer is compulsory.
+    ///
+    /// A [`Coupon`] must answer `Some(self)`, never `Some` of some other
+    /// coupon: `coupon_cast` (`coupon.cpp:88`) can only ever yield the flow it
+    /// was handed, so a wrapper answering with its inner coupon would let
+    /// `bps` read a nominal and an accrual period that `npv` never priced.
+    /// Neither rule is checkable at compile time in this shape, and the
+    /// analytics cannot detect a violation of either.
+    fn as_coupon(&self) -> Option<&dyn Coupon>;
 
     /// Whether the flow trades ex-coupon as of `ref_date` (the evaluation date
     /// when `None`).
@@ -157,6 +169,10 @@ mod tests {
 
         fn ex_coupon_date(&self) -> Option<Date> {
             self.ex_coupon_date
+        }
+
+        fn as_coupon(&self) -> Option<&dyn Coupon> {
+            None
         }
     }
 

--- a/crates/libitofin/src/cashflows/dividend.rs
+++ b/crates/libitofin/src/cashflows/dividend.rs
@@ -10,6 +10,7 @@
 //! [`SimpleQuote`](crate::quotes::SimpleQuote) precedent.
 
 use crate::cashflow::{CashFlow, cash_flow_has_occurred};
+use crate::cashflows::Coupon;
 use crate::errors::QlResult;
 use crate::event::Event;
 use crate::patterns::observable::{AsObservable, Observable};
@@ -70,6 +71,10 @@ impl CashFlow for FixedDividend {
     }
 
     fn ex_coupon_date(&self) -> Option<Date> {
+        None
+    }
+
+    fn as_coupon(&self) -> Option<&dyn Coupon> {
         None
     }
 }
@@ -145,6 +150,10 @@ impl CashFlow for FractionalDividend {
     }
 
     fn ex_coupon_date(&self) -> Option<Date> {
+        None
+    }
+
+    fn as_coupon(&self) -> Option<&dyn Coupon> {
         None
     }
 }

--- a/crates/libitofin/src/cashflows/simplecashflow.rs
+++ b/crates/libitofin/src/cashflows/simplecashflow.rs
@@ -7,6 +7,7 @@
 //! that gives them their meaning.
 
 use crate::cashflow::{CashFlow, cash_flow_has_occurred};
+use crate::cashflows::Coupon;
 use crate::errors::QlResult;
 use crate::event::Event;
 use crate::patterns::observable::{AsObservable, Observable};
@@ -61,6 +62,10 @@ impl CashFlow for SimpleCashFlow {
     fn ex_coupon_date(&self) -> Option<Date> {
         None
     }
+
+    fn as_coupon(&self) -> Option<&dyn Coupon> {
+        None
+    }
 }
 
 macro_rules! simple_cash_flow_alias {
@@ -103,6 +108,10 @@ macro_rules! simple_cash_flow_alias {
 
             fn ex_coupon_date(&self) -> Option<Date> {
                 self.0.ex_coupon_date()
+            }
+
+            fn as_coupon(&self) -> Option<&dyn Coupon> {
+                self.0.as_coupon()
             }
         }
     };

--- a/crates/libitofin/tests/external_coupon.rs
+++ b/crates/libitofin/tests/external_coupon.rs
@@ -52,6 +52,10 @@ impl CashFlow for SimpleFixedRateCoupon {
     fn ex_coupon_date(&self) -> Option<Date> {
         self.base.ex_coupon_date()
     }
+
+    fn as_coupon(&self) -> Option<&dyn Coupon> {
+        Some(self)
+    }
 }
 
 impl Coupon for SimpleFixedRateCoupon {


### PR DESCRIPTION
A defaulted `as_coupon` lets a `Coupon` implementor forget the override with no
diagnostic, and the analytics then read the coupon as a plain payment: it
contributes nothing to `bps`, in `atm_rate` its `amount()` accumulates into
`non_sens_npv` and is subtracted from the target, and `start_date` /
`maturity_date` read its payment date instead of its accrual bounds.

What that produces depends on the leg. Beside coupons that answer correctly, it
skews the ATM rate (a leg paying 5% and 9% reports 5.00% where the true rate is
7.00%); the skew vanishes when every coupon pays one simple-compounded rate,
because the forgotten coupon leaves numerator and denominator together. Alone in
a leg with no explicit target it returns `Ok(0.0)`, short-circuiting before the
`null bps` guard. Only a leg of forgetful coupons with an explicit target
reaches that guard and errors. None of the three is an obvious failure.

Remove the default, as `ex_coupon_date` already has none, and make every
implementor state its answer. `tests/external_coupon.rs`, written to prove a
`Coupon` is implementable from outside the crate, is the downstream-shaped case:
it compiled clean without the override and now does not.

This forces an answer, not a correct one. A `Coupon` may still answer `None`
deliberately, or answer with a coupon other than itself, and no analytic can
tell. A blanket `impl<T: Coupon> CashFlow for T` would make both a compile
error, since a downstream `impl CashFlow` for a coupon then collides with the
upstream impl; the cost is that every `CashFlow` method a coupon overrides has
to move onto `Coupon` under a new name. That is a larger break than this one and
is tracked separately.

Third instance of the pattern on this epic, after `has_occurred` and
`ex_coupon_date`. The rule: a trait method whose wrong-but-compiling answer
produces a plausible number rather than an obvious failure must be required,
not defaulted.

BREAKING CHANGE: `CashFlow::as_coupon` no longer has a default body. Downstream
implementors of `CashFlow` must return `Some(self)` from a `Coupon` and `None`
from a plain payment.

close https://github.com/benbenbang/libitofin/issues/258