### PR TITLE
feat(settings): add D11 fixing store with per-index observability (#297)

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,19 @@ oversight) and is documented at the point of divergence in the source.
   no clock (for determinism and FFI), so operations that need the evaluation date
   return `Err` when it is unset rather than silently pricing a possibly-expired
   instrument as live.
+- **Past index fixings live on `Settings`, not in a global `IndexManager`
+  singleton (D11).** QuantLib stores fixing history in `IndexManager::instance()`,
+  a global-singleton `map<string, TimeSeries<Real>>`; D5 forbids that singleton,
+  so the history moves onto `Settings` as a `fixing_store`, exactly like the
+  evaluation date. It stays shared across every handle to an index (a `Settings`
+  is shared, and the store is keyed by the case-insensitive index name), so two
+  handles to "the same" Euribor observe one history, as C++'s global map
+  guarantees. Each index name owns an `Observable`, so adding or clearing a
+  fixing notifies exactly that index's observers, and those notifiers outlive a
+  `clear_fixings`. A conflicting fixing on an existing date returns `Err` (D4)
+  where QuantLib notifies and then throws. The `enforces_todays_historic_fixings`
+  flag's today's-fixing rule is applied by the index layer that reads the store,
+  as `InterestRateIndex::fixing` does in C++, not by the store itself.
 
 **Cash flows (EPIC-7):**
 

--- a/crates/libitofin/src/settings.rs
+++ b/crates/libitofin/src/settings.rs
@@ -17,11 +17,30 @@
 //! [`Shared<Settings<D>>`](crate::shared::Shared) so that an observer may read
 //! the evaluation date while being notified of its change, rather than meeting
 //! a mutable borrow the notifying caller still holds.
+//!
+//! # Past index fixings (D11)
+//!
+//! QuantLib keeps historical index fixings in `IndexManager::instance()`, a
+//! global-singleton `map<string, TimeSeries<Real>>`. D5 forbids that singleton,
+//! so per D11 the fixing history lives here on `Settings` (a `fixing_store`,
+//! exactly like `evaluation_date`): explicit rather than hidden, yet shared
+//! across every handle to the same index, since two handles to "the same"
+//! Euribor must observe one fixing history - the guarantee C++'s global map
+//! provides. Index names are matched case-insensitively, as in `IndexManager`.
+//! Each index name carries its own [`Observable`], so adding a fixing notifies
+//! exactly the observers of that index (mirroring `IndexManager::notifier`);
+//! the notifiers outlive [`clear_fixings`](Settings::clear_fixings), so an index
+//! registered once keeps hearing later fixings.
 
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
+use std::collections::{BTreeMap, HashMap};
 
+use crate::math::comparison::close;
 use crate::patterns::observable::{Observable, Observer};
-use crate::shared::SharedMut;
+use crate::require;
+use crate::shared::{Shared, SharedMut};
+use crate::time::date::Date;
+use crate::types::Rate;
 
 /// Run-time settings governing pricing.
 ///
@@ -32,6 +51,8 @@ pub struct Settings<D> {
     include_reference_date_events: Cell<bool>,
     include_todays_cash_flows: Cell<Option<bool>>,
     enforces_todays_historic_fixings: Cell<bool>,
+    fixing_store: RefCell<HashMap<String, BTreeMap<Date, Rate>>>,
+    fixing_notifiers: RefCell<HashMap<String, Shared<Observable>>>,
 }
 
 impl<D> Default for Settings<D> {
@@ -42,6 +63,8 @@ impl<D> Default for Settings<D> {
             include_reference_date_events: Cell::new(false),
             include_todays_cash_flows: Cell::new(None),
             enforces_todays_historic_fixings: Cell::new(false),
+            fixing_store: RefCell::new(HashMap::new()),
+            fixing_notifiers: RefCell::new(HashMap::new()),
         }
     }
 }
@@ -123,8 +146,127 @@ impl<D> Settings<D> {
     }
 
     /// Sets the [`enforces_todays_historic_fixings`](Self::enforces_todays_historic_fixings) flag.
