### PR TITLE
feat(models): add settable TermStructureFittingParameter::NumericalImpl

### DIFF
--- a/crates/libitofin/src/models/parameter.rs
+++ b/crates/libitofin/src/models/parameter.rs
@@ -13,11 +13,10 @@
 //!
 //! - `PiecewiseConstantParameter` (`parameter.hpp:119`) is time-dependent and
 //!   used only by the numerical tree/lattice path; it lands with those tickets.
-//! - `TermStructureFittingParameter::NumericalImpl` (`parameter.hpp:147`), the
-//!   tree-fitting value law read back by `tree()`, stays deferred with the
-//!   lattice machinery. The analytic seam (the generic `Impl` constructor,
-//!   `parameter.hpp:178`) is ported here as [`TermStructureFittingParameter`];
-//!   concrete fitting laws (Extended CIR's `phi(t)`) are supplied by each model.
+//! - `NumericalImpl::change` (`parameter.hpp:156`) rewrites the last-set value in
+//!   place; it is used only by the generic Brent-fitting `ShortRateTree` ctor
+//!   (`onefactormodel.cpp:56`), which is deferred (#463 ports Hull-White's
+//!   closed-form `tree()`, which only `reset`s and `set`s). Omitted, not stubbed.
 //!
 //! ## Divergences from QuantLib
 //!
@@ -35,12 +34,15 @@
 
 #![allow(clippy::new_ret_no_self)]
 
+use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::errors::QlResult;
+use crate::handle::Handle;
 use crate::math::array::Array;
 use crate::math::optimization::constraint::{Constraint, NoConstraint};
 use crate::require;
+use crate::termstructures::yieldtermstructure::YieldTermStructure;
 use crate::types::{Real, Size, Time};
 
 /// A state-capturing, possibly time-dependent value law for a [`Parameter`]
@@ -213,6 +215,83 @@ impl TermStructureFittingParameter {
     }
 }
 
