### PR TITLE
chore(gitignore): ignore mutants output files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,4 @@ QuantLib
 /target
 .zed
 fable*.txt
+mutants*


### PR DESCRIPTION
Add `mutants*` pattern to `.gitignore` to exclude mutation testing output files from version control.
