### PR TITLE
feat(pricingengines): add the Bachelier normal-model pricing pair

### DIFF
--- a/crates/libitofin/src/cashflows/capflooredcoupon.rs
+++ b/crates/libitofin/src/cashflows/capflooredcoupon.rs
@@ -177,12 +177,15 @@ impl Coupon for CappedFlooredCoupon {
         let Some(pricer) = self.underlying.pricer() else {
             fail!("pricer not set");
         };
+        let forward = self.underlying.index_fixing();
         let mut rate = swaplet;
         if self.is_floored {
-            rate += pricer.borrow().floorlet_rate(self.effective_floor())?;
+            rate += pricer
+                .borrow()
+                .floorlet_rate(self.effective_floor(), forward.clone())?;
         }
         if self.is_capped {
-            rate -= pricer.borrow().caplet_rate(self.effective_cap())?;
+            rate -= pricer.borrow().caplet_rate(self.effective_cap(), forward)?;
         }
         Ok(rate)
     }

--- a/crates/libitofin/src/cashflows/capflooredcoupon.rs
+++ b/crates/libitofin/src/cashflows/capflooredcoupon.rs
@@ -1,0 +1,394 @@
+//! Floating-rate coupon with an added cap and/or floor.
+//!
+//! Port of `ql/cashflows/capflooredcoupon.{hpp,cpp}`. A [`CappedFlooredCoupon`]
+//! wraps a floating coupon and layers a cap and/or floor on its rate:
+//! `rate = underlying + max(floor - underlying, 0) - max(underlying - cap, 0)`,
+//! the floorlet and caplet coming from the underlying's pricer. Only the ibor
+//! variant is in scope; [`CappedFlooredIborCoupon`] is its constructor.
+//!
+//! ## Shape
+//!
+//! C++ derives `CappedFlooredCoupon` from `FloatingRateCoupon` and holds the
+//! wrapped coupon as `underlying_`. The port keeps only the composition: the
+//! wrapper holds a [`Shared`] [`IborCoupon`] and delegates its [`Coupon`] face -
+//! dates, nominal, day counter - to it, overriding [`rate`](Coupon::rate) to
+//! add the caplet/floorlet. It carries no pricer of its own; the C++ base's
+//! `pricer_` is unused once `rate()` is overridden, and every optionlet reads
+//! the underlying's pricer.
+//!
+//! ## Divergences from QuantLib
+//!
+//! `setPricer` forwards to the wrapper *and* the underlying in C++ (one call,
+//! two installs), the classic "composition loses virtual dispatch" hazard. The
+//! port has a single install: [`set_pricer`](CappedFlooredCoupon::set_pricer)
+//! sets the underlying's pricer, and both the wrapper's rate path and the
+//! underlying's read that one instance, so they cannot diverge.
+//!
+//! `CappedFlooredCoupon` is a `LazyObject` in C++, caching `rate_` behind
+//! `performCalculations`. As with the rest of the cash-flow layer the cache is
+//! omitted: [`rate`](Coupon::rate) recomputes each call from the same inputs.
+//! The behavioural half is kept - the wrapper's observable *is* the underlying's
+//! (`observable()`): the cap and floor are fixed at construction, so the wrapper
+//! has nothing of its own to notify, and observers registering on it see every
+//! index, pricer or evaluation-date change the underlying broadcasts. This
+//! stands in for the C++ `registerWith(underlying_)` re-broadcast.
+//!
+//! `CappedFlooredCmsCoupon` (needs a swap index) and the visitor `accept`
+//! overrides have no port here.
+
+use super::coupon::{Coupon, CouponBase};
+use super::couponpricer::FloatingRateCouponPricer;
+use super::iborcoupon::IborCoupon;
+use crate::errors::QlResult;
+use crate::indexes::iborindex::IborIndex;
+use crate::patterns::observable::{AsObservable, Observable};
+use crate::shared::{Shared, SharedMut, shared};
+use crate::time::businessdayconvention::BusinessDayConvention;
+use crate::time::date::Date;
+use crate::time::daycounter::DayCounter;
+use crate::types::{Natural, Rate, Real, Spread};
+use crate::{fail, require};
+
+/// A floating-rate coupon capped and/or floored.
+///
+/// Built from an underlying [`IborCoupon`] with [`new`](Self::new), or directly
+/// through [`CappedFlooredIborCoupon::new`]. A pricer carrying the optionlet
+/// volatility is attached with [`set_pricer`](Self::set_pricer).
+pub struct CappedFlooredCoupon {
+    underlying: Shared<IborCoupon>,
+    is_capped: bool,
+    is_floored: bool,
+    cap: Rate,
+    floor: Rate,
+}
+
+impl CappedFlooredCoupon {
+    /// Wraps `underlying` with an optional `cap` and `floor`
+    /// (`CappedFlooredCoupon::CappedFlooredCoupon`).
+    ///
+    /// A negative gearing swaps the roles: the passed cap becomes the effective
+    /// floor and vice versa (`capflooredcoupon.cpp:46-64`), so a capped
+    /// negative-gearing coupon is floored internally.
+    ///
+    /// # Errors
+    ///
+    /// When both a cap and a floor are given, the cap must not sit below the
+    /// floor.
+    pub fn new(
+        underlying: Shared<IborCoupon>,
+        cap: Option<Rate>,
+        floor: Option<Rate>,
+    ) -> QlResult<CappedFlooredCoupon> {
+        let mut is_capped = false;
+        let mut is_floored = false;
+        let mut cap_value = 0.0;
+        let mut floor_value = 0.0;
+
+        if underlying.gearing() > 0.0 {
+            if let Some(cap) = cap {
+                is_capped = true;
+                cap_value = cap;
+            }
+            if let Some(floor) = floor {
+                is_floored = true;
+                floor_value = floor;
+            }
+        } else {
+            if let Some(cap) = cap {
+                is_floored = true;
+                floor_value = cap;
+            }
+            if let Some(floor) = floor {
+                is_capped = true;
+                cap_value = floor;
+            }
+        }
+
+        if let (Some(cap), Some(floor)) = (cap, floor) {
+            let cap_at_least_floor = cap >= floor;
+            require!(
+                cap_at_least_floor,
+                "cap level ({cap}) less than floor level ({floor})"
+            );
+        }
+
+        Ok(CappedFlooredCoupon {
+            underlying,
+            is_capped,
+            is_floored,
+            cap: cap_value,
+            floor: floor_value,
+        })
+    }
+
+    /// The wrapped coupon.
+    pub fn underlying(&self) -> &Shared<IborCoupon> {
+        &self.underlying
+    }
+
+    /// Whether a cap applies (`isCapped`).
+    pub fn is_capped(&self) -> bool {
+        self.is_capped
+    }
+
+    /// Whether a floor applies (`isFloored`).
+    pub fn is_floored(&self) -> bool {
+        self.is_floored
+    }
+
+    /// The de-spread, de-geared cap the caplet is struck at,
+    /// `(cap - spread) / gearing` (`effectiveCap`).
+    fn effective_cap(&self) -> Rate {
+        (self.cap - self.underlying.spread()) / self.underlying.gearing()
+    }
+
+    /// The de-spread, de-geared floor the floorlet is struck at,
+    /// `(floor - spread) / gearing` (`effectiveFloor`).
+    fn effective_floor(&self) -> Rate {
+        (self.floor - self.underlying.spread()) / self.underlying.gearing()
+    }
+
+    /// Attaches `pricer` to the underlying coupon (`CappedFlooredCoupon::setPricer`).
+    ///
+    /// One install, not the C++ two: the wrapper reads the underlying's pricer
+    /// for both the swaplet and the optionlets.
+    pub fn set_pricer(&self, pricer: SharedMut<dyn FloatingRateCouponPricer>) {
+        self.underlying.set_pricer(pricer);
+    }
+}
+
+impl AsObservable for CappedFlooredCoupon {
+    fn observable(&self) -> &Observable {
+        self.underlying.observable()
+    }
+}
+
+impl Coupon for CappedFlooredCoupon {
+    fn coupon_base(&self) -> &CouponBase {
+        self.underlying.coupon_base()
+    }
+
+    fn amount(&self) -> QlResult<Real> {
+        Ok(self.rate()? * self.accrual_period() * self.nominal())
+    }
+
+    fn rate(&self) -> QlResult<Rate> {
+        let swaplet = self.underlying.rate()?;
+        let Some(pricer) = self.underlying.pricer() else {
+            fail!("pricer not set");
+        };
+        let mut rate = swaplet;
+        if self.is_floored {
+            rate += pricer.borrow().floorlet_rate(self.effective_floor())?;
+        }
+        if self.is_capped {
+            rate -= pricer.borrow().caplet_rate(self.effective_cap())?;
+        }
+        Ok(rate)
+    }
+
+    fn day_counter(&self) -> DayCounter {
+        self.underlying.day_counter()
+    }
+
+    fn accrued_amount(&self, date: Date) -> QlResult<Real> {
+        if date <= self.accrual_start_date() || date > self.coupon_base().payment_date() {
+            Ok(0.0)
+        } else {
+            Ok(self.nominal() * self.rate()? * self.accrued_period(date))
+        }
+    }
+}
+
+/// Constructor for an ibor coupon wrapped in a cap and/or floor
+/// (`CappedFlooredIborCoupon`).
+///
+/// C++ derives this from [`CappedFlooredCoupon`] purely to build the underlying
+/// [`IborCoupon`] and carry a visitor override. With no visitor, it reduces to
+/// the constructor, which builds the coupon and returns the wrapper.
+pub struct CappedFlooredIborCoupon;
+
+impl CappedFlooredIborCoupon {
+    /// Builds an [`IborCoupon`] and wraps it with `cap` and `floor`.
+    ///
+    /// Returns the base [`CappedFlooredCoupon`]: the C++ subclass adds only the
+    /// construction and a visitor, so with no visitor the constructor yields the
+    /// base directly.
+    ///
+    /// # Errors
+    ///
+    /// As [`IborCoupon::new`] and [`CappedFlooredCoupon::new`].
+    #[allow(clippy::too_many_arguments, clippy::new_ret_no_self)]
+    pub fn new(
+        payment_date: Date,
+        nominal: Real,
+        accrual_start_date: Date,
+        accrual_end_date: Date,
+        fixing_days: Option<Natural>,
+        index: Shared<IborIndex>,
+        gearing: Real,
+        spread: Spread,
+        cap: Option<Rate>,
+        floor: Option<Rate>,
+        ref_period_start: Option<Date>,
+        ref_period_end: Option<Date>,
+        day_counter: Option<DayCounter>,
+        is_in_arrears: bool,
+        ex_coupon_date: Option<Date>,
+        fixing_convention: BusinessDayConvention,
+    ) -> QlResult<CappedFlooredCoupon> {
+        let underlying = IborCoupon::new(
+            payment_date,
+            nominal,
+            accrual_start_date,
+            accrual_end_date,
+            fixing_days,
+            index,
+            gearing,
+            spread,
+            ref_period_start,
+            ref_period_end,
+            day_counter,
+            is_in_arrears,
+            ex_coupon_date,
+            fixing_convention,
+        )?;
+        CappedFlooredCoupon::new(shared(underlying), cap, floor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! The wrapper's own logic - the gearing-sign cap/floor swap, the
+    //! decomposition on a determined coupon, and the single-install pin - kept
+    //! independent of a curve or a volatility surface. The full Black-model
+    //! decomposition is pinned against `capflooredcoupon.cpp`.
+
+    use super::*;
+    use crate::currency::Currency;
+    use crate::handle::Handle;
+    use crate::indexes::index::Index;
+    use crate::settings::Settings;
+    use crate::shared::shared_mut;
+    use crate::termstructures::yieldtermstructure::YieldTermStructure;
+    use crate::time::calendars::target::Target;
+    use crate::time::date::Month;
+    use crate::time::daycounters::actual360::Actual360;
+    use crate::time::period::Period;
+    use crate::time::timeunit::TimeUnit;
+
+    fn determined_coupon(gearing: Real, spread: Spread) -> Shared<IborCoupon> {
+        let today = Date::new(15, Month::June, 2026);
+        let settings = shared(Settings::<Date>::new());
+        settings.set_evaluation_date(today);
+        let index = shared(IborIndex::new(
+            "foo".into(),
+            Period::new(6, TimeUnit::Months),
+            2,
+            Currency::eur(),
+            Target::new(),
+            BusinessDayConvention::Following,
+            false,
+            Actual360::new(),
+            Handle::<dyn YieldTermStructure>::empty(),
+            settings,
+        ));
+        let start = Date::new(3, Month::June, 2026);
+        let end = Date::new(3, Month::December, 2026);
+        let coupon = shared(
+            IborCoupon::new(
+                end,
+                100.0,
+                start,
+                end,
+                Some(2),
+                index.clone(),
+                gearing,
+                spread,
+                None,
+                None,
+                None,
+                false,
+                None,
+                BusinessDayConvention::Preceding,
+            )
+            .unwrap(),
+        );
+        index.add_fixing(coupon.fixing_date(), 0.05).unwrap();
+        coupon
+    }
+
+    fn pricer() -> SharedMut<dyn FloatingRateCouponPricer> {
+        shared_mut(super::super::couponpricer::BlackIborCouponPricer::new())
+            as SharedMut<dyn FloatingRateCouponPricer>
+    }
+
+    /// A collar clamps the determined fixing into `[floor, cap]`: at a 0.05
+    /// fixing with cap 0.03 and floor 0.02 the coupon caps to 0.03.
+    #[test]
+    fn a_collar_clamps_the_determined_rate() {
+        let coupon =
+            CappedFlooredCoupon::new(determined_coupon(1.0, 0.0), Some(0.03), Some(0.02)).unwrap();
+        coupon.set_pricer(pricer());
+
+        assert!(coupon.is_capped() && coupon.is_floored());
+        assert!((coupon.rate().unwrap() - 0.03).abs() < 1e-15);
+    }
+
+    /// A floor lifts the determined fixing: at 0.05 with a 0.06 floor and no cap
+    /// the coupon floors to 0.06.
+    #[test]
+    fn a_floor_lifts_the_determined_rate() {
+        let coupon =
+            CappedFlooredCoupon::new(determined_coupon(1.0, 0.0), None, Some(0.06)).unwrap();
+        coupon.set_pricer(pricer());
+
+        assert!(coupon.is_floored() && !coupon.is_capped());
+        assert!((coupon.rate().unwrap() - 0.06).abs() < 1e-15);
+    }
+
+    /// A negative gearing swaps the roles: a passed cap becomes the effective
+    /// floor (`capflooredcoupon.cpp:55-63`), so a "capped" negative-gearing
+    /// coupon is floored internally.
+    #[test]
+    fn a_negative_gearing_swaps_cap_and_floor() {
+        let coupon =
+            CappedFlooredCoupon::new(determined_coupon(-1.5, 0.0), Some(0.10), None).unwrap();
+
+        assert!(coupon.is_floored() && !coupon.is_capped());
+    }
+
+    /// One pricer install, read by the rate path: after a swap the underlying
+    /// carries exactly the new instance, so the wrapper and the underlying can
+    /// never price against different pricers.
+    #[test]
+    fn set_pricer_installs_the_one_instance_the_rate_path_reads() {
+        let coupon =
+            CappedFlooredCoupon::new(determined_coupon(1.0, 0.0), Some(0.03), None).unwrap();
+
+        let p1 = pricer();
+        coupon.set_pricer(p1.clone());
+        assert!(SharedMut::ptr_eq(
+            &coupon.underlying().pricer().unwrap(),
+            &p1
+        ));
+        let first = coupon.rate().unwrap();
+
+        let p2 = pricer();
+        coupon.set_pricer(p2.clone());
+        assert!(SharedMut::ptr_eq(
+            &coupon.underlying().pricer().unwrap(),
+            &p2
+        ));
+        assert!((coupon.rate().unwrap() - first).abs() < 1e-15);
+    }
+
+    /// A cap below its floor is rejected at construction.
+    #[test]
+    fn a_cap_below_its_floor_is_rejected() {
+        let err = CappedFlooredCoupon::new(determined_coupon(1.0, 0.0), Some(0.02), Some(0.03))
+            .err()
+            .expect("a cap below its floor is an error");
+        assert!(err.message().contains("less than floor"));
+    }
+}

--- a/crates/libitofin/src/cashflows/capflooredcoupon_oracle.rs
+++ b/crates/libitofin/src/cashflows/capflooredcoupon_oracle.rs
@@ -1,0 +1,357 @@
+//! `test-suite/capflooredcoupon.cpp` `CommonVars`: `testLargeRates` (:188)
+//! and `testDecomposition` (:232). A 20-year annual leg over Euribor 1Y on a
+//! flat 5% continuous `Actual/Actual (ISDA)` curve, volatility 0.20. The
+//! evaluation date is `Date::todaysDate()` in C++; the port pins a fixed
+//! TARGET business day, the decomposition identities being self-consistent
+//! for any date. Every capped-leg swap NPV is checked against its vanilla
+//! leg less (or plus) the matching cap/floor/collar instrument.
+
+use crate::cashflow::{CashFlow, Leg};
+use crate::cashflows::couponpricer::{BlackIborCouponPricer, FloatingRateCouponPricer};
+use crate::cashflows::{FixedRateLeg, IborCoupon, IborLeg, set_coupon_pricer};
+use crate::handle::Handle;
+use crate::indexes::ibor::Euribor;
+use crate::indexes::iborindex::IborIndex;
+use crate::indexes::interestrateindex::InterestRateIndex;
+use crate::instrument::Instrument;
+use crate::instruments::{CapFloor, Swap};
+use crate::interestrate::Compounding;
+use crate::pricingengine::PricingEngine;
+use crate::pricingengines::{BlackCapFloorEngine, DiscountingSwapEngine};
+use crate::quotes::make_quote_handle;
+use crate::settings::Settings;
+use crate::shared::{Shared, SharedMut, shared, shared_mut};
+use crate::termstructures::volatility::{
+    ConstantOptionletVolatility, OptionletVolatilityStructure, VolatilityType,
+};
+use crate::termstructures::yields::FlatForward;
+use crate::termstructures::yieldtermstructure::YieldTermStructure;
+use crate::time::businessdayconvention::BusinessDayConvention;
+use crate::time::calendar::Calendar;
+use crate::time::calendars::target::Target;
+use crate::time::date::{Date, Month};
+use crate::time::daycounters::actual365fixed::Actual365Fixed;
+use crate::time::daycounters::actualactual::{ActualActual, Convention as ActualActualConvention};
+use crate::time::daycounters::thirty360::{Convention as Thirty360Convention, Thirty360};
+use crate::time::frequency::Frequency;
+use crate::time::schedule::{MakeSchedule, Schedule};
+use crate::time::timeunit::TimeUnit;
+use crate::types::{Rate, Real, Spread, Volatility};
+
+const MODIFIED_FOLLOWING: BusinessDayConvention = BusinessDayConvention::ModifiedFollowing;
+
+struct Vars {
+    settings: Shared<Settings<Date>>,
+    calendar: Calendar,
+    curve: Handle<dyn YieldTermStructure>,
+    index: Shared<IborIndex>,
+    start_date: Date,
+    length: i32,
+    nominal: Real,
+    volatility: Volatility,
+}
+
+impl Vars {
+    fn new() -> Vars {
+        let calendar = Target::new();
+        let today = calendar.adjust(
+            Date::new(15, Month::June, 2026),
+            BusinessDayConvention::Following,
+        );
+        let settings = shared(Settings::new());
+        settings.set_evaluation_date(today);
+        let settlement = calendar.advance(
+            today,
+            2,
+            TimeUnit::Days,
+            BusinessDayConvention::Following,
+            false,
+        );
+        let curve: Handle<dyn YieldTermStructure> = Handle::new(shared(FlatForward::with_rate(
+            settlement,
+            0.05,
+            ActualActual::with_convention(ActualActualConvention::ISDA),
+            Compounding::Continuous,
+            Frequency::Annual,
+        ))
+            as Shared<dyn YieldTermStructure>);
+        let index = shared(Euribor::one_year(curve.clone(), settings.clone()));
+        Vars {
+            settings,
+            calendar,
+            curve,
+            index,
+            start_date: settlement,
+            length: 20,
+            nominal: 100.0,
+            volatility: 0.20,
+        }
+    }
+
+    fn schedule(&self) -> Schedule {
+        let end = self.calendar.advance(
+            self.start_date,
+            self.length,
+            TimeUnit::Years,
+            MODIFIED_FOLLOWING,
+            false,
+        );
+        MakeSchedule::new()
+            .from(self.start_date)
+            .to(end)
+            .with_frequency(Frequency::Annual)
+            .with_calendar(self.calendar.clone())
+            .with_convention(MODIFIED_FOLLOWING)
+            .with_termination_date_convention(MODIFIED_FOLLOWING)
+            .forwards()
+            .build()
+    }
+
+    fn fixed_leg(&self) -> Leg {
+        FixedRateLeg::new(self.schedule())
+            .with_notional(self.nominal)
+            .with_coupon_rate(
+                0.0,
+                Thirty360::with_convention(Thirty360Convention::BondBasis),
+                Compounding::Simple,
+                Frequency::Annual,
+            )
+            .unwrap()
+            .build()
+            .unwrap()
+    }
+
+    fn ibor_leg(&self, gearing: Real, spread: Spread) -> IborLeg {
+        IborLeg::new(self.schedule(), self.index.clone())
+            .with_notional(self.nominal)
+            .with_payment_day_counter(self.index.day_counter().clone())
+            .with_payment_adjustment(MODIFIED_FOLLOWING)
+            .with_fixing_days(2)
+            .with_gearing(gearing)
+            .with_spread(spread)
+    }
+
+    fn float_coupons(&self, gearing: Real, spread: Spread) -> Vec<Shared<IborCoupon>> {
+        self.ibor_leg(gearing, spread).coupons().unwrap()
+    }
+
+    fn capped_floored_leg(
+        &self,
+        caps: Vec<Rate>,
+        floors: Vec<Rate>,
+        gearing: Real,
+        spread: Spread,
+    ) -> Leg {
+        let mut builder = self.ibor_leg(gearing, spread);
+        if !caps.is_empty() {
+            builder = builder.with_caps(caps);
+        }
+        if !floors.is_empty() {
+            builder = builder.with_floors(floors);
+        }
+        let coupons = builder.capped_floored_coupons().unwrap();
+        set_coupon_pricer(&coupons, self.vol_pricer());
+        coupons
+            .into_iter()
+            .map(|coupon| coupon as Shared<dyn CashFlow>)
+            .collect()
+    }
+
+    fn vol_pricer(&self) -> SharedMut<dyn FloatingRateCouponPricer> {
+        let surface = ConstantOptionletVolatility::moving(
+            0,
+            self.calendar.clone(),
+            BusinessDayConvention::Following,
+            self.volatility,
+            Actual365Fixed::new(),
+            VolatilityType::ShiftedLognormal,
+            0.0,
+            self.settings.clone(),
+        );
+        let handle = Handle::new(shared(surface) as Shared<dyn OptionletVolatilityStructure>);
+        shared_mut(BlackIborCouponPricer::with_vol(handle))
+            as SharedMut<dyn FloatingRateCouponPricer>
+    }
+
+    fn swap_npv(&self, fixed: Leg, floating: Leg) -> Real {
+        let mut swap = Swap::two_leg(fixed, floating, self.settings.clone());
+        let engine = shared_mut(DiscountingSwapEngine::new(
+            self.curve.clone(),
+            None,
+            None,
+            None,
+            self.settings.clone(),
+        ));
+        swap.base_mut()
+            .set_pricing_engine(engine as SharedMut<dyn PricingEngine>);
+        swap.npv().unwrap()
+    }
+
+    fn cap_floor_npv(&self, cap_floor: QlResult<CapFloor>) -> Real {
+        let mut cap_floor = cap_floor.unwrap();
+        let vol = make_quote_handle(self.volatility).handle();
+        let engine = shared_mut(
+            BlackCapFloorEngine::with_flat_vol(
+                self.curve.clone(),
+                vol,
+                Actual365Fixed::new(),
+                0.0,
+                self.settings.clone(),
+            )
+            .unwrap(),
+        );
+        cap_floor
+            .base_mut()
+            .set_pricing_engine(engine as SharedMut<dyn PricingEngine>);
+        cap_floor.npv().unwrap()
+    }
+}
+
+use crate::errors::QlResult;
+
+fn erase(coupons: &[Shared<IborCoupon>]) -> Leg {
+    coupons
+        .iter()
+        .map(|coupon| coupon.clone() as Shared<dyn CashFlow>)
+        .collect()
+}
+
+/// `testLargeRates` (:188): a leg capped at 100 and floored at 0 is a no-op,
+/// so its swap NPV matches the plain floating leg within 1e-10.
+#[test]
+fn a_degenerate_collar_matches_the_vanilla_leg() {
+    let vars = Vars::new();
+    let n = vars.length as usize;
+
+    let fixed = vars.fixed_leg();
+    let float_coupons = vars.float_coupons(1.0, 0.0);
+    let vanilla = vars.swap_npv(fixed.clone(), erase(&float_coupons));
+    let collared = vars.swap_npv(
+        fixed,
+        vars.capped_floored_leg(vec![100.0; n], vec![0.0; n], 1.0, 0.0),
+    );
+
+    assert!(
+        (vanilla - collared).abs() < 1e-10,
+        "vanilla {vanilla} vs collared {collared}"
+    );
+}
+
+/// `testDecomposition` (:232): every capped/floored/collared leg equals the
+/// vanilla leg plus or minus the matching cap/floor/collar instrument, at
+/// gearing 1 and at positive and negative gearings with a spread, within
+/// 1e-12.
+#[test]
+fn a_capped_floored_leg_matches_its_cap_floor_decomposition() {
+    let vars = Vars::new();
+    let n = vars.length as usize;
+    let tol = 1e-12;
+    let floor_strike = 0.05;
+    let cap_strike = 0.10;
+    let caps = vec![cap_strike; n];
+    let floors = vec![floor_strike; n];
+    let gearing_p = 0.5;
+    let spread_p = 0.002;
+    let gearing_n = -1.5;
+    let spread_n = 0.12;
+
+    let fixed = vars.fixed_leg();
+    let float = vars.float_coupons(1.0, 0.0);
+    let float_p = vars.float_coupons(gearing_p, spread_p);
+    let float_n = vars.float_coupons(gearing_n, spread_n);
+    let vanilla = vars.swap_npv(fixed.clone(), erase(&float));
+    let vanilla_p = vars.swap_npv(fixed.clone(), erase(&float_p));
+    let vanilla_n = vars.swap_npv(fixed.clone(), erase(&float_n));
+
+    let settings = vars.settings.clone();
+    let cap = |coupons: &[Shared<IborCoupon>], strike: Rate| {
+        vars.cap_floor_npv(CapFloor::cap(
+            coupons.to_vec(),
+            vec![strike],
+            settings.clone(),
+        ))
+    };
+    let floor = |coupons: &[Shared<IborCoupon>], strike: Rate| {
+        vars.cap_floor_npv(CapFloor::floor(
+            coupons.to_vec(),
+            vec![strike],
+            settings.clone(),
+        ))
+    };
+    let collar = |coupons: &[Shared<IborCoupon>], cap: Rate, floor: Rate| {
+        vars.cap_floor_npv(CapFloor::collar(
+            coupons.to_vec(),
+            vec![cap],
+            vec![floor],
+            settings.clone(),
+        ))
+    };
+    let cap_leg = |caps: Vec<Rate>, floors: Vec<Rate>, gearing, spread| {
+        vars.swap_npv(
+            fixed.clone(),
+            vars.capped_floored_leg(caps, floors, gearing, spread),
+        )
+    };
+    let close = |label: &str, got: Real, expected: Real| {
+        assert!(
+            (got - expected).abs() < tol,
+            "{label}: {got} vs {expected} (diff {})",
+            (got - expected).abs()
+        );
+    };
+
+    close(
+        "capped g=1",
+        cap_leg(caps.clone(), Vec::new(), 1.0, 0.0),
+        vanilla - cap(&float, cap_strike),
+    );
+    close(
+        "floored g=1",
+        cap_leg(Vec::new(), floors.clone(), 1.0, 0.0),
+        vanilla + floor(&float, floor_strike),
+    );
+    close(
+        "collared g=1",
+        cap_leg(caps.clone(), floors.clone(), 1.0, 0.0),
+        vanilla - collar(&float, cap_strike, floor_strike),
+    );
+
+    close(
+        "capped g=0.5",
+        cap_leg(caps.clone(), Vec::new(), gearing_p, spread_p),
+        vanilla_p - cap(&float_p, cap_strike),
+    );
+    close(
+        "capped g=-1.5",
+        cap_leg(caps.clone(), Vec::new(), gearing_n, spread_n),
+        vanilla_n + gearing_n * floor(&float, (cap_strike - spread_n) / gearing_n),
+    );
+
+    close(
+        "floored g=0.5",
+        cap_leg(Vec::new(), floors.clone(), gearing_p, spread_p),
+        vanilla_p + floor(&float_p, floor_strike),
+    );
+    close(
+        "floored g=-1.5",
+        cap_leg(Vec::new(), floors.clone(), gearing_n, spread_n),
+        vanilla_n - gearing_n * cap(&float, (floor_strike - spread_n) / gearing_n),
+    );
+
+    close(
+        "collared g=0.5",
+        cap_leg(caps.clone(), floors.clone(), gearing_p, spread_p),
+        vanilla_p - collar(&float_p, cap_strike, floor_strike),
+    );
+    close(
+        "collared g=-1.5",
+        cap_leg(caps.clone(), floors.clone(), gearing_n, spread_n),
+        vanilla_n
+            - gearing_n
+                * collar(
+                    &float,
+                    (floor_strike - spread_n) / gearing_n,
+                    (cap_strike - spread_n) / gearing_n,
+                ),
+    );
+}

--- a/crates/libitofin/src/cashflows/couponpricer.rs
+++ b/crates/libitofin/src/cashflows/couponpricer.rs
@@ -72,15 +72,20 @@ pub trait FloatingRateCouponPricer: AsObservable {
 
     /// The rate of a caplet struck at `effective_cap` (`capletRate`).
     ///
-    /// `gearing * optionletRate(Call, effective_cap)`. A pricer with no
-    /// optionlet volatility refuses.
-    fn caplet_rate(&self, effective_cap: Rate) -> QlResult<Rate>;
+    /// `gearing * optionletRate(Call, effective_cap)`. `forward` is the coupon's
+    /// adjusted forward, threaded in as [`swaplet_rate_for`](Self::swaplet_rate_for)
+    /// threads the swaplet fixing: the pricer captures the base coupon's natural
+    /// forecast, which on a stub differs from the mode-aware par forecast the
+    /// caplet must be struck against. A pricer with no optionlet volatility
+    /// refuses.
+    fn caplet_rate(&self, effective_cap: Rate, forward: QlResult<Rate>) -> QlResult<Rate>;
 
     /// The rate of a floorlet struck at `effective_floor` (`floorletRate`).
     ///
-    /// `gearing * optionletRate(Put, effective_floor)`. A pricer with no
-    /// optionlet volatility refuses.
-    fn floorlet_rate(&self, effective_floor: Rate) -> QlResult<Rate>;
+    /// `gearing * optionletRate(Put, effective_floor)`, with `forward` threaded
+    /// as in [`caplet_rate`](Self::caplet_rate). A pricer with no optionlet
+    /// volatility refuses.
+    fn floorlet_rate(&self, effective_floor: Rate, forward: QlResult<Rate>) -> QlResult<Rate>;
 }
 
 /// Black-formula pricer for ibor coupons (`BlackIborCouponPricer` over the
@@ -97,22 +102,20 @@ pub trait FloatingRateCouponPricer: AsObservable {
 ///
 /// It captures the coupon's gearing, spread, in-arrears flag, index fixing,
 /// fixing date and the evaluation date when [`initialize`](Self::initialize)
-/// runs, mirroring the C++ pricer caching them off the coupon.
+/// runs, mirroring the C++ pricer caching them off the coupon. The optionlet
+/// forward is not read from that captured fixing but threaded in by the coupon
+/// through [`caplet_rate`](FloatingRateCouponPricer::caplet_rate) and
+/// [`floorlet_rate`](FloatingRateCouponPricer::floorlet_rate), so the caplet is
+/// struck against the mode-aware par forecast the swaplet uses rather than the
+/// base coupon's natural forecast (the two diverge on a stub); the captured
+/// fixing only serves the plain [`swaplet_rate`](Self::swaplet_rate).
 ///
 /// ## Divergences from QuantLib
 ///
-/// The captured index fixing is the base coupon's natural (indexed) forecast,
-/// the one [`FloatingRateCoupon::index_fixing`] reads. It equals the mode-aware
-/// par/indexed forecast [`IborCoupon`] threads through
-/// [`swaplet_rate_for`](FloatingRateCouponPricer::swaplet_rate_for) whenever the
-/// coupon spans the index tenor - the whole capped/floored oracle - and diverges
-/// only on a stub, where threading the mode into the caplet path is deferred with
-/// the same par/indexed split.
-///
-/// `adjustedFixing()` reduces to the index fixing here: the in-arrears convexity
-/// adjustment is refused (as in the swaplet path) and only the `Black76` timing
-/// is modelled, so no convexity term applies. The C++ `discount_` and
-/// `accrualPeriod_` feed only the omitted `*Price` methods.
+/// `adjustedFixing()` reduces to the threaded forward here: the in-arrears
+/// convexity adjustment is refused (as in the swaplet path) and only the
+/// `Black76` timing is modelled, so no convexity term applies. The C++
+/// `discount_` and `accrualPeriod_` feed only the omitted `*Price` methods.
 ///
 /// [`IborCoupon`]: super::iborcoupon::IborCoupon
 pub struct BlackIborCouponPricer {
@@ -173,20 +176,23 @@ impl BlackIborCouponPricer {
         self.observable.notify_observers();
     }
 
-    /// The optionlet rate of `option_type` struck at `eff_strike`
-    /// (`BlackIborCouponPricer::optionletRate`).
+    /// The optionlet rate of `option_type` struck at `eff_strike` against
+    /// `forward`, the coupon's adjusted forward
+    /// (`BlackIborCouponPricer::optionletRate`, whose `adjustedFixing()` the
+    /// coupon threads in).
     ///
     /// A determined coupon returns the intrinsic `max`; an undetermined one the
     /// Black (shifted-lognormal) or Bachelier (normal) optionlet value, refusing
     /// when the surface is missing.
-    fn optionlet_rate(&self, option_type: OptionType, eff_strike: Rate) -> QlResult<Rate> {
+    fn optionlet_rate(
+        &self,
+        option_type: OptionType,
+        eff_strike: Rate,
+        forward: Rate,
+    ) -> QlResult<Rate> {
         let Some(fixing_date) = self.fixing_date else {
             fail!("pricer not initialized: no coupon captured");
         };
-        let Some(index_fixing) = &self.index_fixing else {
-            fail!("pricer not initialized: no coupon captured");
-        };
-        let forward = index_fixing.clone()?;
         let Some(eval_date) = self.eval_date else {
             fail!("no evaluation date set: a caplet needs a reference date");
         };
@@ -247,12 +253,12 @@ impl FloatingRateCouponPricer for BlackIborCouponPricer {
         Ok(self.gearing * index_fixing? + self.spread)
     }
 
-    fn caplet_rate(&self, effective_cap: Rate) -> QlResult<Rate> {
-        Ok(self.gearing * self.optionlet_rate(OptionType::Call, effective_cap)?)
+    fn caplet_rate(&self, effective_cap: Rate, forward: QlResult<Rate>) -> QlResult<Rate> {
+        Ok(self.gearing * self.optionlet_rate(OptionType::Call, effective_cap, forward?)?)
     }
 
-    fn floorlet_rate(&self, effective_floor: Rate) -> QlResult<Rate> {
-        Ok(self.gearing * self.optionlet_rate(OptionType::Put, effective_floor)?)
+    fn floorlet_rate(&self, effective_floor: Rate, forward: QlResult<Rate>) -> QlResult<Rate> {
+        Ok(self.gearing * self.optionlet_rate(OptionType::Put, effective_floor, forward?)?)
     }
 }
 
@@ -341,11 +347,12 @@ mod tests {
 
         let mut pricer = BlackIborCouponPricer::new();
         pricer.initialize(&coupon);
+        let forward = || coupon.index_fixing();
 
-        assert!((pricer.caplet_rate(0.03).unwrap() - 0.02).abs() < 1e-15);
-        assert_eq!(pricer.caplet_rate(0.06).unwrap(), 0.0);
-        assert!((pricer.floorlet_rate(0.06).unwrap() - 0.01).abs() < 1e-15);
-        assert_eq!(pricer.floorlet_rate(0.03).unwrap(), 0.0);
+        assert!((pricer.caplet_rate(0.03, forward()).unwrap() - 0.02).abs() < 1e-15);
+        assert_eq!(pricer.caplet_rate(0.06, forward()).unwrap(), 0.0);
+        assert!((pricer.floorlet_rate(0.06, forward()).unwrap() - 0.01).abs() < 1e-15);
+        assert_eq!(pricer.floorlet_rate(0.03, forward()).unwrap(), 0.0);
     }
 
     /// An undetermined coupon with no optionlet volatility surface refuses,
@@ -380,7 +387,7 @@ mod tests {
         let mut pricer = BlackIborCouponPricer::new();
         pricer.initialize(&coupon);
 
-        let err = pricer.caplet_rate(0.03).unwrap_err();
+        let err = pricer.caplet_rate(0.03, coupon.index_fixing()).unwrap_err();
         assert!(err.message().contains("missing optionlet volatility"));
     }
 
@@ -390,7 +397,7 @@ mod tests {
         let pricer = BlackIborCouponPricer::new();
         assert!(
             pricer
-                .caplet_rate(0.03)
+                .caplet_rate(0.03, Ok(0.05))
                 .unwrap_err()
                 .message()
                 .contains("not initialized")

--- a/crates/libitofin/src/cashflows/couponpricer.rs
+++ b/crates/libitofin/src/cashflows/couponpricer.rs
@@ -1,37 +1,44 @@
 //! Pricers for floating-rate coupons.
 //!
 //! Port of the `FloatingRateCouponPricer` base of
-//! `ql/cashflows/couponpricer.hpp`. A [`FloatingRateCoupon`] does not compute
-//! its own rate: it hands itself to a pricer and reads back
+//! `ql/cashflows/couponpricer.hpp` and the `IborCouponPricer` /
+//! `BlackIborCouponPricer` derived from it. A [`FloatingRateCoupon`] does not
+//! compute its own rate: it hands itself to a pricer and reads back
 //! [`swaplet_rate`](FloatingRateCouponPricer::swaplet_rate)
 //! (`floatingratecoupon.cpp:88`). The pricer folds the coupon's gearing and
-//! spread into that result, so the coupon reapplies neither.
-//!
-//! ## Scope of this slice
-//!
-//! Only [`swaplet_rate`](FloatingRateCouponPricer::swaplet_rate) is exercised by
-//! the base floating slice. [`caplet_rate`](FloatingRateCouponPricer::caplet_rate)
-//! and [`floorlet_rate`](FloatingRateCouponPricer::floorlet_rate) belong to the
-//! capped/floored slice, which needs an optionlet volatility surface not yet
-//! ported. They are *required*, not provided: a real pricer must implement them
-//! consciously, and a base-slice pricer implements them as an explicit `Err`
-//! refusal rather than a silent wrong number.
+//! spread into that result, so the coupon reapplies neither. A capped/floored
+//! coupon reads back [`caplet_rate`](FloatingRateCouponPricer::caplet_rate) and
+//! [`floorlet_rate`](FloatingRateCouponPricer::floorlet_rate) on top.
 //!
 //! ## Divergences from QuantLib
 //!
 //! The C++ interface also declares `swapletPrice`, `capletPrice` and
-//! `floorletPrice`. None is reached by the base slice: a coupon prices through
-//! `amount() * discount`, not the pricer, so the `*Price` variants are omitted
-//! until a consumer needs them.
+//! `floorletPrice`. None is reached by the ported code: a coupon prices through
+//! `amount() * discount`, not the pricer, and a cap/floor decomposition reads
+//! the caplet/floorlet *rate* (`capflooredcoupon.cpp:88-95`), not its price. The
+//! `*Price` variants - and the forwarding curve's `discount_` and
+//! `accrualPeriod_` they alone read (`couponpricer.cpp:170-174`) - are therefore
+//! omitted until a consumer needs them, rather than restored.
+//!
+//! C++ splits the caplet-volatility state onto an intermediate `IborCouponPricer`
+//! base. With only the Black pricer in scope (the CMS pricer is deferred) that
+//! base folds into [`BlackIborCouponPricer`] itself: the caplet-volatility
+//! handle, [`set_caplet_volatility`](BlackIborCouponPricer::set_caplet_volatility)
+//! and its registration live there directly rather than on a separate type.
 //!
 //! The C++ base is both `Observer` and `Observable` (its `update()` forwards
-//! notifications). Here it is [`AsObservable`] only: the coupon registers as an
-//! observer of the pricer, but a base-slice pricer observes nothing. The
-//! `Observer` face (a pricer watching a volatility surface) arrives with the
-//! cap/floor slice.
+//! notifications). Here [`BlackIborCouponPricer`] forwards a caplet-volatility
+//! change on to its own observers through a [`ResetThenNotify`], the same
+//! forwarding shape [`FloatingRateCoupon`] uses for its index.
 
 use crate::errors::QlResult;
-use crate::patterns::observable::{AsObservable, Observable};
+use crate::handle::Handle;
+use crate::option::OptionType;
+use crate::patterns::observable::{AsObservable, Observable, Observer, ResetThenNotify};
+use crate::pricingengines::blackformula::{bachelier_black_formula, black_formula};
+use crate::shared::{Shared, SharedMut};
+use crate::termstructures::volatility::{OptionletVolatilityStructure, VolatilityType};
+use crate::time::date::Date;
 use crate::types::{Rate, Real, Spread};
 use crate::{fail, require};
 
@@ -65,61 +72,147 @@ pub trait FloatingRateCouponPricer: AsObservable {
 
     /// The rate of a caplet struck at `effective_cap` (`capletRate`).
     ///
-    /// The cap/floor slice is not ported; a base-slice pricer returns `Err`.
+    /// `gearing * optionletRate(Call, effective_cap)`. A pricer with no
+    /// optionlet volatility refuses.
     fn caplet_rate(&self, effective_cap: Rate) -> QlResult<Rate>;
 
     /// The rate of a floorlet struck at `effective_floor` (`floorletRate`).
     ///
-    /// The cap/floor slice is not ported; a base-slice pricer returns `Err`.
+    /// `gearing * optionletRate(Put, effective_floor)`. A pricer with no
+    /// optionlet volatility refuses.
     fn floorlet_rate(&self, effective_floor: Rate) -> QlResult<Rate>;
 }
 
-/// Black-formula pricer for ibor coupons - the swaplet path
-/// (`BlackIborCouponPricer` in `ql/cashflows/couponpricer.{hpp,cpp}`).
+/// Black-formula pricer for ibor coupons (`BlackIborCouponPricer` over the
+/// `IborCouponPricer` base in `ql/cashflows/couponpricer.{hpp,cpp}`).
 ///
 /// The swaplet rate is `gearing * adjustedFixing + spread`
-/// (`couponpricer.hpp:215`), and for a non-in-arrears coupon under the default
+/// (`couponpricer.hpp:215`); for a non-in-arrears coupon under the default
 /// `Black76` timing the adjusted fixing reduces to the coupon's index fixing
-/// with no convexity adjustment (`couponpricer.cpp adjustedFixing`), so this
-/// path needs no volatility. It captures the coupon's gearing, spread,
-/// in-arrears flag and index fixing when [`initialize`](Self::initialize) runs,
-/// mirroring the C++ pricer caching them off the coupon.
+/// with no convexity adjustment, so that path needs no volatility. The caplet
+/// and floorlet rates take the optionlet path (`couponpricer.cpp:138-168`): a
+/// determined coupon (fixing on or before the evaluation date) returns the
+/// intrinsic `max`, an undetermined one the Black or Bachelier optionlet value
+/// against the caplet-volatility surface.
+///
+/// It captures the coupon's gearing, spread, in-arrears flag, index fixing,
+/// fixing date and the evaluation date when [`initialize`](Self::initialize)
+/// runs, mirroring the C++ pricer caching them off the coupon.
 ///
 /// ## Divergences from QuantLib
 ///
-/// The C++ pricer also captures the forwarding curve's `discount_`, but only
-/// [`swapletPrice`](swaplet-price) reads it - not `swapletRate`. The `*Price`
-/// methods (and the caplet/floorlet optionlet path, the in-arrears convexity
-/// adjustment, and the `IborCouponPricer` cached dates that feed the par/indexed
-/// forecast) belong to the cap/floor slice and are not ported. An in-arrears
-/// coupon is refused rather than priced with a missing convexity term.
+/// The captured index fixing is the base coupon's natural (indexed) forecast,
+/// the one [`FloatingRateCoupon::index_fixing`] reads. It equals the mode-aware
+/// par/indexed forecast [`IborCoupon`] threads through
+/// [`swaplet_rate_for`](FloatingRateCouponPricer::swaplet_rate_for) whenever the
+/// coupon spans the index tenor - the whole capped/floored oracle - and diverges
+/// only on a stub, where threading the mode into the caplet path is deferred with
+/// the same par/indexed split.
 ///
-/// [swaplet-price]: FloatingRateCouponPricer::swaplet_rate
+/// `adjustedFixing()` reduces to the index fixing here: the in-arrears convexity
+/// adjustment is refused (as in the swaplet path) and only the `Black76` timing
+/// is modelled, so no convexity term applies. The C++ `discount_` and
+/// `accrualPeriod_` feed only the omitted `*Price` methods.
+///
+/// [`IborCoupon`]: super::iborcoupon::IborCoupon
 pub struct BlackIborCouponPricer {
     gearing: Real,
     spread: Spread,
     is_in_arrears: bool,
     index_fixing: Option<QlResult<Rate>>,
-    observable: Observable,
+    fixing_date: Option<Date>,
+    eval_date: Option<Date>,
+    caplet_vol: Handle<dyn OptionletVolatilityStructure>,
+    observable: Shared<Observable>,
+    forwarder: SharedMut<ResetThenNotify>,
 }
 
 impl Default for BlackIborCouponPricer {
     fn default() -> Self {
+        let (observable, forwarder) = ResetThenNotify::forwarder();
         BlackIborCouponPricer {
             gearing: 1.0,
             spread: 0.0,
             is_in_arrears: false,
             index_fixing: None,
-            observable: Observable::new(),
+            fixing_date: None,
+            eval_date: None,
+            caplet_vol: Handle::empty(),
+            observable,
+            forwarder,
         }
     }
 }
 
 impl BlackIborCouponPricer {
-    /// Builds a pricer with no coupon captured yet; a coupon is captured on the
-    /// first [`initialize`](FloatingRateCouponPricer::initialize).
+    /// Builds a pricer with no caplet volatility and no coupon captured yet; a
+    /// coupon is captured on the first
+    /// [`initialize`](FloatingRateCouponPricer::initialize).
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Builds a pricer carrying the caplet-volatility surface `vol` (the C++
+    /// `BlackIborCouponPricer(v)` constructor).
+    pub fn with_vol(vol: Handle<dyn OptionletVolatilityStructure>) -> Self {
+        let mut pricer = Self::default();
+        pricer.set_caplet_volatility(vol);
+        pricer
+    }
+
+    /// Attaches the caplet-volatility surface `vol`, registering for its changes
+    /// (`IborCouponPricer::setCapletVolatility`).
+    ///
+    /// The registration is add-only: [`Handle`] exposes no unregister, and the
+    /// surface is set once at construction, so a rare re-set would leave the
+    /// prior handle notifying a forwarder that harmlessly rebroadcasts.
+    pub fn set_caplet_volatility(&mut self, vol: Handle<dyn OptionletVolatilityStructure>) {
+        self.caplet_vol = vol;
+        let observer = self.forwarder.clone() as SharedMut<dyn Observer>;
+        self.caplet_vol.register_observer(&observer);
+        self.observable.notify_observers();
+    }
+
+    /// The optionlet rate of `option_type` struck at `eff_strike`
+    /// (`BlackIborCouponPricer::optionletRate`).
+    ///
+    /// A determined coupon returns the intrinsic `max`; an undetermined one the
+    /// Black (shifted-lognormal) or Bachelier (normal) optionlet value, refusing
+    /// when the surface is missing.
+    fn optionlet_rate(&self, option_type: OptionType, eff_strike: Rate) -> QlResult<Rate> {
+        let Some(fixing_date) = self.fixing_date else {
+            fail!("pricer not initialized: no coupon captured");
+        };
+        let Some(index_fixing) = &self.index_fixing else {
+            fail!("pricer not initialized: no coupon captured");
+        };
+        let forward = index_fixing.clone()?;
+        let Some(eval_date) = self.eval_date else {
+            fail!("no evaluation date set: a caplet needs a reference date");
+        };
+
+        if fixing_date <= eval_date {
+            let (a, b) = match option_type {
+                OptionType::Call => (forward, eff_strike),
+                OptionType::Put => (eff_strike, forward),
+            };
+            return Ok((a - b).max(0.0));
+        }
+
+        require!(!self.caplet_vol.is_empty(), "missing optionlet volatility");
+        let surface = self.caplet_vol.current_link()?;
+        let std_dev = surface
+            .black_variance_date(fixing_date, eff_strike, false)?
+            .sqrt();
+        let shift = surface.displacement();
+        match surface.volatility_type() {
+            VolatilityType::ShiftedLognormal => {
+                black_formula(option_type, eff_strike, forward, std_dev, 1.0, shift)
+            }
+            VolatilityType::Normal => {
+                bachelier_black_formula(option_type, eff_strike, forward, std_dev, 1.0)
+            }
+        }
     }
 }
 
@@ -135,6 +228,8 @@ impl FloatingRateCouponPricer for BlackIborCouponPricer {
         self.spread = coupon.spread();
         self.is_in_arrears = coupon.is_in_arrears();
         self.index_fixing = Some(coupon.index_fixing());
+        self.fixing_date = Some(coupon.fixing_date());
+        self.eval_date = coupon.index().base().settings().evaluation_date();
     }
 
     fn swaplet_rate(&self) -> QlResult<Rate> {
@@ -152,11 +247,153 @@ impl FloatingRateCouponPricer for BlackIborCouponPricer {
         Ok(self.gearing * index_fixing? + self.spread)
     }
 
-    fn caplet_rate(&self, _effective_cap: Rate) -> QlResult<Rate> {
-        fail!("caplet rate not ported: cap/floor slice")
+    fn caplet_rate(&self, effective_cap: Rate) -> QlResult<Rate> {
+        Ok(self.gearing * self.optionlet_rate(OptionType::Call, effective_cap)?)
     }
 
-    fn floorlet_rate(&self, _effective_floor: Rate) -> QlResult<Rate> {
-        fail!("floorlet rate not ported: cap/floor slice")
+    fn floorlet_rate(&self, effective_floor: Rate) -> QlResult<Rate> {
+        Ok(self.gearing * self.optionlet_rate(OptionType::Put, effective_floor)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! The determined-optionlet and refusal paths of `optionletRate`. The
+    //! undetermined Black/Bachelier branch is exercised end-to-end against
+    //! `capflooredcoupon.cpp` where the leg decomposition pins the numbers.
+
+    use super::*;
+    use crate::currency::Currency;
+    use crate::handle::Handle;
+    use crate::indexes::iborindex::IborIndex;
+    use crate::indexes::index::Index;
+    use crate::interestrate::Compounding;
+    use crate::settings::Settings;
+    use crate::shared::shared;
+    use crate::termstructures::yields::FlatForward;
+    use crate::termstructures::yieldtermstructure::YieldTermStructure;
+    use crate::time::businessdayconvention::BusinessDayConvention;
+    use crate::time::calendars::target::Target;
+    use crate::time::date::{Date, Month};
+    use crate::time::daycounters::actual360::Actual360;
+    use crate::time::frequency::Frequency;
+    use crate::time::period::Period;
+    use crate::time::timeunit::TimeUnit;
+
+    fn index_on(
+        settings: Shared<Settings<Date>>,
+        forwarding: Handle<dyn YieldTermStructure>,
+    ) -> Shared<IborIndex> {
+        shared(IborIndex::new(
+            "foo".into(),
+            Period::new(6, TimeUnit::Months),
+            2,
+            Currency::eur(),
+            Target::new(),
+            BusinessDayConvention::Following,
+            false,
+            Actual360::new(),
+            forwarding,
+            settings,
+        ))
+    }
+
+    fn flat_curve(reference: Date, rate: Rate) -> Handle<dyn YieldTermStructure> {
+        Handle::new(shared(FlatForward::with_rate(
+            reference,
+            rate,
+            Actual360::new(),
+            Compounding::Continuous,
+            Frequency::Annual,
+        )) as Shared<dyn YieldTermStructure>)
+    }
+
+    /// A determined coupon (fixing on or before the evaluation date) prices its
+    /// optionlets off the intrinsic value: the caplet is `max(fixing - cap, 0)`
+    /// and the floorlet `max(floor - fixing, 0)`, both scaled by the gearing.
+    #[test]
+    fn a_determined_coupon_prices_the_intrinsic_optionlet() {
+        let today = Date::new(15, Month::June, 2026);
+        let settings = shared(Settings::<Date>::new());
+        settings.set_evaluation_date(today);
+        let index = index_on(settings, Handle::empty());
+
+        let start = Date::new(3, Month::June, 2026);
+        let end = Date::new(3, Month::December, 2026);
+        let coupon = FloatingRateCoupon::new(
+            end,
+            100.0,
+            start,
+            end,
+            Some(2),
+            index.clone(),
+            1.0,
+            0.0,
+            None,
+            None,
+            None,
+            false,
+            None,
+            BusinessDayConvention::Preceding,
+        )
+        .unwrap();
+        index.add_fixing(coupon.fixing_date(), 0.05).unwrap();
+
+        let mut pricer = BlackIborCouponPricer::new();
+        pricer.initialize(&coupon);
+
+        assert!((pricer.caplet_rate(0.03).unwrap() - 0.02).abs() < 1e-15);
+        assert_eq!(pricer.caplet_rate(0.06).unwrap(), 0.0);
+        assert!((pricer.floorlet_rate(0.06).unwrap() - 0.01).abs() < 1e-15);
+        assert_eq!(pricer.floorlet_rate(0.03).unwrap(), 0.0);
+    }
+
+    /// An undetermined coupon with no optionlet volatility surface refuses,
+    /// rather than pricing the caplet as if the volatility were zero.
+    #[test]
+    fn an_undetermined_coupon_without_a_surface_refuses() {
+        let today = Date::new(15, Month::June, 2026);
+        let settings = shared(Settings::<Date>::new());
+        settings.set_evaluation_date(today);
+        let index = index_on(settings, flat_curve(today, 0.03));
+
+        let start = Date::new(15, Month::June, 2027);
+        let end = Date::new(15, Month::December, 2027);
+        let coupon = FloatingRateCoupon::new(
+            end,
+            100.0,
+            start,
+            end,
+            Some(2),
+            index,
+            1.0,
+            0.0,
+            None,
+            None,
+            None,
+            false,
+            None,
+            BusinessDayConvention::Preceding,
+        )
+        .unwrap();
+
+        let mut pricer = BlackIborCouponPricer::new();
+        pricer.initialize(&coupon);
+
+        let err = pricer.caplet_rate(0.03).unwrap_err();
+        assert!(err.message().contains("missing optionlet volatility"));
+    }
+
+    /// A pricer with no coupon captured yet cannot price an optionlet.
+    #[test]
+    fn an_uninitialized_pricer_refuses_the_optionlet() {
+        let pricer = BlackIborCouponPricer::new();
+        assert!(
+            pricer
+                .caplet_rate(0.03)
+                .unwrap_err()
+                .message()
+                .contains("not initialized")
+        );
     }
 }

--- a/crates/libitofin/src/cashflows/floatingratecoupon.rs
+++ b/crates/libitofin/src/cashflows/floatingratecoupon.rs
@@ -413,12 +413,16 @@ mod tests {
             Ok(self.swaplet)
         }
 
-        fn caplet_rate(&self, _effective_cap: Rate) -> QlResult<Rate> {
-            fail!("caplet rate not ported: cap/floor slice")
+        fn caplet_rate(&self, _effective_cap: Rate, _forward: QlResult<Rate>) -> QlResult<Rate> {
+            fail!("caplet rate not priced by the recording stub")
         }
 
-        fn floorlet_rate(&self, _effective_floor: Rate) -> QlResult<Rate> {
-            fail!("floorlet rate not ported: cap/floor slice")
+        fn floorlet_rate(
+            &self,
+            _effective_floor: Rate,
+            _forward: QlResult<Rate>,
+        ) -> QlResult<Rate> {
+            fail!("floorlet rate not priced by the recording stub")
         }
     }
 
@@ -468,17 +472,17 @@ mod tests {
     }
 
     #[test]
-    fn the_cap_floor_slice_refuses() {
+    fn the_recording_stub_does_not_price_optionlets() {
         let (pricer, ..) = RecordingPricer::new(0.05);
         let pricer = pricer.borrow();
         assert!(
             pricer
-                .caplet_rate(0.03)
+                .caplet_rate(0.03, Ok(0.05))
                 .unwrap_err()
                 .message()
-                .contains("not ported")
+                .contains("recording stub")
         );
-        assert!(pricer.floorlet_rate(0.01).is_err());
+        assert!(pricer.floorlet_rate(0.01, Ok(0.05)).is_err());
     }
 
     #[test]

--- a/crates/libitofin/src/cashflows/iborcoupon.rs
+++ b/crates/libitofin/src/cashflows/iborcoupon.rs
@@ -121,6 +121,18 @@ impl IborCoupon {
         &self.ibor_index
     }
 
+    /// The spread paid over the index fixing (`spread`), delegated to the base
+    /// [`FloatingRateCoupon`].
+    pub fn spread(&self) -> Spread {
+        self.base.spread()
+    }
+
+    /// The multiplicative coefficient applied to the index (`gearing`),
+    /// delegated to the base [`FloatingRateCoupon`].
+    pub fn gearing(&self) -> Real {
+        self.base.gearing()
+    }
+
     /// The coupon's fixing date (`fixingDate`).
     pub fn fixing_date(&self) -> Date {
         self.base.fixing_date()

--- a/crates/libitofin/src/cashflows/iborleg.rs
+++ b/crates/libitofin/src/cashflows/iborleg.rs
@@ -22,12 +22,14 @@
 //! [`IborLeg::coupons`], which keeps the concrete [`IborCoupon`] type, and
 //! [`IborLeg::build`], which erases it into a [`Leg`]; C++ recovers the concrete
 //! type with `dynamic_pointer_cast`, which the port has no counterpart for. The
-//! default [`BlackIborCouponPricer`] that `operator Leg()` attaches when no
+//! default [`BlackIborCouponPricer`] that `operator Leg()` attaches only when no
 //! caps, floors or in-arrears feature is present is attached in
-//! [`coupons`](IborLeg::coupons); since those features are deferred the condition
-//! always holds. C++ attaches it through the free `setCouponPricer(leg, pricer)`,
-//! which downcasts each flow; the port's [`set_coupon_pricer`] takes the concrete
-//! coupons instead, the erased [`Leg`] carrying no downcast.
+//! [`coupons`](IborLeg::coupons) under the same guard; with a cap or floor set
+//! the coupons come from [`capped_floored_coupons`](IborLeg::capped_floored_coupons)
+//! and the caller installs a volatility-carrying pricer instead. C++ attaches it
+//! through the free `setCouponPricer(leg, pricer)`, which downcasts each flow;
+//! the port's [`set_coupon_pricer`] takes the concrete coupons instead, the
+//! erased [`Leg`] carrying no downcast.
 //!
 //! The stub reference date uses `calendar.adjust(end - tenor, bdc)` as the
 //! `FloatingLeg` template does, ignoring the schedule's end-of-month flag; the
@@ -36,16 +38,19 @@
 //!
 //! ## Deferred (later sub-tickets of #69)
 //!
-//! Caps and floors (`withCaps`/`withFloors`, which yield `CappedFlooredIborCoupon`
-//! through a `BlackIborCouponPricer` optionlet path), the in-arrears convexity
-//! adjustment (`inArrears`), zero and indexed-coupon modes, digital and CMS
-//! coupons and the overnight-indexed leg. Their builder methods are omitted
-//! entirely rather than accepted and ignored. A zero gearing, which the template
-//! collapses to a `FixedRateCoupon`, is likewise not special-cased: the port's
-//! [`IborCoupon`] rejects it, so `with_gearing(0.0)` surfaces that error rather
-//! than a silent fixed coupon.
+//! The in-arrears convexity adjustment (`inArrears`), zero and indexed-coupon
+//! modes, digital and CMS coupons and the overnight-indexed leg. Their builder
+//! methods are omitted entirely rather than accepted and ignored. A zero
+//! gearing, which the template collapses to a `FixedRateCoupon`, is likewise not
+//! special-cased: the port's [`IborCoupon`] rejects it, so `with_gearing(0.0)`
+//! surfaces that error rather than a silent fixed coupon.
+//!
+//! Caps and floors (`withCaps`/`withFloors`) are ported: they yield
+//! [`CappedFlooredCoupon`](crate::cashflows::CappedFlooredCoupon)s over the
+//! [`BlackIborCouponPricer`] optionlet path.
 
 use crate::cashflow::{CashFlow, Leg};
+use crate::cashflows::capflooredcoupon::CappedFlooredCoupon;
 use crate::cashflows::couponpricer::{BlackIborCouponPricer, FloatingRateCouponPricer};
 use crate::cashflows::iborcoupon::IborCoupon;
 use crate::errors::QlResult;
@@ -60,7 +65,7 @@ use crate::time::daycounter::DayCounter;
 use crate::time::period::Period;
 use crate::time::schedule::Schedule;
 use crate::time::timeunit::TimeUnit;
-use crate::types::{Integer, Natural, Real, Spread};
+use crate::types::{Integer, Natural, Rate, Real, Spread};
 
 /// Builds a sequence of [`IborCoupon`]s from a [`Schedule`].
 #[must_use]
@@ -75,6 +80,8 @@ pub struct IborLeg {
     fixing_days: Vec<Natural>,
     gearings: Vec<Real>,
     spreads: Vec<Spread>,
+    caps: Vec<Rate>,
+    floors: Vec<Rate>,
     fixing_convention: BusinessDayConvention,
     ex_coupon_period: Option<Period>,
     ex_coupon_calendar: Calendar,
@@ -99,6 +106,8 @@ impl IborLeg {
             fixing_days: Vec::new(),
             gearings: Vec::new(),
             spreads: Vec::new(),
+            caps: Vec::new(),
+            floors: Vec::new(),
             fixing_convention: BusinessDayConvention::Preceding,
             ex_coupon_period: None,
             ex_coupon_calendar: NullCalendar::new(),
@@ -177,6 +186,25 @@ impl IborLeg {
         self
     }
 
+    /// A cap per coupon; the last one carries over. An empty list, the default,
+    /// leaves the coupons uncapped.
+    ///
+    /// Setting a cap or a floor makes [`build`](Self::build) and
+    /// [`capped_floored_coupons`](Self::capped_floored_coupons) produce
+    /// [`CappedFlooredCoupon`]s, and stops the plain-path default pricer being
+    /// attached: the caller installs a volatility-carrying pricer instead.
+    pub fn with_caps(mut self, caps: Vec<Rate>) -> IborLeg {
+        self.caps = caps;
+        self
+    }
+
+    /// A floor per coupon; the last one carries over. An empty list, the
+    /// default, leaves the coupons unfloored. See [`with_caps`](Self::with_caps).
+    pub fn with_floors(mut self, floors: Vec<Rate>) -> IborLeg {
+        self.floors = floors;
+        self
+    }
+
     /// The convention the fixing dates are computed with.
     pub fn with_fixing_convention(mut self, convention: BusinessDayConvention) -> IborLeg {
         self.fixing_convention = convention;
@@ -198,16 +226,10 @@ impl IborLeg {
         self
     }
 
-    /// The coupons the leg is made of, each carrying the default
-    /// [`BlackIborCouponPricer`].
-    ///
-    /// # Errors
-    ///
-    /// Errors if no notional was given, if the schedule holds fewer than two
-    /// dates, if more notionals, gearings or spreads were given than the schedule
-    /// has periods, or if a coupon fails its [`IborCoupon::new`] preconditions (a
-    /// zero gearing among them).
-    pub fn coupons(&self) -> QlResult<Vec<Shared<IborCoupon>>> {
+    /// The bare underlying coupons, no pricer attached: the loop shared by the
+    /// plain [`coupons`](Self::coupons) and the capped
+    /// [`capped_floored_coupons`](Self::capped_floored_coupons) paths.
+    fn raw_coupons(&self) -> QlResult<Vec<Shared<IborCoupon>>> {
         require!(!self.notionals.is_empty(), "no notional given");
         let size = self.schedule.len();
         require!(size >= 2, "schedule with {size} date(s) spans no period");
@@ -226,6 +248,16 @@ impl IborLeg {
             self.spreads.len() <= periods,
             "too many spreads ({}), only {periods} required",
             self.spreads.len()
+        );
+        require!(
+            self.caps.len() <= periods,
+            "too many caps ({}), only {periods} required",
+            self.caps.len()
+        );
+        require!(
+            self.floors.len() <= periods,
+            "too many floors ({}), only {periods} required",
+            self.floors.len()
         );
 
         let calendar = self.schedule.calendar();
@@ -286,24 +318,109 @@ impl IborLeg {
                 ex_coupon_date,
                 self.fixing_convention,
             )?;
-            let coupon = shared(coupon);
-            coupon.set_pricer(default_pricer());
-            coupons.push(coupon);
+            coupons.push(shared(coupon));
+        }
+        Ok(coupons)
+    }
+
+    /// The coupons the leg is made of.
+    ///
+    /// Each carries the default [`BlackIborCouponPricer`] on the plain path.
+    /// With a cap or floor set the plain coupons are returned unpriced, the C++
+    /// `operator Leg()` guard withholding the default pricer;
+    /// [`capped_floored_coupons`](Self::capped_floored_coupons) is then the
+    /// intended entry.
+    ///
+    /// # Errors
+    ///
+    /// Errors if no notional was given, if the schedule holds fewer than two
+    /// dates, if more notionals, gearings, spreads, caps or floors were given
+    /// than the schedule has periods, or if a coupon fails its
+    /// [`IborCoupon::new`] preconditions (a zero gearing among them).
+    pub fn coupons(&self) -> QlResult<Vec<Shared<IborCoupon>>> {
+        let coupons = self.raw_coupons()?;
+        if self.caps.is_empty() && self.floors.is_empty() {
+            for coupon in &coupons {
+                coupon.set_pricer(default_pricer());
+            }
+        }
+        Ok(coupons)
+    }
+
+    /// The coupons wrapped in their per-coupon cap and floor, no pricer
+    /// attached: the caller installs a volatility-carrying pricer through
+    /// [`set_coupon_pricer`].
+    ///
+    /// # Errors
+    ///
+    /// As [`coupons`](Self::coupons), plus any [`CappedFlooredCoupon::new`]
+    /// precondition (a cap below its floor).
+    pub fn capped_floored_coupons(&self) -> QlResult<Vec<Shared<CappedFlooredCoupon>>> {
+        let raw = self.raw_coupons()?;
+        let mut coupons = Vec::with_capacity(raw.len());
+        for (i, underlying) in raw.into_iter().enumerate() {
+            let cap = pick(&self.caps, i);
+            let floor = pick(&self.floors, i);
+            coupons.push(shared(CappedFlooredCoupon::new(underlying, cap, floor)?));
         }
         Ok(coupons)
     }
 
     /// The coupons as a [`Leg`], with their concrete type erased.
     ///
+    /// The plain path erases [`coupons`](Self::coupons); with a cap or floor set
+    /// it erases [`capped_floored_coupons`](Self::capped_floored_coupons), whose
+    /// coupons carry no pricer, so the caller must install one on the concrete
+    /// coupons through [`set_coupon_pricer`] before erasing rather than through
+    /// this method.
+    ///
     /// # Errors
     ///
-    /// As [`coupons`](Self::coupons).
+    /// As [`coupons`](Self::coupons) or
+    /// [`capped_floored_coupons`](Self::capped_floored_coupons).
     pub fn build(&self) -> QlResult<Leg> {
-        Ok(self
-            .coupons()?
-            .into_iter()
-            .map(|coupon| coupon as Shared<dyn CashFlow>)
-            .collect())
+        if self.caps.is_empty() && self.floors.is_empty() {
+            Ok(self
+                .coupons()?
+                .into_iter()
+                .map(|coupon| coupon as Shared<dyn CashFlow>)
+                .collect())
+        } else {
+            Ok(self
+                .capped_floored_coupons()?
+                .into_iter()
+                .map(|coupon| coupon as Shared<dyn CashFlow>)
+                .collect())
+        }
+    }
+}
+
+/// The `index`-th rate as a cap/floor, or `None` when the list is empty
+/// (an uncapped or unfloored coupon).
+fn pick(rates: &[Rate], index: usize) -> Option<Rate> {
+    if rates.is_empty() {
+        None
+    } else {
+        Some(broadcast(rates, index, 0.0))
+    }
+}
+
+/// A coupon a pricer can be attached to (an [`IborCoupon`] or a
+/// [`CappedFlooredCoupon`]), so [`set_coupon_pricer`] spans both.
+pub trait AttachPricer {
+    /// Attaches `pricer` to the coupon.
+    fn attach_pricer(&self, pricer: SharedMut<dyn FloatingRateCouponPricer>);
+}
+
+impl AttachPricer for IborCoupon {
+    fn attach_pricer(&self, pricer: SharedMut<dyn FloatingRateCouponPricer>) {
+        self.set_pricer(pricer);
+    }
+}
+
+impl AttachPricer for CappedFlooredCoupon {
+    fn attach_pricer(&self, pricer: SharedMut<dyn FloatingRateCouponPricer>) {
+        self.set_pricer(pricer);
     }
 }
 
@@ -311,13 +428,14 @@ impl IborLeg {
 ///
 /// The free `setCouponPricer(Leg&, pricer)` of `couponpricer.cpp`, taking the
 /// concrete coupons rather than an erased [`Leg`] since the port cannot downcast
-/// a [`CashFlow`](crate::cashflow::CashFlow) back to a coupon.
-pub fn set_coupon_pricer(
-    coupons: &[Shared<IborCoupon>],
+/// a [`CashFlow`](crate::cashflow::CashFlow) back to a coupon. Generic over the
+/// coupon type so a plain or a capped/floored leg can be priced the same way.
+pub fn set_coupon_pricer<C: AttachPricer>(
+    coupons: &[Shared<C>],
     pricer: SharedMut<dyn FloatingRateCouponPricer>,
 ) {
     for coupon in coupons {
-        coupon.set_pricer(pricer.clone());
+        coupon.attach_pricer(pricer.clone());
     }
 }
 
@@ -526,5 +644,23 @@ mod tests {
             leg.last().unwrap().reference_period_end(),
             Date::new(30, Month::September, 2020)
         );
+    }
+
+    /// With a cap set the builder yields [`CappedFlooredCoupon`]s over one coupon
+    /// per period, and the guard withholds the default pricer: the underlyings
+    /// carry none until [`set_coupon_pricer`] installs a volatility-carrying one,
+    /// so a rate query errors rather than pricing with a wrong pricer.
+    #[test]
+    fn a_capped_leg_withholds_the_default_pricer() {
+        let periods = monthly_schedule().len() - 1;
+        let leg = IborLeg::new(monthly_schedule(), euribor3m())
+            .with_notional(100.0)
+            .with_caps(vec![0.05]);
+
+        let capped = leg.capped_floored_coupons().unwrap();
+        assert_eq!(capped.len(), periods);
+        assert!(capped[0].is_capped() && !capped[0].is_floored());
+        assert!(capped[0].underlying().pricer().is_none());
+        assert!(capped[0].rate().is_err());
     }
 }

--- a/crates/libitofin/src/cashflows/mod.rs
+++ b/crates/libitofin/src/cashflows/mod.rs
@@ -32,7 +32,7 @@ pub use fixedratecoupon::FixedRateCoupon;
 pub use fixedrateleg::FixedRateLeg;
 pub use floatingratecoupon::{FloatingIndex, FloatingRateCoupon};
 pub use iborcoupon::IborCoupon;
-pub use iborleg::{IborLeg, set_coupon_pricer};
+pub use iborleg::{AttachPricer, IborLeg, set_coupon_pricer};
 pub use overnightindexedcoupon::OvernightIndexedCoupon;
 pub use overnightindexedcouponpricer::{
     CompoundingOvernightIndexedCouponPricer, OvernightSchedule,

--- a/crates/libitofin/src/cashflows/mod.rs
+++ b/crates/libitofin/src/cashflows/mod.rs
@@ -4,6 +4,7 @@
 //! base. The items are re-exported flat, so a coupon is `cashflows::Coupon`
 //! rather than `cashflows::coupon::Coupon`.
 
+mod capflooredcoupon;
 #[allow(clippy::module_inception)]
 mod cashflows;
 mod coupon;
@@ -21,6 +22,7 @@ mod overnightleg;
 mod rateaveraging;
 mod simplecashflow;
 
+pub use capflooredcoupon::{CappedFlooredCoupon, CappedFlooredIborCoupon};
 pub use cashflows::CashFlows;
 pub use coupon::{Coupon, CouponBase};
 pub use couponpricer::{BlackIborCouponPricer, FloatingRateCouponPricer};

--- a/crates/libitofin/src/cashflows/mod.rs
+++ b/crates/libitofin/src/cashflows/mod.rs
@@ -5,6 +5,8 @@
 //! rather than `cashflows::coupon::Coupon`.
 
 mod capflooredcoupon;
+#[cfg(test)]
+mod capflooredcoupon_oracle;
 #[allow(clippy::module_inception)]
 mod cashflows;
 mod coupon;

--- a/crates/libitofin/src/cashflows/overnightindexedcouponpricer.rs
+++ b/crates/libitofin/src/cashflows/overnightindexedcouponpricer.rs
@@ -309,11 +309,11 @@ impl FloatingRateCouponPricer for CompoundingOvernightIndexedCouponPricer {
         )
     }
 
-    fn caplet_rate(&self, _effective_cap: Rate) -> QlResult<Rate> {
+    fn caplet_rate(&self, _effective_cap: Rate, _forward: QlResult<Rate>) -> QlResult<Rate> {
         fail!("caplet rate not ported: overnight cap/floor slice")
     }
 
-    fn floorlet_rate(&self, _effective_floor: Rate) -> QlResult<Rate> {
+    fn floorlet_rate(&self, _effective_floor: Rate, _forward: QlResult<Rate>) -> QlResult<Rate> {
         fail!("floorlet rate not ported: overnight cap/floor slice")
     }
 }
@@ -381,8 +381,8 @@ mod tests {
             index, schedule, 1.0, 0.0, false,
         ));
         let pricer = pricer.borrow();
-        assert!(pricer.caplet_rate(0.03).is_err());
-        assert!(pricer.floorlet_rate(0.01).is_err());
+        assert!(pricer.caplet_rate(0.03, Ok(0.01)).is_err());
+        assert!(pricer.floorlet_rate(0.01, Ok(0.01)).is_err());
         assert!(pricer.swaplet_rate_for(Ok(0.01)).is_err());
     }
 }

--- a/crates/libitofin/src/instruments/capfloor.rs
+++ b/crates/libitofin/src/instruments/capfloor.rs
@@ -1,0 +1,423 @@
+//! Cap, floor and collar instruments.
+//!
+//! Port of `ql/instruments/capfloor.{hpp,cpp}`. A [`CapFloor`] is an
+//! [`Instrument`] over a floating leg plus per-coupon cap and/or floor strike
+//! vectors and a [`CapFloorType`]; [`CapFloor::cap`], [`CapFloor::floor`] and
+//! [`CapFloor::collar`] are the thin constructors the C++ `Cap`/`Floor`/`Collar`
+//! subclasses provide. [`setup_arguments`](Instrument::setup_arguments) fills the
+//! [`CapFloorArguments`] a `CapFloor::engine` reads.
+//!
+//! ## Leg shape
+//!
+//! C++ holds a generic `Leg` of `FloatingRateCoupon`s and, in `setupArguments`,
+//! `dynamic_pointer_cast`s each flow back to a `FloatingRateCoupon`. The port
+//! cannot downcast an erased [`Leg`](crate::cashflow::Leg), and the par/indexed
+//! forecast that drives the cached price lives only on the concrete
+//! [`IborCoupon`] (its mode-aware [`rate`](crate::cashflows::coupon::Coupon::rate)),
+//! not on the base `FloatingRateCoupon`. So [`CapFloor`] holds concrete
+//! `Vec<Shared<IborCoupon>>`, the same choice [`IborLeg::coupons`] makes for the
+//! same reason. The forward the engine prices from is the coupon's adjusted
+//! fixing `(rate - spread) / gearing`, read off the mode-aware rate.
+//!
+//! ## Divergences from QuantLib
+//!
+//! - The generic `Leg`/`FloatingRateCoupon` surface becomes the concrete
+//!   `IborCoupon`, as above; the fixture only ever builds ibor legs.
+//! - `MakeCapFloor` is not ported (the fixture constructs `Cap`/`Floor`
+//!   directly); nor are `optionlet`, `lastFloatingRateCoupon`, `impliedVolatility`
+//!   or `deepUpdate`, none of which the ported tests reach.
+//! - The `CapFloor::arguments` bundle keeps only the fields the Black engine
+//!   reads: the C++ `startDates`, `spreads` and `indexes` are filled but unread,
+//!   so they are omitted here.
+//! - The D5 `Settings` handle replaces `Settings::instance()` for the evaluation
+//!   date the expiry check and the forward guard read.
+
+use std::any::Any;
+
+use crate::cashflow::{CashFlow, Leg};
+use crate::cashflows::{CashFlows, Coupon, IborCoupon};
+use crate::errors::QlResult;
+use crate::event::Event;
+use crate::instrument::{Instrument, InstrumentBase};
+use crate::patterns::observable::AsObservable;
+use crate::pricingengine::Arguments;
+use crate::settings::Settings;
+use crate::shared::Shared;
+use crate::termstructures::yieldtermstructure::YieldTermStructure;
+use crate::time::date::Date;
+use crate::types::{Rate, Real, Time};
+use crate::{fail, require};
+
+/// Whether the instrument caps, floors or collars its floating leg
+/// (`CapFloor::Type`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CapFloorType {
+    /// A cap: long a call on each coupon's rate at the cap strike.
+    Cap,
+    /// A floor: long a put on each coupon's rate at the floor strike.
+    Floor,
+    /// A collar: long the cap, short the floor.
+    Collar,
+}
+
+/// Argument bundle a `CapFloor::engine` prices (`CapFloor::arguments`).
+///
+/// Per optionlet: the payment date (`end_dates`), fixing date, accrual time,
+/// nominal, gearing, the coupon's adjusted forward (`None` for a past-fixing
+/// coupon, the C++ `Null<Rate>`), and the de-spread cap and floor strikes
+/// (`None` where the type has none).
+#[derive(Default)]
+pub struct CapFloorArguments {
+    /// The instrument type, set by `setup_arguments`.
+    pub cap_floor_type: Option<CapFloorType>,
+    /// Each coupon's fixing date.
+    pub fixing_dates: Vec<Date>,
+    /// Each coupon's payment date (the C++ `endDates`).
+    pub end_dates: Vec<Date>,
+    /// Each coupon's accrual period as a year fraction.
+    pub accrual_times: Vec<Time>,
+    /// Each coupon's de-spread cap strike, `None` for a pure floor.
+    pub cap_rates: Vec<Option<Rate>>,
+    /// Each coupon's de-spread floor strike, `None` for a pure cap.
+    pub floor_rates: Vec<Option<Rate>>,
+    /// Each coupon's adjusted forward, `None` when its fixing has passed.
+    pub forwards: Vec<Option<Rate>>,
+    /// Each coupon's gearing.
+    pub gearings: Vec<Real>,
+    /// Each coupon's nominal.
+    pub nominals: Vec<Real>,
+}
+
+impl Arguments for CapFloorArguments {
+    fn validate(&self) -> QlResult<()> {
+        let n = self.end_dates.len();
+        require!(self.cap_floor_type.is_some(), "cap/floor type not set");
+        require!(self.fixing_dates.len() == n, "fixing-date count mismatch");
+        require!(self.accrual_times.len() == n, "accrual-time count mismatch");
+        require!(self.cap_rates.len() == n, "cap-rate count mismatch");
+        require!(self.floor_rates.len() == n, "floor-rate count mismatch");
+        require!(self.forwards.len() == n, "forward count mismatch");
+        require!(self.gearings.len() == n, "gearing count mismatch");
+        require!(self.nominals.len() == n, "nominal count mismatch");
+        Ok(())
+    }
+}
+
+/// A cap, floor or collar over a floating (ibor) leg.
+pub struct CapFloor {
+    base: InstrumentBase,
+    cap_floor_type: CapFloorType,
+    coupons: Vec<Shared<IborCoupon>>,
+    cap_rates: Vec<Rate>,
+    floor_rates: Vec<Rate>,
+    settings: Shared<Settings<Date>>,
+}
+
+impl CapFloor {
+    /// Builds a cap/floor/collar over `coupons`, padding the strike vectors to
+    /// the leg length by repeating the last strike (the C++ constructor's
+    /// `while (rates.size() < leg.size()) push_back(rates.back())`).
+    ///
+    /// A `Cap` or `Collar` requires at least one cap rate, a `Floor` or `Collar`
+    /// at least one floor rate.
+    pub fn new(
+        cap_floor_type: CapFloorType,
+        coupons: Vec<Shared<IborCoupon>>,
+        mut cap_rates: Vec<Rate>,
+        mut floor_rates: Vec<Rate>,
+        settings: Shared<Settings<Date>>,
+    ) -> QlResult<CapFloor> {
+        let n = coupons.len();
+        if matches!(cap_floor_type, CapFloorType::Cap | CapFloorType::Collar) {
+            require!(!cap_rates.is_empty(), "no cap rates given");
+            while cap_rates.len() < n {
+                cap_rates.push(*cap_rates.last().expect("non-empty"));
+            }
+        }
+        if matches!(cap_floor_type, CapFloorType::Floor | CapFloorType::Collar) {
+            require!(!floor_rates.is_empty(), "no floor rates given");
+            while floor_rates.len() < n {
+                floor_rates.push(*floor_rates.last().expect("non-empty"));
+            }
+        }
+
+        let base = InstrumentBase::new();
+        for coupon in &coupons {
+            base.register_with(coupon.observable());
+        }
+        settings.register_eval_date_observer(&base.observer());
+
+        Ok(CapFloor {
+            base,
+            cap_floor_type,
+            coupons,
+            cap_rates,
+            floor_rates,
+            settings,
+        })
+    }
+
+    /// A cap over `coupons` struck at `strikes` (the C++ `Cap`).
+    pub fn cap(
+        coupons: Vec<Shared<IborCoupon>>,
+        strikes: Vec<Rate>,
+        settings: Shared<Settings<Date>>,
+    ) -> QlResult<CapFloor> {
+        CapFloor::new(CapFloorType::Cap, coupons, strikes, Vec::new(), settings)
+    }
+
+    /// A floor over `coupons` struck at `strikes` (the C++ `Floor`).
+    pub fn floor(
+        coupons: Vec<Shared<IborCoupon>>,
+        strikes: Vec<Rate>,
+        settings: Shared<Settings<Date>>,
+    ) -> QlResult<CapFloor> {
+        CapFloor::new(CapFloorType::Floor, coupons, Vec::new(), strikes, settings)
+    }
+
+    /// A collar over `coupons`, long the cap at `cap_rates` and short the floor
+    /// at `floor_rates` (the C++ `Collar`).
+    pub fn collar(
+        coupons: Vec<Shared<IborCoupon>>,
+        cap_rates: Vec<Rate>,
+        floor_rates: Vec<Rate>,
+        settings: Shared<Settings<Date>>,
+    ) -> QlResult<CapFloor> {
+        CapFloor::new(
+            CapFloorType::Collar,
+            coupons,
+            cap_rates,
+            floor_rates,
+            settings,
+        )
+    }
+
+    /// The instrument type.
+    pub fn cap_floor_type(&self) -> CapFloorType {
+        self.cap_floor_type
+    }
+
+    /// The padded cap strikes.
+    pub fn cap_rates(&self) -> &[Rate] {
+        &self.cap_rates
+    }
+
+    /// The padded floor strikes.
+    pub fn floor_rates(&self) -> &[Rate] {
+        &self.floor_rates
+    }
+
+    /// The floating coupons.
+    pub fn coupons(&self) -> &[Shared<IborCoupon>] {
+        &self.coupons
+    }
+
+    /// The leg's earliest accrual start (`startDate`).
+    pub fn start_date(&self) -> QlResult<Date> {
+        CashFlows::start_date(&self.cash_flows())
+    }
+
+    /// The leg's latest accrual end (`maturityDate`).
+    pub fn maturity_date(&self) -> QlResult<Date> {
+        CashFlows::maturity_date(&self.cash_flows())
+    }
+
+    /// The at-the-money rate: the fixed rate that reprices the floating leg on
+    /// `discount_curve` (`atmRate`).
+    pub fn atm_rate(&self, discount_curve: &dyn YieldTermStructure) -> QlResult<Rate> {
+        let reference = discount_curve.reference_date()?;
+        CashFlows::atm_rate(
+            &self.cash_flows(),
+            discount_curve,
+            &self.settings,
+            Some(false),
+            Some(reference),
+            None,
+            None,
+        )
+    }
+
+    /// The concrete coupons erased to a [`Leg`] for the [`CashFlows`] analytics.
+    fn cash_flows(&self) -> Leg {
+        self.coupons
+            .iter()
+            .map(|coupon| Shared::clone(coupon) as Shared<dyn CashFlow>)
+            .collect()
+    }
+}
+
+impl Instrument for CapFloor {
+    fn base(&self) -> &InstrumentBase {
+        &self.base
+    }
+
+    fn base_mut(&mut self) -> &mut InstrumentBase {
+        &mut self.base
+    }
+
+    fn is_expired(&self) -> QlResult<bool> {
+        for coupon in self.coupons.iter().rev() {
+            if !coupon.has_occurred(&self.settings, None, None)? {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+
+    fn setup_arguments(&self, arguments: &mut dyn Arguments) -> QlResult<()> {
+        let Some(args) = (arguments as &mut dyn Any).downcast_mut::<CapFloorArguments>() else {
+            fail!("wrong argument type");
+        };
+        let today = match self.settings.evaluation_date() {
+            Some(today) => today,
+            None => fail!("no evaluation date set: a cap/floor needs a reference date"),
+        };
+
+        let n = self.coupons.len();
+        args.cap_floor_type = Some(self.cap_floor_type);
+        args.fixing_dates = Vec::with_capacity(n);
+        args.end_dates = Vec::with_capacity(n);
+        args.accrual_times = Vec::with_capacity(n);
+        args.cap_rates = Vec::with_capacity(n);
+        args.floor_rates = Vec::with_capacity(n);
+        args.forwards = Vec::with_capacity(n);
+        args.gearings = Vec::with_capacity(n);
+        args.nominals = Vec::with_capacity(n);
+
+        let has_cap = matches!(
+            self.cap_floor_type,
+            CapFloorType::Cap | CapFloorType::Collar
+        );
+        let has_floor = matches!(
+            self.cap_floor_type,
+            CapFloorType::Floor | CapFloorType::Collar
+        );
+
+        for (i, coupon) in self.coupons.iter().enumerate() {
+            let spread = coupon.spread();
+            let gearing = coupon.gearing();
+            let end_date = coupon.date();
+
+            args.fixing_dates.push(coupon.fixing_date());
+            args.end_dates.push(end_date);
+            args.accrual_times.push(coupon.accrual_period());
+            args.nominals.push(coupon.nominal());
+            args.gearings.push(gearing);
+
+            // Passed explicitly for precision, but only if the coupon can still
+            // pay (`capfloor.cpp:245`): a past-fixing coupon has no forward.
+            let forward = if end_date >= today {
+                Some((coupon.rate()? - spread) / gearing)
+            } else {
+                None
+            };
+            args.forwards.push(forward);
+
+            args.cap_rates.push(if has_cap {
+                Some((self.cap_rates[i] - spread) / gearing)
+            } else {
+                None
+            });
+            args.floor_rates.push(if has_floor {
+                Some((self.floor_rates[i] - spread) / gearing)
+            } else {
+                None
+            });
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cashflows::IborLeg;
+    use crate::handle::Handle;
+    use crate::indexes::ibor::Euribor;
+    use crate::shared::shared;
+    use crate::termstructures::yieldtermstructure::YieldTermStructure;
+    use crate::time::businessdayconvention::BusinessDayConvention;
+    use crate::time::calendars::target::Target;
+    use crate::time::date::{Date, Month};
+    use crate::time::frequency::Frequency;
+    use crate::time::schedule::MakeSchedule;
+
+    fn settings_on(today: Date) -> Shared<Settings<Date>> {
+        let settings = shared(Settings::<Date>::new());
+        settings.set_evaluation_date(today);
+        settings
+    }
+
+    /// A three-coupon 18-month leg over an unlinked Euribor 6M.
+    fn leg(settings: Shared<Settings<Date>>) -> Vec<Shared<IborCoupon>> {
+        let index = shared(Euribor::six_months(
+            Handle::<dyn YieldTermStructure>::empty(),
+            settings,
+        ));
+        let schedule = MakeSchedule::new()
+            .from(Date::new(15, Month::January, 2026))
+            .to(Date::new(15, Month::July, 2027))
+            .with_frequency(Frequency::Semiannual)
+            .with_calendar(Target::new())
+            .with_convention(BusinessDayConvention::ModifiedFollowing)
+            .build();
+        IborLeg::new(schedule, index)
+            .with_notional(100.0)
+            .coupons()
+            .unwrap()
+    }
+
+    #[test]
+    fn a_cap_pads_the_strike_to_the_leg_length() {
+        let settings = settings_on(Date::new(2, Month::January, 2026));
+        let coupons = leg(settings.clone());
+        let n = coupons.len();
+        let cap = CapFloor::cap(coupons, vec![0.03], settings).unwrap();
+
+        assert_eq!(cap.cap_floor_type(), CapFloorType::Cap);
+        assert_eq!(cap.cap_rates(), vec![0.03; n].as_slice());
+        assert!(cap.floor_rates().is_empty());
+    }
+
+    #[test]
+    fn a_collar_keeps_both_padded_strike_vectors() {
+        let settings = settings_on(Date::new(2, Month::January, 2026));
+        let coupons = leg(settings.clone());
+        let n = coupons.len();
+        let collar = CapFloor::collar(coupons, vec![0.06], vec![0.02], settings).unwrap();
+
+        assert_eq!(collar.cap_floor_type(), CapFloorType::Collar);
+        assert_eq!(collar.cap_rates(), vec![0.06; n].as_slice());
+        assert_eq!(collar.floor_rates(), vec![0.02; n].as_slice());
+    }
+
+    #[test]
+    fn a_cap_needs_at_least_one_rate() {
+        let settings = settings_on(Date::new(2, Month::January, 2026));
+        let coupons = leg(settings.clone());
+        let err = CapFloor::cap(coupons, Vec::new(), settings).err().unwrap();
+        assert_eq!(err.message(), "no cap rates given");
+    }
+
+    #[test]
+    fn a_floor_needs_at_least_one_rate() {
+        let settings = settings_on(Date::new(2, Month::January, 2026));
+        let coupons = leg(settings.clone());
+        let err = CapFloor::floor(coupons, Vec::new(), settings)
+            .err()
+            .unwrap();
+        assert_eq!(err.message(), "no floor rates given");
+    }
+
+    /// `CapFloor::isExpired`: expired once every coupon has paid.
+    #[test]
+    fn a_cap_is_expired_only_once_all_coupons_have_paid() {
+        let settings = settings_on(Date::new(2, Month::January, 2026));
+        let coupons = leg(settings.clone());
+        let cap = CapFloor::cap(coupons, vec![0.03], settings.clone()).unwrap();
+        assert!(!cap.is_expired().unwrap());
+
+        settings.set_evaluation_date(Date::new(15, Month::August, 2027));
+        assert!(cap.is_expired().unwrap());
+    }
+}

--- a/crates/libitofin/src/instruments/mod.rs
+++ b/crates/libitofin/src/instruments/mod.rs
@@ -5,6 +5,7 @@
 
 mod bond;
 mod bonds;
+mod capfloor;
 mod fixedvsfloatingswap;
 mod makeois;
 mod makevanillaswap;
@@ -16,6 +17,7 @@ mod vanillaswap;
 
 pub use bond::{Bond, BondArguments, BondEngine, BondPrice, BondResults};
 pub use bonds::FixedRateBond;
+pub use capfloor::{CapFloor, CapFloorArguments, CapFloorType};
 pub use fixedvsfloatingswap::{
     FixedVsFloatingSwap, FixedVsFloatingSwapArguments, FixedVsFloatingSwapEngine,
     FixedVsFloatingSwapResults, FloatingArgumentsFn,

--- a/crates/libitofin/src/pricingengines/capfloor/blackcapfloorengine.rs
+++ b/crates/libitofin/src/pricingengines/capfloor/blackcapfloorengine.rs
@@ -274,3 +274,392 @@ impl PricingEngine for BlackCapFloorEngine {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cashflows::{IborCoupon, IborLeg};
+    use crate::indexes::IborIndex;
+    use crate::indexes::ibor::Euribor;
+    use crate::indexes::interestrateindex::InterestRateIndex;
+    use crate::instrument::Instrument;
+    use crate::instruments::CapFloor;
+    use crate::instruments::{SwapType, VanillaSwap};
+    use crate::interestrate::Compounding;
+    use crate::pricingengines::DiscountingSwapEngine;
+    use crate::quotes::make_quote_handle;
+    use crate::shared::{SharedMut, shared, shared_mut};
+    use crate::termstructures::yields::FlatForward;
+    use crate::time::businessdayconvention::BusinessDayConvention;
+    use crate::time::calendar::Calendar;
+    use crate::time::calendars::target::Target;
+    use crate::time::date::Month;
+    use crate::time::daycounters::actual360::Actual360;
+    use crate::time::daycounters::actual365fixed::Actual365Fixed;
+    use crate::time::frequency::Frequency;
+    use crate::time::schedule::{MakeSchedule, Schedule};
+    use crate::time::timeunit::TimeUnit;
+    use crate::types::{Integer, Rate, Volatility};
+
+    /// The `capfloor.cpp` `CommonVars` fixture, retargeted to the cached test's
+    /// dates (`testCachedValue:542`): today 14-Mar-2002, settlement 18-Mar-2002,
+    /// a flat 5% Actual360 curve at settlement, a Euribor 6M index forecasting
+    /// off it, and a semiannual leg on a nominal of 100.
+    struct Vars {
+        settings: Shared<Settings<Date>>,
+        calendar: Calendar,
+        curve: Handle<dyn YieldTermStructure>,
+        index: Shared<IborIndex>,
+    }
+
+    impl Vars {
+        fn new(using_at_par: bool) -> Vars {
+            let settings = shared(Settings::new());
+            settings.set_evaluation_date(Date::new(14, Month::March, 2002));
+            settings.set_using_at_par_coupons(using_at_par);
+            let settlement = Date::new(18, Month::March, 2002);
+            let curve: Handle<dyn YieldTermStructure> = Handle::new(shared(FlatForward::with_rate(
+                settlement,
+                0.05,
+                Actual360::new(),
+                Compounding::Continuous,
+                Frequency::Annual,
+            ))
+                as Shared<dyn YieldTermStructure>);
+            let index = shared(Euribor::six_months(curve.clone(), Shared::clone(&settings)));
+            Vars {
+                settings,
+                calendar: Target::new(),
+                curve,
+                index,
+            }
+        }
+
+        /// The `length`-year semiannual ModifiedFollowing schedule from `start`.
+        fn schedule(&self, start: Date, length: Integer) -> Schedule {
+            let end = self.calendar.advance(
+                start,
+                length,
+                TimeUnit::Years,
+                BusinessDayConvention::ModifiedFollowing,
+                false,
+            );
+            MakeSchedule::new()
+                .from(start)
+                .to(end)
+                .with_frequency(Frequency::Semiannual)
+                .with_calendar(self.calendar.clone())
+                .with_convention(BusinessDayConvention::ModifiedFollowing)
+                .with_termination_date_convention(BusinessDayConvention::ModifiedFollowing)
+                .forwards()
+                .end_of_month(false)
+                .build()
+        }
+
+        /// `CommonVars::makeLeg` (`capfloor.cpp:78`): a leg on the index day
+        /// counter, ModifiedFollowing, two fixing days.
+        fn make_leg(&self, start: Date, length: Integer) -> Vec<Shared<IborCoupon>> {
+            IborLeg::new(self.schedule(start, length), Shared::clone(&self.index))
+                .with_notional(100.0)
+                .with_payment_day_counter(self.index.day_counter().clone())
+                .with_payment_adjustment(BusinessDayConvention::ModifiedFollowing)
+                .with_fixing_days(2)
+                .coupons()
+                .unwrap()
+        }
+
+        /// The `capfloor.cpp` parity/ATM swap: a Payer swap fixed against the
+        /// same index on one shared schedule, priced with the discounting engine.
+        fn make_swap(&self, start: Date, length: Integer, fixed_rate: Rate) -> VanillaSwap {
+            let schedule = self.schedule(start, length);
+            let mut swap = VanillaSwap::new(
+                SwapType::Payer,
+                100.0,
+                schedule.clone(),
+                fixed_rate,
+                self.index.day_counter().clone(),
+                schedule,
+                Shared::clone(&self.index),
+                0.0,
+                self.index.day_counter().clone(),
+                None,
+                Shared::clone(&self.settings),
+            )
+            .unwrap();
+            let engine = shared_mut(DiscountingSwapEngine::new(
+                self.curve.clone(),
+                None,
+                None,
+                None,
+                Shared::clone(&self.settings),
+            ));
+            swap.base_mut()
+                .set_pricing_engine(engine as SharedMut<dyn PricingEngine>);
+            swap
+        }
+
+        /// `CommonVars::makeEngine` (`capfloor.cpp:90`): the Black engine over a
+        /// flat volatility quote.
+        fn engine(&self, volatility: Volatility) -> SharedMut<dyn PricingEngine> {
+            let vol = make_quote_handle(volatility).handle();
+            let engine = BlackCapFloorEngine::with_flat_vol(
+                self.curve.clone(),
+                vol,
+                Actual365Fixed::new(),
+                0.0,
+                Shared::clone(&self.settings),
+            )
+            .unwrap();
+            shared_mut(engine) as SharedMut<dyn PricingEngine>
+        }
+
+        fn start_date(&self) -> Date {
+            self.curve.current_link().unwrap().reference_date().unwrap()
+        }
+    }
+
+    /// `capfloor.cpp` `testCachedValue` (`:536`): a 20Y cap at 0.07 and floor at
+    /// 0.03, vol 0.20, reproduce the cached NPVs at 1e-11. The value splits on
+    /// the par/indexed convention (`:554`): the par arm (default `Settings`) is
+    /// cap 6.87570026732 / floor 2.65812927959, the indexed arm cap
+    /// 6.87630307745 / floor 2.65796764715. Parameterising on the flag pins both.
+    #[test]
+    fn cached_value_reproduces_the_par_and_indexed_arms() {
+        for (using_at_par, expected_cap, expected_floor) in [
+            (true, 6.87570026732, 2.65812927959),
+            (false, 6.87630307745, 2.65796764715),
+        ] {
+            let vars = Vars::new(using_at_par);
+            let start = vars.start_date();
+            let leg = vars.make_leg(start, 20);
+
+            let mut cap =
+                CapFloor::cap(leg.clone(), vec![0.07], Shared::clone(&vars.settings)).unwrap();
+            cap.base_mut().set_pricing_engine(vars.engine(0.20));
+            let mut floor =
+                CapFloor::floor(leg, vec![0.03], Shared::clone(&vars.settings)).unwrap();
+            floor.base_mut().set_pricing_engine(vars.engine(0.20));
+
+            let cap_npv = cap.npv().unwrap();
+            let floor_npv = floor.npv().unwrap();
+            assert!(
+                (cap_npv - expected_cap).abs() <= 1.0e-11,
+                "par={using_at_par}: cap {cap_npv} vs cached {expected_cap} (error {})",
+                (cap_npv - expected_cap).abs()
+            );
+            assert!(
+                (floor_npv - expected_floor).abs() <= 1.0e-11,
+                "par={using_at_par}: floor {floor_npv} vs cached {expected_floor} (error {})",
+                (floor_npv - expected_floor).abs()
+            );
+        }
+    }
+
+    /// Builds a cap (or floor) over `leg`, priced with the flat-vol engine.
+    fn priced(
+        vars: &Vars,
+        leg: &[Shared<IborCoupon>],
+        is_cap: bool,
+        strike: Rate,
+        vol: Volatility,
+    ) -> CapFloor {
+        let mut cf = if is_cap {
+            CapFloor::cap(leg.to_vec(), vec![strike], Shared::clone(&vars.settings))
+        } else {
+            CapFloor::floor(leg.to_vec(), vec![strike], Shared::clone(&vars.settings))
+        }
+        .unwrap();
+        cf.base_mut().set_pricing_engine(vars.engine(vol));
+        cf
+    }
+
+    /// `capfloor.cpp:254`: the engine strike is de-spread `(strike - spread)/gearing`.
+    /// A leg with a nonzero spread and gearing != 1 pins it through the arguments.
+    #[test]
+    fn setup_arguments_despreads_the_strike_by_spread_and_gearing() {
+        let vars = Vars::new(true);
+        let start = vars.start_date();
+        let coupons = IborLeg::new(vars.schedule(start, 2), Shared::clone(&vars.index))
+            .with_notional(100.0)
+            .with_payment_day_counter(vars.index.day_counter().clone())
+            .with_payment_adjustment(BusinessDayConvention::ModifiedFollowing)
+            .with_fixing_days(2)
+            .with_gearing(2.0)
+            .with_spread(0.01)
+            .coupons()
+            .unwrap();
+        let cap = CapFloor::cap(coupons, vec![0.07], Shared::clone(&vars.settings)).unwrap();
+
+        let mut args = CapFloorArguments::default();
+        cap.setup_arguments(&mut args).unwrap();
+        assert!(!args.cap_rates.is_empty());
+        for strike in &args.cap_rates {
+            assert!((strike.expect("cap strike") - (0.07 - 0.01) / 2.0).abs() < 1e-15);
+        }
+        assert!(args.floor_rates.iter().all(Option::is_none));
+    }
+
+    /// `testCachedValueFromOptionLets` (`:580`): the `optionletsPrice` result has
+    /// one entry per coupon (40 for a 20Y semiannual leg) and sums to the cached
+    /// cap/floor NPV at 1e-11, on both par and indexed arms.
+    #[test]
+    fn cached_value_equals_the_sum_of_optionlet_prices() {
+        for (using_at_par, expected_cap, expected_floor) in [
+            (true, 6.87570026732, 2.65812927959),
+            (false, 6.87630307745, 2.65796764715),
+        ] {
+            let vars = Vars::new(using_at_par);
+            let start = vars.start_date();
+            let leg = vars.make_leg(start, 20);
+            let mut cap = priced(&vars, &leg, true, 0.07, 0.20);
+            let mut floor = priced(&vars, &leg, false, 0.03, 0.20);
+
+            let cap_prices = cap.result::<Vec<Real>>("optionletsPrice").unwrap();
+            let floor_prices = floor.result::<Vec<Real>>("optionletsPrice").unwrap();
+            assert_eq!(cap_prices.len(), 40);
+            assert_eq!(floor_prices.len(), 40);
+
+            let cap_sum: Real = cap_prices.iter().sum();
+            let floor_sum: Real = floor_prices.iter().sum();
+            assert!(
+                (cap_sum - expected_cap).abs() <= 1.0e-11,
+                "par={using_at_par}: cap sum {cap_sum} vs {expected_cap}"
+            );
+            assert!(
+                (floor_sum - expected_floor).abs() <= 1.0e-11,
+                "par={using_at_par}: floor sum {floor_sum} vs {expected_floor}"
+            );
+        }
+    }
+
+    /// `testStrikeDependency` (`:196`): a cap's NPV falls with the strike, a
+    /// floor's rises.
+    #[test]
+    fn cap_npv_falls_and_floor_npv_rises_with_the_strike() {
+        let vars = Vars::new(true);
+        let start = vars.start_date();
+        for length in [1, 5, 10, 20] {
+            let leg = vars.make_leg(start, length);
+            let mut caps = Vec::new();
+            let mut floors = Vec::new();
+            for strike in [0.03, 0.04, 0.05, 0.06, 0.07] {
+                caps.push(priced(&vars, &leg, true, strike, 0.20).npv().unwrap());
+                floors.push(priced(&vars, &leg, false, strike, 0.20).npv().unwrap());
+            }
+            for pair in caps.windows(2) {
+                assert!(
+                    pair[0] >= pair[1],
+                    "cap NPV increased with strike: {pair:?}"
+                );
+            }
+            for pair in floors.windows(2) {
+                assert!(
+                    pair[0] <= pair[1],
+                    "floor NPV decreased with strike: {pair:?}"
+                );
+            }
+        }
+    }
+
+    /// `testVega` (`:147`): the `"vega"` result matches a central finite
+    /// difference of the NPV in the volatility, to 0.5% relative.
+    #[test]
+    fn analytical_vega_matches_a_finite_difference() {
+        let vars = Vars::new(true);
+        let start = vars.start_date();
+        let shift = 1.0e-8;
+        for length in [1, 5, 10, 20] {
+            let leg = vars.make_leg(start, length);
+            for strike in [0.03, 0.05, 0.07] {
+                for is_cap in [true, false] {
+                    let analytical = priced(&vars, &leg, is_cap, strike, 0.20)
+                        .result::<Real>("vega")
+                        .unwrap();
+                    let up = priced(&vars, &leg, is_cap, strike, 0.20 + shift)
+                        .npv()
+                        .unwrap();
+                    let down = priced(&vars, &leg, is_cap, strike, 0.20 - shift)
+                        .npv()
+                        .unwrap();
+                    let numerical = (up - down) / (2.0 * shift);
+                    if numerical > 1.0e-4 {
+                        let discrepancy = (numerical - analytical).abs() / numerical;
+                        assert!(
+                            discrepancy <= 0.005,
+                            "vega {length}y strike {strike} cap={is_cap}: \
+                             analytical {analytical} vs numerical {numerical}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// `testParity` (`:354`): a cap minus a floor at the same strike equals a
+    /// payer swap fixed at that strike.
+    #[test]
+    fn cap_minus_floor_equals_the_underlying_swap() {
+        let vars = Vars::new(true);
+        let start = vars.start_date();
+        for length in [1, 5, 10, 20] {
+            let leg = vars.make_leg(start, length);
+            for strike in [0.0, 0.03, 0.05, 0.07] {
+                let cap = priced(&vars, &leg, true, strike, 0.20).npv().unwrap();
+                let floor = priced(&vars, &leg, false, strike, 0.20).npv().unwrap();
+                let swap = vars.make_swap(start, length, strike).npv().unwrap();
+                assert!(
+                    ((cap - floor) - swap).abs() <= 1.0e-10,
+                    "parity {length}y strike {strike}: cap-floor {} vs swap {swap}",
+                    cap - floor
+                );
+            }
+        }
+    }
+
+    /// `testATMRate` (`:397`): the cap and floor share an ATM rate, and a swap
+    /// struck at it prices to zero.
+    #[test]
+    fn a_swap_struck_at_the_atm_rate_prices_to_zero() {
+        let vars = Vars::new(true);
+        let start = vars.start_date();
+        let curve = vars.curve.current_link().unwrap();
+        for length in [1, 5, 10, 20] {
+            let leg = vars.make_leg(start, length);
+            let cap =
+                CapFloor::cap(leg.clone(), vec![0.05], Shared::clone(&vars.settings)).unwrap();
+            let floor = CapFloor::floor(leg, vec![0.05], Shared::clone(&vars.settings)).unwrap();
+            let cap_atm = cap.atm_rate(&*curve).unwrap();
+            let floor_atm = floor.atm_rate(&*curve).unwrap();
+            assert!((cap_atm - floor_atm).abs() <= 1.0e-10);
+            let swap = vars.make_swap(start, length, floor_atm).npv().unwrap();
+            assert!(swap.abs() <= 1.0e-10, "atm swap {length}y npv {swap}");
+        }
+    }
+
+    /// `testConsistency` (`:249`), the collar identity only: a collar equals the
+    /// cap minus the floor at the same strikes.
+    #[test]
+    fn a_collar_equals_the_cap_minus_the_floor() {
+        let vars = Vars::new(true);
+        let start = vars.start_date();
+        for length in [1, 5, 10, 20] {
+            let leg = vars.make_leg(start, length);
+            for (cap_rate, floor_rate) in [(0.05, 0.03), (0.06, 0.04), (0.07, 0.03)] {
+                let cap = priced(&vars, &leg, true, cap_rate, 0.20).npv().unwrap();
+                let floor = priced(&vars, &leg, false, floor_rate, 0.20).npv().unwrap();
+                let mut collar = CapFloor::collar(
+                    leg.clone(),
+                    vec![cap_rate],
+                    vec![floor_rate],
+                    Shared::clone(&vars.settings),
+                )
+                .unwrap();
+                collar.base_mut().set_pricing_engine(vars.engine(0.20));
+                assert!(
+                    ((cap - floor) - collar.npv().unwrap()).abs() <= 1.0e-10,
+                    "collar {length}y cap {cap_rate} floor {floor_rate}"
+                );
+            }
+        }
+    }
+}

--- a/crates/libitofin/src/pricingengines/capfloor/blackcapfloorengine.rs
+++ b/crates/libitofin/src/pricingengines/capfloor/blackcapfloorengine.rs
@@ -1,0 +1,276 @@
+//! Black-formula cap/floor engine.
+//!
+//! Port of `ql/pricingengines/capfloor/blackcapfloorengine.{hpp,cpp}`:
+//! [`BlackCapFloorEngine`] prices each optionlet of a
+//! [`CapFloor`](crate::instruments::CapFloor) with the Black 1976 formula over an
+//! [`OptionletVolatilityStructure`], discounting on a separate
+//! [`YieldTermStructure`]. It does not go through the coupon pricer: it reads the
+//! forwards, strikes, gearings, nominals, accrual times and fixing dates the
+//! instrument's `setup_arguments` filled and calls [`black_formula`] directly
+//! (`blackcapfloorengine.cpp:77-166`).
+//!
+//! The engine reports `value`, the additional result `"vega"` (the sum of the
+//! optionlet vegas, required by the instrument, `capfloor.cpp:104`) and
+//! `"optionletsPrice"` (one price per coupon, including the zeros of coupons that
+//! have already paid, so its length always equals the coupon count).
+//!
+//! ## Divergences from QuantLib
+//!
+//! - The C++ `Settings::instance()` singleton has no counterpart; the flat-vol
+//!   convenience constructor threads an explicit [`Settings`] into the moving
+//!   [`ConstantOptionletVolatility`] it builds (D5).
+//! - Only the [`ShiftedLognormal`](VolatilityType::ShiftedLognormal) path is
+//!   priced. The C++ `optionletsDelta`/`optionletsStdDev`/`optionletsAtmForward`
+//!   additional results feed only the deferred delta and implied-vol tests and
+//!   are not produced.
+
+use crate::errors::QlResult;
+use crate::handle::Handle;
+use crate::instrument::InstrumentResults;
+use crate::instruments::{CapFloorArguments, CapFloorType};
+use crate::option::OptionType;
+use crate::patterns::observable::{AsObservable, Observable};
+use crate::pricingengine::{Arguments, GenericEngine, PricingEngine, Results};
+use crate::pricingengines::blackformula::{black_formula, black_formula_std_dev_derivative};
+use crate::quotes::Quote;
+use crate::settings::Settings;
+use crate::shared::{Shared, shared};
+use crate::termstructures::volatility::{
+    ConstantOptionletVolatility, OptionletVolatilityStructure, VolatilityType,
+};
+use crate::termstructures::yieldtermstructure::YieldTermStructure;
+use crate::time::businessdayconvention::BusinessDayConvention;
+use crate::time::calendars::nullcalendar::NullCalendar;
+use crate::time::date::Date;
+use crate::time::daycounter::DayCounter;
+use crate::types::Real;
+use crate::{fail, require};
+use std::any::Any;
+
+/// Black-formula engine for caps, floors and collars.
+pub struct BlackCapFloorEngine {
+    base: GenericEngine<CapFloorArguments, InstrumentResults>,
+    discount_curve: Handle<dyn YieldTermStructure>,
+    vol: Handle<dyn OptionletVolatilityStructure>,
+    displacement: Real,
+}
+
+impl BlackCapFloorEngine {
+    /// Builds the engine over a discount curve and an optionlet volatility
+    /// surface (the C++ `Handle<OptionletVolatilityStructure>` constructor).
+    ///
+    /// The surface must be stripped with the shifted-lognormal model. A given
+    /// `displacement` must equal the surface's own; `None` adopts the surface's
+    /// displacement (`blackcapfloorengine.cpp:56-75`).
+    pub fn new(
+        discount_curve: Handle<dyn YieldTermStructure>,
+        vol: Handle<dyn OptionletVolatilityStructure>,
+        displacement: Option<Real>,
+    ) -> QlResult<BlackCapFloorEngine> {
+        let surface = vol.current_link()?;
+        require!(
+            surface.volatility_type() == VolatilityType::ShiftedLognormal,
+            "BlackCapFloorEngine needs a shifted-lognormal optionlet surface"
+        );
+        let displacement = match displacement {
+            Some(displacement) => {
+                require!(
+                    surface.displacement() == displacement,
+                    "displacement ({displacement}) differs from the surface's ({})",
+                    surface.displacement()
+                );
+                displacement
+            }
+            None => surface.displacement(),
+        };
+        drop(surface);
+
+        let base = GenericEngine::new(CapFloorArguments::default(), InstrumentResults::default());
+        discount_curve.register_observer(&base.observer());
+        vol.register_observer(&base.observer());
+        Ok(BlackCapFloorEngine {
+            base,
+            discount_curve,
+            vol,
+            displacement,
+        })
+    }
+
+    /// Builds the engine over a flat volatility quote, wrapping it in a moving
+    /// [`ConstantOptionletVolatility`] on a null calendar (the C++
+    /// `Handle<Quote>` constructor, `blackcapfloorengine.cpp:44-54`).
+    pub fn with_flat_vol(
+        discount_curve: Handle<dyn YieldTermStructure>,
+        vol: Handle<dyn Quote>,
+        day_counter: DayCounter,
+        displacement: Real,
+        settings: Shared<Settings<Date>>,
+    ) -> QlResult<BlackCapFloorEngine> {
+        let surface = ConstantOptionletVolatility::moving_with_quote(
+            0,
+            NullCalendar::new(),
+            BusinessDayConvention::Following,
+            vol,
+            day_counter,
+            VolatilityType::ShiftedLognormal,
+            displacement,
+            settings,
+        );
+        let vol = Handle::new(shared(surface) as Shared<dyn OptionletVolatilityStructure>);
+        BlackCapFloorEngine::new(discount_curve, vol, None)
+    }
+
+    /// The lognormal shift applied to forwards and strikes.
+    pub fn displacement(&self) -> Real {
+        self.displacement
+    }
+}
+
+impl AsObservable for BlackCapFloorEngine {
+    fn observable(&self) -> &Observable {
+        self.base.observable()
+    }
+}
+
+impl PricingEngine for BlackCapFloorEngine {
+    fn arguments_mut(&mut self) -> &mut dyn Arguments {
+        self.base.arguments_mut()
+    }
+
+    fn results(&self) -> &dyn Results {
+        self.base.results()
+    }
+
+    fn reset(&mut self) {
+        self.base.reset();
+    }
+
+    fn calculate(&mut self) -> QlResult<()> {
+        let discount = self.discount_curve.current_link()?;
+        let surface = self.vol.current_link()?;
+        let today = surface.reference_date()?;
+        let settlement = discount.reference_date()?;
+        let displacement = self.displacement;
+
+        let arguments = self.base.arguments();
+        let cap_floor_type = match arguments.cap_floor_type {
+            Some(cap_floor_type) => cap_floor_type,
+            None => fail!("cap/floor type not set"),
+        };
+        let has_cap = matches!(cap_floor_type, CapFloorType::Cap | CapFloorType::Collar);
+        let has_floor = matches!(cap_floor_type, CapFloorType::Floor | CapFloorType::Collar);
+
+        let n = arguments.end_dates.len();
+        let mut values = Vec::with_capacity(n);
+        let mut value = 0.0;
+        let mut vega = 0.0;
+
+        for i in 0..n {
+            let payment_date = arguments.end_dates[i];
+            // Settlement/npv-date handling is not modelled; expired caplets are
+            // simply discarded (`blackcapfloorengine.cpp:92-95`), but still keep a
+            // zero entry so `optionletsPrice` spans every coupon.
+            if payment_date <= settlement {
+                values.push(0.0);
+                continue;
+            }
+            let d = discount.discount_date(payment_date, false)?;
+            let accrual_factor =
+                arguments.nominals[i] * arguments.gearings[i] * arguments.accrual_times[i];
+            let discounted_accrual = d * accrual_factor;
+            let Some(forward) = arguments.forwards[i] else {
+                values.push(0.0);
+                continue;
+            };
+
+            let fixing_date = arguments.fixing_dates[i];
+            let sqrt_time = if fixing_date > today {
+                surface.time_from_reference(fixing_date)?.sqrt()
+            } else {
+                0.0
+            };
+
+            let mut optionlet_value = 0.0;
+            let mut optionlet_vega = 0.0;
+
+            if has_cap {
+                let strike = arguments.cap_rates[i].expect("cap rate set for cap/collar");
+                let mut std_dev = 0.0;
+                if sqrt_time > 0.0 {
+                    std_dev = surface
+                        .black_variance_date(fixing_date, strike, false)?
+                        .sqrt();
+                    optionlet_vega += black_formula_std_dev_derivative(
+                        strike,
+                        forward,
+                        std_dev,
+                        discounted_accrual,
+                        displacement,
+                    )? * sqrt_time;
+                }
+                optionlet_value += black_formula(
+                    OptionType::Call,
+                    strike,
+                    forward,
+                    std_dev,
+                    discounted_accrual,
+                    displacement,
+                )?;
+            }
+
+            if has_floor {
+                let strike = arguments.floor_rates[i].expect("floor rate set for floor/collar");
+                let mut std_dev = 0.0;
+                let mut floorlet_vega = 0.0;
+                if sqrt_time > 0.0 {
+                    std_dev = surface
+                        .black_variance_date(fixing_date, strike, false)?
+                        .sqrt();
+                    floorlet_vega = black_formula_std_dev_derivative(
+                        strike,
+                        forward,
+                        std_dev,
+                        discounted_accrual,
+                        displacement,
+                    )? * sqrt_time;
+                }
+                let floorlet = black_formula(
+                    OptionType::Put,
+                    strike,
+                    forward,
+                    std_dev,
+                    discounted_accrual,
+                    displacement,
+                )?;
+                if cap_floor_type == CapFloorType::Floor {
+                    optionlet_value = floorlet;
+                    optionlet_vega = floorlet_vega;
+                } else {
+                    // A collar is long the cap and short the floor.
+                    optionlet_value -= floorlet;
+                    optionlet_vega -= floorlet_vega;
+                }
+            }
+
+            values.push(optionlet_value);
+            value += optionlet_value;
+            vega += optionlet_vega;
+        }
+
+        drop(discount);
+        drop(surface);
+
+        let results = self.base.results_mut();
+        results.value = Some(value);
+        results.error_estimate = None;
+        results.valuation_date = None;
+        results
+            .additional_results
+            .insert("vega".to_string(), shared(vega) as Shared<dyn Any>);
+        results.additional_results.insert(
+            "optionletsPrice".to_string(),
+            shared(values) as Shared<dyn Any>,
+        );
+        Ok(())
+    }
+}

--- a/crates/libitofin/src/pricingengines/capfloor/mod.rs
+++ b/crates/libitofin/src/pricingengines/capfloor/mod.rs
@@ -1,0 +1,8 @@
+//! Cap/floor pricing engines.
+//!
+//! Port of `ql/pricingengines/capfloor/`: the Black-formula engine that prices
+//! a [`CapFloor`](crate::instruments::CapFloor) optionlet by optionlet.
+
+mod blackcapfloorengine;
+
+pub use blackcapfloorengine::BlackCapFloorEngine;

--- a/crates/libitofin/src/pricingengines/mod.rs
+++ b/crates/libitofin/src/pricingengines/mod.rs
@@ -7,11 +7,13 @@
 pub mod blackcalculator;
 pub mod blackformula;
 pub mod bond;
+pub mod capfloor;
 pub mod swap;
 pub mod vanilla;
 
 pub use blackcalculator::BlackCalculator;
 pub use bond::{BondFunctions, DiscountingBondEngine};
+pub use capfloor::BlackCapFloorEngine;
 pub use swap::DiscountingSwapEngine;
 pub use vanilla::AnalyticEuropeanEngine;
 


### PR DESCRIPTION
- **feat(cashflows): expose spread and gearing on IborCoupon**
- **feat(instruments): port the CapFloor cap/floor/collar instrument**
- **feat(pricingengines): port the Black cap/floor engine**
- **test(pricingengines): oracle the Black cap/floor engine against capfloor.cpp**
- **feat(cashflows): complete the Black ibor caplet/floorlet pricer**
- **feat(cashflows): port the capped/floored ibor coupon**
- **feat(cashflows): add caps and floors to the ibor leg builder**
- **fix(cashflows): strike the ibor caplet against the coupon's forward**
- **test(cashflows): oracle the capped/floored coupon against QuantLib**

close #352

close #353