### PR TITLE
feat(indexes): port OvernightIndex plus Sofr, Estr, and Currency::usd

### DIFF
--- a/crates/libitofin/src/cashflows/mod.rs
+++ b/crates/libitofin/src/cashflows/mod.rs
@@ -15,6 +15,9 @@ mod fixedrateleg;
 mod floatingratecoupon;
 mod iborcoupon;
 mod iborleg;
+mod overnightindexedcoupon;
+mod overnightindexedcouponpricer;
+mod rateaveraging;
 mod simplecashflow;
 
 pub use cashflows::CashFlows;
@@ -27,4 +30,9 @@ pub use fixedrateleg::FixedRateLeg;
 pub use floatingratecoupon::{FloatingIndex, FloatingRateCoupon};
 pub use iborcoupon::IborCoupon;
 pub use iborleg::{IborLeg, set_coupon_pricer};
+pub use overnightindexedcoupon::OvernightIndexedCoupon;
+pub use overnightindexedcouponpricer::{
+    CompoundingOvernightIndexedCouponPricer, OvernightSchedule,
+};
+pub use rateaveraging::RateAveraging;
 pub use simplecashflow::{AmortizingPayment, Redemption, SimpleCashFlow};

--- a/crates/libitofin/src/cashflows/overnightindexedcoupon.rs
+++ b/crates/libitofin/src/cashflows/overnightindexedcoupon.rs
@@ -262,3 +262,312 @@ impl Coupon for OvernightIndexedCoupon {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! Oracles from `test-suite/overnightindexedcoupon.cpp`, the six cases that
+    //! build a plain compounding SOFR coupon: `testPastCouponRate`,
+    //! `testPastSpreadedCouponRate`, `testCurrentCouponRate`,
+    //! `testFutureCouponRate`, `testRateWhenTodayIsHoliday` and
+    //! `testAccruedAmountInThePast`. The lookback/lockout/observation-shift,
+    //! telescopic-value-date, Black cap/floor and `OvernightLeg` cases exercise
+    //! surfaces this ticket does not port.
+    //!
+    //! The fixture pre-loads the C++ `CommonVars` history (the SOFR fixings at
+    //! `overnightindexedcoupon.cpp:95-140`) on the default evaluation date of
+    //! 23 November 2021.
+
+    use super::*;
+    use crate::handle::RelinkableHandle;
+    use crate::indexes::ibor::Sofr;
+    use crate::indexes::index::Index;
+    use crate::interestrate::Compounding;
+    use crate::settings::Settings;
+    use crate::shared::shared;
+    use crate::termstructures::yields::FlatForward;
+    use crate::termstructures::yieldtermstructure::YieldTermStructure;
+    use crate::time::date::Month::{August, December, January, July, June, November, October};
+    use crate::time::daycounters::actual360::Actual360;
+    use crate::time::frequency::Frequency;
+
+    const NOTIONAL: Real = 10000.0;
+
+    /// The C++ `CommonVars`: an evaluation date, a SOFR index over a relinkable
+    /// forecast curve, and the pre-loaded fixing history. The handle is returned
+    /// so a test can link a forecast curve after construction.
+    fn common_vars(
+        today: Date,
+    ) -> (
+        Shared<Settings<Date>>,
+        RelinkableHandle<dyn YieldTermStructure>,
+        Shared<OvernightIndex>,
+    ) {
+        let settings = shared(Settings::<Date>::new());
+        settings.set_evaluation_date(today);
+        let curve: RelinkableHandle<dyn YieldTermStructure> = RelinkableHandle::empty();
+        let sofr = shared(Sofr::new(curve.handle(), settings.clone()));
+
+        let past_dates = [
+            Date::new(21, June, 2019),
+            Date::new(24, June, 2019),
+            Date::new(25, June, 2019),
+            Date::new(26, June, 2019),
+            Date::new(27, June, 2019),
+            Date::new(28, June, 2019),
+            Date::new(1, July, 2019),
+            Date::new(2, July, 2019),
+            Date::new(3, July, 2019),
+            Date::new(5, July, 2019),
+            Date::new(8, July, 2019),
+            Date::new(9, July, 2019),
+            Date::new(10, July, 2019),
+            Date::new(11, July, 2019),
+            Date::new(12, July, 2019),
+            Date::new(15, July, 2019),
+            Date::new(16, July, 2019),
+            Date::new(17, July, 2019),
+            Date::new(18, July, 2019),
+            Date::new(19, July, 2019),
+            Date::new(22, July, 2019),
+            Date::new(23, July, 2019),
+            Date::new(24, July, 2019),
+            Date::new(25, July, 2019),
+            Date::new(26, July, 2019),
+            Date::new(29, July, 2019),
+            Date::new(30, July, 2019),
+            Date::new(31, July, 2019),
+            Date::new(1, August, 2019),
+            Date::new(2, August, 2019),
+            Date::new(5, August, 2019),
+            Date::new(18, October, 2021),
+            Date::new(19, October, 2021),
+            Date::new(20, October, 2021),
+            Date::new(21, October, 2021),
+            Date::new(22, October, 2021),
+            Date::new(25, October, 2021),
+            Date::new(26, October, 2021),
+            Date::new(27, October, 2021),
+            Date::new(28, October, 2021),
+            Date::new(29, October, 2021),
+            Date::new(1, November, 2021),
+            Date::new(2, November, 2021),
+            Date::new(3, November, 2021),
+            Date::new(4, November, 2021),
+            Date::new(5, November, 2021),
+            Date::new(8, November, 2021),
+            Date::new(9, November, 2021),
+            Date::new(10, November, 2021),
+            Date::new(12, November, 2021),
+            Date::new(15, November, 2021),
+            Date::new(16, November, 2021),
+            Date::new(17, November, 2021),
+            Date::new(18, November, 2021),
+            Date::new(19, November, 2021),
+            Date::new(22, November, 2021),
+        ];
+        let past_rates = [
+            0.0237, 0.0239, 0.0241, 0.0243, 0.0242, 0.025, 0.0242, 0.0251, 0.0256, 0.0259, 0.0248,
+            0.0245, 0.0246, 0.0241, 0.0236, 0.0246, 0.0247, 0.0247, 0.0246, 0.0241, 0.024, 0.024,
+            0.0241, 0.0242, 0.0241, 0.024, 0.0239, 0.0255, 0.0219, 0.0219, 0.0213, 0.0008, 0.0009,
+            0.0008, 0.0010, 0.0012, 0.0011, 0.0013, 0.0012, 0.0012, 0.0008, 0.0009, 0.0010, 0.0011,
+            0.0014, 0.0013, 0.0011, 0.0009, 0.0008, 0.0007, 0.0008, 0.0008, 0.0007, 0.0009, 0.0010,
+            0.0009,
+        ];
+        sofr.add_fixings(past_dates.into_iter().zip(past_rates))
+            .unwrap();
+
+        (settings, curve, sofr)
+    }
+
+    /// The C++ `flatRate(rate, Actual360())`: a flat continuously-compounded
+    /// forward curve anchored at the evaluation date.
+    fn flat_rate(reference: Date, rate: Rate) -> Shared<dyn YieldTermStructure> {
+        shared(FlatForward::with_rate(
+            reference,
+            rate,
+            Actual360::new(),
+            Compounding::Continuous,
+            Frequency::Annual,
+        )) as Shared<dyn YieldTermStructure>
+    }
+
+    /// The C++ `CommonVars::makeCoupon`: a plain compounding SOFR coupon paid on
+    /// its accrual end.
+    fn make_coupon(sofr: Shared<OvernightIndex>, start: Date, end: Date) -> OvernightIndexedCoupon {
+        OvernightIndexedCoupon::new(
+            end,
+            NOTIONAL,
+            start,
+            end,
+            sofr,
+            1.0,
+            0.0,
+            None,
+            None,
+            None,
+            RateAveraging::Compound,
+            false,
+            None,
+        )
+        .unwrap()
+    }
+
+    /// The C++ `CommonVars::makeSpreadedCoupon`.
+    fn make_spreaded_coupon(
+        sofr: Shared<OvernightIndex>,
+        start: Date,
+        end: Date,
+        spread: Spread,
+        compound_spread_daily: bool,
+    ) -> OvernightIndexedCoupon {
+        OvernightIndexedCoupon::new(
+            end,
+            NOTIONAL,
+            start,
+            end,
+            sofr,
+            1.0,
+            spread,
+            None,
+            None,
+            None,
+            RateAveraging::Compound,
+            compound_spread_daily,
+            None,
+        )
+        .unwrap()
+    }
+
+    /// `testPastCouponRate` (overnightindexedcoupon.cpp:339): a coupon entirely
+    /// in the past compounds its recorded fixings to 0.000987136104, and its
+    /// amount is `notional * rate * 31/360`.
+    #[test]
+    fn a_past_coupon_compounds_its_recorded_fixings() {
+        let (_settings, _curve, sofr) = common_vars(Date::new(23, November, 2021));
+        let coupon = make_coupon(
+            sofr,
+            Date::new(18, October, 2021),
+            Date::new(18, November, 2021),
+        );
+
+        let expected_rate = 0.000987136104;
+        assert!((coupon.rate().unwrap() - expected_rate).abs() < 1e-12);
+
+        let expected_amount = NOTIONAL * expected_rate * 31.0 / 360.0;
+        assert!((coupon.amount().unwrap() - expected_amount).abs() < 1e-8);
+    }
+
+    /// `testPastSpreadedCouponRate` (:356): the spread compounded daily gives
+    /// 0.0010871445057780704; added after compounding, 0.0010871361040194164.
+    #[test]
+    fn a_past_spreaded_coupon_prices_both_spread_modes() {
+        let (_settings, _curve, sofr) = common_vars(Date::new(23, November, 2021));
+
+        let compounded_daily = make_spreaded_coupon(
+            sofr.clone(),
+            Date::new(18, October, 2021),
+            Date::new(18, November, 2021),
+            0.0001,
+            true,
+        );
+        let expected_rate = 0.0010871445057780704;
+        assert!((compounded_daily.rate().unwrap() - expected_rate).abs() < 1e-12);
+        let expected_amount = NOTIONAL * expected_rate * 31.0 / 360.0;
+        assert!((compounded_daily.amount().unwrap() - expected_amount).abs() < 1e-8);
+
+        let added_after = make_spreaded_coupon(
+            sofr,
+            Date::new(18, October, 2021),
+            Date::new(18, November, 2021),
+            0.0001,
+            false,
+        );
+        assert!((added_after.rate().unwrap() - 0.0010871361040194164).abs() < 1e-12);
+    }
+
+    /// `testCurrentCouponRate` (:379): a coupon spanning today forecasts today's
+    /// missing fixing (0.000926701551), then reads it once recorded
+    /// (0.000916700760). This is the D11 today-border fallthrough.
+    #[test]
+    fn a_current_coupon_forecasts_then_reads_todays_fixing() {
+        let (settings, curve, sofr) = common_vars(Date::new(23, November, 2021));
+        curve.link_to(flat_rate(settings.evaluation_date().unwrap(), 0.0010));
+
+        let coupon = make_coupon(
+            sofr.clone(),
+            Date::new(10, November, 2021),
+            Date::new(10, December, 2021),
+        );
+
+        let expected_rate = 0.000926701551;
+        assert!((coupon.rate().unwrap() - expected_rate).abs() < 1e-12);
+        let expected_amount = NOTIONAL * expected_rate * 30.0 / 360.0;
+        assert!((coupon.amount().unwrap() - expected_amount).abs() < 1e-8);
+
+        sofr.add_fixing(Date::new(23, November, 2021), 0.0007)
+            .unwrap();
+
+        let expected_rate = 0.000916700760;
+        assert!((coupon.rate().unwrap() - expected_rate).abs() < 1e-12);
+        let expected_amount = NOTIONAL * expected_rate * 30.0 / 360.0;
+        assert!((coupon.amount().unwrap() - expected_amount).abs() < 1e-8);
+    }
+
+    /// `testFutureCouponRate` (:406): a coupon entirely in the future forecasts
+    /// every fixing off the flat curve to 0.001000043057.
+    #[test]
+    fn a_future_coupon_forecasts_every_fixing() {
+        let (settings, curve, sofr) = common_vars(Date::new(23, November, 2021));
+        curve.link_to(flat_rate(settings.evaluation_date().unwrap(), 0.0010));
+
+        let coupon = make_coupon(
+            sofr,
+            Date::new(10, December, 2021),
+            Date::new(10, January, 2022),
+        );
+
+        let expected_rate = 0.001000043057;
+        assert!((coupon.rate().unwrap() - expected_rate).abs() < 1e-12);
+        let expected_amount = NOTIONAL * expected_rate * 31.0 / 360.0;
+        assert!((coupon.amount().unwrap() - expected_amount).abs() < 1e-8);
+    }
+
+    /// `testRateWhenTodayIsHoliday` (:424): with the evaluation date on a
+    /// weekend, the coupon spanning it prices to 0.000930035180.
+    #[test]
+    fn a_coupon_prices_when_today_is_a_holiday() {
+        let (settings, curve, sofr) = common_vars(Date::new(23, November, 2021));
+        settings.set_evaluation_date(Date::new(20, November, 2021));
+        curve.link_to(flat_rate(Date::new(20, November, 2021), 0.0010));
+
+        let coupon = make_coupon(
+            sofr,
+            Date::new(10, November, 2021),
+            Date::new(10, December, 2021),
+        );
+
+        let expected_rate = 0.000930035180;
+        assert!((coupon.rate().unwrap() - expected_rate).abs() < 1e-12);
+        let expected_amount = NOTIONAL * expected_rate * 30.0 / 360.0;
+        assert!((coupon.amount().unwrap() - expected_amount).abs() < 1e-8);
+    }
+
+    /// `testAccruedAmountInThePast` (:442): the accrued amount at an interior
+    /// past date compounds only up to that date - here reproducing the
+    /// 18-Oct-to-18-Nov past-coupon rate over `notional * rate * 31/360`.
+    #[test]
+    fn accrued_amount_in_the_past_compounds_up_to_the_date() {
+        let (_settings, _curve, sofr) = common_vars(Date::new(23, November, 2021));
+        let coupon = make_coupon(
+            sofr,
+            Date::new(18, October, 2021),
+            Date::new(18, January, 2022),
+        );
+
+        let expected_amount = NOTIONAL * 0.000987136104 * 31.0 / 360.0;
+        let accrued = coupon
+            .accrued_amount(Date::new(18, November, 2021))
+            .unwrap();
+        assert!((accrued - expected_amount).abs() < 1e-8);
+    }
+}

