### PR TITLE
feat(pricingengines): add the Bachelier normal-model pricing pair

### DIFF
--- a/crates/libitofin/src/pricingengines/blackformula.rs
+++ b/crates/libitofin/src/pricingengines/blackformula.rs
@@ -8,9 +8,17 @@
 //! not the volatility itself, and an optional lognormal `displacement`
 //! shifting both forward and strike.
 //!
+//! The Bachelier (normal-model) pricing pair, [`bachelier_black_formula`] and
+//! its forward derivative [`bachelier_black_formula_forward_derivative`], sit
+//! beside the Black family; the optionlet volatility surface selects between
+//! the two through its volatility type. Unlike the lognormal family the normal
+//! model admits negative forwards and strikes and applies no displacement, so
+//! these two functions deliberately skip [`check_parameters`]: they validate
+//! only the standard deviation and discount, exactly as the C++ reference does.
+//!
 //! Out of scope, left as follow-ups with the quotes that need them: the
-//! implied-standard-deviation family (approximations and solvers) and the
-//! Bachelier (normal-model) family.
+//! implied-standard-deviation family (approximations and solvers), including
+//! its Bachelier variants.
 //!
 //! One deviation from the C++ reference: at `std_dev == 0` the reference's
 //! `blackFormulaAssetItmProbability` tests `forward * sign < strike * sign`,
@@ -297,6 +305,78 @@ pub fn black_formula_std_dev_second_derivative(
     let d1_prime = -(forward / strike).ln() / (std_dev * std_dev) + 0.5;
     let density = NormalDistribution::standard();
     Ok(discount * forward * density.derivative(d1) * d1_prime)
+}
+
+/// Bachelier (normal-model) value of a European option on the given forward.
+///
+/// Port of `bachelierBlackFormula` (`blackformula.cpp:705`). With
+/// `d = (forward - strike) * sign` and `h = d / std_dev`, the premium is
+/// `discount * (std_dev * phi(h) + d * Phi(h))`, where `phi`/`Phi` are the
+/// standard normal density and cumulative distribution. The normal model
+/// prices negative forwards and strikes, so only `std_dev` and `discount` are
+/// validated; the terminal non-negativity check mirrors C++'s `QL_ENSURE`.
+pub fn bachelier_black_formula(
+    option_type: OptionType,
+    strike: Real,
+    forward: Real,
+    std_dev: Real,
+    discount: Real,
+) -> QlResult<Real> {
+    check_std_dev_and_discount(std_dev, discount)?;
+
+    let sign = sign_of(option_type);
+    let d = (forward - strike) * sign;
+
+    if std_dev == 0.0 {
+        return Ok(discount * d.max(0.0));
+    }
+
+    let h = d / std_dev;
+    let phi = CumulativeNormalDistribution::standard();
+    let result = discount * (std_dev * phi.derivative(h) + d * phi.value(h));
+    if result.is_nan() || result < 0.0 {
+        fail!(
+            "negative value ({result}) for {std_dev} stdDev, {option_type} option, \
+             {strike} strike, {forward} forward"
+        );
+    }
+    Ok(result)
+}
+
+/// Derivative of [`bachelier_black_formula`] with respect to the forward.
+///
+/// Port of `bachelierBlackFormulaForwardDerivative` (`blackformula.cpp:738`),
+/// which equals `sign * Phi(h) * discount`. At `std_dev == 0` the reference
+/// collapses this to `sign * max(boost_sign((forward - strike) * sign), 0) *
+/// discount`; `boost::math::sign` yields `0` at the money, so the derivative
+/// is `0` exactly when `forward == strike` (distinct from `f64::signum`, which
+/// never returns zero).
+pub fn bachelier_black_formula_forward_derivative(
+    option_type: OptionType,
+    strike: Real,
+    forward: Real,
+    std_dev: Real,
+    discount: Real,
+) -> QlResult<Real> {
+    check_std_dev_and_discount(std_dev, discount)?;
+
+    let sign = sign_of(option_type);
+    let moneyness = (forward - strike) * sign;
+
+    if std_dev == 0.0 {
+        let boost_sign: Real = if moneyness > 0.0 {
+            1.0
+        } else if moneyness < 0.0 {
+            -1.0
+        } else {
+            0.0
+        };
+        return Ok(sign * boost_sign.max(0.0) * discount);
+    }
+
+    let h = moneyness / std_dev;
+    let phi = CumulativeNormalDistribution::standard();
+    Ok(sign * phi.value(h) * discount)
 }
 
 #[cfg(test)]
