### PR TITLE
docs(graphify): document post-commit hook and refresh port map

### DIFF
--- a/graphify/COVERAGE.md
+++ b/graphify/COVERAGE.md
@@ -1,6 +1,6 @@
 # QuantLib -> libitofin port coverage
 
-Generated 2026-07-13 from `port_map.json`.
+Generated 2026-07-14 from `port_map.json`.
 
 > **This is a hypothesis layer, not an audit.** Every mapping below comes from matching *names*
 > and *paths* between the two trees - never from reading behaviour. It tells you which file to
@@ -14,28 +14,28 @@ Generated 2026-07-13 from `port_map.json`.
 | --- | ---: | ---: | ---: |
 | experimental | 225 | 1 | 0% |
 | math | 167 | 50 | 30% |
-| pricingengines | 156 | 4 | 3% |
+| pricingengines | 156 | 5 | 3% |
 | methods | 138 | 1 | 1% |
 | models | 138 | 0 | 0% |
 | termstructures | 122 | 18 | 15% |
-| instruments | 89 | 4 | 4% |
+| instruments | 89 | 9 | 10% |
 | time | 78 | 78 | 100% |
-| indexes | 65 | 3 | 5% |
+| indexes | 65 | 5 | 8% |
 | (root) | 45 | 15 | 33% |
-| cashflows | 35 | 9 | 26% |
+| cashflows | 35 | 12 | 34% |
 | processes | 21 | 1 | 5% |
 | legacy | 15 | 0 | 0% |
 | quotes | 11 | 5 | 45% |
 | utilities | 10 | 4 | 40% |
 | currencies | 7 | 0 | 0% |
 | patterns | 5 | 3 | 60% |
-| **TOTAL** | **1327** | **196** | **15%** |
+| **TOTAL** | **1327** | **207** | **16%** |
 
 ## Map quality
 
-- Rust modules: **257** - of which **60** have no QuantLib counterpart by name (internal helpers, or a port under a different name).
-- QuantLib modules with no Rust counterpart: **1131** (the `unported` list in `port_map.json` - a candidate backlog, not a validated one).
-- Entries verified against source by a human: **1** of 257.
+- Rust modules: **269** - of which **61** have no QuantLib counterpart by name (internal helpers, or a port under a different name).
+- QuantLib modules with no Rust counterpart: **1120** (the `unported` list in `port_map.json` - a candidate backlog, not a validated one).
+- Entries verified against source by a human: **1** of 269.
 
 ## Oracle tests
 
@@ -45,9 +45,9 @@ link is coarser than the module link:
 
 | how the oracle was matched | entries | trust |
 | --- | ---: | --- |
-| `stem` / `stem-plural` (module name == test name) | 20 | good |
-| `dir-stem` (parent directory == test name) | 97 | coarse - the test file covers a whole family |
-| none found | 140 | no oracle identified; find it by hand |
+| `stem` / `stem-plural` (module name == test name) | 23 | good |
+| `dir-stem` (parent directory == test name) | 103 | coarse - the test file covers a whole family |
+| none found | 143 | no oracle identified; find it by hand |
 
 ## Known false positives this map cannot see
 

--- a/graphify/README.md
+++ b/graphify/README.md
@@ -133,29 +133,45 @@ are disposable and gitignored.
 
 ## How to update
 
-Run these from the repo root. All of it is AST-only: **no LLM, no API key, no token cost.** The
-extraction cache means only changed files are re-read.
+**Mostly you do not.** A `post-commit` hook keeps the Rust graph and the port map current
+automatically. All of it is AST-only: **no LLM, no API key, no token cost.**
 