+/// The runtime-settable fitting law behind a [`TermStructureFittingParameter`]
+/// (C++'s `TermStructureFittingParameter::NumericalImpl`, `parameter.hpp:147`).
+///
+/// A short-rate model's numerical `tree()` fits `phi(t)` node by node: it
+/// [`reset`](Self::reset)s the law, then [`set`](Self::set)s the fitted value at
+/// each grid time as it walks forward. The tree's dynamics read those values
+/// back through [`value`](ParameterValue::value) while the fit is still in flight
+/// (an earlier grid node's discount feeds the next node's state prices), so the
+/// values live behind interior mutability ([`RefCell`]) and the fit must
+/// [`set`](Self::set) on the *same* instance the dynamics reads. C++ shares one
+/// `NumericalImpl` between the fit and the dynamics via
+/// `dynamic_pointer_cast`; here the caller retains a concrete [`Rc<NumericalImpl>`](Rc)
+/// and clones it into the [`Parameter`] as an [`Rc<dyn ParameterValue>`](ParameterValue)
+/// before type-erasing, so both ends share the one [`RefCell`].
+///
+/// ## Divergences from QuantLib
+///
+/// - [`value`](ParameterValue::value) matches C++'s `std::find(times, t)`
+///   semantics exactly: an **exact** `Time` equality, not a tolerance compare
+///   (`parameter.hpp:164`). The fit `set`s at `grid[i]` and the dynamics read at
+///   `timeGrid()[i]` - the same `f64` from the same [`TimeGrid`], so exact
+///   equality is the right and faithful lookup.
+/// - C++'s `QL_REQUIRE` on a missing time surfaces here as a documented `expect`
+///   panic, not a `Result`: [`ParameterValue::value`] is infallible by design
+///   (the eval boundary), and a lookup at an unset time is a programming error -
+///   the fit always `set`s every grid node before the dynamics read it.
+pub struct NumericalImpl {
+    nodes: RefCell<Vec<(Time, Real)>>,
+    term_structure: Handle<dyn YieldTermStructure>,
+}
+
+impl NumericalImpl {
+    /// `NumericalImpl(Handle<YieldTermStructure>)` (`parameter.hpp:149`): an empty
+    /// law over `term_structure`. Returns an [`Rc`] so the caller can retain a
+    /// concrete handle for the fit and clone a type-erased one into a
+    /// [`Parameter`] (both sharing the interior [`RefCell`]).
+    pub fn new(term_structure: Handle<dyn YieldTermStructure>) -> Rc<Self> {
+        Rc::new(NumericalImpl {
+            nodes: RefCell::new(Vec::new()),
+            term_structure,
+        })
+    }
+
+    /// `set(Time t, Real x)` (`parameter.hpp:152`): appends the fitted value `x`
+    /// at time `t`.
+    pub fn set(&self, t: Time, x: Real) {
+        self.nodes.borrow_mut().push((t, x));
+    }
+
+    /// `reset()` (`parameter.hpp:159`): clears all fitted nodes, readying the law
+    /// for a fresh forward fit.
+    pub fn reset(&self) {
+        self.nodes.borrow_mut().clear();
+    }
+
+    /// `termStructure()` (`parameter.hpp:169`): the curve the fit reprices. Read
+    /// by the deferred Brent-fitting `ShortRateTree` ctor (`onefactormodel.cpp:69`);
+    /// Hull-White's closed-form `tree()` reads the curve off the model instead.
+    pub fn term_structure(&self) -> &Handle<dyn YieldTermStructure> {
+        &self.term_structure
+    }
+}
+
+impl ParameterValue for NumericalImpl {
+    /// `value(const Array&, Time t)` (`parameter.hpp:163`): the fitted value at
+    /// the grid node whose time equals `t` exactly. Panics if `t` was never
+    /// `set` (C++'s `QL_REQUIRE(..., "fitting parameter not set!")`).
+    fn value(&self, _params: &Array, t: Time) -> Real {
+        let nodes = self.nodes.borrow();
+        nodes
+            .iter()
+            .find(|(time, _)| *time == t)
+            .map(|(_, x)| *x)
+            .expect("fitting parameter not set!")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -335,5 +414,71 @@ mod tests {
         assert_eq!(phi.size(), 0);
         assert!((phi.value(2.0) - (0.05 + 0.01 * 2.0)).abs() < 1e-9);
         assert!((phi.value(0.5) - (0.05 + 0.01 * 0.5)).abs() < 1e-9);
+    }
+
+    fn flat_handle() -> Handle<dyn YieldTermStructure> {
+        let curve = FlatForward::with_rate(
+            Date::new(17, Month::May, 1998),
+            0.05,
+            Actual360::new(),
+            Compounding::Continuous,
+            Frequency::Annual,
+        );
+        Handle::new(shared(curve) as Shared<dyn YieldTermStructure>)
+    }
+
+    #[test]
+    fn numerical_impl_set_then_value_round_trips_per_node() {
+        // parameter.hpp:152-167: set appends (t, x); value(t) returns the x set at
+        // that exact t. reset clears back to empty.
+        let impl_ = NumericalImpl::new(flat_handle());
+        impl_.set(1.0, 0.031);
+        impl_.set(2.0, 0.042);
+        impl_.set(3.0, 0.055);
+        assert_eq!(impl_.value(&Array::new(), 1.0), 0.031);
+        assert_eq!(impl_.value(&Array::new(), 2.0), 0.042);
+        assert_eq!(impl_.value(&Array::new(), 3.0), 0.055);
+    }
+
+    #[test]
+    #[should_panic(expected = "fitting parameter not set!")]
+    fn numerical_impl_value_at_an_unset_time_panics_with_the_cpp_message() {
+        // parameter.hpp:165: QL_REQUIRE(found, "fitting parameter not set!"). Here
+        // the infallible eval boundary surfaces it as a documented panic.
+        let impl_ = NumericalImpl::new(flat_handle());
+        impl_.set(1.0, 0.03);
+        impl_.value(&Array::new(), 2.0);
+    }
+
+    #[test]
+    #[should_panic(expected = "fitting parameter not set!")]
+    fn numerical_impl_lookup_is_exact_not_tolerant() {
+        // parameter.hpp:164: std::find is operator==, an EXACT Time match. A time a
+        // hair off a set node is "not set", never a nearest-node fallback. This is
+        // safe because the fit and the dynamics share the identical grid f64s.
+        let impl_ = NumericalImpl::new(flat_handle());
+        impl_.set(1.0, 0.03);
+        impl_.value(&Array::new(), 1.0 + 1e-12);
+    }
+
+    #[test]
+    fn numerical_impl_reset_clears_every_node() {
+        let impl_ = NumericalImpl::new(flat_handle());
+        impl_.set(1.0, 0.03);
+        impl_.reset();
+        impl_.set(2.0, 0.07);
+        assert_eq!(impl_.value(&Array::new(), 2.0), 0.07);
+    }
+
+    #[test]
+    fn set_through_the_retained_rc_is_visible_through_the_type_erased_parameter() {
+        // The gate-amendment same-impl wiring at the parameter level: the fit
+        // retains a concrete Rc<NumericalImpl> and clones a type-erased copy into
+        // the Parameter; a set() through the retained handle must be seen by
+        // Parameter::value (they share the one RefCell).
+        let impl_ = NumericalImpl::new(flat_handle());
+        let phi = TermStructureFittingParameter::new(impl_.clone() as Rc<dyn ParameterValue>);
+        impl_.set(2.5, 0.037);
+        assert_eq!(phi.value(2.5), 0.037);
     }
 }

--- a/crates/libitofin/src/models/shortrate/hullwhite.rs
+++ b/crates/libitofin/src/models/shortrate/hullwhite.rs
@@ -1113,4 +1113,169 @@ mod tests {
             );
         }
     }
