### PR TITLE
fix(core)!: reject invalid numeric state at the API boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,35 @@ oversight) and is documented at the point of divergence in the source.
   the cost of moving every `CashFlow` body a coupon overrides onto `Coupon`;
   it is tracked separately.
 
+**Non-finite inputs (cross-cutting):**
+
+- **Non-finite arguments are rejected at the API boundary.** QuantLib validates
+  signs (`stdDev >= 0`, `forward > 0`, `t >= 0`) and relies on NaN failing every
+  such comparison, so a NaN is already an error wherever a sign is checked. An
+  infinity is not: it passes `>= 0.0` and propagates to a NaN result several
+  layers down, and where a curve extrapolates the range check is skipped
+  entirely. Following D10, this port widens each of those guards from "not NaN"
+  to "finite", and adds finiteness checks where C++ has none at all: solver
+  arguments and functor values (`solver1d.rs`), sampled quadrature abscissae
+  (`discrete.rs`), Black-Scholes process arguments (`blackscholesprocess.rs`),
+  and the volatility and variance an implementation returns
+  (`termstructures/volatility/`). Each site names the C++ guard it extends, or
+  states that none exists. The only behavioural change is for infinities; every
+  finite input QuantLib accepts is still accepted, so no priced number moves.
+- **Statistics accumulators reject a NaN sample value, and accept infinities.**
+  QuantLib's only sample guard is `QL_REQUIRE(weight >= 0.0)`
+  (`generalstatistics.hpp:233`, `incrementalstatistics.cpp:127`), which this
+  port keeps verbatim, written `!(weight >= 0.0)` so a NaN weight fails it as it
+  does in C++. A NaN *value* has no C++ guard: it is accumulated and poisons
+  every subsequent mean, variance and percentile with no diagnostic. Infinite
+  values remain accepted, as in C++, being meaningful to `min`, `max` and the
+  risk measures.
+- **Shape mismatches panic with a named cause.** `SVD::solveFor`
+  (`svd.cpp:528`) and the default `CostFunction::gradient` / `jacobian` have no
+  `QL_REQUIRE`; a wrongly-sized output leaves stale entries the optimiser reads
+  as real derivatives. These are caller errors, not market-data errors, so the
+  port asserts rather than returning `Err`.
+
 ## License
 
 [BSD-3-Clause](LICENSE) — the same license as QuantLib, the ported source.

--- a/README.md
+++ b/README.md
@@ -232,6 +232,27 @@ oversight) and is documented at the point of divergence in the source.
   the cost of moving every `CashFlow` body a coupon overrides onto `Coupon`;
   it is tracked separately.
 
+**Pricing engines (Milestone 1):**
+
+- **Zero-volatility Black greeks dispatch on the stored option type, not on the
+  sign of `alpha_`.** This is a deliberate divergence where the oracle is
+  wrong, and the only place in the port where a *finite* priced number
+  intentionally disagrees with QuantLib. Upstream (tree `v1.42.1-266-g9863b578a`,
+  from commit `17f1a1bed` "Fixing zero vol for Black") detects the option type
+  in its zero-vol branches with `if (alpha_ >= 0) // Call`, at nine sites
+  (`blackcalculator.cpp:215,222,229,257,264,271,439,446,453`). For a
+  plain-vanilla put, `alpha_ = -1.0 + cum_d1_` (`blackcalculator.cpp:137`), and
+  at zero volatility an out-of-the-money put has `cum_d1_ == 1.0` exactly, so
+  `alpha_ == 0.0` exactly and `0.0 >= 0` takes the Call branch: the OTM put is
+  handed a delta of `+1.0` where the correct value is `0.0`. This port instead
+  dispatches on the option type stored in the calculator, implementing the
+  values the reference's own comments state, so the OTM-put delta is `0.0`. The
+  full zero-vol ladder is pinned by `zero_volatility_ladder_matches_stated_intent`
+  and `zero_volatility_otm_put_gets_put_greeks_not_call_greeks` in
+  `blackcalculator.rs`, which assert the corrected numbers (OTM `0.0`, ATM
+  `-0.5`, ITM `-1.0` for the put, and the call mirror), so a regression to the
+  `alpha_ >= 0` form is a test failure.
+
 **Non-finite inputs (cross-cutting):**
 
 - **Non-finite arguments are rejected at the API boundary.** QuantLib validates