-### After you change Rust code (the common case)
+### The automatic path (post-commit hook)
+
+Installed in `.git/hooks/post-commit`. After any commit that touches `crates/**/*.rs` it rebuilds, in
+the background, so `git commit` returns immediately:
+
+1. `build_rust.py` -> `graphify-out/` (~10s warm)
+2. `port_map.py` -> `graphify/port_map.json`
+3. `coverage.py` -> `graphify/COVERAGE.md`
+
+Log: `~/.cache/graphify-rebuild.log`. Skip once with `GRAPHIFY_SKIP_HOOK=1 git commit ...`.
+
+It stays silent on doc-only commits, during rebase/merge/cherry-pick, and in a worktree that has no
+`graphify-out/` yet (it refreshes an existing graph; it never builds one from cold).
+
+**Consequence you will notice:** the commit that triggers a rebuild does not contain the refreshed
+`port_map.json` / `COVERAGE.md` - they land in your **next** commit. That is intended; staging them
+mid-commit would fight the `prek` pre-commit hooks.
+
+> **Do NOT run `graphify hook install`.** The stock hook resolves its root from
+> `graphify-out/.graphify_root` (which is `crates/`), so it rebuilds into **`crates/graphify-out/`** -
+> a directory nothing queries - while the graph you actually query goes stale, and it never touches
+> `port_map.json` or `COVERAGE.md`. This was live in the repo and had been quietly doing it for a day.
+> The hook in `.git/hooks/post-commit` now replaces it. Same reason: do not run `graphify claude
+> install` (it overwrites the `## graphify` section of `CLAUDE.md`).
+
+### The manual path
 
 ```bash
-python graphify/scripts/build_rust.py    # ~9s warm; re-extracts only changed files
+python graphify/scripts/build_rust.py    # graph only
+python graphify/scripts/port_map.py      # re-derive the Rust <-> QuantLib mapping
+python graphify/scripts/coverage.py      # regenerate COVERAGE.md from it
 ```
-
-That is the whole loop. Do it when you have added or moved types, modules, or call sites; skip it for
-edits that do not change structure (a formula body, a test assertion).
 
 **Do not run `graphify update .` from the repo root.** It would rescan the whole repo, pull the 271
 markdown files under `.agents/` into the Rust graph, and stop it being language-pure. The scripts
 here are the supported path.
-
-### After you port a module (also update the map)
-
-```bash
-python graphify/scripts/build_rust.py
-python graphify/scripts/port_map.py      # re-derives the Rust <-> QuantLib mapping
-python graphify/scripts/coverage.py      # regenerates COVERAGE.md from it
-```
 
 ### After you verify a mapping against source
 

--- a/graphify/port_map.json
+++ b/graphify/port_map.json
@@ -114,6 +114,46 @@
       "confidence": 0.95,
       "match": "exact-path",
       "note": "",