+
+    // ------------------------------------------------------------------
+    // #463: ShortRateDynamics / ShortRateTree / HullWhite::tree oracle
+    // ------------------------------------------------------------------
+
+    use crate::math::timegrid::TimeGrid;
+    use crate::methods::lattices::TreeLatticeImpl;
+
+    /// The WIRING-PIN quantity at slice `i`: `sum_j statePrices(i)[j] *
+    /// discount(i, j)`, where `discount(i, j) = exp(-shortRate(t_i, x_j) * dt_i)`
+    /// reads `phi(t_i)` back through the tree's dynamics. Paired with the curve's
+    /// `P(t_{i+1})`, this is the identity the closed-form fit enforces.
+    fn pin_at(
+        lattice: &TreeLattice1D<ShortRateTree>,
+        curve: &Shared<dyn YieldTermStructure>,
+        grid: &TimeGrid,
+        i: usize,
+    ) -> (Real, Real) {
+        let sp = lattice.state_prices(i);
+        let sum: Real = (0..sp.size())
+            .map(|j| sp[j] * lattice.implementation().discount(i, j))
+            .sum();
+        let bond = curve.discount(grid[i + 1], false).unwrap();
+        (sum, bond)
+    }
+
+    /// Builds the numerical lattice exactly as [`HullWhite::tree`] does, but stops
+    /// before the fit and hands back the retained `phi` impl and the trinomial, so
+    /// a stub test can drive (or mis-wire) the fit itself. Mirrors the ctor half of
+    /// `hullwhite.cpp:45-51`.
+    fn build_unfitted(
+        curve: Handle<dyn YieldTermStructure>,
+        a: Real,
+        sigma: Real,
+        grid: &TimeGrid,
+    ) -> (
+        Rc<NumericalImpl>,
+        Shared<TrinomialTree>,
+        TreeLattice1D<ShortRateTree>,
+    ) {
+        let phi_impl = NumericalImpl::new(curve);
+        let phi = TermStructureFittingParameter::new(phi_impl.clone() as Rc<dyn ParameterValue>);
+        let dynamics: Shared<dyn ShortRateDynamics> =
+            shared(HullWhiteDynamics::new(phi, a, sigma).unwrap());
+        let trinomial =
+            shared(TrinomialTree::new(dynamics.process(), grid.clone(), false).unwrap());
+        let short_rate_tree = ShortRateTree::new(
+            Shared::clone(&trinomial),
+            Shared::clone(&dynamics),
+            grid.clone(),
+        );
+        let lattice = TreeLattice1D::new(short_rate_tree, grid.clone()).unwrap();
+        (phi_impl, trinomial, lattice)
+    }
+
+    #[test]
+    fn dynamics_variable_and_short_rate_are_inverse_through_phi() {
+        // hullwhite.hpp:114-115: shortRate(t,x) = x + phi(t), variable(t,r) =
+        // r - phi(t), so shortRate(t, variable(t,r)) == r. process() is the
+        // zero-mean OU (x0 = 0), kept distinct from the model's r0.
+        let curve = flat(0.05);
+        let phi_impl = NumericalImpl::new(Handle::new(curve.clone()));
+        phi_impl.set(1.0, 0.02);
+        let phi = TermStructureFittingParameter::new(phi_impl.clone() as Rc<dyn ParameterValue>);
+        let dynamics = HullWhiteDynamics::new(phi, 0.1, 0.01).unwrap();
+
+        let r = 0.05;
+        let x = dynamics.variable(1.0, r);
+        assert!((x - (r - 0.02)).abs() < 1e-15);
+        assert!((dynamics.short_rate(1.0, x) - r).abs() < 1e-15);
+        assert_eq!(dynamics.process().x0().unwrap(), 0.0);
+    }
+
+    #[test]
+    fn tree_reprices_the_flat_curve_wiring_pin() {
+        // WIRING PIN (tautological in the state-price VALUES - #462 owns those; see
+        // the GATE AMENDMENT). It validates set/get + EXACT-time lookup +
+        // shortRate = x + phi composition + the same-impl wiring: after tree(), the
+        // fitted tree reprices the curve's discount bonds. Asserted at several
+        // i >= 1 up to size-2 (i=0 is one-node and degenerate).
+        let curve = flat(0.05);
+        let model = HullWhite::new(Handle::new(curve.clone()), 0.1, 0.01).unwrap();
+        let grid = TimeGrid::new(3.0, 12).unwrap();
+        let lattice = model.borrow().tree(grid.clone()).unwrap();
+
+        for i in [1usize, 4, 7, 11] {
+            let (sum, bond) = pin_at(&lattice, &curve, &grid, i);
+            assert!(
+                (sum - bond).abs() < 1e-10,
+                "flat pin slice {i}: {sum} vs {bond}"
+            );
+        }
+    }
+
+    #[test]
+    fn tree_reprices_the_sloped_curve_wiring_pin() {
+        // The sloped arm: phi_i genuinely varies across slices, so a constant-phi
+        // or off-by-one (wrong-time) lookup passes flat but fails here. Same pin,
+        // on the ZeroCurve fixture shared with the C++ generator.
+        let handle = sloped_curve();
+        let curve = handle.current_link().unwrap();
+        let model = HullWhite::new(handle, 0.1, 0.01).unwrap();
+        let grid = TimeGrid::new(3.0, 12).unwrap();
+        let lattice = model.borrow().tree(grid.clone()).unwrap();
+
+        for i in [1usize, 4, 7, 11] {
+            let (sum, bond) = pin_at(&lattice, &curve, &grid, i);
+            assert!(
+                (sum - bond).abs() < 1e-10,
+                "sloped pin slice {i}: {sum} vs {bond}"
+            );
+        }
+    }
+
+    #[test]
+    fn unfitted_tree_misprices_the_curve_confirm_by_stub() {
+        // CONFIRM-BY-STUB (a): with phi = 0 at every node instead of the fit, the
+        // tree discounts at the raw OU state (~0), NOT the curve, so the wiring pin
+        // FAILS with margin. Proves the fit is load-bearing (a numeric failure, so
+        // it fails informatively rather than via the unset-lookup panic).
+        let curve = flat(0.05);
+        let grid = TimeGrid::new(3.0, 12).unwrap();
+        let (phi_impl, _trinomial, lattice) =
+            build_unfitted(Handle::new(curve.clone()), 0.1, 0.01, &grid);
+        for i in 0..(grid.size() - 1) {
+            phi_impl.set(grid[i], 0.0);
+        }
+        let (sum, bond) = pin_at(&lattice, &curve, &grid, 6);
+        assert!(
+            (sum - bond).abs() > 1e-6,
+            "phi=0 must misprice the curve: {sum} vs {bond}"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "fitting parameter not set!")]
+    fn breaking_the_same_impl_wiring_panics_confirm_by_stub() {
+        // CONFIRM-BY-STUB (b): the fit sets a DIFFERENT NumericalImpl than the
+        // dynamics reads (the gate-amendment hazard). The dynamics' phi stays
+        // empty, so the first state-price slice that discounts through it (slice 1
+        // -> discount(0, .)) hits the unset EXACT-time lookup and panics. This
+        // pins that the fit and the dynamics MUST share one impl.
+        let curve = flat(0.05);
+        let handle = Handle::new(curve.clone());
+        let grid = TimeGrid::new(3.0, 12).unwrap();
+        let (_dynamics_phi, trinomial, lattice) = build_unfitted(handle.clone(), 0.1, 0.01, &grid);
+
+        let fit_phi = NumericalImpl::new(handle);
+        fit_phi.reset();
+        for i in 0..(grid.size() - 1) {
+            let bond = curve.discount(grid[i + 1], false).unwrap();
+            let sp = lattice.state_prices(i);
+            let size = trinomial.size(i);
+            let dt = grid.dt(i);
+            let dx = trinomial.dx(i);
+            let mut x = trinomial.underlying(i, 0);
+            let mut value = 0.0;
+            for j in 0..size {
+                value += sp[j] * (-x * dt).exp();
+                x += dx;
+            }
+            value = (value / bond).ln() / dt;
+            fit_phi.set(grid[i], value);
+        }
+    }
 }