--- a/crates/libitofin/src/cashflows/overnightindexedcoupon.rs
+++ b/crates/libitofin/src/cashflows/overnightindexedcoupon.rs
@@ -1,0 +1,264 @@
+//! The daily-compounding overnight coupon.
+//!
+//! Port of `ql/cashflows/overnightindexedcoupon.{hpp,cpp}`. An
+//! [`OvernightIndexedCoupon`] is a [`FloatingRateCoupon`] on a concrete
+//! [`OvernightIndex`] that pays the daily overnight fixings compounded over the
+//! accrual period. Unlike [`IborCoupon`], whose caller attaches a pricer, this
+//! coupon's constructor builds and installs its own
+//! [`CompoundingOvernightIndexedCouponPricer`] (mirroring
+//! `overnightindexedcoupon.cpp:181-193`, where the constructor switches on the
+//! averaging method and calls `setPricer` itself). No caller ever attaches one.
+//!
+//! [`IborCoupon`]: super::iborcoupon::IborCoupon
+//!
+//! ## The rate-computation schedule
+//!
+//! The constructor builds the coupon's value/interest/fixing date schedule and
+//! daily accrual fractions once, into a [`Shared`] [`OvernightSchedule`] held by
+//! both the coupon (for its inspectors) and the pricer (for the compounding
+//! loop). See [`OvernightSchedule::new`].
+//!
+//! ## The dispatch trap
+//!
+//! C++ overrides `amount()` and `accruedAmount()` and gets the compounded rate
+//! back through the virtual `rate()`. The Rust port embeds a
+//! [`FloatingRateCoupon`] rather than inheriting one, so a base method cannot
+//! dispatch back down: [`amount`](Coupon::amount) and
+//! [`accrued_amount`](Coupon::accrued_amount) are re-routed explicitly.
+//! [`accrued_amount`](Coupon::accrued_amount) in particular reads
+//! [`average_rate`](Self::average_rate) - the rate compounded only up to the
+//! given date - not the full-period [`rate`](Coupon::rate).
+//!
+//! ## Divergences from QuantLib
+//!
+//! Only [`RateAveraging::Compound`](super::rateaveraging::RateAveraging::Compound),
+//! the default, is ported; a simple-averaged coupon is refused at construction.
+//! The constructor knobs `lookbackDays`, `lockoutDays`, `applyObservationShift`,
+//! `telescopicValueDates`, `rateComputationStartDate`/`rateComputationEndDate`
+//! and `roundingPrecision` are not ported at all - they are omitted from the
+//! signature rather than accepted and ignored, so the schedule always follows
+//! the default path (fixing days from the index, no lockout, no observation
+//! shift). The `amount()` rounding those knobs would drive is likewise omitted.
+//! `CappedFlooredOvernightIndexedCoupon`, `OvernightLeg` and the
+//! arithmetic-averaging pricer are separate later tickets.
+
+use super::coupon::{Coupon, CouponBase};
+use super::couponpricer::FloatingRateCouponPricer;
+use super::floatingratecoupon::FloatingRateCoupon;
+use super::overnightindexedcouponpricer::{
+    CompoundingOvernightIndexedCouponPricer, OvernightSchedule,
+};
+use super::rateaveraging::RateAveraging;
+use crate::errors::QlResult;
+use crate::indexes::iborindex::OvernightIndex;
+use crate::indexes::index::Index;
+use crate::patterns::observable::{AsObservable, Observable};
+use crate::require;
+use crate::shared::{Shared, SharedMut, shared, shared_mut};
+use crate::time::businessdayconvention::BusinessDayConvention;
+use crate::time::date::Date;
+use crate::time::daycounter::DayCounter;
+use crate::types::{Rate, Real, Spread, Time};
+
+/// A coupon paying the compounded daily overnight rate
+/// (`ql/cashflows/overnightindexedcoupon.hpp`).
+///
+/// Built with [`new`](Self::new), which installs its own compounding pricer. Its
+/// [`Coupon`] (and hence [`CashFlow`]) face delegates its dates to the embedded
+/// [`FloatingRateCoupon`] and re-routes the rate-bearing methods through the
+/// pricer.
+///
+/// [`CashFlow`]: crate::cashflow::CashFlow
+pub struct OvernightIndexedCoupon {
+    base: FloatingRateCoupon,
+    overnight_index: Shared<OvernightIndex>,
+    schedule: Shared<OvernightSchedule>,
+    averaging_method: RateAveraging,
+    compound_spread_daily: bool,
+    pricer: SharedMut<CompoundingOvernightIndexedCouponPricer>,
+}
+
+impl OvernightIndexedCoupon {
+    /// Builds an overnight coupon over `index`, installing its compounding
+    /// pricer.
+    ///
+    /// Mirrors the C++ constructor: it composes a [`FloatingRateCoupon`] over the
+    /// index (fixing days taken from the index, never in arrears), builds the
+    /// rate-computation schedule, and - switching on `averaging_method` - builds
+    /// and installs a [`CompoundingOvernightIndexedCouponPricer`]. A `None`
+    /// `day_counter` defaults to the index's, as in the base; a null gearing is
+    /// rejected there. Only [`RateAveraging::Compound`] is supported.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        payment_date: Date,
+        nominal: Real,
+        start_date: Date,
+        end_date: Date,
+        index: Shared<OvernightIndex>,
+        gearing: Real,
+        spread: Spread,
+        ref_period_start: Option<Date>,
+        ref_period_end: Option<Date>,
+        day_counter: Option<DayCounter>,
+        averaging_method: RateAveraging,
+        compound_spread_daily: bool,
+        ex_coupon_date: Option<Date>,
+    ) -> QlResult<OvernightIndexedCoupon> {
+        require!(start_date < end_date, "startDate must be less than endDate");
+        require!(
+            payment_date >= end_date,
+            "Payment date cannot be earlier than accrual end date"
+        );
+        require!(
+            averaging_method == RateAveraging::Compound,
+            "simple-averaged overnight coupon not ported: only compound averaging"
+        );
+
+        let schedule = shared(OvernightSchedule::new(&index, start_date, end_date)?);
+
+        let base = FloatingRateCoupon::new(
+            payment_date,
+            nominal,
+            start_date,
+            end_date,
+            None,
+            index.clone(),
+            gearing,
+            spread,
+            ref_period_start,
+            ref_period_end,
+            day_counter,
+            false,
+            ex_coupon_date,
+            BusinessDayConvention::Preceding,
+        )?;
+
+        let pricer = shared_mut(CompoundingOvernightIndexedCouponPricer::new(
+            index.clone(),
+            schedule.clone(),
+            gearing,
+            spread,
+            compound_spread_daily,
+        ));
+        base.set_pricer(pricer.clone() as SharedMut<dyn FloatingRateCouponPricer>);
+
+        Ok(OvernightIndexedCoupon {
+            base,
+            overnight_index: index,
+            schedule,
+            averaging_method,
+            compound_spread_daily,
+            pricer,
+        })
+    }
+
+    /// The concrete overnight index (`index()`).
+    pub fn overnight_index(&self) -> &Shared<OvernightIndex> {
+        &self.overnight_index
+    }
+
+    /// The fixing dates for the rates to be compounded (`fixingDates`).
+    pub fn fixing_dates(&self) -> &[Date] {
+        &self.schedule.fixing_dates
+    }
+
+    /// The value dates for the rates to be compounded (`valueDates`).
+    pub fn value_dates(&self) -> &[Date] {
+        &self.schedule.value_dates
+    }
+
+    /// The interest dates for the rates to be compounded (`interestDates`).
+    pub fn interest_dates(&self) -> &[Date] {
+        &self.schedule.interest_dates
+    }
+
+    /// The daily accrual (compounding) periods (`dt`).
+    pub fn dt(&self) -> &[Time] {
+        &self.schedule.dt
+    }
+
+    /// The averaging method (always [`RateAveraging::Compound`] here).
+    pub fn averaging_method(&self) -> RateAveraging {
+        self.averaging_method
+    }
+
+    /// Whether the spread is compounded daily or added after compounding
+    /// (`compoundSpreadDaily`).
+    pub fn compound_spread_daily(&self) -> bool {
+        self.compound_spread_daily
+    }
+
+    /// The date the coupon is fully determined: the last fixing date
+    /// (`fixingDate`, overriding the base).
+    pub fn fixing_date(&self) -> Date {
+        *self
+            .schedule
+            .fixing_dates
+            .last()
+            .expect("an overnight schedule always has at least one fixing date")
+    }
+
+    /// The fixings to be compounded, one per fixing date (`indexFixings`): each
+    /// read through the index's own decision tree (past, today's border case, or
+    /// forecast).
+    pub fn index_fixings(&self) -> QlResult<Vec<Rate>> {
+        self.schedule
+            .fixing_dates
+            .iter()
+            .map(|&date| self.overnight_index.fixing(date, false))
+            .collect()
+    }
+
+    /// The spread reproducing the coupon amount as
+    /// `gearing * effectiveIndexFixing + effectiveSpread` (`effectiveSpread`).
+    pub fn effective_spread(&self) -> QlResult<Spread> {
+        self.pricer.borrow().effective_spread()
+    }
+
+    /// The index fixing reproducing the coupon amount alongside
+    /// [`effective_spread`](Self::effective_spread) (`effectiveIndexFixing`).
+    pub fn effective_index_fixing(&self) -> QlResult<Rate> {
+        self.pricer.borrow().effective_index_fixing()
+    }
+
+    /// The rate compounded only up to `date` (`averageRate`, private in C++):
+    /// the rate that [`accrued_amount`](Coupon::accrued_amount) accrues at.
+    fn average_rate(&self, date: Date) -> QlResult<Rate> {
+        self.pricer.borrow().average_rate(date)
+    }
+}
+
+impl AsObservable for OvernightIndexedCoupon {
+    fn observable(&self) -> &Observable {
+        self.base.observable()
+    }
+}
+
+impl Coupon for OvernightIndexedCoupon {
+    fn coupon_base(&self) -> &CouponBase {
+        self.base.coupon_base()
+    }
+
+    fn amount(&self) -> QlResult<Real> {
+        Ok(self.rate()? * self.accrual_period() * self.nominal())
+    }
+
+    fn rate(&self) -> QlResult<Rate> {
+        self.base.rate()
+    }
+
+    fn day_counter(&self) -> DayCounter {
+        self.base.day_counter()
+    }
+
+    fn accrued_amount(&self, date: Date) -> QlResult<Real> {
+        if date <= self.accrual_start_date() || date > self.coupon_base().payment_date() {
+            Ok(0.0)
+        } else if self.trades_ex_coupon_on(date) {
+            Ok(self.nominal() * self.average_rate(date)? * self.accrued_period(date))
+        } else {
+            let capped = date.min(self.accrual_end_date());
+            Ok(self.nominal() * self.average_rate(capped)? * self.accrued_period(date))
+        }
+    }
+}