+    ///
+    /// The today's-fixing rule this flag governs (whether a missing fixing on
+    /// the evaluation date is an error or a forecast) is applied by the index
+    /// layer that reads the store, not by the store itself - as in QuantLib,
+    /// where `IndexManager` records fixings and `InterestRateIndex::fixing`
+    /// consults the flag.
     pub fn set_enforces_todays_historic_fixings(&self, value: bool) {
         self.enforces_todays_historic_fixings.set(value);
+    }
+
+    /// Case-insensitive lookup key for an index name (`IndexManager` semantics).
+    fn fixing_key(index_name: &str) -> String {
+        index_name.to_uppercase()
+    }
+
+    /// The [`Observable`] for an index name, created on first use and shared by
+    /// every observer and mutation of that name's fixings.
+    fn fixing_notifier(&self, key: &str) -> Shared<Observable> {
+        let mut notifiers = self.fixing_notifiers.borrow_mut();
+        if let Some(notifier) = notifiers.get(key) {
+            return Shared::clone(notifier);
+        }
+        let notifier = Shared::new(Observable::new());
+        notifiers.insert(key.to_string(), Shared::clone(&notifier));
+        notifier
+    }
+
+    /// Registers an observer to be notified when a fixing of `index_name` is
+    /// added or cleared.
+    pub fn register_fixing_observer(
+        &self,
+        index_name: &str,
+        observer: &SharedMut<dyn Observer>,
+    ) -> bool {
+        let key = Self::fixing_key(index_name);
+        self.fixing_notifier(&key).register_observer(observer)
+    }
+
+    /// Records a single past fixing for `index_name`, notifying its observers.
+    ///
+    /// See [`add_fixings`](Self::add_fixings) for the overwrite rule.
+    pub fn add_fixing(
+        &self,
+        index_name: &str,
+        date: Date,
+        rate: Rate,
+    ) -> crate::errors::QlResult<()> {
+        self.add_fixings(index_name, [(date, rate)])
+    }
+
+    /// Records several past fixings for `index_name`, notifying its observers once.
+    ///
+    /// A fixing that repeats an existing date with a [`close`] value is a no-op;
+    /// one that conflicts with a stored value is rejected (mirroring
+    /// `IndexManager::addFixings`' duplicated-fixing guard) and leaves the store
+    /// unchanged. The observers of `index_name` are notified only once the store
+    /// has been updated and its borrow released, so an observer reading a fixing
+    /// back from its `update` sees the new value.
+    pub fn add_fixings(
+        &self,
+        index_name: &str,
+        fixings: impl IntoIterator<Item = (Date, Rate)>,
+    ) -> crate::errors::QlResult<()> {
+        let key = Self::fixing_key(index_name);
+        let notifier = self.fixing_notifier(&key);
+        {
+            let mut store = self.fixing_store.borrow_mut();
+            let history = store.entry(key).or_default();
+            let pending: Vec<(Date, Rate)> = fixings.into_iter().collect();
+            for &(date, rate) in &pending {
+                if let Some(&existing) = history.get(&date) {
+                    require!(
+                        close(existing, rate),
+                        "duplicated fixing {rate} on {date:?} while {existing} is already present"
+                    );
+                }
+            }
+            for (date, rate) in pending {
+                history.insert(date, rate);
+            }
+        }
+        notifier.notify_observers();
+        Ok(())
+    }
+
+    /// The stored fixing of `index_name` on `date`, if one was recorded.
+    pub fn fixing(&self, index_name: &str, date: Date) -> Option<Rate> {
+        let key = Self::fixing_key(index_name);
+        self.fixing_store
+            .borrow()
+            .get(&key)
+            .and_then(|history| history.get(&date).copied())
+    }
+
+    /// Whether a fixing of `index_name` is on record for `date`.
+    ///
+    /// Mirrors `IndexManager::hasHistoricalFixing`.
+    pub fn has_historical_fixing(&self, index_name: &str, date: Date) -> bool {
+        self.fixing(index_name, date).is_some()
+    }
+
+    /// Clears the recorded fixings of a single index, notifying its observers.
+    ///
+    /// Mirrors `IndexManager::clearHistory`, which notifies unconditionally.
+    pub fn clear_fixing(&self, index_name: &str) {
+        let key = Self::fixing_key(index_name);
+        self.fixing_notifier(&key).notify_observers();
+        self.fixing_store.borrow_mut().remove(&key);
+    }
+
+    /// Clears every recorded fixing, notifying the observers of each index that
+    /// had a history.
+    ///
+    /// Mirrors `IndexManager::clearHistories`. The per-index notifiers survive,
+    /// so an observer registered before the clear still hears later fixings.
+    pub fn clear_fixings(&self) {
+        let names: Vec<String> = self.fixing_store.borrow().keys().cloned().collect();
+        for name in &names {
+            self.fixing_notifier(name).notify_observers();
+        }
+        self.fixing_store.borrow_mut().clear();
     }
 }
 