--- a/crates/libitofin/src/models/shortrate/hullwhite.rs
+++ b/crates/libitofin/src/models/shortrate/hullwhite.rs
@@ -32,9 +32,13 @@
 //!   fitting law are deferred with the dynamics/tree path (#377). Consequently
 //!   [`generate_arguments`](crate::models::CalibratedModelHolder::generate_arguments)
 //!   here refreshes only the cached `r0`; the `phi_` rebuild lands with `dynamics()`.
-//! - `HullWhite::Dynamics` (`hullwhite.hpp:107`), `tree` (`hullwhite.cpp:43`) and
-//!   `FixedReversion` (`hullwhite.hpp:80`) are the simulation/lattice paths,
-//!   deferred with the short-rate dynamics per #377. The analytic
+//! - `HullWhite::Dynamics` (`hullwhite.hpp:107`) and `tree` (`hullwhite.cpp:43`)
+//!   are ported here (#463): [`HullWhite::tree`] builds a numerical short-rate
+//!   lattice whose deterministic drift is fitted in closed form. The public
+//!   analytic-`phi` `dynamics()` accessor (`hullwhite.hpp:159`) stays deferred
+//!   with the analytic `FittingParameter`; `tree()` builds its own numerical
+//!   `phi` and never reads `phi_`. `FixedReversion` (`hullwhite.hpp:80`) is the
+//!   calibration mask, deferred. The analytic
 //!   `testCachedHullWhite` calibration oracle (`shortratemodels.cpp:83`) is ported
 //!   in `hull_white_calibrates_to_the_cached_swaption_values` below (#399), on the
 //!   Jamshidian-engine path (#392); `testCachedHullWhiteFixedReversion`