--- a/crates/libitofin/src/cashflows/overnightindexedcouponpricer.rs
+++ b/crates/libitofin/src/cashflows/overnightindexedcouponpricer.rs
@@ -317,3 +317,72 @@ impl FloatingRateCouponPricer for CompoundingOvernightIndexedCouponPricer {
         fail!("floorlet rate not ported: overnight cap/floor slice")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::handle::Handle;
+    use crate::indexes::ibor::Sofr;
+    use crate::settings::Settings;
+    use crate::shared::{shared, shared_mut};
+    use crate::time::date::Month;
+
+    fn sofr() -> Shared<OvernightIndex> {
+        let settings = shared(Settings::<Date>::new());
+        settings.set_evaluation_date(Date::new(23, Month::November, 2021));
+        shared(Sofr::new(Handle::empty(), settings))
+    }
+
+    fn schedule(index: &OvernightIndex) -> Shared<OvernightSchedule> {
+        shared(
+            OvernightSchedule::new(
+                index,
+                Date::new(18, Month::October, 2021),
+                Date::new(18, Month::November, 2021),
+            )
+            .unwrap(),
+        )
+    }
+
+    /// `OvernightSchedule::new` (overnightindexedcoupon.cpp:92-179, default path):
+    /// one more value date than fixing date, the true accrual start and end pinned
+    /// at the interest-date ends, and one accrual fraction per fixing.
+    #[test]
+    fn the_schedule_has_consistent_lengths_and_endpoints() {
+        let index = sofr();
+        let start = Date::new(18, Month::October, 2021);
+        let end = Date::new(18, Month::November, 2021);
+        let schedule = OvernightSchedule::new(&index, start, end).unwrap();
+
+        assert!(schedule.value_dates.len() >= 2);
+        assert_eq!(schedule.fixing_dates.len(), schedule.value_dates.len() - 1);
+        assert_eq!(schedule.dt.len(), schedule.fixing_dates.len());
+        assert_eq!(schedule.interest_dates.len(), schedule.value_dates.len());
+        assert_eq!(*schedule.interest_dates.first().unwrap(), start);
+        assert_eq!(*schedule.interest_dates.last().unwrap(), end);
+    }
+
+    /// A start date after the end date has no business days between: a degenerate
+    /// schedule is refused.
+    #[test]
+    fn a_degenerate_schedule_is_refused() {
+        let index = sofr();
+        let day = Date::new(18, Month::October, 2021);
+        assert!(OvernightSchedule::new(&index, day, day).is_err());
+    }
+
+    /// The compounding pricer prices only the swaplet path; the caplet, floorlet
+    /// and per-fixing entry points refuse (the cap/floor slice is not ported).
+    #[test]
+    fn the_pricer_refuses_the_unported_entry_points() {
+        let index = sofr();
+        let schedule = schedule(&index);
+        let pricer = shared_mut(CompoundingOvernightIndexedCouponPricer::new(
+            index, schedule, 1.0, 0.0, false,
+        ));
+        let pricer = pricer.borrow();
+        assert!(pricer.caplet_rate(0.03).is_err());
+        assert!(pricer.floorlet_rate(0.01).is_err());
+        assert!(pricer.swaplet_rate_for(Ok(0.01)).is_err());
+    }
+}