--- a/crates/libitofin/src/cashflows/cashflows.rs
+++ b/crates/libitofin/src/cashflows/cashflows.rs
@@ -1145,7 +1145,7 @@ mod tests {
     /// redemption sharing the coupon's payment date.
     fn leg() -> Leg {
         vec![
-            shared(SimpleCashFlow::new(5.0, early_payment())) as Shared<dyn CashFlow>,
+            shared(SimpleCashFlow::new(5.0, early_payment()).unwrap()) as Shared<dyn CashFlow>,
             shared(FixedRateCoupon::from_rate(
                 payment(),
                 100.0,
@@ -1157,7 +1157,7 @@ mod tests {
                 None,
                 None,
             )) as Shared<dyn CashFlow>,
-            shared(Redemption::new(100.0, payment())) as Shared<dyn CashFlow>,
+            shared(Redemption::new(100.0, payment()).unwrap()) as Shared<dyn CashFlow>,
         ]
     }
 
@@ -1356,7 +1356,7 @@ mod analytics_tests {
     /// days after.
     fn unit_leg() -> Leg {
         (0..3)
-            .map(|i| shared(SimpleCashFlow::new(1.0, today() + i)) as Shared<dyn CashFlow>)
+            .map(|i| shared(SimpleCashFlow::new(1.0, today() + i).unwrap()) as Shared<dyn CashFlow>)
             .collect()
     }
 
@@ -1544,7 +1544,7 @@ mod analytics_tests {
 
         assert!((atm(&leg, None) - RATE).abs() < 1e-14);
 
-        leg.push(shared(Redemption::new(NOMINAL, maturity())) as Shared<dyn CashFlow>);
+        leg.push(shared(Redemption::new(NOMINAL, maturity()).unwrap()) as Shared<dyn CashFlow>);
         assert!((atm(&leg, None) - RATE).abs() < 1e-14);
 
         let npv = CashFlows::npv(&leg, &curve, &settings, None, None, None).unwrap();
@@ -1584,7 +1584,8 @@ mod analytics_tests {
     fn the_atm_rate_needs_a_target_and_a_sensitivity() {
         let (settings, curve) = (settings(), curve(FORWARD));
         let leg = fixed_leg(RATE);
-        let bare: Leg = vec![shared(Redemption::new(NOMINAL, maturity())) as Shared<dyn CashFlow>];
+        let bare: Leg =
+            vec![shared(Redemption::new(NOMINAL, maturity()).unwrap()) as Shared<dyn CashFlow>];
         let atm = |leg: &Leg, target| {
             CashFlows::atm_rate(leg, &curve, &settings, None, None, None, target)
         };
@@ -1863,7 +1864,9 @@ mod analytics_tests {
     #[test]
     fn only_the_surviving_flows_of_nonzero_amount_can_change_sign() {
         let settings = settings();
-        let flow = |amount, date| shared(SimpleCashFlow::new(amount, date)) as Shared<dyn CashFlow>;
+        let flow = |amount, date| {
+            shared(SimpleCashFlow::new(amount, date).expect("valid flow")) as Shared<dyn CashFlow>
+        };
         let solve = |leg: &Leg, npv| {
             CashFlows::solve_yield(
                 leg,
@@ -1918,7 +1921,7 @@ mod analytics_tests {
     /// not outlive, so an IRR exists against a positive price.
     fn redeeming_leg() -> Leg {
         let mut leg = fixed_leg(RATE);
-        leg.push(shared(Redemption::new(NOMINAL, maturity())) as Shared<dyn CashFlow>);
+        leg.push(shared(Redemption::new(NOMINAL, maturity()).unwrap()) as Shared<dyn CashFlow>);
         leg
     }
 
@@ -2216,7 +2219,7 @@ mod bonds_tests {
             .with_ex_coupon_period(ex_coupon_period, ex_coupon_calendar, unadjusted, false)
             .build()
             .unwrap();
-        leg.push(shared(Redemption::new(100.0, maturity)) as Shared<dyn CashFlow>);
+        leg.push(shared(Redemption::new(100.0, maturity).unwrap()) as Shared<dyn CashFlow>);
         (leg, day_counter)
     }
 
@@ -2425,7 +2428,7 @@ mod basis_point_value_tests {
             .with_payment_adjustment(unadjusted)
             .build()
             .unwrap();
-        leg.push(shared(Redemption::new(FACE_AMOUNT, maturity())) as Shared<dyn CashFlow>);
+        leg.push(shared(Redemption::new(FACE_AMOUNT, maturity()).unwrap()) as Shared<dyn CashFlow>);
         leg
     }
 

--- a/crates/libitofin/src/cashflows/simplecashflow.rs
+++ b/crates/libitofin/src/cashflows/simplecashflow.rs
@@ -14,6 +14,8 @@ use crate::patterns::observable::{AsObservable, Observable};
 use crate::settings::Settings;
 use crate::time::date::Date;
 use crate::types::Real;
+use crate::utilities::null::Null;
+use crate::{fail, require};
 
 /// A payment of a predetermined amount on a given date.
 pub struct SimpleCashFlow {
@@ -24,12 +26,24 @@ pub struct SimpleCashFlow {
 
 impl SimpleCashFlow {
     /// Creates a flow paying `amount` on `date`.
-    pub fn new(amount: Real, date: Date) -> Self {
-        SimpleCashFlow {
+    ///
+    /// Both guards are QuantLib's, verbatim, from the `SimpleCashFlow`
+    /// constructor body (`simplecashflow.cpp:29` and `:31`), error strings
+    /// included. They were omitted when this type was first ported.
+    ///
+    /// # Errors
+    ///
+    /// Errors if `date` is the null date or `amount` is the null `Real`.
+    pub fn new(amount: Real, date: Date) -> QlResult<Self> {
+        require!(date != Date::null(), "null date SimpleCashFlow");
+        if amount.is_null() {
+            fail!("null amount SimpleCashFlow");
+        }
+        Ok(SimpleCashFlow {
             amount,
             date,
             observable: Observable::new(),
-        }
+        })
     }
 }
 
@@ -75,8 +89,12 @@ macro_rules! simple_cash_flow_alias {
 
         impl $name {
             /// Creates a flow paying `amount` on `date`.
-            pub fn new(amount: Real, date: Date) -> Self {
-                $name(SimpleCashFlow::new(amount, date))
+            ///
+            /// # Errors
+            ///
+            /// As for [`SimpleCashFlow::new`].
+            pub fn new(amount: Real, date: Date) -> QlResult<Self> {
+                Ok($name(SimpleCashFlow::new(amount, date)?))
             }
         }
 
@@ -144,7 +162,7 @@ mod tests {
     fn leg(settings: &Settings<Date>) -> Leg {
         settings.set_evaluation_date(today());
         (0..3)
-            .map(|i| shared(SimpleCashFlow::new(1.0, today() + i)) as Shared<dyn CashFlow>)
+            .map(|i| shared(SimpleCashFlow::new(1.0, today() + i).unwrap()) as Shared<dyn CashFlow>)
             .collect()
     }
 
@@ -157,11 +175,29 @@ mod tests {
 
     #[test]
     fn a_simple_cash_flow_pays_its_amount_on_its_date() {
-        let flow = SimpleCashFlow::new(105.0, today());
+        let flow = SimpleCashFlow::new(105.0, today()).unwrap();
 
         assert_eq!(flow.date(), today());
         assert_eq!(flow.amount().unwrap(), 105.0);
         assert_eq!(flow.ex_coupon_date(), None);
+    }
+
+    #[test]
+    fn a_simple_cash_flow_rejects_quantlib_null_inputs() {
+        assert_eq!(
+            SimpleCashFlow::new(105.0, Date::null())
+                .err()
+                .unwrap()
+                .message(),
+            "null date SimpleCashFlow"
+        );
+        assert_eq!(
+            SimpleCashFlow::new(Real::null(), today())
+                .err()
+                .unwrap()
+                .message(),
+            "null amount SimpleCashFlow"
+        );
     }
 
     /// `cashflows.cpp::testSettings`, cases 1 and 2: reference-date payments
@@ -236,8 +272,8 @@ mod tests {
         settings.set_include_reference_date_events(true);
         settings.set_include_todays_cash_flows(Some(false));
 
-        let redemption = Redemption::new(100.0, today());
-        let amortizing = AmortizingPayment::new(2.5, today());
+        let redemption = Redemption::new(100.0, today()).unwrap();
+        let amortizing = AmortizingPayment::new(2.5, today()).unwrap();
 
         assert_eq!(redemption.date(), today());
         assert_eq!(redemption.amount().unwrap(), 100.0);

--- a/crates/libitofin/src/instrument.rs
+++ b/crates/libitofin/src/instrument.rs
@@ -65,10 +65,13 @@ struct Updater {
 
 impl Observer for Updater {
     fn update(&mut self) {
-        let notify = self.lazy.borrow_mut().deferred_update();
-        if let Some(observable) = notify {
-            observable.notify_observers();
+        if let Some(update) = LazyObject::deferred_update(&self.lazy) {
+            update.notify_observers();
         }
+    }
+
+    fn defer_reentrant_update(&self) -> bool {
+        false
     }
 }
 
@@ -133,9 +136,8 @@ impl InstrumentBase {
             new.borrow().observable().register_observer(&observer);
         }
         self.engine = engine;
-        let notify = self.lazy.borrow_mut().deferred_update();
-        if let Some(observable) = notify {
-            observable.notify_observers();
+        if let Some(update) = LazyObject::deferred_update(&self.lazy) {
+            update.notify_observers();
         }
     }
 
@@ -779,6 +781,50 @@ mod tests {
             Some(10.0),
             "a notified observer must be able to reprice the instrument"
         );
+    }
+
+    struct WriteBackObserver {
+        market: Shared<SimpleQuote>,
+        updates: usize,
+    }
+
+    impl Observer for WriteBackObserver {
+        fn update(&mut self) {
+            self.updates += 1;
+            if self.updates == 1 {
+                self.market.set_value(6.0);
+            }
+        }
+    }
+
+    #[test]
+    fn recursive_input_change_during_instrument_notification_is_suppressed() {
+        let market = shared(SimpleQuote::new(2.0));
+        let mut instrument = MockInstrument::new(Shared::clone(&market));
+        let (engine, _) = mock_engine(true);
+        instrument.base_mut().set_pricing_engine(engine);
+        instrument.npv().unwrap();
+
+        let writer = shared_mut(WriteBackObserver {
+            market: Shared::clone(&market),
+            updates: 0,
+        });
+        instrument
+            .base()
+            .register_observer(&(SharedMut::clone(&writer) as SharedMut<dyn Observer>));
+
+        market.set_value(5.0);
+
+        assert_eq!(
+            writer.borrow().updates,
+            1,
+            "LazyObject::update must suppress recursive notifications"
+        );
+        assert!(
+            !instrument.base().is_calculated(),
+            "the first input change still invalidates the cache"
+        );
+        assert_eq!(instrument.npv().unwrap(), 12.0);
     }
 
     #[test]

--- a/crates/libitofin/src/math/integrals/discrete.rs
+++ b/crates/libitofin/src/math/integrals/discrete.rs
@@ -12,6 +12,26 @@ use crate::math::integrals::Integrator;
 use crate::types::{Real, Size};
 use crate::{fail, require};
 
+/// Reject non-finite abscissae or ordinates before they enter the quadrature.
+///
+/// Divergence: `discreteintegrals.cpp` guards only `n == x.size()`
+/// (`:28`, `:46`). A NaN or infinite sample propagates through the weighted sum
+/// and the caller receives a NaN integral with no indication of which sample
+/// produced it.
+fn require_finite_samples(x: &[Real], f: &[Real]) -> QlResult<()> {
+    for &xi in x {
+        if !xi.is_finite() {
+            fail!("x values must be finite, got {xi}");
+        }
+    }
+    for &fi in f {
+        if !fi.is_finite() {
+            fail!("function values must be finite, got {fi}");
+        }
+    }
+    Ok(())
+}
+
 /// Trapezoidal integration of samples `(x, f)` on an arbitrary grid.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct DiscreteTrapezoidIntegral;
@@ -22,7 +42,8 @@ impl DiscreteTrapezoidIntegral {
     ///
     /// # Errors
     ///
-    /// Returns an error if `x` and `f` have different lengths.
+    /// Returns an error if `x` and `f` have different lengths, or if any sample
+    /// is non-finite.
     pub fn integrate(&self, x: &[Real], f: &[Real]) -> QlResult<Real> {
         require!(
             x.len() == f.len(),
@@ -30,6 +51,7 @@ impl DiscreteTrapezoidIntegral {
             x.len(),
             f.len()
         );
+        require_finite_samples(x, f)?;
         let n = f.len();
         if n < 2 {
             return Ok(0.0);
@@ -51,9 +73,14 @@ impl DiscreteSimpsonIntegral {
     /// generalised to non-uniform spacing, closing an odd final panel with the
     /// trapezoid rule. Fewer than two points integrate to zero.
     ///
+    /// Divergence: the distinct-adjacent-`x` guard has no counterpart in
+    /// `discreteintegrals.cpp`. The panel weight is `dd / (6 * dxjp1 * dxj)`,
+    /// so a repeated abscissa divides by zero and C++ returns NaN silently.
+    ///
     /// # Errors
     ///
-    /// Returns an error if `x` and `f` have different lengths.
+    /// Returns an error if `x` and `f` have different lengths, if any sample is
+    /// non-finite, or if two adjacent abscissae coincide.
     pub fn integrate(&self, x: &[Real], f: &[Real]) -> QlResult<Real> {
         require!(
             x.len() == f.len(),
@@ -61,6 +88,7 @@ impl DiscreteSimpsonIntegral {
             x.len(),
             f.len()
         );
+        require_finite_samples(x, f)?;
         let n = f.len();
         if n < 2 {
             return Ok(0.0);
@@ -70,6 +98,9 @@ impl DiscreteSimpsonIntegral {
         while j + 2 < n {
             let dxj = x[j + 1] - x[j];
             let dxjp1 = x[j + 2] - x[j + 1];
+            if dxj == 0.0 || dxjp1 == 0.0 {
+                fail!("adjacent x values must be distinct");
+            }
 
             let alpha = dxjp1 * (2.0 * dxj - dxjp1);
             let dd = dxj + dxjp1;
@@ -260,6 +291,29 @@ mod tests {
         assert!(
             DiscreteSimpsonIntegral
                 .integrate(&[1.0], &[1.0, 2.0])
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn sampled_formulae_reject_non_finite_values() {
+        assert!(
+            DiscreteTrapezoidIntegral
+                .integrate(&[0.0, Real::NAN], &[1.0, 2.0])
+                .is_err()
+        );
+        assert!(
+            DiscreteSimpsonIntegral
+                .integrate(&[0.0, 1.0, 2.0], &[1.0, Real::INFINITY, 3.0])
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn sampled_simpson_rejects_duplicate_adjacent_x() {
+        assert!(
+            DiscreteSimpsonIntegral
+                .integrate(&[0.0, 1.0, 1.0], &[1.0, 2.0, 3.0])
                 .is_err()
         );
     }

--- a/crates/libitofin/src/math/matrixutilities/svd.rs
+++ b/crates/libitofin/src/math/matrixutilities/svd.rs
@@ -449,7 +449,20 @@ impl Svd {
 
     /// The minimum-norm least-squares solution of `M x = b` via the
     /// pseudo-inverse.
+    ///
+    /// Divergence: `SVD::solveFor` (`svd.cpp:528`) has no dimension check; the
+    /// mismatch surfaces deep inside `Matrix * Array`. The assertion names the
+    /// caller's mistake at the boundary instead.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `b` is not as long as the decomposed matrix has rows.
     pub fn solve_for(&self, b: &Array) -> Array {
+        assert_eq!(
+            b.len(),
+            self.u().rows(),
+            "dimensions of SVD input and b don't match"
+        );
         let n = self.n as usize;
         let mut w = Matrix::with_size(n, n);
         for i in 0..self.rank() {
@@ -493,5 +506,14 @@ mod tests {
             let error = norm_matrix(&(&reconstructed - &a));
             assert!(error <= tol, "product does not recover A ({error})");
         }
+    }
+
+    #[test]
+    fn solve_for_rejects_wrong_rhs_dimension() {
+        let svd = Svd::new(&matrices_m1());
+        let result = std::panic::catch_unwind(|| {
+            let _ = svd.solve_for(&Array::from([1.0, 2.0]));
+        });
+        assert!(result.is_err());
     }
 }

--- a/crates/libitofin/src/math/optimization/costfunction.rs
+++ b/crates/libitofin/src/math/optimization/costfunction.rs
@@ -28,8 +28,29 @@ pub trait CostFunction {
     }
 
     /// Computes `grad`, the first derivative of the scalar cost at `x`.
+    ///
+    /// Divergence: `costfunction.cpp` has no `QL_REQUIRE`. An oversized `grad`
+    /// leaves stale entries past `x.size()` that the optimiser then reads as
+    /// real derivatives, and a zero or non-finite epsilon silently returns NaN.
+    /// Both are caller errors this port names rather than absorbs.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the finite-difference epsilon is not finite and positive, or
+    /// if `grad` and `x` differ in size.
     fn gradient(&self, grad: &mut Array, x: &Array) {
         let eps = self.finite_difference_epsilon();
+        assert!(
+            eps.is_finite() && eps > 0.0,
+            "finite-difference epsilon ({eps}) must be finite and positive"
+        );
+        assert_eq!(
+            grad.size(),
+            x.size(),
+            "gradient size ({}) must match x size ({})",
+            grad.size(),
+            x.size()
+        );
         let mut xx = x.clone();
         for i in 0..x.size() {
             xx[i] += eps;
@@ -48,14 +69,58 @@ pub trait CostFunction {
     }
 
     /// Computes `jac`, the Jacobian of the cost function at `x`.
+    ///
+    /// Divergence: as for [`gradient`](Self::gradient).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the finite-difference epsilon is not finite and positive, if
+    /// `jac`'s columns do not match `x`, or if its rows do not match the
+    /// residual vector.
     fn jacobian(&self, jac: &mut Matrix, x: &Array) {
         let eps = self.finite_difference_epsilon();
+        assert!(
+            eps.is_finite() && eps > 0.0,
+            "finite-difference epsilon ({eps}) must be finite and positive"
+        );
+        assert_eq!(
+            jac.columns(),
+            x.size(),
+            "jacobian columns ({}) must match x size ({})",
+            jac.columns(),
+            x.size()
+        );
+        if x.is_empty() {
+            let residuals = self.values(x);
+            assert_eq!(
+                jac.rows(),
+                residuals.size(),
+                "jacobian rows ({}) must match residual size ({})",
+                jac.rows(),
+                residuals.size()
+            );
+            return;
+        }
         let mut xx = x.clone();
         for i in 0..x.size() {
             xx[i] += eps;
             let fp = self.values(&xx);
             xx[i] -= 2.0 * eps;
             let fm = self.values(&xx);
+            assert_eq!(
+                fp.size(),
+                fm.size(),
+                "finite-difference residual size changed from {} to {}",
+                fp.size(),
+                fm.size()
+            );
+            assert_eq!(
+                jac.rows(),
+                fp.size(),
+                "jacobian rows ({}) must match residual size ({})",
+                jac.rows(),
+                fp.size()
+            );
             for j in 0..fp.size() {
                 jac[(j, i)] = 0.5 * (fp[j] - fm[j]) / eps;
             }
@@ -139,5 +204,51 @@ mod tests {
         let mut jac = Matrix::with_size(2, 2);
         let vals = Quadratic.values_and_jacobian(&mut jac, &x);
         assert_eq!(vals, Quadratic.values(&x));
+    }
+
+    #[test]
+    #[should_panic(expected = "finite-difference epsilon")]
+    fn default_gradient_rejects_invalid_finite_difference_epsilon() {
+        struct BadStep;
+        impl CostFunction for BadStep {
+            fn values(&self, x: &Array) -> Array {
+                x.clone()
+            }
+
+            fn finite_difference_epsilon(&self) -> Real {
+                0.0
+            }
+        }
+
+        let mut grad = Array::with_size(1);
+        BadStep.gradient(&mut grad, &Array::from([1.0]));
+    }
+
+    #[test]
+    #[should_panic(expected = "gradient size")]
+    fn default_gradient_rejects_wrong_output_shape() {
+        let mut grad = Array::with_size(1);
+        Quadratic.gradient(&mut grad, &Array::from([2.0, 3.0]));
+    }
+
+    #[test]
+    #[should_panic(expected = "jacobian rows")]
+    fn default_jacobian_rejects_wrong_output_shape() {
+        let mut jac = Matrix::with_size(1, 2);
+        Quadratic.jacobian(&mut jac, &Array::from([2.0, 3.0]));
+    }
+
+    #[test]
+    #[should_panic(expected = "jacobian rows")]
+    fn default_jacobian_rejects_wrong_rows_with_zero_variables() {
+        struct ConstantResiduals;
+        impl CostFunction for ConstantResiduals {
+            fn values(&self, _x: &Array) -> Array {
+                Array::from([1.0, 2.0])
+            }
+        }
+
+        let mut jac = Matrix::with_size(1, 0);
+        ConstantResiduals.jacobian(&mut jac, &Array::new());
     }
 }

--- a/crates/libitofin/src/math/solver1d.rs
+++ b/crates/libitofin/src/math/solver1d.rs
@@ -141,10 +141,7 @@ pub trait Solver1D {
     where
         F: FnMut(Real) -> Real,
     {
-        if accuracy <= 0.0 {
-            fail!("accuracy ({accuracy}) must be positive");
-        }
-        let accuracy = accuracy.max(Real::EPSILON);
+        let accuracy = check_stepping_args(accuracy, guess, step)?;
         match bracket_by_stepping(self.config(), &mut f, guess, step)? {
             Bracketed::Root(x) => Ok(x),
             Bracketed::Ready(mut st) => self.solve_impl(&mut f, accuracy, &mut st),
@@ -170,10 +167,7 @@ pub trait Solver1D {
     where
         F: FnMut(Real) -> Real,
     {
-        if accuracy <= 0.0 {
-            fail!("accuracy ({accuracy}) must be positive");
-        }
-        let accuracy = accuracy.max(Real::EPSILON);
+        let accuracy = check_bracket_args(accuracy, guess, x_min, x_max)?;
         match bracket_given(self.config(), &mut f, guess, x_min, x_max)? {
             Bracketed::Root(x) => Ok(x),
             Bracketed::Ready(mut st) => self.solve_impl(&mut f, accuracy, &mut st),
@@ -187,6 +181,106 @@ pub(crate) enum Bracketed {
     Root(Real),
     /// A valid bracket prepared for refinement by `solve_impl`.
     Ready(Solver1DState),
+}
+
+/// Validate the arguments of a stepping `solve` entry point and return the
+/// accuracy clamped to at least `Real::EPSILON`.
+///
+/// The `accuracy > 0` check is QuantLib's `solver1d.hpp:89`. The finiteness of
+/// `accuracy`, `guess` and `step` is a divergence: QuantLib does not check it,
+/// and a non-finite argument there drives the bracketing loop into a silent
+/// non-convergence rather than an error.
+///
+/// # Errors
+///
+/// Errors if `accuracy` is not finite and positive, or if `guess` or `step` is
+/// not finite.
+pub(crate) fn check_stepping_args(accuracy: Real, guess: Real, step: Real) -> QlResult<Real> {
+    if !accuracy.is_finite() || accuracy <= 0.0 {
+        fail!("accuracy ({accuracy}) must be finite and positive");
+    }
+    if !guess.is_finite() {
+        fail!("guess ({guess}) must be finite");
+    }
+    if !step.is_finite() {
+        fail!("step ({step}) must be finite");
+    }
+    Ok(accuracy.max(Real::EPSILON))
+}
+
+/// Validate the arguments of a bracketed `solve` entry point and return the
+/// accuracy clamped to at least `Real::EPSILON`.
+///
+/// The `accuracy > 0` check is QuantLib's `solver1d.hpp:169`. The finiteness of
+/// `accuracy`, `guess` and the bracket endpoints is a divergence: QuantLib
+/// checks only the ordering `xMin < xMax` (`solver1d.hpp:177`), which a NaN
+/// endpoint passes silently.
+///
+/// # Errors
+///
+/// Errors if `accuracy` is not finite and positive, or if `guess`, `x_min` or
+/// `x_max` is not finite.
+pub(crate) fn check_bracket_args(
+    accuracy: Real,
+    guess: Real,
+    x_min: Real,
+    x_max: Real,
+) -> QlResult<Real> {
+    if !accuracy.is_finite() || accuracy <= 0.0 {
+        fail!("accuracy ({accuracy}) must be finite and positive");
+    }
+    if !guess.is_finite() {
+        fail!("guess ({guess}) must be finite");
+    }
+    if !x_min.is_finite() || !x_max.is_finite() {
+        fail!("bracket endpoints must be finite, got [{x_min}, {x_max}]");
+    }
+    Ok(accuracy.max(Real::EPSILON))
+}
+
+/// Evaluate a solver callback and reject non-finite values before they enter
+/// bracket/refinement arithmetic.
+///
+/// Divergence: QuantLib never inspects the value a solver functor returns. A
+/// NaN there makes every bracket comparison false, so the C++ solver runs to
+/// its evaluation cap and reports "maximum evaluations exceeded" instead of the
+/// real cause. Failing here turns that silent non-convergence into an error.
+pub(crate) fn checked_value<F>(f: &mut F, x: Real) -> QlResult<Real>
+where
+    F: FnMut(Real) -> Real,
+{
+    let value = f(x);
+    ensure_finite_function_value(x, value)?;
+    Ok(value)
+}
+
+pub(crate) fn ensure_finite_function_value(x: Real, value: Real) -> QlResult<()> {
+    if !value.is_finite() {
+        fail!("function value must be finite, got f({x}) = {value}");
+    }
+    Ok(())
+}
+
+pub(crate) fn checked_function_value<G: Function1D>(g: &mut G, x: Real) -> QlResult<Real> {
+    let value = g.value(x);
+    ensure_finite_function_value(x, value)?;
+    Ok(value)
+}
+
+pub(crate) fn checked_derivative<G: Function1D>(g: &mut G, x: Real) -> QlResult<Real> {
+    let derivative = g.derivative(x);
+    if !derivative.is_finite() {
+        fail!("function derivative must be finite, got f'({x}) = {derivative}");
+    }
+    Ok(derivative)
+}
+
+pub(crate) fn checked_second_derivative<G: Function2D>(g: &mut G, x: Real) -> QlResult<Real> {
+    let second_derivative = g.second_derivative(x);
+    if !second_derivative.is_finite() {
+        fail!("function second derivative must be finite, got f''({x}) = {second_derivative}");
+    }
+    Ok(second_derivative)
 }
 
 /// Auto-bracket a root of `f` near `guess` by scanning outward in steps of
@@ -211,20 +305,20 @@ where
         root: config.enforce_bounds(guess),
         ..Default::default()
     };
-    st.fx_max = f(st.root);
+    st.fx_max = checked_value(f, st.root)?;
 
     // monotonically crescent bias, as in optionValue(volatility)
     if close(st.fx_max, 0.0) {
         return Ok(Bracketed::Root(st.root));
     } else if st.fx_max > 0.0 {
         st.x_min = config.enforce_bounds(st.root - step);
-        st.fx_min = f(st.x_min);
+        st.fx_min = checked_value(f, st.x_min)?;
         st.x_max = st.root;
     } else {
         st.x_min = st.root;
         st.fx_min = st.fx_max;
         st.x_max = config.enforce_bounds(st.root + step);
-        st.fx_max = f(st.x_max);
+        st.fx_max = checked_value(f, st.x_max)?;
     }
 
     st.evaluation_number = 2;
@@ -241,18 +335,18 @@ where
         }
         if st.fx_min.abs() < st.fx_max.abs() {
             st.x_min = config.enforce_bounds(st.x_min + growth_factor * (st.x_min - st.x_max));
-            st.fx_min = f(st.x_min);
+            st.fx_min = checked_value(f, st.x_min)?;
         } else if st.fx_min.abs() > st.fx_max.abs() {
             st.x_max = config.enforce_bounds(st.x_max + growth_factor * (st.x_max - st.x_min));
-            st.fx_max = f(st.x_max);
+            st.fx_max = checked_value(f, st.x_max)?;
         } else if flipflop == -1 {
             st.x_min = config.enforce_bounds(st.x_min + growth_factor * (st.x_min - st.x_max));
-            st.fx_min = f(st.x_min);
+            st.fx_min = checked_value(f, st.x_min)?;
             st.evaluation_number += 1;
             flipflop = 1;
         } else if flipflop == 1 {
             st.x_max = config.enforce_bounds(st.x_max + growth_factor * (st.x_max - st.x_min));
-            st.fx_max = f(st.x_max);
+            st.fx_max = checked_value(f, st.x_max)?;
             flipflop = -1;
         }
         st.evaluation_number += 1;
@@ -299,11 +393,11 @@ where
         fail!("x_max ({x_max}) > enforced upper bound ({ub})");
     }
 
-    st.fx_min = f(st.x_min);
+    st.fx_min = checked_value(f, st.x_min)?;
     if close(st.fx_min, 0.0) {
         return Ok(Bracketed::Root(st.x_min));
     }
-    st.fx_max = f(st.x_max);
+    st.fx_max = checked_value(f, st.x_max)?;
     if close(st.fx_max, 0.0) {
         return Ok(Bracketed::Root(st.x_max));
     }
@@ -456,10 +550,7 @@ pub trait DerivativeSolver {
         guess: Real,
         step: Real,
     ) -> QlResult<Real> {
-        if accuracy <= 0.0 {
-            fail!("accuracy ({accuracy}) must be positive");
-        }
-        let accuracy = accuracy.max(Real::EPSILON);
+        let accuracy = check_stepping_args(accuracy, guess, step)?;
         // Bind before matching so the value-closure's borrow of `g` is released
         // before `refine` takes `&mut g`.
         let bracketed = bracket_by_stepping(self.config(), &mut |x| g.value(x), guess, step)?;
@@ -483,10 +574,7 @@ pub trait DerivativeSolver {
         x_min: Real,
         x_max: Real,
     ) -> QlResult<Real> {
-        if accuracy <= 0.0 {
-            fail!("accuracy ({accuracy}) must be positive");
-        }
-        let accuracy = accuracy.max(Real::EPSILON);
+        let accuracy = check_bracket_args(accuracy, guess, x_min, x_max)?;
         let bracketed = bracket_given(self.config(), &mut |x| g.value(x), guess, x_min, x_max)?;
         match bracketed {
             Bracketed::Root(x) => Ok(x),
@@ -530,7 +618,7 @@ mod tests {
         {
             while st.evaluation_number < self.max_evaluations() {
                 let mid = 0.5 * (st.x_min + st.x_max);
-                let fmid = f(mid);
+                let fmid = checked_value(f, mid)?;
                 st.evaluation_number += 1;
                 if 0.5 * (st.x_max - st.x_min).abs() <= accuracy || close(fmid, 0.0) {
                     return Ok(mid);
@@ -597,6 +685,28 @@ mod tests {
         }
         // non-positive accuracy
         assert!(bisection().solve(quadratic, 0.0, 0.5, 0.1).is_err());
+        assert!(bisection().solve(quadratic, Real::NAN, 0.5, 0.1).is_err());
+        assert!(bisection().solve(quadratic, 1e-8, Real::NAN, 0.1).is_err());
+        assert!(
+            bisection()
+                .solve(quadratic, 1e-8, 0.5, Real::INFINITY)
+                .is_err()
+        );
+        assert!(
+            bisection()
+                .solve_bracketed(quadratic, Real::INFINITY, 0.5, 0.0, 2.0)
+                .is_err()
+        );
+        assert!(
+            bisection()
+                .solve_bracketed(quadratic, 1e-8, Real::NAN, 0.0, 2.0)
+                .is_err()
+        );
+        assert!(
+            bisection()
+                .solve_bracketed(quadratic, 1e-8, 0.5, 0.0, Real::INFINITY)
+                .is_err()
+        );
         // bracket outside the enforced bounds (upper, then lower)
         let mut solver = bisection();
         solver.set_upper_bound(2.0);
@@ -610,6 +720,27 @@ mod tests {
         assert!(
             solver
                 .solve_bracketed(quadratic, 1e-8, 0.75, 0.0, 2.0)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn drivers_reject_non_finite_function_values() {
+        let cfg = SolverConfig::new();
+        let mut nan_at_left = |x: Real| if x == 0.0 { Real::NAN } else { x - 1.0 };
+        assert!(bracket_given(&cfg, &mut nan_at_left, 0.5, 0.0, 2.0).is_err());
+
+        let mut inf_at_right = |x: Real| if x == 2.0 { Real::INFINITY } else { x - 1.0 };
+        assert!(bracket_given(&cfg, &mut inf_at_right, 0.5, 0.0, 2.0).is_err());
+
+        assert!(
+            bisection()
+                .solve(
+                    |x: Real| if x == 0.5 { Real::NAN } else { x - 1.0 },
+                    1e-8,
+                    0.5,
+                    0.1
+                )
                 .is_err()
         );
     }

--- a/crates/libitofin/src/math/solvers1d/bisection.rs
+++ b/crates/libitofin/src/math/solvers1d/bisection.rs
@@ -7,7 +7,7 @@
 use crate::errors::QlResult;
 use crate::fail;
 use crate::math::comparison::close;
-use crate::math::solver1d::{Solver1D, Solver1DState, SolverConfig};
+use crate::math::solver1d::{Solver1D, Solver1DState, SolverConfig, checked_value};
 use crate::types::Real;
 
 /// Bisection root finder.
@@ -79,14 +79,14 @@ impl Solver1D for Bisection {
         while st.evaluation_number <= self.max_evaluations() {
             dx /= 2.0;
             let x_mid = st.root + dx;
-            let f_mid = f(x_mid);
+            let f_mid = checked_value(f, x_mid)?;
             st.evaluation_number += 1;
             if f_mid <= 0.0 {
                 st.root = x_mid;
             }
             if dx.abs() < x_accuracy || close(f_mid, 0.0) {
                 // Final call at the root so a stateful functor records it.
-                let _ = f(st.root);
+                let _ = checked_value(f, st.root)?;
                 st.evaluation_number += 1;
                 return Ok(st.root);
             }

--- a/crates/libitofin/src/math/solvers1d/brent.rs
+++ b/crates/libitofin/src/math/solvers1d/brent.rs
@@ -8,7 +8,7 @@
 use crate::errors::QlResult;
 use crate::fail;
 use crate::math::comparison::close;
-use crate::math::solver1d::{Solver1D, Solver1DState, SolverConfig};
+use crate::math::solver1d::{Solver1D, Solver1DState, SolverConfig, checked_value};
 use crate::types::Real;
 
 /// Brent's method root finder.
@@ -75,7 +75,7 @@ impl Solver1D for Brent {
     {
         // Start with root_ (the guess) on one side of the bracket and both
         // x_min and x_max on the other.
-        let mut froot = f(st.root);
+        let mut froot = checked_value(f, st.root)?;
         st.evaluation_number += 1;
         if froot * st.fx_min < 0.0 {
             st.x_max = st.x_min;
@@ -109,7 +109,7 @@ impl Solver1D for Brent {
             if x_mid.abs() <= x_acc1 || close(froot, 0.0) {
                 // QuantLib makes one last call with the root so a stateful
                 // functor records it; preserve that side effect.
-                let _ = f(st.root);
+                let _ = checked_value(f, st.root)?;
                 st.evaluation_number += 1;
                 return Ok(st.root);
             }
@@ -152,7 +152,7 @@ impl Solver1D for Brent {
             } else {
                 st.root += sign(x_acc1, x_mid);
             }
-            froot = f(st.root);
+            froot = checked_value(f, st.root)?;
             st.evaluation_number += 1;
         }
         fail!(

--- a/crates/libitofin/src/math/solvers1d/falseposition.rs
+++ b/crates/libitofin/src/math/solvers1d/falseposition.rs
@@ -8,7 +8,7 @@
 use crate::errors::QlResult;
 use crate::fail;
 use crate::math::comparison::close;
-use crate::math::solver1d::{Solver1D, Solver1DState, SolverConfig};
+use crate::math::solver1d::{Solver1D, Solver1DState, SolverConfig, checked_value};
 use crate::types::Real;
 
 /// False-position root finder.
@@ -78,7 +78,7 @@ impl Solver1D for FalsePosition {
         while st.evaluation_number <= self.max_evaluations() {
             // Step to the secant's x-intercept.
             st.root = xl + (xh - xl) * fl / (fl - fh);
-            let froot = f(st.root);
+            let froot = checked_value(f, st.root)?;
             st.evaluation_number += 1;
             // Replace the end whose sign matches the new point.
             let del = if froot < 0.0 {

--- a/crates/libitofin/src/math/solvers1d/finitedifferencenewtonsafe.rs
+++ b/crates/libitofin/src/math/solvers1d/finitedifferencenewtonsafe.rs
@@ -9,7 +9,7 @@
 use crate::errors::QlResult;
 use crate::fail;
 use crate::math::comparison::close_n;
-use crate::math::solver1d::{Solver1D, Solver1DState, SolverConfig};
+use crate::math::solver1d::{Solver1D, Solver1DState, SolverConfig, checked_value};
 use crate::types::Real;
 
 /// Finite-difference Newton-safe root finder.
@@ -76,7 +76,7 @@ impl Solver1D for FiniteDifferenceNewtonSafe {
             (st.x_max, st.x_min)
         };
 
-        let mut froot = f(st.root);
+        let mut froot = checked_value(f, st.root)?;
         st.evaluation_number += 1;
         // First-order finite-difference derivative, taken from the closer end.
         let mut dfroot = if st.x_max - st.root < st.root - st.x_min {
@@ -102,7 +102,7 @@ impl Solver1D for FiniteDifferenceNewtonSafe {
                 // the difference against xh instead so the secant stays defined.
                 if close_n(st.root, rootold, 2500) {
                     rootold = xh;
-                    frootold = f(xh);
+                    frootold = checked_value(f, xh)?;
                 }
             } else {
                 dx = froot / dfroot;
@@ -111,7 +111,7 @@ impl Solver1D for FiniteDifferenceNewtonSafe {
             if dx.abs() < x_accuracy {
                 return Ok(st.root);
             }
-            froot = f(st.root);
+            froot = checked_value(f, st.root)?;
             st.evaluation_number += 1;
             // Secant-style derivative against the previous point.
             dfroot = (frootold - froot) / (rootold - st.root);

--- a/crates/libitofin/src/math/solvers1d/halley.rs
+++ b/crates/libitofin/src/math/solvers1d/halley.rs
@@ -12,12 +12,23 @@ use crate::errors::QlResult;
 use crate::fail;
 use crate::math::solver1d::{
     Bracketed, DerivativeSolver, Function2D, Solver1DState, SolverConfig, bracket_by_stepping,
-    bracket_given,
+    bracket_given, check_bracket_args, check_stepping_args, checked_derivative,
+    checked_function_value, checked_second_derivative,
 };
 use crate::math::solvers1d::newtonsafe::NewtonSafe;
 use crate::types::Real;
 
 /// Halley's method root finder.
+///
+/// Structural divergence: QuantLib's `Halley` (`halley.hpp:41`) supplies only
+/// `solveImpl` and inherits both `solve` overloads from the `Solver1D<Halley>`
+/// CRTP base, whose `solve` is a template over the functor type and so serves a
+/// value-only, a first-derivative and a second-derivative functor alike. This
+/// port's [`Solver1D`] and [`DerivativeSolver`] traits are typed on
+/// [`Function1D`], which has no second derivative, so Halley cannot reuse
+/// either driver and carries its own `solve` / `solve_bracketed` entry points.
+/// They share the argument validation of the trait drivers via
+/// [`check_stepping_args`] and [`check_bracket_args`].
 #[derive(Clone, Copy, Debug)]
 pub struct Halley {
     config: SolverConfig,
@@ -62,10 +73,7 @@ impl Halley {
         guess: Real,
         step: Real,
     ) -> QlResult<Real> {
-        if accuracy <= 0.0 {
-            fail!("accuracy ({accuracy}) must be positive");
-        }
-        let accuracy = accuracy.max(Real::EPSILON);
+        let accuracy = check_stepping_args(accuracy, guess, step)?;
         // Bind before matching so the value-closure's borrow of `g` is released
         // before `refine` takes ownership.
         let bracketed = bracket_by_stepping(&self.config, &mut |x| g.value(x), guess, step)?;
@@ -89,10 +97,7 @@ impl Halley {
         x_min: Real,
         x_max: Real,
     ) -> QlResult<Real> {
-        if accuracy <= 0.0 {
-            fail!("accuracy ({accuracy}) must be positive");
-        }
-        let accuracy = accuracy.max(Real::EPSILON);
+        let accuracy = check_bracket_args(accuracy, guess, x_min, x_max)?;
         let bracketed = bracket_given(&self.config, &mut |x| g.value(x), guess, x_min, x_max)?;
         match bracketed {
             Bracketed::Root(x) => Ok(x),
@@ -113,9 +118,10 @@ impl Halley {
             if st.evaluation_number > self.config.max_evaluations {
                 break;
             }
-            let fx = g.value(st.root);
-            let f_prime = g.derivative(st.root);
-            let lf = fx * g.second_derivative(st.root) / (f_prime * f_prime);
+            let fx = checked_function_value(&mut g, st.root)?;
+            let f_prime = checked_derivative(&mut g, st.root)?;
+            let f_second = checked_second_derivative(&mut g, st.root)?;
+            let lf = fx * f_second / (f_prime * f_prime);
             let step = 1.0 / (1.0 - 0.5 * lf) * fx / f_prime;
 
             // A zero or non-finite first derivative (or the degenerate
@@ -142,7 +148,7 @@ impl Halley {
             }
             if step.abs() < x_accuracy {
                 // Final call at the root so a stateful functor records it.
-                let _ = g.value(st.root);
+                let _ = checked_function_value(&mut g, st.root)?;
                 st.evaluation_number += 1;
                 return Ok(st.root);
             }
@@ -288,6 +294,26 @@ mod tests {
         assert!(
             Halley::new()
                 .solve_bracketed(func2d(f1, d1, dd1), 1e-8, 5.0, 0.0, 2.0)
+                .is_err()
+        );
+        let non_finite_after_bracket = |x: Real| {
+            if x == 0.0 {
+                -1.0
+            } else if x == 2.0 {
+                1.0
+            } else {
+                Real::NAN
+            }
+        };
+        assert!(
+            Halley::new()
+                .solve_bracketed(
+                    func2d(non_finite_after_bracket, |_| 1.0, |_| 0.0),
+                    1e-8,
+                    1.0,
+                    0.0,
+                    2.0
+                )
                 .is_err()
         );
     }

--- a/crates/libitofin/src/math/solvers1d/newton.rs
+++ b/crates/libitofin/src/math/solvers1d/newton.rs
@@ -11,7 +11,10 @@
 
 use crate::errors::QlResult;
 use crate::fail;
-use crate::math::solver1d::{DerivativeSolver, Function1D, Solver1DState, SolverConfig};
+use crate::math::solver1d::{
+    DerivativeSolver, Function1D, Solver1DState, SolverConfig, checked_derivative,
+    checked_function_value,
+};
 use crate::types::Real;
 
 /// Newton-Raphson root finder.
@@ -64,8 +67,8 @@ impl DerivativeSolver for Newton {
         x_accuracy: Real,
         mut st: Solver1DState,
     ) -> QlResult<Real> {
-        let mut froot = g.value(st.root);
-        let mut dfroot = g.derivative(st.root);
+        let mut froot = checked_function_value(g, st.root)?;
+        let mut dfroot = checked_derivative(g, st.root)?;
         st.evaluation_number += 1;
 
         while st.evaluation_number <= self.config.max_evaluations {
@@ -89,12 +92,12 @@ impl DerivativeSolver for Newton {
             }
             if dx.abs() < x_accuracy {
                 // Final call at the root so a stateful functor records it.
-                let _ = g.value(st.root);
+                let _ = checked_function_value(g, st.root)?;
                 st.evaluation_number += 1;
                 return Ok(st.root);
             }
-            froot = g.value(st.root);
-            dfroot = g.derivative(st.root);
+            froot = checked_function_value(g, st.root)?;
+            dfroot = checked_derivative(g, st.root)?;
             st.evaluation_number += 1;
         }
         fail!(

--- a/crates/libitofin/src/math/solvers1d/newtonsafe.rs
+++ b/crates/libitofin/src/math/solvers1d/newtonsafe.rs
@@ -12,7 +12,10 @@
 use crate::errors::QlResult;
 use crate::fail;
 use crate::math::comparison::close;
-use crate::math::solver1d::{DerivativeSolver, Function1D, Solver1DState, SolverConfig};
+use crate::math::solver1d::{
+    DerivativeSolver, Function1D, Solver1DState, SolverConfig, checked_derivative,
+    checked_function_value,
+};
 use crate::types::Real;
 
 /// Newton-safe root finder (Newton with a bisection fallback).
@@ -75,13 +78,13 @@ impl DerivativeSolver for NewtonSafe {
         let mut dxold = st.x_max - st.x_min;
         let mut dx = dxold;
 
-        let mut froot = g.value(st.root);
+        let mut froot = checked_function_value(g, st.root)?;
         // A root with a zero (or near-zero) derivative - e.g. the flat inflection
         // of (x-1)^3 - is detected here so the step below never divides 0 by 0.
         if close(froot, 0.0) {
             return Ok(st.root);
         }
-        let mut dfroot = g.derivative(st.root);
+        let mut dfroot = checked_derivative(g, st.root)?;
         st.evaluation_number += 1;
 
         while st.evaluation_number <= self.config.max_evaluations {
@@ -100,15 +103,15 @@ impl DerivativeSolver for NewtonSafe {
             }
             if dx.abs() < x_accuracy {
                 // Final call at the root so a stateful functor records it.
-                let _ = g.value(st.root);
+                let _ = checked_function_value(g, st.root)?;
                 st.evaluation_number += 1;
                 return Ok(st.root);
             }
-            froot = g.value(st.root);
+            froot = checked_function_value(g, st.root)?;
             if close(froot, 0.0) {
                 return Ok(st.root);
             }
-            dfroot = g.derivative(st.root);
+            dfroot = checked_derivative(g, st.root)?;
             st.evaluation_number += 1;
             // Keep the new point as the matching bracket end.
             if froot < 0.0 {

--- a/crates/libitofin/src/math/solvers1d/ridder.rs
+++ b/crates/libitofin/src/math/solvers1d/ridder.rs
@@ -8,7 +8,7 @@
 use crate::errors::QlResult;
 use crate::fail;
 use crate::math::comparison::close;
-use crate::math::solver1d::{Solver1D, Solver1DState, SolverConfig};
+use crate::math::solver1d::{Solver1D, Solver1DState, SolverConfig, checked_value};
 use crate::types::Real;
 
 /// Ridder's method root finder.
@@ -79,11 +79,11 @@ impl Solver1D for Ridder {
         while st.evaluation_number <= self.max_evaluations() {
             let x_mid = 0.5 * (st.x_min + st.x_max);
             // First of two evaluations per iteration.
-            let fx_mid = f(x_mid);
+            let fx_mid = checked_value(f, x_mid)?;
             st.evaluation_number += 1;
             let s = (fx_mid * fx_mid - st.fx_min * st.fx_max).sqrt();
             if close(s, 0.0) {
-                let _ = f(st.root);
+                let _ = checked_value(f, st.root)?;
                 st.evaluation_number += 1;
                 return Ok(st.root);
             }
@@ -91,14 +91,14 @@ impl Solver1D for Ridder {
             let direction = if st.fx_min >= st.fx_max { 1.0 } else { -1.0 };
             let next_root = x_mid + (x_mid - st.x_min) * (direction * fx_mid / s);
             if (next_root - st.root).abs() <= x_accuracy {
-                let _ = f(st.root);
+                let _ = checked_value(f, st.root)?;
                 st.evaluation_number += 1;
                 return Ok(st.root);
             }
 
             st.root = next_root;
             // Second of two evaluations per iteration.
-            let froot = f(st.root);
+            let froot = checked_value(f, st.root)?;
             st.evaluation_number += 1;
             if close(froot, 0.0) {
                 return Ok(st.root);
@@ -121,7 +121,7 @@ impl Solver1D for Ridder {
             }
 
             if (st.x_max - st.x_min).abs() <= x_accuracy {
-                let _ = f(st.root);
+                let _ = checked_value(f, st.root)?;
                 st.evaluation_number += 1;
                 return Ok(st.root);
             }

--- a/crates/libitofin/src/math/solvers1d/secant.rs
+++ b/crates/libitofin/src/math/solvers1d/secant.rs
@@ -7,7 +7,7 @@
 use crate::errors::QlResult;
 use crate::fail;
 use crate::math::comparison::close;
-use crate::math::solver1d::{Solver1D, Solver1DState, SolverConfig};
+use crate::math::solver1d::{Solver1D, Solver1DState, SolverConfig, checked_value};
 use crate::types::Real;
 
 /// Secant root finder.
@@ -82,7 +82,7 @@ impl Solver1D for Secant {
             xl = st.root;
             fl = froot;
             st.root += dx;
-            froot = f(st.root);
+            froot = checked_value(f, st.root)?;
             st.evaluation_number += 1;
             if dx.abs() < x_accuracy || close(froot, 0.0) {
                 return Ok(st.root);

--- a/crates/libitofin/src/math/solvers1d/testkit.rs
+++ b/crates/libitofin/src/math/solvers1d/testkit.rs
@@ -117,6 +117,20 @@ pub fn check_rejects_invalid_inputs<S: Solver1D>(make: impl Fn() -> S) {
     assert!(make().solve(f1, 0.0, 0.5, 0.1).is_err());
     assert!(make().solve_bracketed(f1, 1e-8, 2.5, 2.0, 3.0).is_err());
     assert!(make().solve_bracketed(f1, 1e-8, 5.0, 0.0, 2.0).is_err());
+    let non_finite_after_bracket = |x: Real| {
+        if x == 0.0 {
+            -1.0
+        } else if x == 2.0 {
+            1.0
+        } else {
+            Real::NAN
+        }
+    };
+    assert!(
+        make()
+            .solve_bracketed(non_finite_after_bracket, 1e-8, 1.0, 0.0, 2.0)
+            .is_err()
+    );
 }
 
 /// Configured domain bounds are honoured: a bracket past the upper bound is
@@ -201,6 +215,13 @@ pub fn check_derivative_last_call<S: DerivativeSolver>(make: impl Fn() -> S) {
 /// The shared driver rejects malformed inputs for a [`DerivativeSolver`] too.
 pub fn check_derivative_rejects<S: DerivativeSolver>(make: impl Fn() -> S) {
     assert!(make().solve(func1d(f1, d1), 0.0, 0.5, 0.1).is_err());
+    assert!(make().solve(func1d(f1, d1), Real::NAN, 0.5, 0.1).is_err());
+    assert!(make().solve(func1d(f1, d1), 1e-8, Real::NAN, 0.1).is_err());
+    assert!(
+        make()
+            .solve(func1d(f1, d1), 1e-8, 0.5, Real::INFINITY)
+            .is_err()
+    );
     assert!(
         make()
             .solve_bracketed(func1d(f1, d1), 1e-8, 2.5, 2.0, 3.0)
@@ -209,6 +230,41 @@ pub fn check_derivative_rejects<S: DerivativeSolver>(make: impl Fn() -> S) {
     assert!(
         make()
             .solve_bracketed(func1d(f1, d1), 1e-8, 5.0, 0.0, 2.0)
+            .is_err()
+    );
+    assert!(
+        make()
+            .solve_bracketed(func1d(f1, d1), Real::INFINITY, 0.5, 0.0, 2.0)
+            .is_err()
+    );
+    assert!(
+        make()
+            .solve_bracketed(func1d(f1, d1), 1e-8, Real::NAN, 0.0, 2.0)
+            .is_err()
+    );
+    assert!(
+        make()
+            .solve_bracketed(func1d(f1, d1), 1e-8, 0.5, 0.0, Real::INFINITY)
+            .is_err()
+    );
+    let non_finite_after_bracket = |x: Real| {
+        if x == 0.0 {
+            -1.0
+        } else if x == 2.0 {
+            1.0
+        } else {
+            Real::NAN
+        }
+    };
+    assert!(
+        make()
+            .solve_bracketed(
+                func1d(non_finite_after_bracket, |_| 1.0),
+                1e-8,
+                1.0,
+                0.0,
+                2.0
+            )
             .is_err()
     );
 }

--- a/crates/libitofin/src/math/statistics/generalstatistics.rs
+++ b/crates/libitofin/src/math/statistics/generalstatistics.rs
@@ -10,7 +10,7 @@ use crate::errors::QlResult;
 use crate::types::{Real, Size};
 use crate::{fail, require};
 
-use super::{EmpiricalStatistics, MeanStdDev, Statistics};
+use super::{EmpiricalStatistics, MeanStdDev, Statistics, check_sample};
 
 /// Statistics tool accumulating the full sample set.
 #[derive(Clone, Debug)]
@@ -167,9 +167,7 @@ impl Statistics for GeneralStatistics {
     }
 
     fn add_weighted(&mut self, value: Real, weight: Real) -> QlResult<()> {
-        if weight < 0.0 || weight.is_nan() {
-            fail!("negative weight ({weight}) not allowed");
-        }
+        check_sample(value, weight)?;
         self.samples.push((value, weight));
         self.sorted = false;
         Ok(())
@@ -336,6 +334,8 @@ mod tests {
         assert!(s.min().is_err());
         assert!(s.percentile(0.5).is_err());
         assert!(s.add_weighted(1.0, -0.5).is_err());
+        assert!(s.add_weighted(Real::NAN, 1.0).is_err());
+        assert!(s.add_weighted(1.0, Real::NAN).is_err());
 
         s.add(1.0).unwrap();
         assert!(s.variance().is_err());

--- a/crates/libitofin/src/math/statistics/incrementalstatistics.rs
+++ b/crates/libitofin/src/math/statistics/incrementalstatistics.rs
@@ -11,7 +11,7 @@ use crate::errors::QlResult;
 use crate::types::{Real, Size};
 use crate::{fail, require};
 
-use super::{MeanStdDev, Statistics};
+use super::{MeanStdDev, Statistics, check_sample};
 
 /// Single-pass statistics accumulator; it keeps running moments instead of
 /// the samples themselves.
@@ -143,9 +143,7 @@ impl Statistics for IncrementalStatistics {
     }
 
     fn add_weighted(&mut self, value: Real, weight: Real) -> QlResult<()> {
-        if weight < 0.0 || weight.is_nan() {
-            fail!("negative weight ({weight}) not allowed");
-        }
+        check_sample(value, weight)?;
         self.min = if self.count == 0 {
             value
         } else {
@@ -381,6 +379,8 @@ mod tests {
         assert!(s.min().is_err());
         assert!(s.downside_variance().is_err());
         assert!(s.add_weighted(1.0, -1.0).is_err());
+        assert!(s.add_weighted(Real::NAN, 1.0).is_err());
+        assert!(s.add_weighted(1.0, Real::NAN).is_err());
 
         s.add(1.0).unwrap();
         assert!(s.variance().is_err());

--- a/crates/libitofin/src/math/statistics/mod.rs
+++ b/crates/libitofin/src/math/statistics/mod.rs
@@ -9,6 +9,7 @@
 //! whole sample set, such as [`GeneralStatistics`].
 
 use crate::errors::QlResult;
+use crate::fail;
 use crate::types::{Real, Size};
 
 mod gaussianstatistics;
@@ -22,6 +23,34 @@ pub use generalstatistics::GeneralStatistics;
 pub use histogram::{Histogram, HistogramAlgorithm};
 pub use incrementalstatistics::IncrementalStatistics;
 pub use riskstatistics::RiskStatistics;
+
+/// Validate one `(value, weight)` sample before it enters an accumulator.
+///
+/// The weight check is the faithful port of QuantLib's
+/// `QL_REQUIRE(weight >= 0.0, "negative weight not allowed")`
+/// (`generalstatistics.hpp:233`, `incrementalstatistics.cpp:127`). It is
+/// written as `!(weight >= 0.0)` rather than `weight < 0.0` because a NaN
+/// weight fails `weight >= 0.0` in C++ and must fail here too; the negated
+/// form preserves that without a separate NaN clause.
+///
+/// Divergence: rejecting a NaN `value` has no counterpart in QuantLib, which
+/// accumulates it and silently poisons every subsequent mean, variance and
+/// percentile. Infinite values are permitted, as in C++: they are meaningful
+/// inputs to `min`, `max` and the risk measures.
+///
+/// # Errors
+///
+/// Errors if `value` is NaN, or if `weight` is negative or NaN.
+pub(crate) fn check_sample(value: Real, weight: Real) -> QlResult<()> {
+    if value.is_nan() {
+        fail!("sample value must not be NaN");
+    }
+    #[allow(clippy::neg_cmp_op_on_partial_ord)]
+    if !(weight >= 0.0) {
+        fail!("negative weight ({weight}) not allowed");
+    }
+    Ok(())
+}
 
 /// Mean and standard deviation of a distribution, the minimal interface
 /// required by the gaussian-assumption risk measures.
@@ -96,7 +125,7 @@ pub trait Statistics: MeanStdDev {
     ///
     /// # Errors
     ///
-    /// Returns an error if `weight` is negative.
+    /// Returns an error if `value` is NaN, or if `weight` is negative or NaN.
     fn add_weighted(&mut self, value: Real, weight: Real) -> QlResult<()>;
 
     /// Resets the accumulator to an empty sample set.
@@ -106,7 +135,7 @@ pub trait Statistics: MeanStdDev {
     ///
     /// # Errors
     ///
-    /// Never fails; kept fallible for uniformity with [`Self::add_weighted`].
+    /// Returns an error if `value` is NaN.
     fn add(&mut self, value: Real) -> QlResult<()> {
         self.add_weighted(value, 1.0)
     }
@@ -115,7 +144,7 @@ pub trait Statistics: MeanStdDev {
     ///
     /// # Errors
     ///
-    /// Never fails; kept fallible for uniformity with [`Self::add_weighted`].
+    /// Returns an error if any value is NaN.
     fn add_sequence<I>(&mut self, values: I) -> QlResult<()>
     where
         I: IntoIterator<Item = Real>,
@@ -130,7 +159,7 @@ pub trait Statistics: MeanStdDev {
     ///
     /// # Errors
     ///
-    /// Returns an error if any weight is negative.
+    /// Returns an error if any value is NaN, or if any weight is negative or NaN.
     fn add_sequence_weighted<I>(&mut self, values: I) -> QlResult<()>
     where
         I: IntoIterator<Item = (Real, Real)>,

--- a/crates/libitofin/src/patterns/lazyobject.rs
+++ b/crates/libitofin/src/patterns/lazyobject.rs
@@ -41,6 +41,34 @@ pub struct LazyObject {
     updating: bool,
 }
 
+/// A deferred lazy-object notification that keeps the logical C++ `updating_`
+/// guard set while the caller notifies after releasing its `RefCell` borrow.
+///
+/// This is the RAII `LazyObject::UpdateChecker` of `lazyobject.hpp:134-141`,
+/// which sets `updating_` on entry to `update()` and clears it on scope exit
+/// (`:203`), so that an observer which writes back into an input during
+/// notification re-enters `update()` and returns early at `:191`. The port
+/// splits the C++ single `update()` into a state half and a notify half so the
+/// `RefCell` borrow is released before observers run; the guard carries the
+/// `updating_` flag across that gap.
+pub(crate) struct DeferredUpdate {
+    lazy: SharedMut<LazyObject>,
+    observable: Shared<Observable>,
+}
+
+impl DeferredUpdate {
+    /// Notifies observers while this guard is alive.
+    pub(crate) fn notify_observers(&self) {
+        self.observable.notify_observers();
+    }
+}
+
+impl Drop for DeferredUpdate {
+    fn drop(&mut self) {
+        self.lazy.borrow_mut().updating = false;
+    }
+}
+
 impl LazyObject {
     /// Creates a lazy object.
     ///
@@ -111,20 +139,28 @@ impl LazyObject {
     }
 
     /// The state half of [`on_update`](LazyObject::on_update) for lazy objects
-    /// held in a `SharedMut`: applies the invalidation and hands back the
-    /// observable to notify, so the holder can release its borrow first and a
-    /// notified observer may query the lazy object without a borrow conflict.
-    pub fn deferred_update(&mut self) -> Option<Shared<Observable>> {
-        if self.updating || !(self.calculated || self.failed || self.always_forward) {
-            return None;
-        }
-        self.calculated = false;
-        self.failed = false;
-        if self.frozen {
-            None
-        } else {
-            Some(Shared::clone(&self.observable))
-        }
+    /// held in a `SharedMut`: applies the invalidation and hands back a guard
+    /// that notifies after the borrow is released. The guard keeps `updating`
+    /// set until notification completes, matching the C++ recursion guard.
+    pub(crate) fn deferred_update(lazy: &SharedMut<LazyObject>) -> Option<DeferredUpdate> {
+        let observable = {
+            let mut lazy = lazy.borrow_mut();
+            if lazy.updating || !(lazy.calculated || lazy.failed || lazy.always_forward) {
+                return None;
+            }
+            lazy.updating = true;
+            lazy.calculated = false;
+            lazy.failed = false;
+            if lazy.frozen {
+                lazy.updating = false;
+                return None;
+            }
+            Shared::clone(&lazy.observable)
+        };
+        Some(DeferredUpdate {
+            lazy: SharedMut::clone(lazy),
+            observable,
+        })
     }
 
     /// Marks the results calculated without running a calculation, bypassing

--- a/crates/libitofin/src/patterns/observable.rs
+++ b/crates/libitofin/src/patterns/observable.rs
@@ -34,6 +34,23 @@ thread_local! {
     static PENDING: RefCell<Vec<WeakMut<dyn Observer>>> = const { RefCell::new(Vec::new()) };
 }
 
+struct ObserverEntry {
+    observer: WeakMut<dyn Observer>,
+    defer_reentrant: bool,
+}
+
+impl ObserverEntry {
+    fn new(observer: &SharedMut<dyn Observer>) -> Self {
+        let defer_reentrant = observer
+            .try_borrow()
+            .map_or(true, |observer| observer.defer_reentrant_update());
+        ObserverEntry {
+            observer: SharedMut::downgrade(observer),
+            defer_reentrant,
+        }
+    }
+}
+
 /// RAII depth counter for [`DEPTH`], panic-safe like `LazyObject`'s guard.
 struct DepthGuard;
 
@@ -135,6 +152,19 @@ fn drain_pending() {
 pub trait Observer {
     /// Called by the observables this instance registered with on a change.
     fn update(&mut self);
+
+    /// Whether a reentrant notification that finds this observer already
+    /// updating should be replayed after the borrow releases.
+    ///
+    /// Divergence: C++ has no such hook. It exists because this port detects
+    /// re-entrancy as a failed `RefCell::try_borrow_mut`, where C++ simply
+    /// re-enters `update()` and lets the callee decide. An observer whose
+    /// `update` already implements C++'s own recursion guard - a lazy object,
+    /// via `updating_` - must return `false` here, or the port would replay a
+    /// notification that C++ discards.
+    fn defer_reentrant_update(&self) -> bool {
+        true
+    }
 }
 
 /// Contract for types that embed an [`Observable`] and broadcast through it.
@@ -228,7 +258,7 @@ impl Observer for ResetThenNotify {
 /// or otherwise touch this observable while being notified.
 #[derive(Default)]
 pub struct Observable {
-    observers: RefCell<Vec<WeakMut<dyn Observer>>>,
+    observers: RefCell<Vec<ObserverEntry>>,
 }
 
 impl Observable {
@@ -244,11 +274,11 @@ impl Observable {
     pub fn register_observer(&self, observer: &SharedMut<dyn Observer>) -> bool {
         let weak = SharedMut::downgrade(observer);
         let mut observers = self.observers.borrow_mut();
-        observers.retain(|w| w.strong_count() > 0);
-        if observers.iter().any(|w| w.ptr_eq(&weak)) {
+        observers.retain(|entry| entry.observer.strong_count() > 0);
+        if observers.iter().any(|entry| entry.observer.ptr_eq(&weak)) {
             return false;
         }
-        observers.push(weak);
+        observers.push(ObserverEntry::new(observer));
         true
     }
 
@@ -257,12 +287,12 @@ impl Observable {
         let target = SharedMut::downgrade(observer);
         let mut observers = self.observers.borrow_mut();
         let mut removed = false;
-        observers.retain(|w| {
-            if w.ptr_eq(&target) {
+        observers.retain(|entry| {
+            if entry.observer.ptr_eq(&target) {
                 removed = true;
                 return false;
             }
-            w.strong_count() > 0
+            entry.observer.strong_count() > 0
         });
         removed
     }
@@ -292,17 +322,29 @@ impl Observable {
     /// the notification): it stays queued and is delivered at the end of the
     /// next outermost notification on the thread.
     pub fn notify_observers(&self) {
-        let snapshot: Vec<SharedMut<dyn Observer>> = {
+        let snapshot: Vec<(SharedMut<dyn Observer>, bool)> = {
             let mut observers = self.observers.borrow_mut();
-            observers.retain(|w| w.strong_count() > 0);
-            observers.iter().filter_map(WeakMut::upgrade).collect()
+            observers.retain(|entry| entry.observer.strong_count() > 0);
+            observers
+                .iter()
+                .filter_map(|entry| {
+                    entry
+                        .observer
+                        .upgrade()
+                        .map(|observer| (observer, entry.defer_reentrant))
+                })
+                .collect()
         };
         {
             let _depth = DepthGuard::enter();
-            for observer in snapshot {
+            for (observer, defer_reentrant) in snapshot {
                 match observer.try_borrow_mut() {
                     Ok(mut observer) => observer.update(),
-                    Err(_) => defer(&observer),
+                    Err(_) => {
+                        if defer_reentrant {
+                            defer(&observer);
+                        }
+                    }
                 }
             }
         }

--- a/crates/libitofin/src/pricingengines/blackcalculator.rs
+++ b/crates/libitofin/src/pricingengines/blackcalculator.rs
@@ -6,6 +6,13 @@
 //! visitor dispatch on the other striked payoffs follows those payoffs as a
 //! follow-up, as do `strike_gamma`, `vanna` and `volga`.
 //!
+//! Divergence, throughout: every argument requirement here is QuantLib's own
+//! (`blackcalculator.cpp:66,68,72,74` for the constructor, `:204` and `:316`
+//! for `spot > 0`, `:364,373,392,411` for `maturity >= 0`), but each is
+//! written `!is_finite() || ...` where C++ relies on NaN failing the
+//! comparison. That widens rejection to `+inf` only, which C++ accepts and
+//! propagates as a NaN result.
+//!
 //! One deviation from the C++ reference: its zero-volatility branches detect
 //! the option type with `alpha_ >= 0`, which misreads an out-of-the-money put
 //! (`alpha_ == 0` exactly) as a call and hands it in-the-money call greeks.
@@ -50,6 +57,18 @@ pub struct BlackCalculator {
 
 impl BlackCalculator {
     /// Builds a calculator for the given option type and strike.
+    ///
+    /// The four requirements are QuantLib's, from the `BlackCalculator`
+    /// constructor (`blackcalculator.cpp:66,68,72,74`): `strike >= 0`,
+    /// `forward > 0`, `stdDev >= 0`, `discount > 0`.
+    ///
+    /// Divergence: each is written `!is_finite() || ...` rather than
+    /// `is_nan() || ...`. NaN already fails the C++ comparison, so this widens
+    /// rejection only to `+inf`, which C++ accepts and turns into a NaN price.
+    ///
+    /// # Errors
+    ///
+    /// Errors if any argument is non-finite or violates its sign requirement.
     pub fn new(
         option_type: OptionType,
         strike: Real,
@@ -57,16 +76,16 @@ impl BlackCalculator {
         std_dev: Real,
         discount: Real,
     ) -> QlResult<BlackCalculator> {
-        if strike.is_nan() || strike < 0.0 {
+        if !strike.is_finite() || strike < 0.0 {
             fail!("strike ({strike}) must be non-negative");
         }
-        if forward.is_nan() || forward <= 0.0 {
+        if !forward.is_finite() || forward <= 0.0 {
             fail!("forward ({forward}) must be positive");
         }
-        if std_dev.is_nan() || std_dev < 0.0 {
+        if !std_dev.is_finite() || std_dev < 0.0 {
             fail!("stdDev ({std_dev}) must be non-negative");
         }
-        if discount.is_nan() || discount <= 0.0 {
+        if !discount.is_finite() || discount <= 0.0 {
             fail!("discount ({discount}) must be positive");
         }
 
@@ -188,7 +207,7 @@ impl BlackCalculator {
 
     /// Sensitivity to a change in the underlying spot price.
     pub fn delta(&self, spot: Real) -> QlResult<Real> {
-        if spot.is_nan() || spot <= 0.0 {
+        if !spot.is_finite() || spot <= 0.0 {
             fail!("positive spot value required: {spot} not allowed");
         }
 
@@ -247,7 +266,7 @@ impl BlackCalculator {
 
     /// Second-order sensitivity to a change in the spot price.
     pub fn gamma(&self, spot: Real) -> QlResult<Real> {
-        if spot.is_nan() || spot <= 0.0 {
+        if !spot.is_finite() || spot <= 0.0 {
             fail!("positive spot value required: {spot} not allowed");
         }
 
@@ -274,7 +293,7 @@ impl BlackCalculator {
 
     /// Sensitivity to the passage of time.
     pub fn theta(&self, spot: Real, maturity: Time) -> QlResult<Real> {
-        if maturity.is_nan() || maturity < 0.0 {
+        if !maturity.is_finite() || maturity < 0.0 {
             fail!("maturity ({maturity}) must be non-negative");
         }
         if close(maturity, 0.0) {
@@ -293,7 +312,7 @@ impl BlackCalculator {
 
     /// Sensitivity to volatility.
     pub fn vega(&self, maturity: Time) -> QlResult<Real> {
-        if maturity.is_nan() || maturity < 0.0 {
+        if !maturity.is_finite() || maturity < 0.0 {
             fail!("negative maturity not allowed");
         }
 
@@ -312,7 +331,7 @@ impl BlackCalculator {
 
     /// Sensitivity to the discounting rate.
     pub fn rho(&self, maturity: Time) -> QlResult<Real> {
-        if maturity.is_nan() || maturity < 0.0 {
+        if !maturity.is_finite() || maturity < 0.0 {
             fail!("negative maturity not allowed");
         }
 
@@ -330,7 +349,7 @@ impl BlackCalculator {
 
     /// Sensitivity to the dividend or growth rate.
     pub fn dividend_rho(&self, maturity: Time) -> QlResult<Real> {
-        if maturity.is_nan() || maturity < 0.0 {
+        if !maturity.is_finite() || maturity < 0.0 {
             fail!("negative maturity not allowed");
         }
 
@@ -601,12 +620,30 @@ mod tests {
         assert!(
             BlackCalculator::new(OptionType::Call, Real::NAN, FORWARD, STD_DEV, DISCOUNT).is_err()
         );
+        assert!(
+            BlackCalculator::new(OptionType::Call, Real::INFINITY, FORWARD, STD_DEV, DISCOUNT)
+                .is_err()
+        );
+        assert!(
+            BlackCalculator::new(OptionType::Call, STRIKE, Real::INFINITY, STD_DEV, DISCOUNT)
+                .is_err()
+        );
+        assert!(
+            BlackCalculator::new(OptionType::Call, STRIKE, FORWARD, Real::INFINITY, DISCOUNT)
+                .is_err()
+        );
+        assert!(
+            BlackCalculator::new(OptionType::Call, STRIKE, FORWARD, STD_DEV, Real::INFINITY)
+                .is_err()
+        );
 
         let calculator = hull(OptionType::Call);
         assert!(calculator.delta(0.0).is_err());
         assert!(calculator.delta(Real::NAN).is_err());
+        assert!(calculator.delta(Real::INFINITY).is_err());
         assert!(calculator.gamma(-1.0).is_err());
         assert!(calculator.theta(SPOT, -0.5).is_err());
+        assert!(calculator.theta(SPOT, Time::INFINITY).is_err());
         assert!(calculator.vega(-0.5).is_err());
         assert!(calculator.rho(-0.5).is_err());
         assert!(calculator.dividend_rho(-0.5).is_err());

--- a/crates/libitofin/src/pricingengines/blackformula.rs
+++ b/crates/libitofin/src/pricingengines/blackformula.rs
@@ -26,27 +26,54 @@ use crate::math::distributions::normal::{CumulativeNormalDistribution, NormalDis
 use crate::option::OptionType;
 use crate::types::Real;
 
+/// QuantLib's `checkParameters` (`blackformula.cpp:44,47,50`): the
+/// `displacement >= 0`, `strike + displacement >= 0` and
+/// `forward + displacement > 0` requirements, kept intact.
+///
+/// Divergence: the standalone finiteness checks on `strike` and `forward`, and
+/// the `!is_finite()` clauses replacing C++'s implicit NaN handling. In C++ a
+/// NaN argument fails every comparison, so `QL_REQUIRE(x >= 0.0)` already
+/// throws; an infinite one does not, and `+inf - inf` in the shifted sums then
+/// yields NaN downstream. Rejecting both here keeps the failure at the boundary.
 fn check_parameters(strike: Real, forward: Real, displacement: Real) -> QlResult<()> {
-    if displacement.is_nan() || displacement < 0.0 {
+    if !displacement.is_finite() || displacement < 0.0 {
         fail!("displacement ({displacement}) must be non-negative");
     }
+    if !strike.is_finite() {
+        fail!("strike ({strike}) must be finite");
+    }
+    if !forward.is_finite() {
+        fail!("forward ({forward}) must be finite");
+    }
     let shifted_strike = strike + displacement;
-    if shifted_strike.is_nan() || shifted_strike < 0.0 {
+    if !shifted_strike.is_finite() || shifted_strike < 0.0 {
         fail!("strike + displacement ({strike} + {displacement}) must be non-negative");
     }
     let shifted_forward = forward + displacement;
-    if shifted_forward.is_nan() || shifted_forward <= 0.0 {
+    if !shifted_forward.is_finite() || shifted_forward <= 0.0 {
         fail!("forward + displacement ({forward} + {displacement}) must be positive");
     }
     Ok(())
 }
 
 fn check_std_dev_and_discount(std_dev: Real, discount: Real) -> QlResult<()> {
-    if std_dev.is_nan() || std_dev < 0.0 {
-        fail!("stdDev ({std_dev}) must be non-negative");
-    }
-    if discount.is_nan() || discount <= 0.0 {
+    check_std_dev(std_dev)?;
+    if !discount.is_finite() || discount <= 0.0 {
         fail!("discount ({discount}) must be positive");
+    }
+    Ok(())
+}
+
+/// QuantLib's `QL_REQUIRE(stdDev >= 0.0)` (`blackformula.cpp:67`), extended to
+/// reject `+inf`.
+///
+/// Divergence: `blackFormulaCashItmProbability` and
+/// `blackFormulaAssetItmProbability` call only `checkParameters` and never
+/// validate `stdDev`, so a negative one silently flips the sign of `d2`. This
+/// port applies the same check there as in `black_formula`.
+fn check_std_dev(std_dev: Real) -> QlResult<()> {
+    if !std_dev.is_finite() || std_dev < 0.0 {
+        fail!("stdDev ({std_dev}) must be non-negative");
     }
     Ok(())
 }
@@ -147,6 +174,7 @@ pub fn black_formula_cash_itm_probability(
     displacement: Real,
 ) -> QlResult<Real> {
     check_parameters(strike, forward, displacement)?;
+    check_std_dev(std_dev)?;
 
     let sign = sign_of(option_type);
 
@@ -180,6 +208,7 @@ pub fn black_formula_asset_itm_probability(
     displacement: Real,
 ) -> QlResult<Real> {
     check_parameters(strike, forward, displacement)?;
+    check_std_dev(std_dev)?;
 
     let sign = sign_of(option_type);
 
@@ -559,5 +588,35 @@ mod tests {
                 .expect("valid inputs");
             assert_close(cash, 0.0, 0.0);
         }
+    }
+
+    #[test]
+    fn itm_probabilities_reject_invalid_standard_deviation() {
+        assert!(
+            black_formula_cash_itm_probability(OptionType::Call, 40.0, 44.0, -0.1, 0.0).is_err()
+        );
+        assert!(
+            black_formula_asset_itm_probability(OptionType::Call, 40.0, 44.0, -0.1, 0.0).is_err()
+        );
+        assert!(
+            black_formula_cash_itm_probability(OptionType::Call, 40.0, 44.0, Real::NAN, 0.0)
+                .is_err()
+        );
+        assert!(
+            black_formula_asset_itm_probability(OptionType::Call, 40.0, 44.0, Real::NAN, 0.0)
+                .is_err()
+        );
+        assert!(
+            black_formula_cash_itm_probability(OptionType::Call, 40.0, 44.0, Real::INFINITY, 0.0)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn black_formula_rejects_non_finite_inputs() {
+        assert!(black_formula(OptionType::Call, Real::INFINITY, 44.0, 0.2, 0.95, 0.0).is_err());
+        assert!(black_formula(OptionType::Call, 40.0, Real::INFINITY, 0.2, 0.95, 0.0).is_err());
+        assert!(black_formula(OptionType::Call, 40.0, 44.0, 0.2, Real::INFINITY, 0.0).is_err());
+        assert!(black_formula(OptionType::Call, 40.0, 44.0, 0.2, 0.95, Real::INFINITY).is_err());
     }
 }

--- a/crates/libitofin/src/pricingengines/vanilla.rs
+++ b/crates/libitofin/src/pricingengines/vanilla.rs
@@ -530,6 +530,7 @@ mod greek_gate {
 
     use super::test_market::{market, time_to_days, today};
     use crate::instrument::Instrument;
+    use crate::instruments::EuropeanOption;
     use crate::option::OptionType::{self, Call, Put};
     use crate::types::{Rate, Real, Time, Volatility};
 
@@ -622,6 +623,89 @@ mod greek_gate {
                 row.itm_cash,
             );
         }
+    }
+
+    /// The ten quantities the greek gate locks: NPV plus the nine greeks.
+    fn snapshot(option: &mut EuropeanOption) -> [Real; 10] {
+        [
+            option.npv().unwrap(),
+            option.delta().unwrap(),
+            option.gamma().unwrap(),
+            option.theta().unwrap(),
+            option.vega().unwrap(),
+            option.rho().unwrap(),
+            option.dividend_rho().unwrap(),
+            option.strike_sensitivity().unwrap(),
+            option.itm_cash_probability().unwrap(),
+            option.theta_per_day().unwrap(),
+        ]
+    }
+
+    /// The recursive-notification suppression of the D1 lazy-object change,
+    /// exercised on the real Milestone 1 pricing path rather than the unit
+    /// mock in `instrument.rs`.
+    ///
+    /// An observer on the option writes the spot back to its primed value from
+    /// inside the option's own notification, while the option's lazy object is
+    /// mid-update. Without the guard this re-entrant path double-borrows the
+    /// lazy object and panics (the original bug); with it, the write is safe
+    /// and the net input state is unchanged, so every greek must be
+    /// byte-identical to the primed snapshot. A dropped recalculation would
+    /// leave the cache stale, and a recompute against the transient spot would
+    /// perturb the greeks; the exact compare catches both.
+    #[test]
+    fn recursive_input_writeback_leaves_the_m1_greeks_unchanged() {
+        use crate::patterns::observable::Observer;
+        use crate::quotes::SimpleQuote;
+        use crate::shared::{Shared, SharedMut, shared_mut};
+
+        let spot0 = 100.0;
+        let market = market();
+        market.set(spot0, 0.10, 0.10, 0.15);
+        let expiry = today() + time_to_days(0.10);
+        let mut option = market.option(Call, 100.0, expiry);
+
+        let primed = snapshot(&mut option);
+
+        struct Restore {
+            spot: Shared<SimpleQuote>,
+            to: Real,
+            fired: usize,
+        }
+        impl Observer for Restore {
+            fn update(&mut self) {
+                self.fired += 1;
+                if self.fired == 1 {
+                    self.spot.set_value(self.to);
+                }
+            }
+        }
+
+        let restore = shared_mut(Restore {
+            spot: Shared::clone(&market.spot),
+            to: spot0,
+            fired: 0,
+        });
+        option
+            .base()
+            .register_observer(&(SharedMut::clone(&restore) as SharedMut<dyn Observer>));
+
+        market.spot.set_value(105.0);
+
+        assert!(
+            restore.borrow().fired >= 1,
+            "the perturbation must actually reach the option's observers",
+        );
+        assert!(
+            !option.base().is_calculated(),
+            "the perturbation still invalidates the cached greeks",
+        );
+
+        let restored = snapshot(&mut option);
+        assert_eq!(
+            primed, restored,
+            "the suppressed write-back must leave every greek byte-identical",
+        );
     }
 }
 

--- a/crates/libitofin/src/processes/blackscholesprocess.rs
+++ b/crates/libitofin/src/processes/blackscholesprocess.rs
@@ -205,6 +205,30 @@ impl GeneralizedBlackScholesProcess {
     }
 }
 
+/// Reject a non-finite process argument.
+///
+/// Divergence: `blackscholesprocess.cpp` contains no `QL_REQUIRE` at all. A
+/// non-finite `t` or `x` reaches the volatility curve, whose own range checks
+/// pass it through, and the caller receives a NaN drift or diffusion. Under D10
+/// the port fails at the boundary instead.
+fn check_finite(name: &str, value: Real) -> QlResult<()> {
+    if !value.is_finite() {
+        fail!("{name} ({value}) must be finite");
+    }
+    Ok(())
+}
+
+/// Reject a negative or non-finite evolution step.
+///
+/// Divergence: as for [`check_finite`]. A negative `dt` makes `variance`
+/// negative and `std_deviation` returns NaN from the square root.
+fn check_time_step(dt: Time) -> QlResult<()> {
+    if !dt.is_finite() || dt < 0.0 {
+        fail!("dt ({dt}) must be non-negative");
+    }
+    Ok(())
+}
+
 impl AsObservable for GeneralizedBlackScholesProcess {
     fn observable(&self) -> &Observable {
         &self.observable
@@ -217,6 +241,8 @@ impl StochasticProcess1D for GeneralizedBlackScholesProcess {
     }
 
     fn drift(&self, t: Time, x: Real) -> QlResult<Real> {
+        check_finite("t", t)?;
+        check_finite("x", x)?;
         let sigma = self.diffusion(t, x)?;
         let t1 = t + 0.0001;
         let r = self.forward(&self.risk_free_rate, t, t1)?;
@@ -225,18 +251,26 @@ impl StochasticProcess1D for GeneralizedBlackScholesProcess {
     }
 
     fn diffusion(&self, t: Time, x: Real) -> QlResult<Real> {
+        check_finite("t", t)?;
+        check_finite("x", x)?;
         self.local_volatility()?
             .current_link()?
             .local_vol(t, x, true)
     }
 
     fn expectation(&self, t0: Time, x0: Real, dt: Time) -> QlResult<Real> {
+        check_finite("t0", t0)?;
+        check_finite("x0", x0)?;
+        check_time_step(dt)?;
         self.local_volatility()?;
         require!(self.is_strike_independent.get(), "not implemented");
         Ok(x0 * (dt * self.exact_growth_rate(t0, dt)?).exp())
     }
 
     fn std_deviation(&self, t0: Time, x0: Real, dt: Time) -> QlResult<Real> {
+        check_finite("t0", t0)?;
+        check_finite("x0", x0)?;
+        check_time_step(dt)?;
         self.local_volatility()?;
         if self.is_strike_independent.get() {
             Ok(self.variance(t0, x0, dt)?.sqrt())
@@ -246,6 +280,9 @@ impl StochasticProcess1D for GeneralizedBlackScholesProcess {
     }
 
     fn variance(&self, t0: Time, x0: Real, dt: Time) -> QlResult<Real> {
+        check_finite("t0", t0)?;
+        check_finite("x0", x0)?;
+        check_time_step(dt)?;
         self.local_volatility()?;
         if self.is_strike_independent.get() {
             let vol = self.black_volatility.current_link()?;
@@ -257,6 +294,10 @@ impl StochasticProcess1D for GeneralizedBlackScholesProcess {
     }
 
     fn evolve(&self, t0: Time, x0: Real, dt: Time, dw: Real) -> QlResult<Real> {
+        check_finite("t0", t0)?;
+        check_finite("x0", x0)?;
+        check_time_step(dt)?;
+        check_finite("dw", dw)?;
         self.local_volatility()?;
         if self.is_strike_independent.get() {
             let var = self.variance(t0, x0, dt)?;
@@ -397,6 +438,18 @@ mod tests {
         let evolved = f.process.evolve(t0, x0, dt, dw).unwrap();
         let expected = x0 * ((R - Q) * dt - 0.5 * var + var.sqrt() * dw).exp();
         assert!((evolved - expected).abs() < 1e-12);
+    }
+
+    #[test]
+    fn process_rejects_non_finite_inputs_and_negative_time_steps() {
+        let f = european_option_fixture();
+
+        assert!(f.process.drift(Time::INFINITY, SPOT).is_err());
+        assert!(f.process.diffusion(0.25, Real::NAN).is_err());
+        assert!(f.process.expectation(0.25, SPOT, -0.5).is_err());
+        assert!(f.process.variance(0.25, SPOT, Time::INFINITY).is_err());
+        assert!(f.process.std_deviation(0.25, Real::INFINITY, 0.5).is_err());
+        assert!(f.process.evolve(0.25, SPOT, 0.5, Real::NAN).is_err());
     }
 
     #[test]

--- a/crates/libitofin/src/termstructures/mod.rs
+++ b/crates/libitofin/src/termstructures/mod.rs
@@ -332,10 +332,15 @@ pub trait TermStructure: AsObservable {
         Ok(())
     }
 
-    /// Time-range check: `t` must be non-negative and, unless extrapolation
-    /// applies, within the maximum time.
+    /// Time-range check: `t` must be finite, non-negative and, unless
+    /// extrapolation applies, within the maximum time.
+    ///
+    /// The `t >= 0` requirement is QuantLib's `checkRange`
+    /// (`termstructure.cpp:66`). Divergence: the finiteness clause. `+inf`
+    /// passes `t >= 0` in C++, and an extrapolating curve never compares it
+    /// against `maxTime()`, so it reaches the interpolator unchecked.
     fn check_range_time(&self, t: Time, extrapolate: bool) -> QlResult<()> {
-        if t < 0.0 || t.is_nan() {
+        if !t.is_finite() || t < 0.0 {
             fail!("negative time ({t}) given");
         }
         if extrapolate || self.allows_extrapolation() {
@@ -509,6 +514,16 @@ mod tests {
         assert!(curve.check_range_time(0.5, false).is_ok());
         curve.disable_extrapolation();
         assert!(curve.check_range_time(0.5, false).is_err());
+    }
+
+    #[test]
+    fn range_check_rejects_non_finite_time_even_with_extrapolation() {
+        let curve = TestCurve::fixed(Date::new(15, Month::June, 2026));
+        curve.enable_extrapolation();
+
+        assert!(curve.check_range_time(Time::INFINITY, false).is_err());
+        assert!(curve.check_range_time(Time::NEG_INFINITY, true).is_err());
+        assert!(curve.check_range_time(Time::NAN, true).is_err());
     }
 
     #[test]

--- a/crates/libitofin/src/termstructures/volatility/localconstantvol.rs
+++ b/crates/libitofin/src/termstructures/volatility/localconstantvol.rs
@@ -193,6 +193,13 @@ mod tests {
     }
 
     #[test]
+    fn local_vol_rejects_non_finite_quotes() {
+        let (_, curve) = flat_curve(Volatility::INFINITY);
+
+        assert!(curve.local_vol(1.0, 100.0, false).is_err());
+    }
+
+    #[test]
     fn quote_changes_propagate_and_notify() {
         let reference = Date::new(15, Month::June, 2026);
         let handle = make_quote_handle(0.18);

--- a/crates/libitofin/src/termstructures/volatility/localvoltermstructure.rs
+++ b/crates/libitofin/src/termstructures/volatility/localvoltermstructure.rs
@@ -11,6 +11,7 @@
 //! trait), following the crate convention.
 
 use crate::errors::QlResult;
+use crate::fail;
 use crate::time::date::Date;
 use crate::types::{Real, Time, Volatility};
 
@@ -35,7 +36,9 @@ pub trait LocalVolTermStructure: VolatilityTermStructure {
         self.check_range_date(date, extrapolate)?;
         self.check_strike(underlying_level, extrapolate)?;
         let t = self.time_from_reference(date)?;
-        self.local_vol_impl(t, underlying_level)
+        let vol = self.local_vol_impl(t, underlying_level)?;
+        ensure_finite_volatility(vol)?;
+        Ok(vol)
     }
 
     /// Local volatility at a time and underlying level.
@@ -47,6 +50,20 @@ pub trait LocalVolTermStructure: VolatilityTermStructure {
     ) -> QlResult<Volatility> {
         self.check_range_time(t, extrapolate)?;
         self.check_strike(underlying_level, extrapolate)?;
-        self.local_vol_impl(t, underlying_level)
+        let vol = self.local_vol_impl(t, underlying_level)?;
+        ensure_finite_volatility(vol)?;
+        Ok(vol)
     }
+}
+
+/// Reject a non-finite local volatility.
+///
+/// Divergence: `localvoltermstructure.hpp` checks the time and strike ranges
+/// but never the value `localVolImpl` returns, so a curve built on an infinite
+/// quote silently seeds a NaN into every path of a Monte Carlo evolution.
+fn ensure_finite_volatility(vol: Volatility) -> QlResult<()> {
+    if !vol.is_finite() {
+        fail!("volatility ({vol}) must be finite");
+    }
+    Ok(())
 }

--- a/crates/libitofin/src/termstructures/volatility/mod.rs
+++ b/crates/libitofin/src/termstructures/volatility/mod.rs
@@ -83,7 +83,15 @@ pub trait VolatilityTermStructure: TermStructure {
 
     /// Strike-range check: `strike` must sit inside the curve domain unless
     /// extrapolation applies.
+    ///
+    /// Divergence: the finiteness clause. QuantLib's `checkStrike` compares
+    /// against `minStrike()` / `maxStrike()` only, and an extrapolating curve
+    /// short-circuits that comparison entirely, so `+inf` reaches the
+    /// interpolator.
     fn check_strike(&self, strike: Rate, extrapolate: bool) -> QlResult<()> {
+        if !strike.is_finite() {
+            fail!("strike ({strike}) must be finite");
+        }
         require!(
             extrapolate
                 || self.allows_extrapolation()
@@ -122,6 +130,7 @@ pub trait BlackVolTermStructure: VolatilityTermStructure + Any {
     /// `BlackVolatilityTermStructure` adapter).
     fn variance_from_vol(&self, t: Time, strike: Real) -> QlResult<Real> {
         let vol = self.black_vol_impl(t, strike)?;
+        ensure_finite_volatility(vol)?;
         Ok(vol * vol * t)
     }
 
@@ -135,14 +144,18 @@ pub trait BlackVolTermStructure: VolatilityTermStructure + Any {
         self.check_range_date(maturity, extrapolate)?;
         self.check_strike(strike, extrapolate)?;
         let t = self.time_from_reference(maturity)?;
-        self.black_vol_impl(t, strike)
+        let vol = self.black_vol_impl(t, strike)?;
+        ensure_finite_volatility(vol)?;
+        Ok(vol)
     }
 
     /// Spot volatility at a time.
     fn black_vol(&self, maturity: Time, strike: Real, extrapolate: bool) -> QlResult<Volatility> {
         self.check_range_time(maturity, extrapolate)?;
         self.check_strike(strike, extrapolate)?;
-        self.black_vol_impl(maturity, strike)
+        let vol = self.black_vol_impl(maturity, strike)?;
+        ensure_finite_volatility(vol)?;
+        Ok(vol)
     }
 
     /// Spot variance at a date.
@@ -155,14 +168,18 @@ pub trait BlackVolTermStructure: VolatilityTermStructure + Any {
         self.check_range_date(maturity, extrapolate)?;
         self.check_strike(strike, extrapolate)?;
         let t = self.time_from_reference(maturity)?;
-        self.black_variance_impl(t, strike)
+        let var = self.black_variance_impl(t, strike)?;
+        ensure_valid_variance(var)?;
+        Ok(var)
     }
 
     /// Spot variance at a time.
     fn black_variance(&self, maturity: Time, strike: Real, extrapolate: bool) -> QlResult<Real> {
         self.check_range_time(maturity, extrapolate)?;
         self.check_strike(strike, extrapolate)?;
-        self.black_variance_impl(maturity, strike)
+        let var = self.black_variance_impl(maturity, strike)?;
+        ensure_valid_variance(var)?;
+        Ok(var)
     }
 
     /// Forward (at-the-money) volatility between two dates.
@@ -188,7 +205,7 @@ pub trait BlackVolTermStructure: VolatilityTermStructure + Any {
         strike: Real,
         extrapolate: bool,
     ) -> QlResult<Volatility> {
-        if time1 > time2 || time1.is_nan() || time2.is_nan() {
+        if time1 > time2 || !time1.is_finite() || !time2.is_finite() {
             fail!("{time1} later than {time2}");
         }
         self.check_range_time(time2, extrapolate)?;
@@ -197,6 +214,7 @@ pub trait BlackVolTermStructure: VolatilityTermStructure + Any {
             if time1 == 0.0 {
                 let epsilon = 1.0e-5;
                 let var = self.black_variance_impl(epsilon, strike)?;
+                ensure_valid_variance(var)?;
                 Ok((var / epsilon).sqrt())
             } else {
                 let epsilon = Time::min(1.0e-5, time1);
@@ -236,7 +254,7 @@ pub trait BlackVolTermStructure: VolatilityTermStructure + Any {
         strike: Real,
         extrapolate: bool,
     ) -> QlResult<Real> {
-        if time1 > time2 || time1.is_nan() || time2.is_nan() {
+        if time1 > time2 || !time1.is_finite() || !time2.is_finite() {
             fail!("{time1} later than {time2}");
         }
         self.check_range_time(time2, extrapolate)?;
@@ -249,8 +267,31 @@ pub trait BlackVolTermStructure: VolatilityTermStructure + Any {
 }
 
 fn ensure_non_decreasing(var1: Real, var2: Real) -> QlResult<()> {
-    if var2 < var1 || var1.is_nan() || var2.is_nan() {
+    ensure_valid_variance(var1)?;
+    ensure_valid_variance(var2)?;
+    if var2 < var1 {
         fail!("variances must be non-decreasing");
+    }
+    Ok(())
+}
+
+/// Reject a variance that is negative or non-finite.
+///
+/// Divergence: `voltermstructure.hpp` / `blackvoltermstructure.cpp` validate
+/// only the time and strike ranges, never the value an implementation returns.
+/// A curve whose `blackVarianceImpl` yields a negative variance hands C++ a NaN
+/// volatility from `std::sqrt`; this port fails at the source instead.
+fn ensure_valid_variance(var: Real) -> QlResult<()> {
+    if !var.is_finite() || var < 0.0 {
+        fail!("variance ({var}) must be finite and non-negative");
+    }
+    Ok(())
+}
+
+/// Reject a non-finite volatility. Divergence: as for [`ensure_valid_variance`].
+fn ensure_finite_volatility(vol: Volatility) -> QlResult<()> {
+    if !vol.is_finite() {
+        fail!("volatility ({vol}) must be finite");
     }
     Ok(())
 }
@@ -338,6 +379,19 @@ mod tests {
     }
 
     #[test]
+    fn spot_variance_rejects_invalid_variance() {
+        let mut curve = MockVolCurve::flat(0.2);
+        curve.variance_override = Some(|_| Real::INFINITY);
+        assert!(curve.black_variance(1.0, 100.0, false).is_err());
+
+        curve.variance_override = Some(|_| -1.0);
+        assert!(curve.black_variance(1.0, 100.0, false).is_err());
+
+        let maturity = curve.reference_date().unwrap() + 30;
+        assert!(curve.black_variance_date(maturity, 100.0, false).is_err());
+    }
+
+    #[test]
     fn forward_vol_of_a_flat_curve_is_the_flat_vol() {
         let curve = MockVolCurve::flat(0.2);
         for (t1, t2) in [(0.5, 1.5), (0.0, 0.0), (1.0, 1.0), (0.0, 2.0)] {
@@ -359,6 +413,16 @@ mod tests {
     }
 
     #[test]
+    fn zero_time_forward_vol_rejects_invalid_variance() {
+        let mut curve = MockVolCurve::flat(0.2);
+        curve.variance_override = Some(|_| Real::INFINITY);
+        assert!(curve.black_forward_vol(0.0, 0.0, 100.0, false).is_err());
+
+        curve.variance_override = Some(|_| -1.0);
+        assert!(curve.black_forward_vol(0.0, 0.0, 100.0, false).is_err());
+    }
+
+    #[test]
     fn strike_checks_gate_the_curve_domain() {
         let mut curve = MockVolCurve::flat(0.2);
         curve.strike_domain = (90.0, 110.0);
@@ -372,6 +436,34 @@ mod tests {
         curve.disable_extrapolation();
         assert!(curve.black_vol(1.0, Rate::NAN, false).is_err());
     }
+
+    #[test]
+    fn non_finite_times_and_strikes_are_rejected_even_when_extrapolating() {
+        let curve = MockVolCurve::flat(0.2);
+
+        assert!(curve.black_vol(Time::INFINITY, 100.0, true).is_err());
+        assert!(
+            curve
+                .black_forward_vol(0.5, Time::INFINITY, 100.0, true)
+                .is_err()
+        );
+        assert!(
+            curve
+                .black_forward_variance(0.5, Time::INFINITY, 100.0, true)
+                .is_err()
+        );
+        assert!(curve.black_vol(1.0, Real::INFINITY, true).is_err());
+        assert!(curve.black_vol(1.0, Real::NAN, true).is_err());
+    }
+
+    #[test]
+    fn variance_from_vol_rejects_non_finite_volatility() {
+        let curve = MockVolCurve::flat(Volatility::INFINITY);
+
+        assert!(curve.black_vol(1.0, 100.0, false).is_err());
+        assert!(curve.black_variance(1.0, 100.0, false).is_err());
+    }
+
     #[test]
     fn forward_variance_of_a_flat_curve_is_additive() {
         let curve = MockVolCurve::flat(0.2);

--- a/crates/libitofin/src/termstructures/yields/impliedtermstructure.rs
+++ b/crates/libitofin/src/termstructures/yields/impliedtermstructure.rs
@@ -220,6 +220,27 @@ mod tests {
     }
 
     #[test]
+    fn max_time_is_measured_from_the_implied_reference_date() {
+        use crate::termstructures::yields::DiscountCurve;
+
+        let original = shared(
+            DiscountCurve::new(
+                vec![today(), today() + 360, today() + 720],
+                vec![1.0, 0.95, 0.90],
+                Actual360::new(),
+                None,
+            )
+            .unwrap(),
+        ) as Shared<dyn YieldTermStructure>;
+        let implied = ImpliedTermStructure::new(Handle::new(original), today() + 360);
+
+        assert!((implied.max_time().unwrap() - 1.0).abs() < 1.0e-15);
+        assert!(implied.discount(1.0, false).is_ok());
+        assert!(implied.discount(1.5, false).is_err());
+        assert!(implied.discount(1.5, true).is_ok());
+    }
+
+    #[test]
     fn notifications_resync_the_extrapolation_flag() {
         let quote = shared(SimpleQuote::new(0.03));
         let curve = flat_curve(quote.clone());

--- a/crates/libitofin/src/time/calendar.rs
+++ b/crates/libitofin/src/time/calendar.rs
@@ -634,6 +634,25 @@ mod tests {
         let next_mon = Date::new(10, Month::January, 2000);
         // (mon, next_mon] excluding first, including last: Tue-Fri + Mon = 5.
         assert_eq!(c.business_days_between(mon, next_mon, false, true), 5);
+        assert_eq!(c.business_days_between(next_mon, mon, true, false), -5);
+        assert_eq!(c.business_days_between(mon, mon, true, true), 1);
+        assert_eq!(c.business_days_between(mon, mon, true, false), 0);
+    }
+
+    #[test]
+    fn advance_unadjusted_end_of_month_uses_calendar_month_end() {
+        let c = cal();
+        let jan31 = Date::new(31, Month::January, 2020);
+        assert_eq!(
+            c.advance(
+                jan31,
+                1,
+                TimeUnit::Months,
+                BusinessDayConvention::Unadjusted,
+                true,
+            ),
+            Date::new(29, Month::February, 2020)
+        );
     }
 
     #[test]

--- a/crates/libitofin/src/time/calendars/jointcalendar.rs
+++ b/crates/libitofin/src/time/calendars/jointcalendar.rs
@@ -70,6 +70,25 @@ impl CalendarImpl for Impl {
         }
     }
 
+    /// The date-aware counterpart of [`is_weekend`](Self::is_weekend), joined
+    /// under the same rule.
+    ///
+    /// `is_weekend_on` is this port's date-aware weekend rule (see the
+    /// "`holiday_list` filters weekends by a date-aware rule" divergence in the
+    /// README). `JointCalendar` overrode only the weekday-keyed `is_weekend`,
+    /// mirroring `jointcalendar.cpp:83`, and inherited the trait default for
+    /// the date-aware one; a joint calendar over a member whose weekend moved
+    /// over time therefore fell back to the weekday-only rule. This restores
+    /// the join for both.
+    fn is_weekend_on(&self, date: Date) -> bool {
+        match self.rule {
+            JointCalendarRule::JoinHolidays => self.calendars.iter().any(|c| c.is_weekend_on(date)),
+            JointCalendarRule::JoinBusinessDays => {
+                self.calendars.iter().all(|c| c.is_weekend_on(date))
+            }
+        }
+    }
+
     fn is_business_day(&self, date: Date) -> bool {
         match self.rule {
             JointCalendarRule::JoinHolidays => {
@@ -85,9 +104,35 @@ impl CalendarImpl for Impl {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::shared::shared;
     use crate::time::calendars::target::Target;
     use crate::time::calendars::weekendsonly::WeekendsOnly;
     use crate::time::date::Month;
+
+    struct SwitchingWeekendCal;
+
+    impl CalendarImpl for SwitchingWeekendCal {
+        fn name(&self) -> String {
+            "switching weekend".to_string()
+        }
+
+        fn is_weekend(&self, weekday: Weekday) -> bool {
+            weekday == Weekday::Friday || weekday == Weekday::Saturday
+        }
+
+        fn is_weekend_on(&self, date: Date) -> bool {
+            let weekday = date.weekday();
+            if date < Date::new(29, Month::June, 2013) {
+                weekday == Weekday::Thursday || weekday == Weekday::Friday
+            } else {
+                weekday == Weekday::Friday || weekday == Weekday::Saturday
+            }
+        }
+
+        fn is_business_day(&self, date: Date) -> bool {
+            !self.is_weekend_on(date)
+        }
+    }
 
     #[test]
     fn join_holidays_is_holiday_if_any_is() {
@@ -123,5 +168,26 @@ mod tests {
             JointCalendarRule::JoinHolidays,
         );
         assert_eq!(joint.name(), "JoinHolidays(TARGET, weekends only)");
+    }
+
+    #[test]
+    fn date_aware_weekends_are_joined() {
+        let switching = Calendar::from_impl(shared(SwitchingWeekendCal));
+        let joint = JointCalendar::of_two(
+            switching,
+            WeekendsOnly::new(),
+            JointCalendarRule::JoinHolidays,
+        );
+
+        let thursday_before_switch = Date::new(27, Month::June, 2013);
+        assert_eq!(thursday_before_switch.weekday(), Weekday::Thursday);
+        assert!(joint.is_holiday(thursday_before_switch));
+        assert!(joint.is_weekend_on(thursday_before_switch));
+        assert!(!joint.is_weekend(thursday_before_switch.weekday()));
+        assert!(
+            joint
+                .holiday_list(thursday_before_switch, thursday_before_switch, false)
+                .is_empty()
+        );
     }
 }

--- a/crates/libitofin/src/time/schedule.rs
+++ b/crates/libitofin/src/time/schedule.rs
@@ -2185,6 +2185,41 @@ mod tests {
     }
 
     #[test]
+    fn truncation_regular_metadata_matches_inserted_or_existing_cut_date() {
+        let s = MakeSchedule::new()
+            .from(d(30, Month::September, 2009))
+            .to(d(30, Month::September, 2011))
+            .with_calendar(NullCalendar::new())
+            .with_tenor(Period::new(6, TimeUnit::Months))
+            .with_convention(BusinessDayConvention::Unadjusted)
+            .forwards()
+            .end_of_month(true)
+            .build();
+
+        let inserted_front = s.after(d(1, Month::January, 2010));
+        assert_eq!(inserted_front.date(0), d(1, Month::January, 2010));
+        assert!(!inserted_front.is_regular_at(1));
+
+        let existing_front = s.after(d(31, Month::March, 2010));
+        assert_eq!(existing_front.date(0), d(31, Month::March, 2010));
+        assert!(existing_front.is_regular_at(1));
+
+        let inserted_back = s.until(d(1, Month::January, 2011));
+        assert_eq!(
+            inserted_back.date(inserted_back.len() - 1),
+            d(1, Month::January, 2011)
+        );
+        assert!(!inserted_back.is_regular_at(inserted_back.len() - 1));
+
+        let existing_back = s.until(d(31, Month::March, 2011));
+        assert_eq!(
+            existing_back.date(existing_back.len() - 1),
+            d(31, Month::March, 2011)
+        );
+        assert!(existing_back.is_regular_at(existing_back.len() - 1));
+    }
+
+    #[test]
     #[should_panic(expected = "null reference date")]
     fn null_reference_date_is_rejected() {
         let s = Schedule::from_dates(vec![d(1, Month::January, 2014)]);


### PR DESCRIPTION
- **fix(cashflows)!: reject the null date and null amount in SimpleCashFlow**
- **fix(patterns): suppress recursive lazy-object notifications**
- **fix(time): join the date-aware weekend rule in JointCalendar**
- **fix(math): narrow the statistics sample and weight guards**
- **refactor(math): share the solver argument checks, reject non-finite ones**
- **fix(math): reject duplicate abscissae and non-finite quadrature samples**
- **feat(pricing): reject non-finite inputs across black formulas and curves**
- **docs(pricing): record the zero-vol black greek dispatch divergence**

close #268 