@@ -60,21 +64,31 @@
 //!   observer holds a weak back-reference to the model and must be stashed after
 //!   the model is shared (C++ registers `this` inside the constructor).
 
+use std::rc::Rc;
+
 use crate::errors::QlResult;
 use crate::handle::Handle;
 use crate::interestrate::Compounding;
+use crate::math::timegrid::TimeGrid;
+use crate::methods::lattices::{Tree, TreeLattice1D, TrinomialTree};
 use crate::models::model::{
     CalibratedModel, CalibratedModelHolder, TermStructureConsistentModel,
     register_with_term_structure,
 };
-use crate::models::parameter::NullParameter;
-use crate::models::shortrate::onefactormodel::OneFactorAffineModel;
+use crate::models::parameter::{
+    NullParameter, NumericalImpl, Parameter, ParameterValue, TermStructureFittingParameter,
+};
+use crate::models::shortrate::onefactormodel::{
+    OneFactorAffineModel, ShortRateDynamics, ShortRateTree,
+};
 use crate::models::shortrate::vasicek::Vasicek;
 use crate::option::OptionType;
 use crate::patterns::observable::Observer;
 use crate::pricingengines::blackformula::black_formula;
+use crate::processes::OrnsteinUhlenbeckProcess;
 use crate::require;