@@ -618,5 +698,142 @@ mod tests {
         assert!(black_formula(OptionType::Call, 40.0, Real::INFINITY, 0.2, 0.95, 0.0).is_err());
         assert!(black_formula(OptionType::Call, 40.0, 44.0, 0.2, Real::INFINITY, 0.0).is_err());
         assert!(black_formula(OptionType::Call, 40.0, 44.0, 0.2, 0.95, Real::INFINITY).is_err());
+    }
+
+    #[test]
+    fn bachelier_put_call_parity_is_exact() {
+        // C - P == discount * (forward - strike) for the normal model, derived from
+        // C - P = discount * [d*Phi(h) + d*(1 - Phi(h))] with d = forward - strike.
+        for (forward, strike) in [(0.03, 0.02), (0.02, 0.02), (-0.01, 0.01), (0.05, -0.02)] {
+            for std_dev in [0.001, 0.02, 0.1] {
+                let call =
+                    bachelier_black_formula(OptionType::Call, strike, forward, std_dev, 0.95)
+                        .expect("valid inputs");
+                let put = bachelier_black_formula(OptionType::Put, strike, forward, std_dev, 0.95)
+                    .expect("valid inputs");
+                assert_close(call - put, 0.95 * (forward - strike), 1e-15);
+            }
+        }
+    }
+
+    #[test]
+    fn bachelier_zero_volatility_is_discounted_intrinsic() {
+        for (forward, strike) in [(0.03, 0.02), (0.01, 0.02), (-0.02, -0.01)] {
+            let call = bachelier_black_formula(OptionType::Call, strike, forward, 0.0, 0.95)
+                .expect("valid inputs");
+            let put = bachelier_black_formula(OptionType::Put, strike, forward, 0.0, 0.95)
+                .expect("valid inputs");
+            assert_close(call, 0.95 * (forward - strike).max(0.0), 0.0);
+            assert_close(put, 0.95 * (strike - forward).max(0.0), 0.0);
+        }
+    }
+
+    #[test]
+    fn bachelier_at_the_money_matches_the_closed_form() {
+        // At forward == strike, d = 0 and h = 0, so the premium collapses to
+        // discount * std_dev * phi(0) = discount * std_dev / sqrt(2*pi).
+        for std_dev in [0.001, 0.05, 0.2] {
+            let expected = 0.95 * std_dev / (2.0 * std::f64::consts::PI).sqrt();
+            for option_type in [OptionType::Call, OptionType::Put] {
+                let premium = bachelier_black_formula(option_type, 1.0, 1.0, std_dev, 0.95)
+                    .expect("valid inputs");
+                assert_close(premium, expected, 1e-16);
+            }
+        }
+    }
+
+    #[test]
+    fn bachelier_matches_the_normal_pricing_definition() {
+        // premium = discount * (std_dev * phi(h) + d * Phi(h)), d = (forward-strike)*sign,
+        // h = d / std_dev, reconstructed from the normal primitives directly.
+        let phi = CumulativeNormalDistribution::standard();
+        for (forward, strike) in [(0.03, 0.025), (-0.01, 0.005), (0.02, 0.02)] {
+            for std_dev in [0.001, 0.01, 0.05] {
+                for option_type in [OptionType::Call, OptionType::Put] {
+                    let sign = Real::from(option_type as i32);
+                    let d = (forward - strike) * sign;
+                    let h = d / std_dev;
+                    let expected = 0.95 * (std_dev * phi.derivative(h) + d * phi.value(h));
+                    let actual =
+                        bachelier_black_formula(option_type, strike, forward, std_dev, 0.95)
+                            .expect("valid inputs");
+                    assert_close(actual, expected, 1e-16);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn bachelier_prices_negative_forward_and_strike() {
+        let premium = bachelier_black_formula(OptionType::Call, -0.005, -0.01, 0.01, 1.0)
+            .expect("normal model admits negative rates");
+        assert!(premium > 0.0);
+    }
+
+    #[test]
+    fn bachelier_rejects_invalid_std_dev_and_discount() {
+        assert!(bachelier_black_formula(OptionType::Call, 1.0, 1.0, -0.1, 0.95).is_err());
+        assert!(bachelier_black_formula(OptionType::Call, 1.0, 1.0, Real::INFINITY, 0.95).is_err());
+        assert!(bachelier_black_formula(OptionType::Call, 1.0, 1.0, 0.1, 0.0).is_err());
+        assert!(bachelier_black_formula(OptionType::Call, 1.0, 1.0, 0.1, -1.0).is_err());
+        assert!(
+            bachelier_black_formula_forward_derivative(OptionType::Call, 1.0, 1.0, -0.1, 0.95)
+                .is_err()
+        );
+        assert!(
+            bachelier_black_formula_forward_derivative(OptionType::Call, 1.0, 1.0, 0.1, 0.0)
+                .is_err()
+        );
+    }
+
+    fn assert_bachelier_forward_derivative(option_type: OptionType, strikes: &[Real], bpvol: Real) {
+        // Mean-value-theorem check ported from blackformula.cpp:357: the analytical
+        // forward derivative must bracket the bumped finite difference of the premium.
+        let forward = 1.0;
+        let tte: Real = 10.0;
+        let std_dev = bpvol * tte.sqrt();
+        let discount = 0.95;
+        let bump = 0.0001;
+        let epsilon = 1.0e-10;
+        for &strike in strikes {
+            let delta = bachelier_black_formula_forward_derivative(
+                option_type,
+                strike,
+                forward,
+                std_dev,
+                discount,
+            )
+            .expect("valid inputs");
+            let bumped_delta = bachelier_black_formula_forward_derivative(
+                option_type,
+                strike,
+                forward + bump,
+                std_dev,
+                discount,
+            )
+            .expect("valid inputs");
+            let base = bachelier_black_formula(option_type, strike, forward, std_dev, discount)
+                .expect("valid inputs");
+            let bumped =
+                bachelier_black_formula(option_type, strike, forward + bump, std_dev, discount)
+                    .expect("valid inputs");
+            let delta_approx = (bumped - base) / bump;
+            assert!(delta.max(bumped_delta) + epsilon > delta_approx);
+            assert!(delta_approx > delta.min(bumped_delta) - epsilon);
+        }
+    }
+
+    #[test]
+    fn bachelier_forward_derivative_brackets_the_bumped_premium() {
+        let strikes = [-3.0, -2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0, 3.0];
+        assert_bachelier_forward_derivative(OptionType::Call, &strikes, 0.001);
+        assert_bachelier_forward_derivative(OptionType::Put, &strikes, 0.001);
+    }
+
+    #[test]
+    fn bachelier_forward_derivative_brackets_the_bumped_premium_zero_vol() {
+        let strikes = [-3.0, -2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0, 3.0];
+        assert_bachelier_forward_derivative(OptionType::Call, &strikes, 0.0);
+        assert_bachelier_forward_derivative(OptionType::Put, &strikes, 0.0);
     }
 }

--- a/crates/libitofin/src/termstructures/volatility/mod.rs
+++ b/crates/libitofin/src/termstructures/volatility/mod.rs
@@ -33,6 +33,8 @@ mod localconstantvol;
 mod localvolcurve;
 mod localvolsurface;
 mod localvoltermstructure;
+mod optionlet;
+mod volatilitytype;
 
 pub use blackconstantvol::BlackConstantVol;
 pub use blackvariancecurve::{BlackVarianceCurve, BlackVolTimeExtrapolation};
@@ -41,6 +43,8 @@ pub use localconstantvol::LocalConstantVol;
 pub use localvolcurve::LocalVolCurve;
 pub use localvolsurface::LocalVolSurface;
 pub use localvoltermstructure::LocalVolTermStructure;
+pub use optionlet::{ConstantOptionletVolatility, OptionletVolatilityStructure};
+pub use volatilitytype::VolatilityType;
 
 use std::any::Any;
 

--- a/crates/libitofin/src/termstructures/volatility/optionlet/constantoptionletvol.rs
+++ b/crates/libitofin/src/termstructures/volatility/optionlet/constantoptionletvol.rs
@@ -1,0 +1,202 @@
+//! Constant caplet/floorlet volatility.
+//!
+//! Port of `ql/termstructures/volatility/optionlet/constantoptionletvol.{hpp,cpp}`:
+//! [`ConstantOptionletVolatility`] implements
+//! [`OptionletVolatilityStructure`](super::OptionletVolatilityStructure) with a
+//! single volatility, no time or strike dependence. The volatility is either a
+//! fixed value (wrapped in an unobservable [`SimpleQuote`], as in C++) or a
+//! quote handle whose changes propagate to the structure's observers. The
+//! business-day convention, volatility type and displacement are pinned by the
+//! constructor; the strike domain spans all of `Real`.
+//!
+//! The moving constructors take the shared [`Settings`] handle explicitly, per
+//! D5.
+
+use crate::errors::QlResult;
+use crate::handle::Handle;
+use crate::patterns::observable::{AsObservable, Observable};
+use crate::quotes::{Quote, make_quote_handle};
+use crate::settings::Settings;
+use crate::shared::Shared;
+use crate::termstructures::volatility::{VolatilityTermStructure, VolatilityType};
+use crate::termstructures::{TermStructure, TermStructureBase};
+use crate::time::businessdayconvention::BusinessDayConvention;
+use crate::time::calendar::Calendar;
+use crate::time::date::Date;
+use crate::time::daycounter::DayCounter;
+use crate::types::{Natural, Rate, Real, Time, Volatility};
+
+use super::OptionletVolatilityStructure;
+
+/// Constant caplet volatility, no time-strike dependence.
+pub struct ConstantOptionletVolatility {
+    base: TermStructureBase,
+    business_day_convention: BusinessDayConvention,
+    volatility: Handle<dyn Quote>,
+    volatility_type: VolatilityType,
+    displacement: Real,
+}
+
+impl ConstantOptionletVolatility {
+    fn wrap(volatility: Volatility) -> Handle<dyn Quote> {
+        make_quote_handle(volatility).handle()
+    }
+
+    fn assemble(
+        base: TermStructureBase,
+        business_day_convention: BusinessDayConvention,
+        volatility: Handle<dyn Quote>,
+        volatility_type: VolatilityType,
+        displacement: Real,
+        observe: bool,
+    ) -> ConstantOptionletVolatility {
+        if observe {
+            volatility.register_observer(&base.updater());
+        }
+        ConstantOptionletVolatility {
+            base,
+            business_day_convention,
+            volatility,
+            volatility_type,
+            displacement,
+        }
+    }
+
+    /// Fixed reference date, fixed market data.
+    pub fn new(
+        reference_date: Date,
+        calendar: Calendar,
+        business_day_convention: BusinessDayConvention,
+        volatility: Volatility,
+        day_counter: DayCounter,
+        volatility_type: VolatilityType,
+        displacement: Real,
+    ) -> ConstantOptionletVolatility {
+        Self::assemble(
+            TermStructureBase::with_reference_date(
+                reference_date,
+                Some(calendar),
+                Some(day_counter),
+            ),
+            business_day_convention,
+            Self::wrap(volatility),
+            volatility_type,
+            displacement,
+            false,
+        )
+    }
+
+    /// Fixed reference date, quote-backed market data; quote changes notify the
+    /// structure's observers.
+    pub fn with_quote(
+        reference_date: Date,
+        calendar: Calendar,
+        business_day_convention: BusinessDayConvention,
+        volatility: Handle<dyn Quote>,
+        day_counter: DayCounter,
+        volatility_type: VolatilityType,
+        displacement: Real,
+    ) -> ConstantOptionletVolatility {
+        Self::assemble(
+            TermStructureBase::with_reference_date(
+                reference_date,
+                Some(calendar),
+                Some(day_counter),
+            ),
+            business_day_convention,
+            volatility,
+            volatility_type,
+            displacement,
+            true,
+        )
+    }
+
+    /// Reference date moving off the evaluation date, fixed market data.
+    #[allow(clippy::too_many_arguments)]
+    pub fn moving(
+        settlement_days: Natural,
+        calendar: Calendar,
+        business_day_convention: BusinessDayConvention,
+        volatility: Volatility,
+        day_counter: DayCounter,
+        volatility_type: VolatilityType,
+        displacement: Real,
+        settings: Shared<Settings<Date>>,
+    ) -> ConstantOptionletVolatility {
+        Self::assemble(
+            TermStructureBase::moving(settlement_days, calendar, Some(day_counter), settings),
+            business_day_convention,
+            Self::wrap(volatility),
+            volatility_type,
+            displacement,
+            false,
+        )
+    }
+
+    /// Reference date moving off the evaluation date, quote-backed market data;
+    /// quote changes notify the structure's observers.
+    #[allow(clippy::too_many_arguments)]
+    pub fn moving_with_quote(
+        settlement_days: Natural,
+        calendar: Calendar,
+        business_day_convention: BusinessDayConvention,
+        volatility: Handle<dyn Quote>,
+        day_counter: DayCounter,
+        volatility_type: VolatilityType,
+        displacement: Real,
+        settings: Shared<Settings<Date>>,
+    ) -> ConstantOptionletVolatility {
+        Self::assemble(
+            TermStructureBase::moving(settlement_days, calendar, Some(day_counter), settings),
+            business_day_convention,
+            volatility,
+            volatility_type,
+            displacement,
+            true,
+        )
+    }
+}
+
+impl AsObservable for ConstantOptionletVolatility {
+    fn observable(&self) -> &Observable {
+        self.base.observable()
+    }
+}
+
+impl TermStructure for ConstantOptionletVolatility {
+    fn base(&self) -> &TermStructureBase {
+        &self.base
+    }
+
+    fn max_date(&self) -> Date {
+        Date::max_date()
+    }
+}
+
+impl VolatilityTermStructure for ConstantOptionletVolatility {
+    fn business_day_convention(&self) -> BusinessDayConvention {
+        self.business_day_convention
+    }
+
+    fn min_strike(&self) -> Rate {
+        Rate::MIN
+    }
+
+    fn max_strike(&self) -> Rate {
+        Rate::MAX
+    }
+}
+
+impl OptionletVolatilityStructure for ConstantOptionletVolatility {
+    fn volatility_impl(&self, _option_time: Time, _strike: Rate) -> QlResult<Volatility> {
+        self.volatility.current_link()?.value()
+    }
+
+    fn volatility_type(&self) -> VolatilityType {
+        self.volatility_type
+    }
+
+    fn displacement(&self) -> Real {
+        self.displacement
+    }
+}

--- a/crates/libitofin/src/termstructures/volatility/optionlet/constantoptionletvol.rs
+++ b/crates/libitofin/src/termstructures/volatility/optionlet/constantoptionletvol.rs
@@ -200,3 +200,154 @@ impl OptionletVolatilityStructure for ConstantOptionletVolatility {
         self.displacement
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::quotes::SimpleQuote;
+    use crate::shared::{Shared, shared};
+    use crate::test_support::{Flag, as_observer};
+    use crate::time::calendars::target::Target;
+    use crate::time::date::Month;
+    use crate::time::daycounters::actual360::Actual360;
+
+    fn flat_surface(vol: Volatility) -> (Date, ConstantOptionletVolatility) {
+        let reference = Date::new(15, Month::June, 2026);
+        let surface = ConstantOptionletVolatility::new(
+            reference,
+            Target::new(),
+            BusinessDayConvention::Following,
+            vol,
+            Actual360::new(),
+            VolatilityType::ShiftedLognormal,
+            0.0,
+        );
+        (reference, surface)
+    }
+
+    #[test]
+    fn volatility_is_constant_across_times_and_strikes() {
+        let (reference, surface) = flat_surface(0.2);
+        for t in [0.0, 0.25, 1.0, 10.0] {
+            for strike in [-0.01, 0.0, 0.03, 1.0e6] {
+                assert_eq!(surface.volatility(t, strike, false).unwrap(), 0.2);
+            }
+        }
+        assert_eq!(
+            surface
+                .volatility_date(reference + 180, 0.03, false)
+                .unwrap(),
+            0.2
+        );
+    }
+
+    #[test]
+    fn black_variance_is_vol_squared_times_time_in_every_form() {
+        let (reference, surface) = flat_surface(0.25);
+        let var = surface.black_variance(2.0, 0.03, false).unwrap();
+        assert!((var - 0.125).abs() < 1e-15);
+
+        let date = reference + 180;
+        let t = surface.time_from_reference(date).unwrap();
+        assert_eq!(t, 0.5);
+        let by_date = surface.black_variance_date(date, 0.03, false).unwrap();
+        let by_time = surface.black_variance(t, 0.03, false).unwrap();
+        assert_eq!(by_date, by_time);
+        assert!((by_date - 0.25 * 0.25 * 0.5).abs() < 1e-15);
+    }
+
+    #[test]
+    fn tenor_queries_advance_on_the_calendar() {
+        use crate::time::period::Period;
+        use crate::time::timeunit::TimeUnit;
+        let (_, surface) = flat_surface(0.2);
+        let tenor = Period::new(6, TimeUnit::Months);
+        let by_tenor = surface.volatility_tenor(tenor, 0.03, false).unwrap();
+        assert_eq!(by_tenor, 0.2);
+        let var = surface.black_variance_tenor(tenor, 0.03, false).unwrap();
+        assert!(var > 0.0);
+    }
+
+    #[test]
+    fn type_and_displacement_are_reported() {
+        let reference = Date::new(15, Month::June, 2026);
+        let surface = ConstantOptionletVolatility::new(
+            reference,
+            Target::new(),
+            BusinessDayConvention::Following,
+            0.2,
+            Actual360::new(),
+            VolatilityType::Normal,
+            0.01,
+        );
+        assert_eq!(surface.volatility_type(), VolatilityType::Normal);
+        assert_eq!(surface.displacement(), 0.01);
+    }
+
+    #[test]
+    fn defaults_report_shifted_lognormal_without_displacement() {
+        let (_, surface) = flat_surface(0.2);
+        assert_eq!(surface.volatility_type(), VolatilityType::ShiftedLognormal);
+        assert_eq!(surface.displacement(), 0.0);
+    }
+
+    #[test]
+    fn every_strike_is_inside_the_domain() {
+        let (_, surface) = flat_surface(0.2);
+        assert!(surface.volatility(1.0, Real::MAX, false).is_ok());
+        assert!(surface.volatility(1.0, Real::MIN, false).is_ok());
+        assert_eq!(surface.min_strike(), Real::MIN);
+        assert_eq!(surface.max_strike(), Real::MAX);
+    }
+
+    #[test]
+    fn quote_changes_propagate_and_notify() {
+        let reference = Date::new(15, Month::June, 2026);
+        let handle = make_quote_handle(0.18);
+        let surface = ConstantOptionletVolatility::with_quote(
+            reference,
+            Target::new(),
+            BusinessDayConvention::Following,
+            handle.handle(),
+            Actual360::new(),
+            VolatilityType::ShiftedLognormal,
+            0.0,
+        );
+        assert_eq!(surface.volatility(1.0, 0.03, false).unwrap(), 0.18);
+
+        let flag = Flag::new();
+        surface.observable().register_observer(&as_observer(&flag));
+
+        let quote = shared(SimpleQuote::new(0.23));
+        handle.link_to(quote.clone() as Shared<dyn Quote>);
+        assert!(Flag::is_up(&flag));
+        assert_eq!(surface.volatility(1.0, 0.03, false).unwrap(), 0.23);
+    }
+
+    #[test]
+    fn moving_reference_date_follows_the_evaluation_date() {
+        let settings = shared(Settings::new());
+        settings.set_evaluation_date(Date::new(15, Month::January, 2026));
+        let surface = ConstantOptionletVolatility::moving(
+            2,
+            Target::new(),
+            BusinessDayConvention::Following,
+            0.2,
+            Actual360::new(),
+            VolatilityType::ShiftedLognormal,
+            0.0,
+            settings.clone(),
+        );
+        assert_eq!(
+            surface.reference_date().unwrap(),
+            Date::new(19, Month::January, 2026)
+        );
+        assert_eq!(surface.volatility(1.0, 0.03, false).unwrap(), 0.2);
+
+        settings.set_evaluation_date(Date::new(16, Month::January, 2026));
+        assert_eq!(
+            surface.reference_date().unwrap(),
+            Date::new(20, Month::January, 2026)
+        );
+    }
+}

--- a/crates/libitofin/src/termstructures/volatility/optionlet/mod.rs
+++ b/crates/libitofin/src/termstructures/volatility/optionlet/mod.rs
@@ -1,0 +1,117 @@
+//! Optionlet (caplet/floorlet) volatility structures.
+//!
+//! Port of `ql/termstructures/volatility/optionlet/`.
+//! [`OptionletVolatilityStructure`] adds the caplet volatility and Black
+//! variance queries on top of [`VolatilityTermStructure`], in tenor, date and
+//! time form, range- and strike-checked exactly as the C++ base performs them
+//! before dispatching to the volatility hook. The volatility type and
+//! displacement select the pricing model the surface feeds the coupon pricer.
+//!
+//! ## Divergences from QuantLib
+//!
+//! - The `smileSection` family and the `smileSectionImpl` hook are not ported:
+//!   they need the smile-section layer, which is not in the crate yet. The
+//!   required hook is therefore [`volatility_impl`](OptionletVolatilityStructure::volatility_impl)
+//!   alone, mirroring C++'s pure-virtual `volatilityImpl(Time, Rate)`; the
+//!   `Date`-based volatility path converts to time and dispatches to it, as the
+//!   C++ default `volatilityImpl(Date, Rate)` does.
+//! - Only the constant surface is ported here ([`ConstantOptionletVolatility`]).
+//!   The stripped and interpolated optionlet surfaces are deferred.
+
+mod constantoptionletvol;
+
+pub use constantoptionletvol::ConstantOptionletVolatility;
+
+use crate::errors::QlResult;
+use crate::termstructures::volatility::{VolatilityTermStructure, VolatilityType};
+use crate::time::date::Date;
+use crate::time::period::Period;
+use crate::types::{Rate, Real, Time, Volatility};
+
+/// Optionlet (caplet/floorlet) volatility structure.
+///
+/// Mirrors QuantLib's `OptionletVolatilityStructure`: concrete surfaces
+/// implement [`volatility_impl`](Self::volatility_impl); the provided queries
+/// run the range and strike checks and dispatch to it, deriving the Black
+/// variance as `volatility^2 * time`. Volatilities are expressed on an annual
+/// basis.
+pub trait OptionletVolatilityStructure: VolatilityTermStructure {
+    /// Volatility calculation hook; range and strike checks have already run.
+    fn volatility_impl(&self, option_time: Time, strike: Rate) -> QlResult<Volatility>;
+
+    /// The pricing model the quoted volatilities are expressed in.
+    fn volatility_type(&self) -> VolatilityType {
+        VolatilityType::ShiftedLognormal
+    }
+
+    /// The lognormal shift applied to forward and strike; `0.0` for the
+    /// unshifted lognormal and the normal model.
+    fn displacement(&self) -> Real {
+        0.0
+    }
+
+    /// Volatility for a given option date and strike rate.
+    fn volatility_date(
+        &self,
+        option_date: Date,
+        strike: Rate,
+        extrapolate: bool,
+    ) -> QlResult<Volatility> {
+        self.check_range_date(option_date, extrapolate)?;
+        self.check_strike(strike, extrapolate)?;
+        let t = self.time_from_reference(option_date)?;
+        self.volatility_impl(t, strike)
+    }
+
+    /// Volatility for a given option time and strike rate.
+    fn volatility(
+        &self,
+        option_time: Time,
+        strike: Rate,
+        extrapolate: bool,
+    ) -> QlResult<Volatility> {
+        self.check_range_time(option_time, extrapolate)?;
+        self.check_strike(strike, extrapolate)?;
+        self.volatility_impl(option_time, strike)
+    }
+
+    /// Volatility for a given option tenor and strike rate.
+    fn volatility_tenor(
+        &self,
+        option_tenor: Period,
+        strike: Rate,
+        extrapolate: bool,
+    ) -> QlResult<Volatility> {
+        let option_date = self.option_date_from_tenor(option_tenor)?;
+        self.volatility_date(option_date, strike, extrapolate)
+    }
+
+    /// Black variance for a given option date and strike rate.
+    fn black_variance_date(
+        &self,
+        option_date: Date,
+        strike: Rate,
+        extrapolate: bool,
+    ) -> QlResult<Real> {
+        let v = self.volatility_date(option_date, strike, extrapolate)?;
+        let t = self.time_from_reference(option_date)?;
+        Ok(v * v * t)
+    }
+
+    /// Black variance for a given option time and strike rate.
+    fn black_variance(&self, option_time: Time, strike: Rate, extrapolate: bool) -> QlResult<Real> {
+        let v = self.volatility(option_time, strike, extrapolate)?;
+        Ok(v * v * option_time)
+    }
+
+    /// Black variance for a given option tenor and strike rate.
+    fn black_variance_tenor(
+        &self,
+        option_tenor: Period,
+        strike: Rate,
+        extrapolate: bool,
+    ) -> QlResult<Real> {
+        let option_date = self.option_date_from_tenor(option_tenor)?;
+        self.black_variance_date(option_date, strike, extrapolate)
+    }
+}

--- a/crates/libitofin/src/termstructures/volatility/volatilitytype.rs
+++ b/crates/libitofin/src/termstructures/volatility/volatilitytype.rs
@@ -1,0 +1,14 @@
+//! Volatility model tag.
+//!
+//! Port of `ql/termstructures/volatility/volatilitytype.hpp`. The variant
+//! selects the pricing model a volatility quote is expressed in: a
+//! (shifted) lognormal Black volatility or a normal Bachelier volatility.
+
+/// The model a volatility is quoted against.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VolatilityType {
+    /// (Shifted) lognormal Black volatility.
+    ShiftedLognormal,
+    /// Normal (Bachelier) volatility.
+    Normal,
+}


### PR DESCRIPTION
- **feat(pricingengines): add the Bachelier normal-model pricing pair**
- **feat(termstructures): port the constant optionlet volatility surface**
- **test(termstructures): oracle the constant optionlet volatility surface**

close #351