--- a/crates/libitofin/src/cashflows/overnightindexedcouponpricer.rs
+++ b/crates/libitofin/src/cashflows/overnightindexedcouponpricer.rs
@@ -1,0 +1,319 @@
+//! The compounding pricer for an overnight-indexed coupon.
+//!
+//! Port of `ql/cashflows/overnightindexedcouponpricer.{hpp,cpp}`, the
+//! [`CompoundingOvernightIndexedCouponPricer`]. It compounds the daily overnight
+//! fixings of an [`OvernightIndexedCoupon`] over the coupon's value-date
+//! schedule (the [`OvernightSchedule`] this module also builds).
+//!
+//! ## The schedule
+//!
+//! [`OvernightSchedule`] is the coupon's rate-computation data
+//! (`overnightindexedcoupon.cpp:92-179`): the value dates (business days
+//! spanning the accrual, front-adjusted `Preceding` and back-adjusted
+//! `Following`), the interest dates (the value dates with the true accrual start
+//! and end pinned at the ends), the fixing dates (each period's value date, the
+//! last excluded), and the daily accrual fractions `dt`. Both the coupon and its
+//! pricer hold the one shared schedule.
+//!
+//! ## The bulk fixing read and the today border case (D11)
+//!
+//! `overnightindexedcouponpricer.cpp:96` bulk-reads `index->timeSeries()` and
+//! indexes it directly, never calling `index->fixing(d)` for the already-fixed
+//! part - so `enforcesTodaysHistoricFixings` (consulted only inside
+//! `InterestRateIndex::fixing`) never applies inside the compounding loop. The
+//! port reads each past fixing through [`Index::past_fixing`], the raw store read
+//! that returns `None` on a miss (never enforcing, never forecasting). A past
+//! fixing that is missing is an error; today's, when missing, deliberately falls
+//! through to the forecast (`overnightindexedcouponpricer.cpp:141-156`) - which
+//! is what pins `testCurrentCouponRate`. Only the forward part forecasts, through
+//! [`Index::fixing`].
+//!
+//! ## Telescoping
+//!
+//! `canApplyTelescopicFormula()` is true on the default path, so C++ replaces the
+//! interior forward product with a discount ratio
+//! (`overnightindexedcouponpricer.cpp:176-197`). Telescoping is an algebraic
+//! identity - the interior daily forward growth factors multiply to exactly that
+//! ratio - so the port compounds the forward part as a plain product and
+//! reproduces the same rate without reading discount factors directly.
+//!
+//! ## Divergences from QuantLib
+//!
+//! `swapletPrice`/`capletPrice`/`floorletPrice` and the caplet/floorlet rates
+//! all `QL_FAIL` in C++ for this pricer; the port keeps only the ported surface
+//! ([`swaplet_rate`](FloatingRateCouponPricer::swaplet_rate) and the concrete
+//! [`average_rate`](Self::average_rate) / [`effective_spread`](Self::effective_spread)
+//! / [`effective_index_fixing`](Self::effective_index_fixing)) and refuses the
+//! rest. The `OvernightIndexedCouponPricer` base (its optionlet-volatility
+//! members and the arithmetic-averaging pricer) is not ported; see the module
+//! doc of [`overnightindexedcoupon`](super::overnightindexedcoupon).
+
+use super::couponpricer::FloatingRateCouponPricer;
+use super::floatingratecoupon::FloatingRateCoupon;
+use crate::errors::QlResult;
+use crate::indexes::iborindex::OvernightIndex;
+use crate::indexes::index::Index;
+use crate::indexes::interestrateindex::InterestRateIndex;
+use crate::patterns::observable::{AsObservable, Observable};
+use crate::shared::Shared;
+use crate::time::businessdayconvention::BusinessDayConvention;
+use crate::time::date::Date;
+use crate::types::{Rate, Real, Spread, Time};
+use crate::{fail, require};
+
+/// The value-date schedule an [`OvernightIndexedCoupon`] compounds over.
+///
+/// Built by [`new`](Self::new) from the accrual `[start, end]` and the index's
+/// fixing calendar and day counter. Held behind a [`Shared`] by both the coupon
+/// (for its inspectors) and the pricer (for the compounding loop).
+///
+/// [`OvernightIndexedCoupon`]: super::overnightindexedcoupon::OvernightIndexedCoupon
+pub struct OvernightSchedule {
+    /// Value dates for the rates to be compounded (`valueDates_`).
+    pub(crate) value_dates: Vec<Date>,
+    /// Interest dates: the value dates with the accrual start/end pinned at the
+    /// ends (`interestDates_`).
+    pub(crate) interest_dates: Vec<Date>,
+    /// Fixing dates for the rates to be compounded (`fixingDates_`).
+    pub(crate) fixing_dates: Vec<Date>,
+    /// Daily accrual (compounding) periods (`dt_`).
+    pub(crate) dt: Vec<Time>,
+}
+
+impl OvernightSchedule {
+    /// Builds the schedule over `[start_date, end_date]` on `index`'s fixing
+    /// calendar (`overnightindexedcoupon.cpp:92-179`, the default path).
+    ///
+    /// The value dates are the business days from the `Preceding`-adjusted start
+    /// to the `Following`-adjusted end; the interest dates copy them with the
+    /// true accrual start and end pinned at the ends; the fixing dates are each
+    /// period's value date (the last value date has no fixing, as the index's
+    /// fixing days are zero); and each `dt` is the index day counter's fraction
+    /// between successive interest dates. Lookback, lockout, observation shift,
+    /// and telescopic value-date optimisation are not ported (see the coupon
+    /// module doc).
+    pub(crate) fn new(
+        index: &OvernightIndex,
+        start_date: Date,
+        end_date: Date,
+    ) -> QlResult<OvernightSchedule> {
+        let fixing_calendar = index.fixing_calendar();
+        let value_dates = fixing_calendar.business_day_list(
+            fixing_calendar.adjust(start_date, BusinessDayConvention::Preceding),
+            fixing_calendar.adjust(end_date, BusinessDayConvention::Following),
+        );
+        require!(value_dates.len() >= 2, "degenerate schedule");
+        let n = value_dates.len() - 1;
+
+        let mut interest_dates = value_dates.clone();
+        interest_dates[0] = start_date;
+        interest_dates[n] = end_date;
+
+        let fixing_dates = value_dates[..n].to_vec();
+
+        let day_counter = index.day_counter();
+        let dt = (0..n)
+            .map(|i| day_counter.year_fraction(interest_dates[i], interest_dates[i + 1]))
+            .collect();
+
+        Ok(OvernightSchedule {
+            value_dates,
+            interest_dates,
+            fixing_dates,
+            dt,
+        })
+    }
+
+    /// The accrual end (last interest date), the date the swaplet rate is
+    /// compounded to.
+    fn accrual_end(&self) -> Date {
+        *self
+            .interest_dates
+            .last()
+            .expect("an overnight schedule always has at least two interest dates")
+    }
+}
+
+/// The number of fixings whose interest date falls before `date`
+/// (`determineNumberOfFixings`): the lower bound of `date` in the interest dates
+/// excluding the last.
+fn determine_number_of_fixings(interest_dates: &[Date], date: Date) -> usize {
+    let searchable = &interest_dates[..interest_dates.len() - 1];
+    searchable.partition_point(|&d| d < date)
+}
+
+/// Prices an [`OvernightIndexedCoupon`] by daily compounding
+/// (`CompoundingOvernightIndexedCouponPricer`).
+///
+/// It captures at construction everything the compounding needs - the overnight
+/// index, the shared [`OvernightSchedule`], and the coupon's gearing, spread and
+/// spread-compounding flag - so [`swaplet_rate`](FloatingRateCouponPricer::swaplet_rate)
+/// is a pure function of those and the current evaluation date, fixing store and
+/// forwarding curve.
+///
+/// [`OvernightIndexedCoupon`]: super::overnightindexedcoupon::OvernightIndexedCoupon
+pub struct CompoundingOvernightIndexedCouponPricer {
+    index: Shared<OvernightIndex>,
+    schedule: Shared<OvernightSchedule>,
+    gearing: Real,
+    spread: Spread,
+    compound_spread_daily: bool,
+    observable: Observable,
+}
+
+impl CompoundingOvernightIndexedCouponPricer {
+    /// Builds a pricer capturing the coupon's compounding inputs.
+    pub(crate) fn new(
+        index: Shared<OvernightIndex>,
+        schedule: Shared<OvernightSchedule>,
+        gearing: Real,
+        spread: Spread,
+        compound_spread_daily: bool,
+    ) -> CompoundingOvernightIndexedCouponPricer {
+        CompoundingOvernightIndexedCouponPricer {
+            index,
+            schedule,
+            gearing,
+            spread,
+            compound_spread_daily,
+            observable: Observable::new(),
+        }
+    }
+
+    /// The compounded rate accrued up to `date` (`averageRate`): gearing and
+    /// spread folded in, the daily fixings compounded over the schedule up to
+    /// `date`.
+    pub fn average_rate(&self, date: Date) -> QlResult<Rate> {
+        Ok(self.compute(date)?.0)
+    }
+
+    /// The spread that reproduces the coupon amount as
+    /// `gearing * effectiveIndexFixing + effectiveSpread` (`effectiveSpread`):
+    /// the coupon's own spread unless it compounds daily.
+    pub fn effective_spread(&self) -> QlResult<Spread> {
+        if !self.compound_spread_daily {
+            return Ok(self.spread);
+        }
+        Ok(self.compute(self.schedule.accrual_end())?.1)
+    }
+
+    /// The index fixing that reproduces the coupon amount alongside
+    /// [`effective_spread`](Self::effective_spread) (`effectiveIndexFixing`).
+    pub fn effective_index_fixing(&self) -> QlResult<Rate> {
+        Ok(self.compute(self.schedule.accrual_end())?.2)
+    }
+
+    /// The compounded rate, effective spread and effective index fixing at
+    /// `date` (`CompoundingOvernightIndexedCouponPricer::compute`).
+    fn compute(&self, date: Date) -> QlResult<(Rate, Spread, Rate)> {
+        let index = &self.index;
+        let today = match index.settings().evaluation_date() {
+            Some(today) => today,
+            None => fail!("no evaluation date set: an overnight coupon needs a reference date"),
+        };
+        let schedule = &self.schedule;
+        let day_counter = index.day_counter();
+        let coupon_spread = self.spread;
+        let compound_spread_daily = self.compound_spread_daily;
+
+        let n = determine_number_of_fixings(&schedule.interest_dates, date);
+
+        let growth_factor = |fixing: Rate, idx: usize| -> (Real, Real) {
+            let span = if date >= schedule.interest_dates[idx + 1] {
+                schedule.dt[idx]
+            } else {
+                day_counter.year_fraction(schedule.interest_dates[idx], date)
+            };
+            let gf = 1.0 + fixing * span;
+            let gf_spread = if compound_spread_daily {
+                gf + coupon_spread * span
+            } else {
+                gf
+            };
+            (gf, gf_spread)
+        };
+
+        let mut compound_factor = 1.0;
+        let mut compound_factor_without_spread = 1.0;
+        let mut i = 0;
+
+        while i < n && schedule.fixing_dates[i] < today {
+            let fixing = match index.past_fixing(schedule.fixing_dates[i])? {
+                Some(fixing) => fixing,
+                None => fail!(
+                    "Missing {} fixing for {:?}",
+                    index.name(),
+                    schedule.fixing_dates[i]
+                ),
+            };
+            let (gf, gf_spread) = growth_factor(fixing, i);
+            compound_factor_without_spread *= gf;
+            compound_factor *= gf_spread;
+            i += 1;
+        }
+
+        if i < n
+            && schedule.fixing_dates[i] == today
+            && let Some(fixing) = index.past_fixing(schedule.fixing_dates[i])?
+        {
+            let (gf, gf_spread) = growth_factor(fixing, i);
+            compound_factor_without_spread *= gf;
+            compound_factor *= gf_spread;
+            i += 1;
+        }
+
+        while i < n {
+            let fixing = index.fixing(schedule.fixing_dates[i], false)?;
+            let (gf, gf_spread) = growth_factor(fixing, i);
+            compound_factor_without_spread *= gf;
+            compound_factor *= gf_spread;
+            i += 1;
+        }
+
+        let rate_accrual_end = date.min(schedule.interest_dates[n]);
+        let tau = day_counter.year_fraction(schedule.interest_dates[0], rate_accrual_end);
+        let rate = (compound_factor - 1.0) / tau;
+
+        let mut swaplet_rate = self.gearing * rate;
+        let effective_spread;
+        let effective_index_fixing;
+        if !compound_spread_daily {
+            swaplet_rate += coupon_spread;
+            effective_spread = coupon_spread;
+            effective_index_fixing = rate;
+        } else {
+            effective_spread = rate - (compound_factor_without_spread - 1.0) / tau;
+            effective_index_fixing = rate - effective_spread;
+        }
+
+        Ok((swaplet_rate, effective_spread, effective_index_fixing))
+    }
+}
+
+impl AsObservable for CompoundingOvernightIndexedCouponPricer {
+    fn observable(&self) -> &Observable {
+        &self.observable
+    }
+}
+
+impl FloatingRateCouponPricer for CompoundingOvernightIndexedCouponPricer {
+    fn initialize(&mut self, _coupon: &FloatingRateCoupon) {}
+
+    fn swaplet_rate(&self) -> QlResult<Rate> {
+        Ok(self.compute(self.schedule.accrual_end())?.0)
+    }
+
+    fn swaplet_rate_for(&self, _index_fixing: QlResult<Rate>) -> QlResult<Rate> {
+        fail!(
+            "swaplet_rate_for not applicable: the overnight compounding pricer reads the whole daily schedule"
+        )
+    }
+
+    fn caplet_rate(&self, _effective_cap: Rate) -> QlResult<Rate> {
+        fail!("caplet rate not ported: overnight cap/floor slice")
+    }
+
+    fn floorlet_rate(&self, _effective_floor: Rate) -> QlResult<Rate> {
+        fail!("floorlet rate not ported: overnight cap/floor slice")
+    }
+}

--- a/crates/libitofin/src/cashflows/rateaveraging.rs
+++ b/crates/libitofin/src/cashflows/rateaveraging.rs
@@ -1,0 +1,14 @@
+//! Overnight-rate averaging conventions.
+//!
+//! Port of `ql/cashflows/rateaveraging.hpp`. An overnight coupon either
+//! compounds its daily fixings ([`Compound`](RateAveraging::Compound), the
+//! default) or averages them arithmetically ([`Simple`](RateAveraging::Simple)).
+
+/// How the daily overnight fixings of a coupon are combined.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum RateAveraging {
+    /// Arithmetic average of the daily fixings.
+    Simple,
+    /// Daily compounding of the fixings (the coupon default).
+    Compound,
+}


### PR DESCRIPTION
- **feat(cashflows): port OvernightIndexedCoupon and its compounding pricer (#328)**
- **test(cashflows): oracle the overnight coupon and its compounding pricer (#328)**

close #328 