-use crate::shared::{SharedMut, shared_mut};
+use crate::shared::{Shared, SharedMut, shared, shared_mut};
+use crate::stochasticprocess::StochasticProcess1D;
 use crate::termstructures::yieldtermstructure::YieldTermStructure;
 use crate::time::frequency::Frequency;
 use crate::types::{Rate, Real, Time};
@@ -315,6 +329,110 @@ impl HullWhite {
         let f = self.discount(bond_maturity)?;
         let k = self.discount(bond_start)? * strike;
         black_formula(option_type, k, f, v, 1.0, 0.0)
+    }
+
+    /// `HullWhite::tree(const TimeGrid&)` (`hullwhite.cpp:43`): the numerical
+    /// short-rate lattice, with the deterministic drift `phi` fitted node by node
+    /// so the tree reprices the model's term structure.
+    ///
+    /// This OVERRIDES the base `OneFactorModel::tree` (`onefactormodel.cpp:89`,
+    /// Brent-fitting, deferred) with a closed-form state-price fit
+    /// (`hullwhite.cpp:57-71`): the fit and the tree's dynamics share one
+    /// [`NumericalImpl`] (the concrete `phi_impl` retained here, cloned type-erased
+    /// into the dynamics' [`Parameter`]), so a `phi_i` set at step `i` is read back
+    /// when step `i+1`'s state prices discount through it. At each step `i`,
+    /// `phi_i = ln( (sum_j statePrices(i)[j] e^{-x_j dt}) / P(t_{i+1}) ) / dt`
+    /// (`x_j` the RAW node value, since `phi_i` is exactly what the fit solves for).
+    ///
+    /// Returns the concrete [`TreeLattice1D`] so the #465 engine (and this ticket's
+    /// oracle) can reach `state_prices`/`underlying`/`implementation`; it coerces
+    /// to `Shared<dyn Lattice>` for the discretized-asset rollback an engine drives.
+    ///
+    /// # Errors
+    ///
+    /// Fails if the fitted curve is unlinked or its discount undefined, if the
+    /// trinomial tree rejects the process/grid, or if `a`/`sigma` violate the
+    /// Ornstein-Uhlenbeck constraints.
+    pub fn tree(&self, grid: TimeGrid) -> QlResult<TreeLattice1D<ShortRateTree>> {
+        let a = self.base.a();
+        let sigma = self.base.sigma();
+
+        let phi_impl = NumericalImpl::new(self.term_structure().clone());
+        let phi = TermStructureFittingParameter::new(phi_impl.clone() as Rc<dyn ParameterValue>);
+        let dynamics: Shared<dyn ShortRateDynamics> =
+            shared(HullWhiteDynamics::new(phi, a, sigma)?);
+
+        let trinomial = shared(TrinomialTree::new(dynamics.process(), grid.clone(), false)?);
+        let short_rate_tree = ShortRateTree::new(
+            Shared::clone(&trinomial),
+            Shared::clone(&dynamics),
+            grid.clone(),
+        );
+        let lattice = TreeLattice1D::new(short_rate_tree, grid.clone())?;
+
+        phi_impl.reset();
+        for i in 0..(grid.size() - 1) {
+            let discount_bond = self
+                .term_structure()
+                .current_link()?
+                .discount(grid[i + 1], false)?;
+            let state_prices = lattice.state_prices(i);
+            let size = trinomial.size(i);
+            let dt = grid.dt(i);
+            let dx = trinomial.dx(i);
+            let mut x = trinomial.underlying(i, 0);
+            let mut value = 0.0;
+            for j in 0..size {
+                value += state_prices[j] * (-x * dt).exp();
+                x += dx;
+            }
+            value = (value / discount_bond).ln() / dt;
+            phi_impl.set(grid[i], value);
+        }
+        Ok(lattice)
+    }
+}
+
+/// `HullWhite::Dynamics` (`hullwhite.hpp:107`): the short rate is
+/// `r_t = phi(t) + x_t`, where `x_t` follows an Ornstein-Uhlenbeck process with
+/// zero mean level and `phi(t)` is the term-structure fitting drift. Built by
+/// [`HullWhite::tree`] with the numerical (tree-fitted) `phi`.
+struct HullWhiteDynamics {
+    process: Shared<dyn StochasticProcess1D>,
+    fitting: Parameter,
+}
+
+impl HullWhiteDynamics {
+    /// `Dynamics(Parameter fitting, Real a, Real sigma)` (`hullwhite.hpp:109`):
+    /// wraps `OrnsteinUhlenbeckProcess(a, sigma)`, whose `x0` and `level` take the
+    /// C++ ctor defaults of `0.0` (`ornsteinuhlenbeckprocess.hpp:45-46`) - the
+    /// zero-mean state the fitting drift is added to, kept distinct from the
+    /// model's `r0`.
+    ///
+    /// # Errors
+    ///
+    /// Fails if `sigma` is negative (the Ornstein-Uhlenbeck volatility
+    /// constraint).
+    fn new(fitting: Parameter, a: Real, sigma: Real) -> QlResult<Self> {
+        Ok(HullWhiteDynamics {
+            process: shared(OrnsteinUhlenbeckProcess::new(a, sigma, 0.0, 0.0)?)
+                as Shared<dyn StochasticProcess1D>,
+            fitting,
+        })
+    }
+}
+
+impl ShortRateDynamics for HullWhiteDynamics {
+    fn variable(&self, t: Time, r: Rate) -> Real {
+        r - self.fitting.value(t)
+    }
+
+    fn short_rate(&self, t: Time, x: Real) -> Rate {
+        x + self.fitting.value(t)
+    }
+
+    fn process(&self) -> Shared<dyn StochasticProcess1D> {
+        Shared::clone(&self.process)
     }
 }
 

