### PR TITLE
feat(iborcoupon): thread par/indexed forecast switch on Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,20 +242,20 @@ oversight) and is documented at the point of divergence in the source.
   traits, so on a concrete coupon with both in scope an unqualified
   `coupon.amount()` is ambiguous; name the trait.
 
-- **`IborCoupon` ports the swaplet path only; the par/indexed forecast switch
-  (a global singleton) is not ported.** QuantLib's `IborCoupon::indexFixing()`
-  forecast branch selects between a par-coupon approximation and an indexed
-  coupon through the `IborCoupon::Settings` singleton (`usingAtParCoupons`,
-  default `true` in this tree). That is a process-global switch, which D5
-  forbids, and its whole effect is confined to the forecast branch. This port
-  keeps `index_fixing` delegating to `FloatingRateCoupon`, which forecasts off
-  the index's natural maturity (the indexed-coupon convention); for every
-  *determined* fixing - the only case the swaplet path reaches - it returns the
-  same required past fixing as the C++ override. The par-coupon approximation
-  and the per-coupon cached dates (`fixingValueDate`/`fixingEndDate`/
-  `spanningTime`) that feed it are deferred to the cap/floor slice, where the
-  mode will be threaded explicitly rather than read from a global.
-  `BlackIborCouponPricer` ports `swapletRate = gearing * indexFixing + spread`;
+- **The `IborCoupon` par/indexed forecast switch is threaded on `Settings`, not
+  a global singleton.** QuantLib's `IborCoupon::indexFixing()` forecast branch
+  selects between a par-coupon approximation (rolls `fixingEndDate` off the
+  coupon's own accrual end) and an indexed coupon (the index's natural maturity)
+  through the `IborCoupon::Settings` singleton (`usingAtParCoupons`, default
+  `true`). That process-global switch is what D5 forbids, so the port drops the
+  singleton and threads the flag explicitly on `Settings`
+  (`using_at_par_coupons`, default `true`) beside the evaluation date and the
+  D11 fixing store. The behaviour it governs is fully reproduced: `index_fixing`
+  computes the cached `fixingValueDate`/`fixingEndDate`/`spanningTime`
+  (`couponpricer.cpp:56-88`) and reads the specialized 3-arg `forecastFixing`
+  off the curve; a *determined* fixing is mode-independent and returns the same
+  required past fixing as the C++ override. `BlackIborCouponPricer` ports
+  `swapletRate = gearing * indexFixing + spread`;
   since a non-in-arrears `Black76` coupon needs no convexity adjustment it needs
   no volatility, and since only `swapletPrice` (not `swapletRate`) reads the
   forwarding-curve discount, the pricer captures no curve. The caplet/floorlet