@@ -230,5 +372,123 @@ mod tests {
 
         settings.reset_evaluation_date();
         assert_eq!(reader.borrow().seen, None);
+    }
+
+    use crate::time::date::Month;
+
+    fn a_date() -> Date {
+        Date::new(15, Month::June, 2026)
+    }
+
+    /// Reproduces `indexes.cpp::testFixingObservability`: an observer of an index
+    /// is notified when a fixing of that index is added, and only that index.
+    /// Reproduced against the store and a minimal observer double, since the
+    /// `Index` hierarchy is #68's scope, not this ticket's.
+    #[test]
+    fn adding_a_fixing_notifies_observers_of_that_index_only() {
+        let settings: Settings<i64> = Settings::new();
+        let date = a_date();
+
+        let f1 = shared_mut(Flag::default());
+        settings.register_fixing_observer("Euribor6M", &(f1.clone() as SharedMut<dyn Observer>));
+        let f2 = shared_mut(Flag::default());
+        settings.register_fixing_observer("BMA", &(f2.clone() as SharedMut<dyn Observer>));
+
+        settings.add_fixing("Euribor6M", date, -0.003).unwrap();
+        assert!(f1.borrow().up);
+        assert!(!f2.borrow().up);
+
+        settings.add_fixing("BMA", date, 0.01).unwrap();
+        assert!(f2.borrow().up);
+    }
+
+    /// Reproduces `indexes.cpp::testFixingHasHistoricalFixing`: a fixing is found
+    /// only for the index it was registered under and only until the histories
+    /// are cleared. The shared-history semantics of two C++ handles to the same
+    /// index are inherent here, as any reader of the name sees the one store.
+    #[test]
+    fn has_historical_fixing_tracks_registered_fixings() {
+        let settings: Settings<i64> = Settings::new();
+        let date = a_date();
+
+        settings.add_fixing("Euribor6M", date, 0.01).unwrap();
+
+        assert!(!settings.has_historical_fixing("Euribor3M", date));
+        assert!(settings.has_historical_fixing("Euribor6M", date));
+        assert_eq!(settings.fixing("Euribor6M", date), Some(0.01));
+
+        settings.clear_fixings();
+
+        assert!(!settings.has_historical_fixing("Euribor3M", date));
+        assert!(!settings.has_historical_fixing("Euribor6M", date));
+    }
+
+    #[test]
+    fn index_names_are_case_insensitive() {
+        let settings: Settings<i64> = Settings::new();
+        let date = a_date();
+        settings.add_fixing("Euribor6M", date, 0.02).unwrap();
+        assert_eq!(settings.fixing("EURIBOR6M", date), Some(0.02));
+        assert!(settings.has_historical_fixing("euribor6m", date));
+    }
+
+    #[test]
+    fn conflicting_fixing_is_rejected_while_identical_is_idempotent() {
+        let settings: Settings<i64> = Settings::new();
+        let date = a_date();
+        settings.add_fixing("Euribor6M", date, 0.02).unwrap();
+        assert!(settings.add_fixing("Euribor6M", date, 0.02).is_ok());
+        assert!(settings.add_fixing("Euribor6M", date, 0.03).is_err());
+        assert_eq!(settings.fixing("Euribor6M", date), Some(0.02));
+    }
+
+    #[test]
+    fn fixing_observers_persist_across_clear() {
+        let settings: Settings<i64> = Settings::new();
+        let date = a_date();
+        let flag = shared_mut(Flag::default());
+        settings.register_fixing_observer("Euribor6M", &(flag.clone() as SharedMut<dyn Observer>));
+
+        settings.add_fixing("Euribor6M", date, 0.01).unwrap();
+        assert!(flag.borrow().up);
+
+        flag.borrow_mut().up = false;
+        settings.clear_fixings();
+        assert!(flag.borrow().up);
+
+        flag.borrow_mut().up = false;
+        settings.add_fixing("Euribor6M", date, 0.02).unwrap();
+        assert!(flag.borrow().up);
+    }
+
+    /// Observer that reads a fixing back while being notified of its addition,
+    /// the fixing-store analogue of [`Reader`]: it must not meet the mutable
+    /// store borrow the notifying `add_fixing` held.
+    struct FixingReader {
+        settings: Shared<Settings<i64>>,
+        date: Date,
+        seen: Option<Rate>,
+    }
+
+    impl Observer for FixingReader {
+        fn update(&mut self) {
+            self.seen = self.settings.fixing("Euribor6M", self.date);
+        }
+    }
+
+    #[test]
+    fn observer_may_read_the_fixing_during_notification() {
+        let settings = shared(Settings::<i64>::new());
+        let date = a_date();
+        let reader = shared_mut(FixingReader {
+            settings: Shared::clone(&settings),
+            date,
+            seen: None,
+        });
+        settings
+            .register_fixing_observer("Euribor6M", &(reader.clone() as SharedMut<dyn Observer>));
+
+        settings.add_fixing("Euribor6M", date, 0.05).unwrap();
+        assert_eq!(reader.borrow().seen, Some(0.05));
     }
 }


### PR DESCRIPTION
Port QuantLib's IndexManager past-fixing repository onto Settings per
D11: the global-singleton map<string, TimeSeries<Real>> that D5 forbids
moves onto Settings as a fixing_store, shared across every handle to an
index and keyed case-insensitively by index name.

Each index name owns an Observable, so add_fixing/add_fixings and
clear_fixing/clear_fixings notify exactly that index's observers; the
notifiers outlive a clear. Notification runs after the store borrow is
released, so an observer may read the fixing back from its update. A
conflicting fixing on an existing date returns Err (D4).

Reproduces indexes.cpp testFixingObservability and
testFixingHasHistoricalFixing against the store and a minimal observer
double, since the Index hierarchy is #68's scope. Records D11 in the
README divergence catalogue.

close #297