--- a/crates/libitofin/src/models/shortrate/mod.rs
+++ b/crates/libitofin/src/models/shortrate/mod.rs
@@ -14,5 +14,5 @@ pub use calibrationhelpers::SwaptionHelper;
 pub use coxingersollross::{CoxIngersollRoss, VolatilityConstraint};
 pub use extendedcoxingersollross::ExtendedCoxIngersollRoss;
 pub use hullwhite::{HullWhite, convexity_bias};
-pub use onefactormodel::{AffineModel, OneFactorAffineModel};
+pub use onefactormodel::{AffineModel, OneFactorAffineModel, ShortRateDynamics, ShortRateTree};
 pub use vasicek::Vasicek;

--- a/crates/libitofin/src/models/shortrate/onefactormodel.rs
+++ b/crates/libitofin/src/models/shortrate/onefactormodel.rs
@@ -33,8 +33,16 @@
 //! concrete affine model embeds a `CalibratedModel` and implements
 //! [`OneFactorAffineModel`] directly.
 
+use std::cell::Cell;
+
 use crate::math::array::Array;
-use crate::types::{Rate, Real, Time};
+use crate::math::timegrid::TimeGrid;
+use crate::methods::lattices::tree::Tree;
+use crate::methods::lattices::treelattice::TreeLatticeImpl;
+use crate::methods::lattices::trinomialtree::TrinomialTree;
+use crate::shared::Shared;
+use crate::stochasticprocess::StochasticProcess1D;
+use crate::types::{Rate, Real, Size, Time};
 
 /// Analytically tractable model (`ql/models/model.hpp:45`), reduced to its one
 /// non-deferred method: the zero-coupon bond price as a function of the state