+      "oracle": "overnightindexedcoupon",
+      "oracle_match": "stem",
+      "quantlib": "cashflows/overnightindexedcoupon",
+      "rust": "cashflows/overnightindexedcoupon",
+      "verified": false
+    },
+    {
+      "confidence": 0.95,
+      "match": "exact-path",
+      "note": "",
+      "oracle": "cashflows",
+      "oracle_match": "dir-stem",
+      "quantlib": "cashflows/overnightindexedcouponpricer",
+      "rust": "cashflows/overnightindexedcouponpricer",
+      "verified": false
+    },
+    {
+      "confidence": 0.0,
+      "match": "none",
+      "note": "no QuantLib module matched by path or stem",
+      "oracle": null,
+      "oracle_match": null,
+      "quantlib": null,
+      "rust": "cashflows/overnightleg",
+      "verified": false
+    },
+    {
+      "confidence": 0.95,
+      "match": "exact-path",
+      "note": "",
+      "oracle": "cashflows",
+      "oracle_match": "dir-stem",
+      "quantlib": "cashflows/rateaveraging",
+      "rust": "cashflows/rateaveraging",
+      "verified": false
+    },
+    {
+      "confidence": 0.95,
+      "match": "exact-path",
+      "note": "",
       "oracle": "cashflows",
       "oracle_match": "dir-stem",
       "quantlib": "cashflows/simplecashflow",
@@ -176,8 +216,28 @@
       "note": "",
       "oracle": null,
       "oracle_match": null,
+      "quantlib": "indexes/ibor/estr",
+      "rust": "indexes/ibor/estr",
+      "verified": false
+    },
+    {
+      "confidence": 0.95,
+      "match": "exact-path",
+      "note": "",
+      "oracle": null,
+      "oracle_match": null,
       "quantlib": "indexes/ibor/euribor",
       "rust": "indexes/ibor/euribor",
+      "verified": false
+    },
+    {
+      "confidence": 0.95,
+      "match": "exact-path",
+      "note": "",
+      "oracle": null,
+      "oracle_match": null,
+      "quantlib": "indexes/ibor/sofr",
+      "rust": "indexes/ibor/sofr",
       "verified": false
     },
     {
@@ -246,8 +306,38 @@
       "note": "",
       "oracle": "instruments",
       "oracle_match": "dir-stem",
+      "quantlib": "instruments/fixedvsfloatingswap",
+      "rust": "instruments/fixedvsfloatingswap",
+      "verified": false
+    },
+    {
+      "confidence": 0.95,
+      "match": "exact-path",
+      "note": "",
+      "oracle": "instruments",
+      "oracle_match": "dir-stem",
+      "quantlib": "instruments/makeois",
+      "rust": "instruments/makeois",
+      "verified": false
+    },
+    {
+      "confidence": 0.95,
+      "match": "exact-path",
+      "note": "",
+      "oracle": "instruments",
+      "oracle_match": "dir-stem",
       "quantlib": "instruments/oneassetoption",
       "rust": "instruments/oneassetoption",
+      "verified": false
+    },
+    {
+      "confidence": 0.95,
+      "match": "exact-path",
+      "note": "",
+      "oracle": "overnightindexedswap",
+      "oracle_match": "stem",
+      "quantlib": "instruments/overnightindexedswap",
+      "rust": "instruments/overnightindexedswap",
       "verified": false
     },
     {
@@ -258,6 +348,26 @@
       "oracle_match": "dir-stem",
       "quantlib": "instruments/payoffs",
       "rust": "instruments/payoffs",
+      "verified": false
+    },
+    {
+      "confidence": 0.95,
+      "match": "exact-path",
+      "note": "",
+      "oracle": "swap",
+      "oracle_match": "stem",
+      "quantlib": "instruments/swap",
+      "rust": "instruments/swap",
+      "verified": false
+    },
+    {
+      "confidence": 0.95,
+      "match": "exact-path",
+      "note": "",
+      "oracle": "instruments",
+      "oracle_match": "dir-stem",
+      "quantlib": "instruments/vanillaswap",
+      "rust": "instruments/vanillaswap",
       "verified": false
     },
     {
@@ -1451,6 +1561,16 @@
       "verified": false
     },
     {
+      "confidence": 0.95,
+      "match": "exact-path",
+      "note": "",
+      "oracle": "swap",
+      "oracle_match": "dir-stem",
+      "quantlib": "pricingengines/swap/discountingswapengine",
+      "rust": "pricingengines/swap/discountingswapengine",
+      "verified": false
+    },
+    {
       "confidence": 0.0,
       "match": "none",
       "note": "no QuantLib module matched by path or stem",
@@ -2571,7 +2691,7 @@
       "verified": false
     }
   ],
-  "generated": "2026-07-13T04:48:00.636680+00:00",
+  "generated": "2026-07-14T00:07:45.631079+00:00",
   "graphs": {
     "quantlib": "graphify-out-ql/graph.json  (query with GRAPHIFY_OUT=graphify-out-ql)",
     "rust": "graphify-out/graph.json"
@@ -2590,7 +2710,7 @@
         "modules": 45
       },
       "cashflows": {
-        "mapped": 9,
+        "mapped": 12,
         "modules": 35
       },
       "currencies": {
@@ -2602,11 +2722,11 @@
         "modules": 225
       },
       "indexes": {
-        "mapped": 3,
+        "mapped": 5,
         "modules": 65
       },
       "instruments": {
-        "mapped": 4,
+        "mapped": 9,
         "modules": 89
       },
       "legacy": {
@@ -2630,7 +2750,7 @@
         "modules": 5
       },
       "pricingengines": {
-        "mapped": 4,
+        "mapped": 5,
         "modules": 156
       },
       "processes": {
@@ -2654,11 +2774,11 @@
         "modules": 10
       }
     },
-    "mapped": 196,
+    "mapped": 207,
     "quantlib_modules": 1327,
