### PR TITLE
feat(engines): port the Heston characteristic function chF/lnChF (Andersen-Lake)

### DIFF
--- a/crates/libitofin/src/math/expm1.rs
+++ b/crates/libitofin/src/math/expm1.rs
@@ -1,0 +1,107 @@
+//! Complex `expm1` and `log1p`.
+//!
+//! Port of `ql/math/expm1.cpp` (Klaus Spanderen, 2023): cancellation-safe
+//! complex versions of `e^z - 1` and `log(1 + z)`. Near the origin the naive
+//! `z.exp() - 1` and `(1 + z).ln()` lose leading digits to subtraction of two
+//! nearly-equal quantities; these forms defer to the real [`f64::exp_m1`] and
+//! [`f64::ln_1p`] on the dominant term to keep full precision. They are the
+//! primitives the Andersen-Lake Heston characteristic function
+//! ([`crate::pricingengines::vanilla::analytichestonengine`]) relies on.
+
+use crate::types::Complex;
+
+/// Complex `e^z - 1` (`expm1.cpp:25`).
+///
+/// For `|z| < 1` uses the real [`f64::exp_m1`] on the real part and the
+/// half-angle identity `cos(b) - 1 = -2 sin^2(b/2)` on the imaginary part to
+/// avoid cancellation; otherwise falls back to `z.exp() - 1`.
+pub fn expm1(z: Complex) -> Complex {
+    if z.norm() < 1.0 {
+        let a = z.re;
+        let b = z.im;
+        let exp_1 = a.exp_m1();
+        let cos_1 = -2.0 * (0.5 * b).sin().powi(2);
+        Complex::new(exp_1 * cos_1 + exp_1 + cos_1, b.sin() * a.exp())
+    } else {
+        z.exp() - Complex::new(1.0, 0.0)
+    }
+}
+
+/// Complex `log(1 + z)` (`expm1.cpp:41`).
+///
+/// For `|Re z| < 0.5` and `|Im z| < 0.5` uses the real [`f64::ln_1p`] on the
+/// squared modulus of `1 + z` to avoid cancellation in the real part;
+/// otherwise falls back to `(1 + z).ln()`.
+pub fn log1p(z: Complex) -> Complex {
+    let a = z.re;
+    let b = z.im;
+    if a.abs() < 0.5 && b.abs() < 0.5 {
+        let re = 0.5 * (a * a + 2.0 * a + b * b).ln_1p();
+        Complex::new(re, (Complex::new(1.0, 0.0) + z).arg())
+    } else {
+        (Complex::new(1.0, 0.0) + z).ln()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::Real;
+
+    const EPS: Real = f64::EPSILON;
+
+    /// `expm1` at a tiny argument keeps full precision where the naive
+    /// `z.exp() - 1` loses leading digits.
+    ///
+    /// Reference: `ql/math/expm1.cpp:25`. Analytic value at
+    /// `z = 1e-10 + 1e-10 i`: `e^z - 1 = z + z^2/2 + ... `. With `a = b = 1e-10`
+    /// the `z^2/2` term is `Re = (a^2 - b^2)/2 = 0`, `Im = a*b = 1e-20`, so
+    /// `Re = 1e-10` and `Im = 1e-10 + 1e-20` to full double precision.
+    #[test]
+    fn expm1_tiny_beats_naive() {
+        let z = Complex::new(1e-10, 1e-10);
+
+        let got = expm1(z);
+        let naive = z.exp() - Complex::new(1.0, 0.0);
+
+        let re_ref = 1e-10;
+        let im_ref = 1e-10 + 1e-20;
+
+        assert!((got.re - re_ref).abs() <= 4.0 * EPS * re_ref.abs());
+        assert!((got.im - im_ref).abs() <= 4.0 * EPS * im_ref.abs());
+
+        assert!((naive.re - re_ref).abs() > 1e3 * (got.re - re_ref).abs());
+    }
+
+    /// `log1p` near the origin keeps full precision where the naive
+    /// `(1 + z).ln()` loses leading digits.
+    ///
+    /// Reference: `ql/math/expm1.cpp:41`. Analytic value at `z = 1e-10`:
+    /// `log(1 + z) = z - z^2/2 + ... = 1e-10 - 0.5e-20 + ...` (real).
+    #[test]
+    fn log1p_tiny_beats_naive() {
+        let z = Complex::new(1e-10, 0.0);
+
+        let got = log1p(z);
+        let naive = (Complex::new(1.0, 0.0) + z).ln();
+
+        let re_ref = 1e-10 - 0.5 * 1e-10 * 1e-10;
+
+        assert!((got.re - re_ref).abs() <= 4.0 * EPS * re_ref.abs());
+        assert!((naive.re - re_ref).abs() > 1e3 * (got.re - re_ref).abs());
+    }
+
+    /// Both forms agree with the naive fallback away from the origin (the
+    /// large-argument branch is literally the naive form).
+    #[test]
+    fn expm1_log1p_match_naive_far_from_origin() {
+        let z = Complex::new(1.5, 0.8);
+        let e = expm1(z);
+        let e_naive = z.exp() - Complex::new(1.0, 0.0);
+        assert!((e - e_naive).norm() <= 8.0 * EPS * e.norm());
+
+        let l = log1p(z);
+        let l_naive = (Complex::new(1.0, 0.0) + z).ln();
+        assert!((l - l_naive).norm() <= 8.0 * EPS * l.norm());
+    }
+}

--- a/crates/libitofin/src/math/mod.rs
+++ b/crates/libitofin/src/math/mod.rs
@@ -6,6 +6,7 @@ pub mod comparison;
 pub mod copulas;
 pub mod distributions;
 pub mod errorfunction;
+pub mod expm1;
 pub mod gammafunction;
 pub mod incompletegamma;
 pub mod integrals;

--- a/crates/libitofin/src/pricingengines/vanilla/analytichestonengine.rs
+++ b/crates/libitofin/src/pricingengines/vanilla/analytichestonengine.rs
@@ -1,0 +1,288 @@
+//! The Heston characteristic function `chF`/`lnChF`.
+//!
+//! Port of the characteristic-function core of
+//! `ql/pricingengines/vanilla/analytichestonengine.cpp:578-657`: the
+//! Andersen-Lake cancellation-safe form of the Heston model's normalized
+//! characteristic function. In C++ `chF`/`lnChF` are `AnalyticHestonEngine`
+//! methods that the `AP_Helper` integrand calls back into
+//! (`analytichestonengine.cpp:578`, `.hpp:143-144`). Porting them as a
+//! parameter-carrying [`HestonChf`] rather than engine methods avoids an
+//! `AP_Helper` <-> engine circular dependency: the future integrand (#416) and
+//! engine (#417) both build a [`HestonChf`] from the five params and call it.
+//!
+//! Deferrals (see the type docs):
+//! - the small-`sigma` series expansion branch of `chF`
+//!   (`analytichestonengine.cpp:584-617`), off the calibrated oracle path;
+//! - the `addOnTerm` virtual hook (`analytichestonengine.hpp:179-181`, base
+//!   returns 0), the Bates jump-diffusion extension point.
+
+use crate::errors::QlResult;
+use crate::fail;
+use crate::math::expm1::{expm1, log1p};
+use crate::types::{Complex, Real, Time};
+
+/// The Heston characteristic function, carrying the five model parameters.
+///
+/// Mirrors the parameters `AnalyticHestonEngine` reads from its `HestonModel`
+/// inside `chF`/`lnChF` (`analytichestonengine.cpp:585-589, 626-630`): `kappa`
+/// (mean-reversion speed), `theta` (long-run variance), `sigma` (vol of vol),
+/// `rho` (spot/variance correlation) and `v0` (initial variance). The
+/// characteristic function reads *only* these five; it takes no term structures
+/// (the C++ code reads no discount curve here either - see the module-level
+/// divergence note in issue #415).
+#[derive(Clone, Copy, Debug)]
+pub struct HestonChf {
+    kappa: Real,
+    theta: Real,
+    sigma: Real,
+    rho: Real,
+    v0: Real,
+}
+
+impl HestonChf {
+    /// Builds the characteristic function from the five Heston parameters.
+    pub fn new(kappa: Real, theta: Real, sigma: Real, rho: Real, v0: Real) -> Self {
+        HestonChf {
+            kappa,
+            theta,
+            sigma,
+            rho,
+            v0,
+        }
+    }
+
+    /// `lnChF(z, t)` (`analytichestonengine.cpp:621-657`): the log
+    /// characteristic function in Andersen-Lake form `A + v0*B`.
+    ///
+    /// The `r` branch (`cpp:638-641`) and the [`expm1`]/[`log1p`] calls
+    /// (`cpp:646, 652`) are the cancellation-error reductions of Andersen &
+    /// Lake; the naive `exp(x)-1` / `ln(1+x)` would lose precision for small
+    /// `D*t` or `r*y`.
+    pub fn ln_chf(&self, z: Complex, t: Time) -> Complex {
+        let kappa = self.kappa;
+        let sigma = self.sigma;
+        let theta = self.theta;
+        let rho = self.rho;
+        let v0 = self.v0;
+
+        let sigma2 = sigma * sigma;
+
+        let g = Complex::new(kappa, 0.0) + rho * sigma * Complex::new(z.im, -z.re);
+
+        let d = (g * g + (z * z + Complex::new(-z.im, z.re)) * sigma2).sqrt();
+
+        let mut r = g - d;
+        if g.re * d.re + g.im * d.im > 0.0 {
+            r = -sigma2 * z * Complex::new(z.re, z.im + 1.0) / (g + d);
+        }
+
+        let y = if d.re != 0.0 || d.im != 0.0 {
+            expm1(-d * t) / (2.0 * d)
+        } else {
+            Complex::new(-0.5 * t, 0.0)
+        };
+
+        let a = kappa * theta / sigma2 * (r * t - 2.0 * log1p(-r * y));
+        let b = z * Complex::new(z.re, z.im + 1.0) * y / (Complex::new(1.0, 0.0) - r * y);
+
+        a + v0 * b
+    }
+
+    /// `chF(z, t)` (`analytichestonengine.cpp:578-619`): the characteristic
+    /// function itself.
+    ///
+    /// The calibrated path (`sigma > 1e-6 || kappa < 1e-8`, `cpp:580`) returns
+    /// `exp(lnChF(z, t))`.
+    ///
+    /// # Errors
+    ///
+    /// The small-`sigma` series expansion (`cpp:584-617`), reached only when
+    /// `sigma <= 1e-6 && kappa >= 1e-8`, is deferred (issue #415): it is off the
+    /// calibrated oracle path, so this returns `Err` rather than silently
+    /// falling through to `exp(lnChF)`.
+    pub fn chf(&self, z: Complex, t: Time) -> QlResult<Complex> {
+        if self.sigma > 1e-6 || self.kappa < 1e-8 {
+            Ok(self.ln_chf(z, t).exp())
+        } else {
+            fail!(
+                "Heston chF small-sigma series expansion (analytichestonengine.cpp:584-617) is \
+                 deferred: only the exp(lnChF) branch (sigma > 1e-6 || kappa < 1e-8) is ported \
+                 (issue #415); got sigma={} kappa={}",
+                self.sigma,
+                self.kappa
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The #417 calibration oracle parameter set (Heston 1993 / QuantLib
+    /// `AnalyticHestonEngine` test fixtures): a moderately-correlated,
+    /// finite-vol-of-vol regime well inside the Feller region.
+    const KAPPA: Real = 3.16;
+    const THETA: Real = 0.09;
+    const SIGMA: Real = 0.4;
+    const RHO: Real = -0.2;
+    const V0: Real = 0.1;
+
+    fn fixture() -> HestonChf {
+        HestonChf::new(KAPPA, THETA, SIGMA, RHO, V0)
+    }
+
+    /// Independent "Little Heston Trap" (Albrecher et al. 2007) closed form of
+    /// the same normalized characteristic function, derived from the standard
+    /// `g`/`D`/`C`/`D`-function Heston literature - NOT from the Andersen-Lake
+    /// code under test.
+    ///
+    /// With `g = kappa - i*rho*sigma*z` and `d = sqrt(g^2 + sigma^2 z(z+i))`
+    /// (`analytichestonengine.cpp:632-636`, since `Complex(z.im,-z.re) = -i z`
+    /// and `Complex(-z.im,z.re) = i z`), the trap form is `C + v0*D` with
+    /// `g2 = (g-d)/(g+d)`,
+    /// `C = kappa*theta/sigma^2 [(g-d)t - 2 ln((1 - g2 e^{-dt})/(1 - g2))]` and
+    /// `D = (g-d)/sigma^2 * (1 - e^{-dt})/(1 - g2 e^{-dt})`. This is
+    /// algebraically identical to the ported `A + v0*B` on the non-swapped
+    /// branch (`A == C`, `B == D`), cross-checking the transcription.
+    fn gatheral_ln_chf(chf: &HestonChf, z: Complex, t: Time) -> Complex {
+        let kappa = chf.kappa;
+        let theta = chf.theta;
+        let sigma = chf.sigma;
+        let rho = chf.rho;
+        let v0 = chf.v0;
+        let sigma2 = sigma * sigma;
+        let i = Complex::new(0.0, 1.0);
+
+        let g = Complex::new(kappa, 0.0) - i * rho * sigma * z;
+        let d = (g * g + sigma2 * z * (z + i)).sqrt();
+        let g2 = (g - d) / (g + d);
+        let emdt = (-d * t).exp();
+
+        let c = kappa * theta / sigma2
+            * ((g - d) * t
+                - 2.0
+                    * ((Complex::new(1.0, 0.0) - g2 * emdt) / (Complex::new(1.0, 0.0) - g2)).ln());
+        let d_func = (g - d) / sigma2 * (Complex::new(1.0, 0.0) - emdt)
+            / (Complex::new(1.0, 0.0) - g2 * emdt);
+
+        c + v0 * d_func
+    }
+
+    /// KEY PIN: the ported Andersen-Lake `lnChF` equals the independent Little
+    /// Heston Trap form at a benign complex point (moderate `u`, `t = 0.5`, away
+    /// from branch cuts and cancellation). Two algebraically-equivalent forms
+    /// agreeing to ~1e-12 on a nontrivial complex value catches transcription
+    /// errors that invariant pins miss.
+    #[test]
+    fn ln_chf_matches_gatheral_little_trap() {
+        let chf = fixture();
+        let t = 0.5;
+        for &z in &[
+            Complex::new(1.5, -0.5),
+            Complex::new(3.0, 0.0),
+            Complex::new(2.0, 1.0),
+        ] {
+            let ported = chf.ln_chf(z, t);
+            let reference = gatheral_ln_chf(&chf, z, t);
+            let err = (ported - reference).norm();
+            assert!(
+                err < 1e-12,
+                "lnChF mismatch at z={z:?}: ported={ported:?} reference={reference:?} err={err:e}"
+            );
+        }
+    }
+
+    /// Invariant pin: `chF(0, t) == 1` (both components). At `z = 0` the
+    /// characteristic function of any distribution is 1; here `r = 0`, so
+    /// `lnChF = 0` and `chF = exp(0) = 1`.
+    #[test]
+    fn chf_at_zero_is_one() {
+        let chf = fixture();
+        for &t in &[0.1, 0.5, 2.0] {
+            let value = chf.chf(Complex::new(0.0, 0.0), t).unwrap();
+            assert!(
+                (value.re - 1.0).abs() < 1e-14,
+                "Re chF(0,{t}) = {}",
+                value.re
+            );
+            assert!(value.im.abs() < 1e-14, "Im chF(0,{t}) = {}", value.im);
+        }
+    }
+
+    /// The deferred small-`sigma` expansion branch returns `Err` (visible
+    /// omission), not a silent fall-through to `exp(lnChF)`. Reached only when
+    /// `sigma <= 1e-6 && kappa >= 1e-8` (`analytichestonengine.cpp:580,584`).
+    #[test]
+    fn chf_small_sigma_branch_is_deferred_error() {
+        let chf = HestonChf::new(1.0, 0.04, 1e-8, -0.5, 0.04);
+        let err = chf.chf(Complex::new(1.0, 0.0), 0.5).unwrap_err();
+        assert!(err.to_string().contains("deferred"));
+    }
+
+    /// CONFIRM-BY-STUBBING: the [`expm1`]/[`log1p`] helpers are load-bearing in
+    /// `lnChF`. A naive re-implementation swapping them for `exp(x)-1` /
+    /// `ln(1+x)` loses precision *relative* to the ported (helper-based) `lnChF`
+    /// at a short-maturity, cancellation-prone point (`D*t -> 0`, so
+    /// `expm1(-D*t)` and `log1p(-r*y)` both subtract two near-equal quantities),
+    /// while the two agree to eps at a benign point. The comparison is relative
+    /// because `lnChF` itself is `O(t)` and vanishes with `t`, so a large
+    /// relative error at tiny `t` is a small absolute norm.
+    ///
+    /// The accurate helper form is the reference: the primitive accuracy pins in
+    /// [`crate::math::expm1`] independently establish that the helper values -
+    /// not the naive ones - are the correct ones.
+    #[test]
+    fn expm1_log1p_helpers_are_load_bearing_in_ln_chf() {
+        let chf = fixture();
+        let z = Complex::new(3.0, -0.5);
+
+        let rel_gap = |t: Time| -> Real {
+            let ported = chf.ln_chf(z, t);
+            let naive = naive_ln_chf(&chf, z, t);
+            (ported - naive).norm() / ported.norm()
+        };
+
+        let short_rel = rel_gap(1e-10);
+        let benign_rel = rel_gap(0.5);
+
+        assert!(
+            benign_rel < 1e-13,
+            "helper and naive lnChF should agree at t=0.5: relative gap={benign_rel:e}"
+        );
+        assert!(
+            short_rel > 1e4 * benign_rel.max(f64::EPSILON),
+            "helper and naive lnChF should diverge at t=1e-10: short_rel={short_rel:e} benign_rel={benign_rel:e}"
+        );
+    }
+
+    /// `lnChF` with the Andersen-Lake helpers replaced by the naive
+    /// `exp(x) - 1` / `ln(1 + x)` forms - the stub for the load-bearing test.
+    fn naive_ln_chf(chf: &HestonChf, z: Complex, t: Time) -> Complex {
+        let kappa = chf.kappa;
+        let sigma = chf.sigma;
+        let theta = chf.theta;
+        let rho = chf.rho;
+        let v0 = chf.v0;
+        let sigma2 = sigma * sigma;
+
+        let g = Complex::new(kappa, 0.0) + rho * sigma * Complex::new(z.im, -z.re);
+        let d = (g * g + (z * z + Complex::new(-z.im, z.re)) * sigma2).sqrt();
+
+        let mut r = g - d;
+        if g.re * d.re + g.im * d.im > 0.0 {
+            r = -sigma2 * z * Complex::new(z.re, z.im + 1.0) / (g + d);
+        }
+
+        let y = if d.re != 0.0 || d.im != 0.0 {
+            ((-d * t).exp() - Complex::new(1.0, 0.0)) / (2.0 * d)
+        } else {
+            Complex::new(-0.5 * t, 0.0)
+        };
+
+        let a = kappa * theta / sigma2 * (r * t - 2.0 * (Complex::new(1.0, 0.0) - r * y).ln());
+        let b = z * Complex::new(z.re, z.im + 1.0) * y / (Complex::new(1.0, 0.0) - r * y);
+
+        a + v0 * b
+    }
+}

--- a/crates/libitofin/src/pricingengines/vanilla/mod.rs
+++ b/crates/libitofin/src/pricingengines/vanilla/mod.rs
@@ -17,6 +17,10 @@
 //!   (and the calculator supports nothing else), so any other payoff is an
 //!   explicit error instead of a silently wrong price.
 
+pub mod analytichestonengine;
+
+pub use analytichestonengine::HestonChf;
+
 use std::any::Any;
 
 use crate::errors::QlResult;


### PR DESCRIPTION
Port the Andersen-Lake cancellation-safe Heston chF/lnChF (analytichestonengine.cpp:578-657) as a parameter-carrying HestonChf, plus the complex expm1/log1p primitives (ql/math/expm1.cpp) it relies on. Convert pricingengines/vanilla.rs to a directory module.

Claude-Session: https://claude.ai/code/session_01BqjAoV8h6STJwmfuq7LSgY