@@ -76,6 +84,92 @@ pub trait OneFactorAffineModel {
 impl<M: OneFactorAffineModel> AffineModel for M {
     fn discount_bond_factors(&self, now: Time, maturity: Time, factors: &Array) -> Real {
         self.discount_bond(now, maturity, factors[0])
+    }
+}
+
+/// Base description of a one-factor short-rate's dynamics
+/// (`OneFactorModel::ShortRateDynamics`, `onefactormodel.hpp:54`).
+///
+/// A model maps between its Markov state variable `x` and the short rate `r`, and
+/// exposes the risk-neutral process the state follows. The numerical tree
+/// discretizes [`process`](Self::process) and reads [`short_rate`](Self::short_rate)
+/// off each node to discount.
+pub trait ShortRateDynamics {
+    /// `variable(Time t, Rate r)` (`onefactormodel.hpp:61`): the state variable
+    /// implied by the short rate `r` at `t`.
+    fn variable(&self, t: Time, r: Rate) -> Real;
+
+    /// `shortRate(Time t, Real variable)` (`onefactormodel.hpp:64`): the short
+    /// rate implied by the state `variable` at `t`.
+    fn short_rate(&self, t: Time, variable: Real) -> Rate;
+
+    /// `process()` (`onefactormodel.hpp:67`): the risk-neutral dynamics of the
+    /// state variable, the tree discretizes.
+    fn process(&self) -> Shared<dyn StochasticProcess1D>;
+}
+
+/// Recombining trinomial tree discretizing a short-rate model's state variable
+/// (`OneFactorModel::ShortRateTree`, `onefactormodel.hpp:75`).
+///
+/// C++'s `ShortRateTree` *is-a* `TreeLattice1D<ShortRateTree>` (CRTP self-
+/// inheritance) and supplies the per-node discount off the model's dynamics.
+/// Here it is instead the [`TreeLatticeImpl`] callback surface a
+/// [`TreeLattice1D`](crate::methods::lattices::TreeLattice1D) induces over: it
+/// embeds the [`TrinomialTree`] (which serves `size`/`descendant`/`probability`/
+/// `underlying`) and the [`ShortRateDynamics`], and computes
+/// [`discount`](TreeLatticeImpl::discount)`(i, index) =
+/// exp(-(short_rate(t_i, x) + spread) * dt_i)` (`onefactormodel.hpp:91`). It
+/// carries its own [`TimeGrid`] clone because the discount callback needs
+/// `t_i`/`dt_i`, and the impl is nested inside - not above - the lattice that
+/// owns the grid (the [`TreeLattice1D`](crate::methods::lattices::TreeLattice1D)
+/// test fixtures do the same).
+///
+/// Only the plain build-up is ported; the Brent-fitting ctor and its `Helper`
+/// (`onefactormodel.cpp:28,56`) belong to the deferred generic `tree()` path
+/// (Hull-White's `tree()` fits `phi` in closed form instead).
+pub struct ShortRateTree {
+    tree: Shared<TrinomialTree>,
+    dynamics: Shared<dyn ShortRateDynamics>,
+    time_grid: TimeGrid,
+    spread: Cell<Real>,
+}
+
+impl ShortRateTree {
+    /// Plain build-up from a trinomial `tree` and short-rate `dynamics` over
+    /// `time_grid` (`onefactormodel.cpp:80`); the spread starts at `0`.
+    pub fn new(
+        tree: Shared<TrinomialTree>,
+        dynamics: Shared<dyn ShortRateDynamics>,
+        time_grid: TimeGrid,
+    ) -> Self {
+        ShortRateTree {
+            tree,
+            dynamics,
+            time_grid,
+            spread: Cell::new(0.0),
+        }
+    }
+
+    /// `setSpread(Spread)` (`onefactormodel.hpp:105`): an additive spread on the
+    /// short rate, used by spread-adjusted engines (e.g. callable bonds). Held
+    /// behind a [`Cell`] so it is settable through the shared, immutable impl the
+    /// lattice exposes via `implementation()`.
+    pub fn set_spread(&self, spread: Real) {
+        self.spread.set(spread);
+    }
+}
+
+impl TreeLatticeImpl for ShortRateTree {
+    type Tree = TrinomialTree;
+
+    fn tree(&self) -> &TrinomialTree {
+        &self.tree
+    }
+
+    fn discount(&self, i: Size, index: Size) -> Real {
+        let x = self.tree.underlying(i, index);
+        let r = self.dynamics.short_rate(self.time_grid[i], x) + self.spread.get();
+        (-r * self.time_grid.dt(i)).exp()
     }
 }
 


### PR DESCRIPTION
- **feat(models): add settable TermStructureFittingParameter::NumericalImpl**
- **feat(models): port ShortRateDynamics, ShortRateTree, and HullWhite::tree**
- **test(models): oracle HullWhite::tree wiring pin on flat and sloped curves**

close #463