### PR TITLE
chore(gitignore): ignore mcp config and graphify output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,5 @@ QuantLib
 .zed
 fable*.txt
 mutants*
+.mcp.json
+graphify-out/


### PR DESCRIPTION
Add `.mcp.json` and `graphify-out/` to `.gitignore` to prevent local MCP configuration and generated graphify output from being tracked in version control.
