### PR TITLE
refactor(cashflows)!: sever coupon from cashflow behind one blanket impl

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,40 +197,37 @@ oversight) and is documented at the point of divergence in the source.
 
 **Cash flows (EPIC-7):**
 
-- **`Event::has_occurred` is a required trait method, not a defaulted one.**
-  C++ gives `Event` a base implementation and lets `CashFlow` override it, so a
-  cash flow on the evaluation date honours `Settings::includeTodaysCashFlows`.
-  Rust has no specialization: an inherited default on the supertrait would hand
-  every cash flow the plain-event rule with no diagnostic, and a competing
-  provided method on `CashFlow` would be ambiguous rather than overriding. Each
-  implementor therefore forwards explicitly to `event_has_occurred` or
-  `cash_flow_has_occurred`, turning a silent wrong answer into a compile error.
-- **`CashFlow::ex_coupon_date` is a required trait method.**
-  C++ answers both `Coupon::accruedPeriod`'s ex-coupon test and
-  `CashFlow::exCouponDate()` from one member (`coupon.hpp:57`). Rust has no
-  specialization, so a `Coupon` cannot override a provided method on its
-  `CashFlow` supertrait, and defaulting that method to `None` would let an
-  implementor accrue ex-coupon while reporting `trading_ex_coupon` as `false`.
-  It is therefore required, so omission is a compile error. The single reader is
-  preserved: `Coupon::trades_ex_coupon_on` goes through `ex_coupon_date`, which
-  a concrete coupon forwards to its `CouponBase`, and both `accrued_period` and
-  `accrued_amount` test the ex-coupon branch through that one helper.
-- **`CashFlow::as_coupon` is a required trait method.**
-  The `isCoupon`/`coupon_cast` pair (`cashflow.hpp:79`, `coupon.hpp:96`), which
-  the `CashFlows` analytics use to tell an accruing flow from a plain payment.
-  C++ needs no default here: its `Coupon` base class overrides `isCoupon()` to
-  `true`, so no coupon can forget. A Rust `Coupon` is a trait and cannot supply
-  its supertrait's method on its implementors' behalf, which is the same
-  no-specialization argument as `ex_coupon_date` above. A coupon answering
-  `None` contributes nothing to `bps`, has its amount subtracted from
-  `atm_rate`'s target, and reports its payment date to `maturity_date` in place
-  of its accrual end: beside coupons that answer correctly this skews the rate,
-  and alone in a leg it drives the rate to `0.0`. The method is therefore
-  required, so omission is a compile error. A deliberate `None` from a `Coupon`
-  remains possible, and the analytics cannot detect it. A blanket
-  `impl<T: Coupon> CashFlow for T` would make that lie a compile error too, at
-  the cost of moving every `CashFlow` body a coupon overrides onto `Coupon`;
-  it is tracked separately.
+- **`Coupon` is not a subtrait of `CashFlow`; one blanket impl derives the
+  cash-flow face from the coupon.**
+  C++ derives `Coupon` from `CashFlow`, and its base class supplies
+  `hasOccurred`, `exCouponDate()` and `isCoupon()` so that no coupon can forget
+  them. Rust has no specialization, so under the subtrait shape a `Coupon`
+  cannot supply its supertrait's methods on its implementors' behalf. All three
+  wrong answers compile and are plausible numbers rather than diagnostics: the
+  plain-event `has_occurred` ignores `Settings::includeTodaysCashFlows` on the
+  evaluation date; a `None` `ex_coupon_date` accrues ex-coupon while reporting
+  `trading_ex_coupon` as `false`; a `None` `as_coupon` contributes nothing to
+  `bps`, has its amount subtracted from `atm_rate`'s target, and reports its
+  payment date to `maturity_date` in place of its accrual end.
+
+  So `Coupon` restates its own surface (`coupon_base`, `amount`, `rate`,
+  `day_counter`, `accrued_amount`, and `AsObservable`), and
+  `impl<T: Coupon> CashFlow for T` writes the three exactly once, reading
+  `CouponBase`. A coupon cannot get them wrong because it cannot supply them.
+  `amount` moves onto `Coupon` for the same reason it must: a blanket that
+  *provided* `amount` would give `FixedRateCoupon` a generic body in place of
+  its compounded one, and a competing `impl CashFlow for FixedRateCoupon`
+  restoring it is a conflicting implementation. The three methods stay required
+  on `CashFlow` and `Event` for the flows that are not coupons, which still
+  forward explicitly to `event_has_occurred` or `cash_flow_has_occurred`.
+
+  Two costs. `dyn Coupon` does not implement `CashFlow`: the `Some(self)` of
+  `as_coupon` is an unsizing coercion, so the blanket takes a `Sized` `T`, and
+  `+ ?Sized` would restore the impl and forbid the `Some(self)`. Nothing needs
+  it - the `CashFlows` analytics hold a `&dyn CashFlow` already and read only
+  `Coupon`'s own methods through the coupon view. And `amount` now sits on both
+  traits, so on a concrete coupon with both in scope an unqualified
+  `coupon.amount()` is ambiguous; name the trait.
 
 **Pricing engines (Milestone 1):**
 