-    "rust_modules": 257,
+    "rust_modules": 269,
     "test_suite_files": 189,
-    "unported_quantlib_modules": 1131,
+    "unported_quantlib_modules": 1120,
     "verified": 1
   },
   "unported": [
@@ -2682,10 +2802,7 @@
     "cashflows/inflationcouponpricer",
     "cashflows/lineartsrpricer",
     "cashflows/multipleresetscoupon",
-    "cashflows/overnightindexedcoupon",
-    "cashflows/overnightindexedcouponpricer",
     "cashflows/rangeaccrual",
-    "cashflows/rateaveraging",
     "cashflows/replication",
     "cashflows/timebasket",
     "cashflows/yoyinflationcoupon",
@@ -2947,7 +3064,6 @@
     "indexes/ibor/destr",
     "indexes/ibor/dkklibor",
     "indexes/ibor/eonia",
-    "indexes/ibor/estr",
     "indexes/ibor/eurlibor",
     "indexes/ibor/fedfunds",
     "indexes/ibor/gbplibor",
@@ -2965,7 +3081,6 @@
     "indexes/ibor/seklibor",
     "indexes/ibor/shibor",
     "indexes/ibor/shir",
-    "indexes/ibor/sofr",
     "indexes/ibor/sonia",
     "indexes/ibor/swestr",
     "indexes/ibor/thbfix",
@@ -3028,7 +3143,6 @@
     "instruments/doublebarriertype",
     "instruments/equitytotalreturnswap",
     "instruments/europeanoption",
-    "instruments/fixedvsfloatingswap",
     "instruments/floatfloatswap",
     "instruments/floatfloatswaption",
     "instruments/forward",
@@ -3044,7 +3158,6 @@
     "instruments/makecds",
     "instruments/makecms",
     "instruments/makemultipleresetsswap",
-    "instruments/makeois",
     "instruments/makeswaption",
     "instruments/makevanillaswap",
     "instruments/makeyoyinflationcapfloor",
@@ -3053,7 +3166,6 @@
     "instruments/multipleresetsswap",
     "instruments/nonstandardswap",
     "instruments/nonstandardswaption",
-    "instruments/overnightindexedswap",
     "instruments/overnightindexfuture",
     "instruments/partialtimebarrieroption",
     "instruments/perpetualfutures",
@@ -3065,13 +3177,11 @@
     "instruments/softbarrieroption",
     "instruments/stickyratchet",
     "instruments/stock",
-    "instruments/swap",
     "instruments/swaption",
     "instruments/twoassetbarrieroption",
     "instruments/twoassetcorrelationoption",
     "instruments/vanillaoption",
     "instruments/vanillastorageoption",
-    "instruments/vanillaswap",
     "instruments/vanillaswingoption",
     "instruments/varianceswap",
     "instruments/writerextensibleoption",
@@ -3588,7 +3698,6 @@
     "pricingengines/quanto/quantoengine",
     "pricingengines/swap/cvaswapengine",
     "pricingengines/swap/discountingconstnotionalcrosscurrencyswapengine",
-    "pricingengines/swap/discountingswapengine",
     "pricingengines/swap/discretizedswap",
     "pricingengines/swap/treeswapengine",
     "pricingengines/swaption/basketgeneratingengine",


### PR DESCRIPTION
This pull request adds a `post-commit` hook workflow to keep the Rust graph and port map current automatically, and regenerates the coverage data to reflect newly ported modules.

**Automation documentation:**
* Documented the automatic `post-commit` path that rebuilds the graph, `port_map.json`, and `COVERAGE.md` in the background after commits touching `crates/**/*.rs`.
* Clarified that refreshed artifacts land in the next commit, and added warnings against running `graphify hook install` and `graphify claude install`, which write to the wrong location and overwrite tracked files.
* Kept the manual path as a documented fallback.

**Coverage and mapping refresh:**
* Regenerated `port_map.json` and `COVERAGE.md`, raising total mapped modules from 196 to 207 (15% to 16%) and Rust modules from 257 to 269.
* Added mappings for newly ported OIS, overnight-indexed, swap, and SOFR/ESTR index modules across cashflows, indexes, instruments, and pricingengines.