--- a/crates/libitofin/src/cashflows/couponpricer.rs
+++ b/crates/libitofin/src/cashflows/couponpricer.rs
@@ -51,6 +51,18 @@ pub trait FloatingRateCouponPricer: AsObservable {
     /// (`swapletRate`).
     fn swaplet_rate(&self) -> QlResult<Rate>;
 
+    /// The swaplet rate for a caller-supplied `index_fixing`, gearing and spread
+    /// folded in.
+    ///
+    /// The mode-aware entry: an [`IborCoupon`] threads its par or indexed
+    /// forecast in here rather than let the pricer read the base coupon's
+    /// natural forecast, which cannot see the par-coupon dates. Gearing, spread
+    /// and the in-arrears refusal are the pricer's, as in
+    /// [`swaplet_rate`](Self::swaplet_rate).
+    ///
+    /// [`IborCoupon`]: super::iborcoupon::IborCoupon
+    fn swaplet_rate_for(&self, index_fixing: QlResult<Rate>) -> QlResult<Rate>;
+
     /// The rate of a caplet struck at `effective_cap` (`capletRate`).
     ///
     /// The cap/floor slice is not ported; a base-slice pricer returns `Err`.
@@ -126,14 +138,18 @@ impl FloatingRateCouponPricer for BlackIborCouponPricer {
     }
 
     fn swaplet_rate(&self) -> QlResult<Rate> {
+        let Some(index_fixing) = &self.index_fixing else {
+            fail!("pricer not initialized: no coupon captured");
+        };
+        self.swaplet_rate_for(index_fixing.clone())
+    }
+
+    fn swaplet_rate_for(&self, index_fixing: QlResult<Rate>) -> QlResult<Rate> {
         require!(
             !self.is_in_arrears,
             "in-arrears convexity adjustment not ported: cap/floor slice"
         );
-        let Some(index_fixing) = &self.index_fixing else {
-            fail!("pricer not initialized: no coupon captured");
-        };
-        Ok(self.gearing * index_fixing.clone()? + self.spread)
+        Ok(self.gearing * index_fixing? + self.spread)
     }
 
     fn caplet_rate(&self, _effective_cap: Rate) -> QlResult<Rate> {

--- a/crates/libitofin/src/cashflows/floatingratecoupon.rs
+++ b/crates/libitofin/src/cashflows/floatingratecoupon.rs
@@ -409,6 +409,10 @@ mod tests {
             Ok(self.swaplet)
         }
 
+        fn swaplet_rate_for(&self, _index_fixing: QlResult<Rate>) -> QlResult<Rate> {
+            Ok(self.swaplet)
+        }
+
         fn caplet_rate(&self, _effective_cap: Rate) -> QlResult<Rate> {
             fail!("caplet rate not ported: cap/floor slice")
         }

--- a/crates/libitofin/src/cashflows/iborcoupon.rs
+++ b/crates/libitofin/src/cashflows/iborcoupon.rs
@@ -543,4 +543,131 @@ mod tests {
         let expected = gearing * forecast + spread;
         assert!((coupon.rate().unwrap() - expected).abs() < 1e-14);
     }
+
+    /// Builds a 6M index on a flat continuous `Actual/360` curve at `rate` and a
+    /// short-stub coupon whose accrual end (3M) genuinely mismatches the index
+    /// tenor, so the par and indexed forecasts differ. Returns the index, the
+    /// coupon, its gearing and spread.
+    fn stub_coupon(rate: Rate) -> (Shared<IborIndex>, IborCoupon, Real, Spread) {
+        let today = Date::new(15, Month::June, 2026);
+        let settings = settings_on(today);
+        let index = shared(IborIndex::new(
+            "foo".into(),
+            Period::new(6, TimeUnit::Months),
+            2,
+            Currency::eur(),
+            Target::new(),
+            BusinessDayConvention::Following,
+            false,
+            Actual360::new(),
+            flat_curve(today, rate),
+            settings,
+        ));
+
+        let fixing_date = Date::new(15, Month::July, 2026);
+        let start_date = index.value_date(fixing_date).unwrap();
+        let end_date = index.fixing_calendar().advance_by_period(
+            start_date,
+            Period::new(3, TimeUnit::Months),
+            BusinessDayConvention::Following,
+            false,
+        );
+        let gearing = 2.0;
+        let spread = 0.01;
+        let coupon = IborCoupon::new(
+            end_date,
+            100.0,
+            start_date,
+            end_date,
+            Some(index.fixing_days()),
+            index.clone(),
+            gearing,
+            spread,
+            None,
+            None,
+            None,
+            false,
+            None,
+            BusinessDayConvention::Preceding,
+        )
+        .unwrap();
+        coupon.set_pricer(pricer());
+        (index, coupon, gearing, spread)
+    }
+
+    /// The default (par) forecast rolls `fixingEndDate` off the coupon's own
+    /// accrual end, not the index maturity. On the flat continuous `Actual/360`
+    /// curve the simple forward over `[fixingValueDate, parFixingEndDate]` is
+    /// analytically `(exp(rate * t) - 1) / t` with `t` the day-count fraction of
+    /// that span; the par dates are reconstructed here from the calendar, not
+    /// read back from the coupon. `rate()` is `gearing * forecast + spread`.
+    #[test]
+    fn a_par_coupon_forecasts_over_its_own_accrual_end() {
+        let rate = 0.03;
+        let (index, coupon, gearing, spread) = stub_coupon(rate);
+        let day_counter = Actual360::new();
+
+        let fixing_value_date = index.value_date(coupon.fixing_date()).unwrap();
+        let calendar = index.fixing_calendar();
+        let next_fixing_date = calendar.advance(
+            coupon.accrual_end_date(),
+            -(index.fixing_days() as i32),
+            TimeUnit::Days,
+            BusinessDayConvention::Following,
+            false,
+        );
+        let par_fixing_end_date = calendar
+            .advance(
+                next_fixing_date,
+                index.fixing_days() as i32,
+                TimeUnit::Days,
+                BusinessDayConvention::Following,
+                false,
+            )
+            .max(fixing_value_date + 1);
+
+        let t = day_counter.year_fraction(fixing_value_date, par_fixing_end_date);
+        let forecast = ((rate * t).exp() - 1.0) / t;
+        let expected = gearing * forecast + spread;
+
+        assert!(!coupon.has_fixed().unwrap());
+        assert!((coupon.rate().unwrap() - expected).abs() < 1e-14);
+    }
+
+    /// On the stub the par default and the indexed convention genuinely diverge:
+    /// par prices over the coupon's 3M accrual end, indexed over the index's 6M
+    /// natural maturity. The default par `rate()` must differ from the indexed
+    /// `gearing * index.forecast_fixing + spread` by well more than tolerance.
+    #[test]
+    fn par_and_indexed_forecasts_differ_on_a_stub() {
+        let (index, coupon, gearing, spread) = stub_coupon(0.03);
+        let par_rate = coupon.rate().unwrap();
+        let indexed = gearing * index.forecast_fixing(coupon.fixing_date()).unwrap() + spread;
+        assert!(
+            (par_rate - indexed).abs() > 1e-6,
+            "par {par_rate} vs indexed {indexed} should differ on a stub"
+        );
+    }
+
+    /// `amount()` and `accrued_amount()` route through the mode-aware
+    /// [`rate`](Coupon::rate), not the base's natural indexed forecast. C++ gets
+    /// this from the virtual `rate()`; the port's embedded-base composition does
+    /// not dispatch back down, so the override is explicit. On the stub, where
+    /// par and indexed diverge, an unfixed coupon's amount would carry the
+    /// indexed fixing without the routing - here it must equal
+    /// `rate() * accrual_period * nominal`, and `accrued_amount` must share the
+    /// same rate.
+    #[test]
+    fn amount_routes_through_the_mode_aware_rate() {
+        let (_index, coupon, _gearing, _spread) = stub_coupon(0.03);
+        assert!(!coupon.has_fixed().unwrap());
+        let rate = coupon.rate().unwrap();
+
+        let expected_amount = rate * coupon.accrual_period() * coupon.nominal();
+        assert!((coupon.amount().unwrap() - expected_amount).abs() < 1e-14);
+
+        let payment_date = coupon.coupon_base().payment_date();
+        let expected_accrued = coupon.nominal() * rate * coupon.accrued_period(payment_date);
+        assert!((coupon.accrued_amount(payment_date).unwrap() - expected_accrued).abs() < 1e-14);
+    }
 }

--- a/crates/libitofin/src/cashflows/iborcoupon.rs
+++ b/crates/libitofin/src/cashflows/iborcoupon.rs
@@ -12,54 +12,51 @@
 //! ## The index fixing
 //!
 //! C++ overrides `indexFixing()` to branch on `hasFixed()`: a determined coupon
-//! returns the required past fixing, an undetermined one forecasts. That branch
-//! is the same one [`Index::fixing`](crate::indexes::index::Index::fixing)
-//! already makes: for a fixing date strictly before today (or on today under
-//! `enforcesTodaysHistoricFixings`) it requires the stored fixing, otherwise it
-//! forecasts. So [`index_fixing`](IborCoupon::index_fixing) delegates to the
-//! base [`FloatingRateCoupon::index_fixing`], which yields the identical value
-//! for every determined case - the only cases this slice's C++ oracles reach.
-//! The forecast branch is nonetheless live: `rate()` on an unfixed coupon over a
-//! linked curve returns the index's natural forecast, i.e. the indexed-coupon
-//! convention, not the par approximation. That behaviour is deliberate and
-//! pinned by `an_unfixed_coupon_forecasts_in_indexed_mode_not_par`, and holds
-//! until the par mode is threaded explicitly (see the divergence below).
+//! returns the required past fixing, an undetermined one forecasts. The
+//! determined branch is the same one
+//! [`Index::fixing`](crate::indexes::index::Index::fixing) already makes, so
+//! [`index_fixing`](IborCoupon::index_fixing) delegates it to the base
+//! [`FloatingRateCoupon::index_fixing`], yielding the identical value for every
+//! determined case. The forecast branch is mode-aware: it computes the cached
+//! `fixingValueDate`/`fixingEndDate`/`spanningTime` (`couponpricer.cpp:56-88`)
+//! and reads the specialized 3-arg
+//! [`forecast_fixing_between`](IborIndex::forecast_fixing_between)
+//! (`iborcoupon.cpp:126`) rather than the index's natural forecast.
 //!
-//! ## Divergences from QuantLib
+//! ## Par vs indexed coupons (`usingAtParCoupons`)
 //!
-//! The C++ `indexFixing()` forecast branch uses a specialized per-coupon
-//! `forecastFixing(valueDate, endDate, spanningTime)` whose dates depend on the
-//! `IborCoupon::Settings` singleton (`usingAtParCoupons`): par coupons roll the
-//! estimation end off the next fixing date, indexed coupons use the index
-//! maturity. That flag is a global singleton, which D5 forbids, and its whole
-//! effect is confined to the forecast branch. The base
-//! [`FloatingRateCoupon::index_fixing`] forecast follows the index's natural
-//! maturity, i.e. the indexed-coupon convention (`QL_USE_INDEXED_COUPON`). The
-//! par-coupon approximation - the C++ compile-time default in this tree - and
-//! the cached-data machinery it needs are deferred to the cap/floor slice, where
-//! the mode is threaded explicitly per D5 rather than read from a global. The
-//! C++ oracles reach only determined fixings, so the deferral changes no number
-//! they pin; the indexed-mode forecast the base takes is itself pinned by a
-//! test, so this divergence is a deliberate, locked behaviour rather than a
-//! latent one.
+//! The forecast estimation end depends on the coupon convention. A **par**
+//! coupon rolls `fixingEndDate` off the next fixing date derived from the
+//! coupon's own accrual end (the approximation that lets a vanilla floater
+//! telescope to par); an **indexed** coupon uses the index's natural maturity,
+//! so its forecast equals `index.forecast_fixing(fixingDate)`. The two coincide
+//! only when the coupon spans exactly the index tenor; on a stub they diverge.
 //!
-//! `fixingValueDate`/`fixingMaturityDate`/`fixingEndDate`/`spanningTime` and the
-//! `IborLeg` builder are omitted for the same reason: they exist to feed the
-//! deferred par/indexed forecast and the leg (#7.10).
+//! C++ toggles the convention through the `IborCoupon::Settings` singleton
+//! (`iborcoupon.hpp:110`, `usingAtParCoupons_ = true` by default), which D5
+//! forbids. The port threads the flag explicitly on
+//! [`Settings`](crate::settings::Settings::using_at_par_coupons) - alongside the
+//! evaluation date and the D11 fixing store - defaulting to par to match the
+//! tree's compile-time default. Only the forecast branch reads it; a determined
+//! fixing is mode-independent. The `IborCoupon::Settings` singleton itself is
+//! the sole divergence: the behaviour it governs is reproduced, the global is
+//! not.
 
 use super::coupon::{Coupon, CouponBase};
 use super::couponpricer::FloatingRateCouponPricer;
 use super::floatingratecoupon::FloatingRateCoupon;
 use crate::errors::QlResult;
-use crate::fail;
 use crate::indexes::iborindex::IborIndex;
 use crate::indexes::index::Index;
+use crate::indexes::interestrateindex::InterestRateIndex;
 use crate::patterns::observable::{AsObservable, Observable};
 use crate::shared::{Shared, SharedMut};
 use crate::time::businessdayconvention::BusinessDayConvention;
 use crate::time::date::Date;
 use crate::time::daycounter::DayCounter;
-use crate::types::{Natural, Rate, Real, Spread};
+use crate::time::timeunit::TimeUnit;
+use crate::types::{Integer, Natural, Rate, Real, Spread, Time};
+use crate::{fail, require};
 
 /// A coupon paying a Libor-type index (`ql/cashflows/iborcoupon.hpp`).
 ///
@@ -129,14 +126,77 @@ impl IborCoupon {
         self.base.fixing_date()
     }
 
-    /// The index fixing at the coupon's [`fixing_date`](Self::fixing_date).
+    /// The index fixing at the coupon's [`fixing_date`](Self::fixing_date)
+    /// (`IborCoupon::indexFixing`).
     ///
-    /// Delegates to the base: for every determined case this is the required
-    /// past fixing the C++ `indexFixing()` returns; an unfixed coupon forecasts
-    /// in the indexed-coupon convention rather than the deferred par
-    /// approximation (see the module docs).
+    /// A determined coupon returns the required past fixing, delegated to the
+    /// base and mode-independent. An undetermined coupon forecasts through the
+    /// specialized 3-arg [`forecast_fixing_between`](IborIndex::forecast_fixing_between)
+    /// over the cached par or indexed dates (see [`forecast_fixing_dates`]),
+    /// replacing the base's natural forecast.
+    ///
+    /// [`forecast_fixing_dates`]: Self::forecast_fixing_dates
     pub fn index_fixing(&self) -> QlResult<Rate> {
-        self.base.index_fixing()
+        if self.has_fixed()? {
+            self.base.index_fixing()
+        } else {
+            let (value_date, end_date, spanning_time) = self.forecast_fixing_dates()?;
+            self.ibor_index
+                .forecast_fixing_between(value_date, end_date, spanning_time)
+        }
+    }
+
+    /// The cached forecast dates `(fixingValueDate, fixingEndDate, spanningTime)`
+    /// the 3-arg forecast reads (`IborCouponPricer::initializeCachedData`,
+    /// `couponpricer.cpp:56-88`).
+    ///
+    /// `fixingValueDate` moves the fixing date forward the index's fixing days
+    /// (identical to [`value_date`](InterestRateIndex::value_date)) and
+    /// `fixingMaturityDate` is the index maturity off it. Under the par
+    /// convention a non-in-arrears coupon rolls `fixingEndDate` off its own
+    /// accrual end - back the *coupon's* fixing days to the next fixing date,
+    /// then forward the *index's* fixing days, floored at `fixingValueDate + 1`
+    /// so the estimation period spans at least a day; an indexed coupon (or any
+    /// in-arrears coupon) uses `fixingMaturityDate`. The convention is read
+    /// explicitly from [`Settings`](crate::settings::Settings::using_at_par_coupons),
+    /// not a global singleton.
+    fn forecast_fixing_dates(&self) -> QlResult<(Date, Date, Time)> {
+        let index = &self.ibor_index;
+        let calendar = index.fixing_calendar();
+        let fixing_value_date = index.value_date(self.fixing_date())?;
+        let fixing_maturity_date = index.maturity_date(fixing_value_date)?;
+
+        let using_at_par = index.settings().using_at_par_coupons();
+        let fixing_end_date = if !using_at_par || self.base.is_in_arrears() {
+            fixing_maturity_date
+        } else {
+            let next_fixing_date = calendar.advance(
+                self.accrual_end_date(),
+                -(self.base.fixing_days() as Integer),
+                TimeUnit::Days,
+                BusinessDayConvention::Following,
+                false,
+            );
+            let end_date = calendar.advance(
+                next_fixing_date,
+                index.fixing_days() as Integer,
+                TimeUnit::Days,
+                BusinessDayConvention::Following,
+                false,
+            );
+            end_date.max(fixing_value_date + 1)
+        };
+
+        let spanning_time = index
+            .day_counter()
+            .year_fraction(fixing_value_date, fixing_end_date);
+        let positive_time = spanning_time > 0.0;
+        require!(
+            positive_time,
+            "cannot calculate forward rate between {fixing_value_date:?} and {fixing_end_date:?}: non positive time ({spanning_time}) using {} daycounter",
+            index.day_counter().name()
+        );
+        Ok((fixing_value_date, fixing_end_date, spanning_time))
     }
 
     /// Whether the coupon's fixing is already determined (`hasFixed`).
@@ -186,11 +246,16 @@ impl Coupon for IborCoupon {
     }
 
     fn amount(&self) -> QlResult<Real> {
-        self.base.amount()
+        Ok(self.rate()? * self.accrual_period() * self.nominal())
     }
 
     fn rate(&self) -> QlResult<Rate> {
-        self.base.rate()
+        let Some(pricer) = self.base.pricer() else {
+            fail!("pricer not set");
+        };
+        pricer.borrow_mut().initialize(&self.base);
+        let index_fixing = self.index_fixing();
+        pricer.borrow().swaplet_rate_for(index_fixing)
     }
 
     fn day_counter(&self) -> DayCounter {
@@ -198,7 +263,11 @@ impl Coupon for IborCoupon {
     }
 
     fn accrued_amount(&self, date: Date) -> QlResult<Real> {
-        self.base.accrued_amount(date)
+        if date <= self.accrual_start_date() || date > self.coupon_base().payment_date() {
+            Ok(0.0)
+        } else {
+            Ok(self.nominal() * self.rate()? * self.accrued_period(date))
+        }
     }
 }
 
@@ -421,17 +490,16 @@ mod tests {
         assert!(coupon.rate().is_err());
     }
 
-    /// Pins the documented forecast divergence. The forecast branch through the
-    /// coupon is live: an unfixed coupon over a linked curve prices off the
-    /// index's own forecast fixing, which follows the indexed-coupon convention
-    /// (the index's natural maturity), not this tree's compile-time-default par
-    /// approximation. `rate()` is exactly `gearing * forecastFixing + spread`,
-    /// so if the deferred par mode ever silently replaced it the number would
-    /// move and this test would catch it.
+    /// Behind the explicit `using_at_par_coupons = false` flag an unfixed coupon
+    /// forecasts in the indexed-coupon convention: `fixingEndDate` is the index's
+    /// natural maturity, so the forecast is exactly `index.forecast_fixing`. This
+    /// is the flag-gated half of the mode switch; the default (par) is pinned by
+    /// `a_par_coupon_forecasts_over_its_own_accrual_end`.
     #[test]
-    fn an_unfixed_coupon_forecasts_in_indexed_mode_not_par() {
+    fn an_unfixed_coupon_forecasts_in_indexed_mode_behind_the_flag() {
         let today = Date::new(15, Month::June, 2026);
         let settings = settings_on(today);
+        settings.set_using_at_par_coupons(false);
         let index = shared(IborIndex::new(
             "foo".into(),
             Period::new(6, TimeUnit::Months),

--- a/crates/libitofin/src/indexes/iborindex.rs
+++ b/crates/libitofin/src/indexes/iborindex.rs
@@ -96,11 +96,15 @@ impl IborIndex {
     }
 
     /// The simple forward rate over `[d1, d2]` with year fraction `t`, read off
-    /// the forwarding curve (the C++ private `forecastFixing(d1, d2, t)`).
+    /// the forwarding curve (the C++ `forecastFixing(d1, d2, t)`).
     ///
-    /// Kept private, as in C++, so a caller cannot pass mismatched dates and ask
-    /// a 6-month index for a 1-year fixing.
-    fn forecast_fixing_between(&self, d1: Date, d2: Date, t: Time) -> QlResult<Rate> {
+    /// C++ keeps this overload private and declares `IborCoupon` a `friend`
+    /// (`iborindex.hpp:81`), so only the coupon may pass cached dates and no
+    /// arbitrary caller can ask a 6-month index for a 1-year fixing. The port
+    /// mirrors that trust boundary with crate visibility: reachable by
+    /// [`IborCoupon`](crate::cashflows::iborcoupon::IborCoupon)'s par/indexed
+    /// forecast, closed to the public API.
+    pub(crate) fn forecast_fixing_between(&self, d1: Date, d2: Date, t: Time) -> QlResult<Rate> {
         require!(
             !self.term_structure.is_empty(),
             "null term structure set to this instance of {}",

--- a/crates/libitofin/src/settings.rs
+++ b/crates/libitofin/src/settings.rs
@@ -51,6 +51,7 @@ pub struct Settings<D> {
     include_reference_date_events: Cell<bool>,
     include_todays_cash_flows: Cell<Option<bool>>,
     enforces_todays_historic_fixings: Cell<bool>,
+    using_at_par_coupons: Cell<bool>,
     fixing_store: RefCell<HashMap<String, BTreeMap<Date, Rate>>>,
     fixing_notifiers: RefCell<HashMap<String, Shared<Observable>>>,
 }
@@ -63,6 +64,7 @@ impl<D> Default for Settings<D> {
             include_reference_date_events: Cell::new(false),
             include_todays_cash_flows: Cell::new(None),
             enforces_todays_historic_fixings: Cell::new(false),
+            using_at_par_coupons: Cell::new(true),
             fixing_store: RefCell::new(HashMap::new()),
             fixing_notifiers: RefCell::new(HashMap::new()),
         }
@@ -154,6 +156,25 @@ impl<D> Settings<D> {
     /// consults the flag.
     pub fn set_enforces_todays_historic_fixings(&self, value: bool) {
         self.enforces_todays_historic_fixings.set(value);
+    }
+
+    /// Whether ibor coupons forecast as par coupons rather than indexed coupons.
+    ///
+    /// The explicit, per-`Settings` port of QuantLib's `IborCoupon::Settings`
+    /// singleton (`iborcoupon.hpp:110`), which D5 forbids: the mode lives here
+    /// alongside the evaluation date and the D11 fixing store rather than in
+    /// global state. The default is `true` (par), matching this tree's
+    /// compile-time default (`usingAtParCoupons_ = true`), so forecast-over-curve
+    /// oracles reproduce out of the box. The par/indexed split governs only the
+    /// forecast branch of [`IborCoupon`](crate::cashflows::iborcoupon::IborCoupon);
+    /// a determined fixing is mode-independent.
+    pub fn using_at_par_coupons(&self) -> bool {
+        self.using_at_par_coupons.get()
+    }
+
+    /// Sets the [`using_at_par_coupons`](Self::using_at_par_coupons) flag.
+    pub fn set_using_at_par_coupons(&self, value: bool) {
+        self.using_at_par_coupons.set(value);
     }
 
     /// Case-insensitive lookup key for an index name (`IndexManager` semantics).


### PR DESCRIPTION
- **feat(iborcoupon): thread par/indexed forecast switch on Settings**
- **test(cashflows): add stub coupon par forecast tests**

close #315 