--- a/crates/libitofin/src/cashflow.rs
+++ b/crates/libitofin/src/cashflow.rs
@@ -28,16 +28,24 @@ use crate::types::Real;
 /// specialization, so a provided method here would collide with the
 /// supertrait's rather than override it; `Event` leaves `has_occurred`
 /// required so that the choice cannot be made by omission.
+///
+/// A [`Coupon`] implements none of this by hand. The blanket
+/// `impl<T: Coupon> CashFlow for T` answers this trait and [`Event`] from the
+/// coupon's [`CouponBase`](crate::cashflows::CouponBase), so the three methods
+/// whose wrong-but-compiling answers below are plausible numbers cannot be
+/// written wrongly, or at all.
 pub trait CashFlow: Event {
     /// The amount paid at [`date`](Event::date), undiscounted.
     fn amount(&self) -> QlResult<Real>;
 
     /// The date from which the flow trades ex-coupon, when it has one.
     ///
-    /// Required rather than defaulted to `None`: a `Coupon` stores this date on
-    /// its base and cannot override a provided method here, so a default would
-    /// let an implementor accrue ex-coupon while reporting
-    /// [`trading_ex_coupon`](CashFlow::trading_ex_coupon) as `false`.
+    /// Required rather than defaulted to `None`, because a default would let an
+    /// implementor accrue ex-coupon while reporting
+    /// [`trading_ex_coupon`](CashFlow::trading_ex_coupon) as `false`. A
+    /// [`Coupon`] never answers it: the blanket reads the one date its
+    /// [`CouponBase`](crate::cashflows::CouponBase) holds, which is also the
+    /// date its accrual tests.
     fn ex_coupon_date(&self) -> Option<Date>;
 
     /// The [`Coupon`] view of this flow, when it is one.
@@ -55,12 +63,12 @@ pub trait CashFlow: Event {
     /// rate; alone in a leg it drives the rate to `0.0`. Neither is an obvious
     /// failure, so the answer is compulsory.
     ///
-    /// A [`Coupon`] must answer `Some(self)`, never `Some` of some other
-    /// coupon: `coupon_cast` (`coupon.cpp:88`) can only ever yield the flow it
-    /// was handed, so a wrapper answering with its inner coupon would let
-    /// `bps` read a nominal and an accrual period that `npv` never priced.
-    /// Neither rule is checkable at compile time in this shape, and the
-    /// analytics cannot detect a violation of either.
+    /// `coupon_cast` (`coupon.cpp:88`) can only ever yield the flow it was
+    /// handed, so a coupon must answer `Some(self)` and never `Some` of some
+    /// other coupon, which would let `bps` read a nominal and an accrual period
+    /// that `npv` never priced. Both rules now hold by construction: the
+    /// blanket is the only `Some` a coupon can produce, and a flow that is not
+    /// a [`Coupon`] has no coupon to answer with.
     fn as_coupon(&self) -> Option<&dyn Coupon>;
 
     /// Whether the flow trades ex-coupon as of `ref_date` (the evaluation date

--- a/crates/libitofin/src/cashflows/coupon.rs
+++ b/crates/libitofin/src/cashflows/coupon.rs
@@ -15,10 +15,28 @@
 //! provided methods read the dates from there. Both are public, so a concrete
 //! coupon can be written outside this crate.
 //!
-//! [`Event::date`] and [`CashFlow::ex_coupon_date`] live on the supertraits and
-//! must be implemented by the concrete type, forwarding to
-//! [`CouponBase::payment_date`] and [`CouponBase::ex_coupon_date`]. Rust has no
-//! specialization, so this trait cannot supply them.
+//! [`Coupon`] is *not* a subtrait of [`CashFlow`], though C++ derives one from
+//! the other. It restates the surface it needs and the blanket
+//! `impl<T: Coupon> CashFlow for T` below gives every coupon its
+//! [`CashFlow`] and [`Event`] faces, deriving them from [`CouponBase`] and from
+//! [`Coupon::amount`]. A coupon therefore cannot forget - or get wrong -
+//! [`Event::has_occurred`], [`CashFlow::ex_coupon_date`] or
+//! [`CashFlow::as_coupon`], the three whose wrong-but-compiling answers are
+//! plausible numbers rather than diagnostics.
+//!
+//! The subtrait shape cannot do this. A blanket impl for `Coupon: CashFlow`
+//! *provides* [`CashFlow::amount`], so [`FixedRateCoupon`] would silently
+//! inherit a generic body in place of its compounded one, and could not
+//! override it: a competing `impl CashFlow for FixedRateCoupon` is a
+//! conflicting implementation. Hence the sever, and hence `amount` moves onto
+//! [`Coupon`].
+//!
+//! The blanket takes an implicitly [`Sized`] `T`, because the `Some(self)` of
+//! [`CashFlow::as_coupon`] is an unsizing coercion. So `dyn Coupon` does not
+//! itself implement [`CashFlow`]; `+ ?Sized` would restore that and forbid
+//! `Some(self)`, and nothing needs it. The analytics of
+//! [`CashFlows`](crate::cashflows::CashFlows) hold a `&dyn CashFlow` already and
+//! read only this trait's own methods through the coupon view.
 //!
 //! ## Divergences from QuantLib
 //!
@@ -36,19 +54,22 @@
 //!
 //! C++ reads the ex-coupon date off a single member (`coupon.hpp:57`), shared
 //! by the accrual and by `CashFlow::exCouponDate()`. The port keeps that single
-//! reader: [`trades_ex_coupon_on`](Coupon::trades_ex_coupon_on) goes through
-//! [`CashFlow::ex_coupon_date`], which a concrete coupon must forward to its
-//! [`CouponBase`]. That method is required rather than defaulted, so the
-//! forwarding cannot be made by omission.
+//! reader: [`trades_ex_coupon_on`](Coupon::trades_ex_coupon_on) and the blanket
+//! [`CashFlow::ex_coupon_date`] both go through
+//! [`CouponBase::ex_coupon_date`], and neither is an implementor's to write.
 //!
-//! [`rate`](Coupon::rate) and [`accrued_amount`](Coupon::accrued_amount) return
-//! [`QlResult`], matching [`CashFlow::amount`]: a floating-rate coupon reads an
-//! index fixing that may be missing. The `accept(AcyclicVisitor&)` override has
-//! no counterpart in the port; `coupon_cast` becomes
-//! [`CashFlow::as_coupon`], which every implementor of this trait must
-//! override.
+//! [`amount`](Coupon::amount), [`rate`](Coupon::rate) and
+//! [`accrued_amount`](Coupon::accrued_amount) return [`QlResult`]: a
+//! floating-rate coupon reads an index fixing that may be missing. The
+//! `accept(AcyclicVisitor&)` override has no counterpart in the port;
+//! `coupon_cast` becomes [`CashFlow::as_coupon`], which the blanket answers.
+//!
+//! [`FixedRateCoupon`]: crate::cashflows::FixedRateCoupon
 
-use crate::cashflow::CashFlow;
+use crate::cashflow::{CashFlow, cash_flow_has_occurred};
+use crate::event::Event;
+use crate::patterns::observable::AsObservable;
+use crate::settings::Settings;
 use crate::time::date::{Date, SerialNumber};
 use crate::time::daycounter::DayCounter;
 use crate::types::{Rate, Real, Time};
@@ -112,12 +133,22 @@ impl CouponBase {
 ///
 /// Mirrors QuantLib's `Coupon`: still abstract, but it gives implementors the
 /// accrual-date algebra. Implementors supply the state through
-/// [`coupon_base`](Self::coupon_base), the [`rate`](Self::rate) and
-/// [`day_counter`](Self::day_counter) the accrual is measured with, and the
+/// [`coupon_base`](Self::coupon_base), the [`amount`](Self::amount) the coupon
+/// pays, the [`rate`](Self::rate) and [`day_counter`](Self::day_counter) the
+/// accrual is measured with, and the
 /// [`accrued_amount`](Self::accrued_amount) that rate implies.
-pub trait Coupon: CashFlow {
+///
+/// Implementing it is enough to be a [`CashFlow`]: the blanket impl below
+/// supplies that face, so nothing else here is an implementor's to get wrong.
+pub trait Coupon: AsObservable {
     /// The coupon's dates and nominal.
     fn coupon_base(&self) -> &CouponBase;
+
+    /// The amount paid at the [`payment_date`](CouponBase::payment_date),
+    /// undiscounted.
+    ///
+    /// The body behind [`CashFlow::amount`] for every coupon.
+    fn amount(&self) -> QlResult<Real>;
 
     /// The rate the coupon accrues at.
     fn rate(&self) -> QlResult<Rate>;
@@ -178,9 +209,11 @@ pub trait Coupon: CashFlow {
     ///
     /// The `tradingExCoupon(d)` of `coupon.hpp` with the date always given.
     /// [`CashFlow::trading_ex_coupon`] is the counterpart that resolves an
-    /// absent date against the evaluation date.
+    /// absent date against the evaluation date, and reads the same
+    /// [`CouponBase::ex_coupon_date`].
     fn trades_ex_coupon_on(&self, date: Date) -> bool {
-        self.ex_coupon_date()
+        self.coupon_base()
+            .ex_coupon_date()
             .is_some_and(|ex_coupon| ex_coupon <= date)
     }
 
@@ -230,13 +263,47 @@ pub trait Coupon: CashFlow {
     }
 }
 
+/// Every [`Coupon`] is an [`Event`] on its payment date, under the cash-flow
+/// occurrence rule rather than the plain-event one.
+impl<T: Coupon> Event for T {
+    fn date(&self) -> Date {
+        self.coupon_base().payment_date()
+    }
+
+    fn has_occurred(
+        &self,
+        settings: &Settings<Date>,
+        ref_date: Option<Date>,
+        include_ref_date: Option<bool>,
+    ) -> QlResult<bool> {
+        cash_flow_has_occurred(
+            self.coupon_base().payment_date(),
+            settings,
+            ref_date,
+            include_ref_date,
+        )
+    }
+}
+
+/// Every [`Coupon`] is a [`CashFlow`] paying what it accrues.
+impl<T: Coupon> CashFlow for T {
+    fn amount(&self) -> QlResult<Real> {
+        Coupon::amount(self)
+    }
+
+    fn ex_coupon_date(&self) -> Option<Date> {
+        self.coupon_base().ex_coupon_date()
+    }
+
+    fn as_coupon(&self) -> Option<&dyn Coupon> {
+        Some(self)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cashflow::cash_flow_has_occurred;
-    use crate::event::Event;
-    use crate::patterns::observable::{AsObservable, Observable};
-    use crate::settings::Settings;
+    use crate::patterns::observable::Observable;
     use crate::time::date::Month;
     use crate::time::daycounters::actual360::Actual360;
     use crate::time::daycounters::thirty360::{Convention, Thirty360};
@@ -265,38 +332,13 @@ mod tests {
         }
     }
 
-    impl Event for TestCoupon {
-        fn date(&self) -> Date {
-            self.base.payment_date()
-        }
-
-        fn has_occurred(
-            &self,
-            settings: &Settings<Date>,
-            ref_date: Option<Date>,
-            include_ref_date: Option<bool>,
-        ) -> QlResult<bool> {
-            cash_flow_has_occurred(self.date(), settings, ref_date, include_ref_date)
-        }
-    }
-
-    impl CashFlow for TestCoupon {
-        fn amount(&self) -> QlResult<Real> {
-            Ok(self.nominal() * self.rate * self.accrual_period())
-        }
-
-        fn ex_coupon_date(&self) -> Option<Date> {
-            self.base.ex_coupon_date()
-        }
-
-        fn as_coupon(&self) -> Option<&dyn Coupon> {
-            Some(self)
-        }
-    }
-
     impl Coupon for TestCoupon {
         fn coupon_base(&self) -> &CouponBase {
             &self.base
+        }
+
+        fn amount(&self) -> QlResult<Real> {
+            Ok(self.nominal() * self.rate * self.accrual_period())
         }
 
         fn rate(&self) -> QlResult<Rate> {

--- a/crates/libitofin/src/cashflows/fixedratecoupon.rs
+++ b/crates/libitofin/src/cashflows/fixedratecoupon.rs
@@ -14,14 +14,18 @@
 //! [`FixedRateCoupon::new`] (an explicit [`InterestRate`]) and
 //! [`FixedRateCoupon::from_rate`] (a rate plus a day counter, taken as simple
 //! and annual). The `accept(AcyclicVisitor&)` override has no counterpart.
+//!
+//! The [`CashFlow`](crate::cashflow::CashFlow) and
+//! [`Event`](crate::event::Event) faces come from the blanket impls on
+//! [`Coupon`], so this file implements [`Coupon`] and nothing else. `amount()`
+//! is the one C++ body that survives the sever, and it lives on [`Coupon`]
+//! precisely so that it can: a blanket impl that provided it would forbid this
+//! override.
 
-use crate::cashflow::{CashFlow, cash_flow_has_occurred};
 use crate::cashflows::coupon::{Coupon, CouponBase};
 use crate::errors::QlResult;
-use crate::event::Event;
 use crate::interestrate::{Compounding, InterestRate};
 use crate::patterns::observable::{AsObservable, Observable};
-use crate::settings::Settings;
 use crate::time::date::Date;
 use crate::time::daycounter::DayCounter;
 use crate::time::frequency::Frequency;
@@ -107,22 +111,11 @@ impl AsObservable for FixedRateCoupon {
     }
 }
 
-impl Event for FixedRateCoupon {
-    fn date(&self) -> Date {
-        self.base.payment_date()
+impl Coupon for FixedRateCoupon {
+    fn coupon_base(&self) -> &CouponBase {
+        &self.base
     }
 
-    fn has_occurred(
-        &self,
-        settings: &Settings<Date>,
-        ref_date: Option<Date>,
-        include_ref_date: Option<bool>,
-    ) -> QlResult<bool> {
-        cash_flow_has_occurred(self.date(), settings, ref_date, include_ref_date)
-    }
-}
-
-impl CashFlow for FixedRateCoupon {
     /// # Errors
     ///
     /// Propagates the [`InterestRate::compound_factor_between_ref`] domain
@@ -135,20 +128,6 @@ impl CashFlow for FixedRateCoupon {
             self.reference_period_end(),
         )?;
         Ok(self.nominal() * (factor - 1.0))
-    }
-
-    fn ex_coupon_date(&self) -> Option<Date> {
-        self.base.ex_coupon_date()
-    }
-
-    fn as_coupon(&self) -> Option<&dyn Coupon> {
-        Some(self)
-    }
-}
-
-impl Coupon for FixedRateCoupon {
-    fn coupon_base(&self) -> &CouponBase {
-        &self.base
     }
 
     fn rate(&self) -> QlResult<Rate> {
@@ -204,9 +183,21 @@ mod tests {
     //! QuantLib test.
 
     use super::*;
+    use crate::cashflow::CashFlow;
+    use crate::event::Event;
+    use crate::settings::Settings;
     use crate::time::date::Month;
     use crate::time::daycounters::actual360::Actual360;
     use crate::time::daycounters::thirty360::{Convention, Thirty360};
+
+    /// The coupon's [`amount`](Coupon::amount) as the blanket
+    /// `impl<T: Coupon> CashFlow for T` reports it. Both traits carry an
+    /// `amount`, so an unqualified call is ambiguous; going through
+    /// [`CashFlow`] is the assertion that the blanket forwards to the coupon's
+    /// own compounded body rather than supplying one of its own.
+    fn amount(coupon: &FixedRateCoupon) -> Real {
+        CashFlow::amount(coupon).unwrap()
+    }
 
     fn start() -> Date {
         Date::new(15, Month::January, 2026)
@@ -240,7 +231,7 @@ mod tests {
 
         assert_eq!(coupon.rate().unwrap(), 0.03);
         assert_eq!(coupon.date(), payment());
-        assert!((coupon.amount().unwrap() - 100.0 * 0.03 * 181.0 / 360.0).abs() < 1e-13);
+        assert!((amount(&coupon) - 100.0 * 0.03 * 181.0 / 360.0).abs() < 1e-13);
     }
 
     /// `performCalculations` compounds the rate over the accrual period rather
@@ -261,8 +252,8 @@ mod tests {
             FixedRateCoupon::new(one_year, 100.0, rate, start(), one_year, None, None, None);
 
         assert!((coupon.accrual_period() - 1.0).abs() < 1e-15);
-        assert!((coupon.amount().unwrap() - 6.09).abs() < 1e-12);
-        assert!((coupon.amount().unwrap() - 100.0 * 0.06 * 1.0).abs() > 0.08);
+        assert!((amount(&coupon) - 6.09).abs() < 1e-12);
+        assert!((amount(&coupon) - 100.0 * 0.06 * 1.0).abs() > 0.08);
     }
 
     /// The accrued amount compounds too: half a year of a semiannual 6% rate is
@@ -298,9 +289,7 @@ mod tests {
         let mid = Date::new(15, Month::April, 2026);
 
         assert!((coupon.accrued_amount(mid).unwrap() - 100.0 * 0.03 * 90.0 / 360.0).abs() < 1e-13);
-        assert!(
-            (coupon.accrued_amount(payment()).unwrap() - coupon.amount().unwrap()).abs() < 1e-13
-        );
+        assert!((coupon.accrued_amount(payment()).unwrap() - amount(&coupon)).abs() < 1e-13);
     }
 
     /// `accruedAmount` flips sign from the ex-coupon date on, and returns to

--- a/crates/libitofin/src/cashflows/fixedrateleg.rs
+++ b/crates/libitofin/src/cashflows/fixedrateleg.rs
@@ -592,7 +592,7 @@ mod tests {
             coupons[0].reference_period_start(),
             Date::new(30, Month::September, 2017)
         );
-        assert!((coupons[0].amount().unwrap() - 0.9375).abs() < 1e-4);
+        assert!((CashFlow::amount(coupons[0].as_ref()).unwrap() - 0.9375).abs() < 1e-4);
     }
 
     /// `cashflows.cpp::testIrregularLastCouponReferenceDatesAtEndOfMonth`.

--- a/crates/libitofin/tests/external_coupon.rs
+++ b/crates/libitofin/tests/external_coupon.rs
@@ -2,8 +2,14 @@
 //!
 //! Integration tests compile as their own crate, so this fails to build if
 //! anything a downstream implementor of [`Coupon`] needs is private.
+//!
+//! `impl Coupon` is the whole of it: `date`, `has_occurred`, `ex_coupon_date`
+//! and `as_coupon` arrive from the blanket `impl<T: Coupon> CashFlow for T`, so
+//! a downstream coupon can no longer answer any of the three wrongly. That the
+//! flow below lands in a `Leg` and reports its own ex-coupon date, without this
+//! file ever naming those methods, is the assertion.
 
-use libitofin::cashflow::{CashFlow, cash_flow_has_occurred};
+use libitofin::cashflow::CashFlow;
 use libitofin::cashflows::{Coupon, CouponBase};
 use libitofin::errors::QlResult;
 use libitofin::event::Event;
@@ -29,38 +35,13 @@ impl AsObservable for SimpleFixedRateCoupon {
     }
 }
 
-impl Event for SimpleFixedRateCoupon {
-    fn date(&self) -> Date {
-        self.base.payment_date()
-    }
-
-    fn has_occurred(
-        &self,
-        settings: &Settings<Date>,
-        ref_date: Option<Date>,
-        include_ref_date: Option<bool>,
-    ) -> QlResult<bool> {
-        cash_flow_has_occurred(self.date(), settings, ref_date, include_ref_date)
-    }
-}
-
-impl CashFlow for SimpleFixedRateCoupon {
-    fn amount(&self) -> QlResult<Real> {
-        Ok(self.nominal() * self.rate * self.accrual_period())
-    }
-
-    fn ex_coupon_date(&self) -> Option<Date> {
-        self.base.ex_coupon_date()
-    }
-
-    fn as_coupon(&self) -> Option<&dyn Coupon> {
-        Some(self)
-    }
-}
-
 impl Coupon for SimpleFixedRateCoupon {
     fn coupon_base(&self) -> &CouponBase {
         &self.base
+    }
+
+    fn amount(&self) -> QlResult<Real> {
+        Ok(self.nominal() * self.rate * self.accrual_period())
     }
 
     fn rate(&self) -> QlResult<Rate> {
@@ -101,7 +82,7 @@ fn a_coupon_defined_outside_the_crate_accrues_and_pays() {
     assert_eq!(coupon.rate().unwrap(), 0.05);
     assert_eq!(coupon.accrual_days(), 181);
     assert!((coupon.accrual_period() - 181.0 / 365.0).abs() < 1e-15);
-    assert!((coupon.amount().unwrap() - 1_000.0 * 0.05 * 181.0 / 365.0).abs() < 1e-12);
+    assert!((CashFlow::amount(&coupon).unwrap() - 1_000.0 * 0.05 * 181.0 / 365.0).abs() < 1e-12);
 
     let mid = Date::new(15, Month::April, 2026);
     assert_eq!(coupon.accrued_days(mid), 90);
@@ -128,4 +109,31 @@ fn an_externally_defined_coupon_is_a_cash_flow_in_a_leg() {
     assert_eq!(leg[0].date(), Date::new(20, Month::July, 2026));
     assert!(!leg[0].has_occurred(&settings, None, None).unwrap());
     assert!(!leg[0].trading_ex_coupon(&settings, None).unwrap());
+}
+
+/// The three methods the blanket owns, none of which this file writes. The
+/// coupon reports itself as a coupon, hands back the ex-coupon date it accrues
+/// against, and takes the cash-flow occurrence rule: a payment on the
+/// evaluation date has not occurred once `include_todays_cash_flows` says so,
+/// where the plain-event rule would ignore the flag.
+#[test]
+fn the_blanket_impl_answers_for_an_externally_defined_coupon() {
+    let ex_coupon = Date::new(1, Month::July, 2026);
+    let coupon = coupon(Some(ex_coupon));
+    let settings = Settings::new();
+    settings.set_evaluation_date(Date::new(20, Month::July, 2026));
+    settings.set_include_reference_date_events(true);
+
+    assert_eq!(coupon.ex_coupon_date(), Some(ex_coupon));
+    assert!(
+        coupon
+            .trading_ex_coupon(&settings, Some(ex_coupon))
+            .unwrap()
+    );
+    assert!(coupon.as_coupon().is_some());
+
+    settings.set_include_todays_cash_flows(Some(false));
+    assert!(coupon.has_occurred(&settings, None, None).unwrap());
+    settings.set_include_todays_cash_flows(Some(true));
+    assert!(!coupon.has_occurred(&settings, None, None).unwrap());
 }


### PR DESCRIPTION
`Coupon` is no longer a subtrait of `CashFlow`. It restates its own surface
(`coupon_base`, `amount`, `rate`, `day_counter`, `accrued_amount`, plus
`AsObservable`), and two blanket impls on `T: Coupon` supply the cash-flow
face: `CashFlow::amount` forwards to `Coupon::amount`, while `date`,
`has_occurred`, `ex_coupon_date` and `as_coupon` are written exactly once,
against `CouponBase`.

That deletes the hand-written overrides on `FixedRateCoupon`, on the
`TestCoupon` double and on the downstream `SimpleFixedRateCoupon` of
`tests/external_coupon.rs`. A coupon can no longer answer `has_occurred`
(#246), `ex_coupon_date` (#247) or `as_coupon` (#258) wrongly, because it
cannot answer them at all: the three defects those tickets fixed one method at
a time are now unrepresentable.

The subtrait shape cannot do this. A blanket impl over `Coupon: CashFlow`
compiles, and *provides* `amount()`, so `FixedRateCoupon` would inherit a
generic body in place of `nominal * (compound_factor_between_ref(..) - 1.0)`,
and the `impl CashFlow for FixedRateCoupon` restoring it is a conflicting
implementation (E0119). Hence the sever, and hence `amount` moves onto
`Coupon`.

An `impl<T: Coupon> Event for T` accompanies the `CashFlow` one, since
`CashFlow: Event` and `Event::has_occurred` is required. Both take a `Sized`
`T`, because the `Some(self)` of `as_coupon` is an unsizing coercion, so
`dyn Coupon` does not implement `CashFlow`. Nothing needs it: `bps`, `npvbps`
and `atm_rate` hold a `&dyn CashFlow` already and read only `nominal()`,
`accrual_period()` and the accrual dates through the coupon view, as does
every other `as_coupon()` call site.

No numbers move. Every numeric constant is untouched; `npv`, `bps`, `npvbps`,
`atm_rate` and the `FixedRateCoupon` values are identical. The `amount` call
sites in the tests are respelled only because `amount` now sits on both
traits, which makes an unqualified `coupon.amount()` ambiguous; they route
through `CashFlow::amount`, which asserts the blanket forwards to the coupon's
own body rather than supplying one. The three "required, not defaulted"
divergence notes in the README collapse into one describing the blanket.

Closes #262.

BREAKING CHANGE: `Coupon` is no longer a subtrait of `CashFlow`, and carries
`amount` itself. An implementor now writes `impl Coupon` alone, dropping its
`impl Event` and `impl CashFlow`; `amount` moves from the latter onto `Coupon`.
`dyn Coupon` no longer implements `CashFlow` or `Event`. On a concrete coupon
with both traits in scope, `coupon.amount()` is ambiguous and must name its
trait.
