### PR TITLE
feat(itofin-py): add Hull-White swaption calibration bindings

### DIFF
--- a/crates/itofin-py/src/hullwhite.rs
+++ b/crates/itofin-py/src/hullwhite.rs
@@ -2,12 +2,22 @@
 //! [`PyEuribor`] index.
 
 use crate::PyQlError;
+use crate::calibration::{PyCalibrationErrorType, PyEndCriteria, PyLevenbergMarquardt};
 use crate::curve::PyFlatForward;
 use crate::option::PyOptionType;
 use crate::settings::PySettings;
+use crate::time::{PyDayCounter, PyPeriod};
+use libitofin::cashflows::RateAveraging;
+use libitofin::handle::Handle;
 use libitofin::indexes::{Euribor, IborIndex};
-use libitofin::models::{CalibratedModelHolder, HullWhite};
-use libitofin::shared::{Shared, SharedMut, shared};
+use libitofin::models::calibrationhelper::{BlackCalibrationHelper, CalibrationHelper};
+use libitofin::models::shortrate::SwaptionHelper;
+use libitofin::models::{CalibratedModelHolder, HullWhite, calibrate};
+use libitofin::pricingengine::PricingEngine;
+use libitofin::pricingengines::JamshidianSwaptionEngine;
+use libitofin::quotes::{Quote, SimpleQuote};
+use libitofin::shared::{Shared, SharedMut, shared, shared_mut};
+use libitofin::termstructures::volatility::VolatilityType;
 use pyo3::prelude::*;
 
 /// Python `HullWhite`: the one-factor Hull-White short-rate model
@@ -66,6 +76,55 @@ impl PyHullWhite {
             .discount_bond_option(option_type.inner(), strike, maturity, bond_maturity)
             .map_err(PyQlError::from)?)
     }
+
+    /// Calibrates the model to `helpers` with `method` under `end_criteria`,
+    /// then writes the fitted `a`/`sigma` back (readable through the getters).
+    ///
+    /// Mirrors the core oracle (`hullwhite.rs:809-864`): one
+    /// [`JamshidianSwaptionEngine`] is built on this model and installed on every
+    /// helper, so all swaptions price through the same analytic engine the
+    /// optimizer drives (keeping W2 independent of the user-facing engine facade).
+    /// `fix_reversion` pins the mean reversion `a` and frees only `sigma`
+    /// (`fix_parameters = [true, false]`, `hullwhite.rs:1043`); otherwise both are
+    /// free. [`calibrate`](libitofin::models::calibrate) fails on an empty helper
+    /// list.
+    fn calibrate(
+        &mut self,
+        helpers: Vec<PyRef<PySwaptionHelper>>,
+        method: &mut PyLevenbergMarquardt,
+        end_criteria: &PyEndCriteria,
+        fix_reversion: bool,
+    ) -> PyResult<()> {
+        let engine = shared_mut(JamshidianSwaptionEngine::new(SharedMut::clone(&self.inner)))
+            as SharedMut<dyn PricingEngine>;
+        for helper in &helpers {
+            helper
+                .inner
+                .borrow_mut()
+                .base_mut()
+                .set_pricing_engine(SharedMut::clone(&engine));
+        }
+        let dyn_helpers: Vec<SharedMut<dyn CalibrationHelper>> = helpers
+            .iter()
+            .map(|helper| SharedMut::clone(&helper.inner) as SharedMut<dyn CalibrationHelper>)
+            .collect();
+        let fix_parameters = if fix_reversion {
+            vec![true, false]
+        } else {
+            Vec::new()
+        };
+        calibrate(
+            &self.inner,
+            &dyn_helpers,
+            method.inner_mut(),
+            end_criteria.inner(),
+            None,
+            Vec::new(),
+            fix_parameters,
+        )
+        .map_err(PyQlError::from)?;
+        Ok(())
+    }
 }
 
 impl PyHullWhite {
@@ -100,8 +159,72 @@ impl PyEuribor {
 
 impl PyEuribor {
     /// A clone of the inner index for the swap/swaption facades.
-    #[allow(dead_code)]
     pub(crate) fn inner(&self) -> Shared<IborIndex> {
         Shared::clone(&self.inner)
+    }
+}
+
+/// Python `SwaptionHelper`: a co-terminal swaption calibration instrument
+/// (`models::shortrate::calibrationhelpers::swaptionhelper::SwaptionHelper`).
+///
+/// The helper builds its own European swaption from the maturity/length and the
+/// index, so no swap or swaption facade is needed. The volatility is assembled
+/// into a `Handle<dyn Quote>` internally from a `SimpleQuote`. The oracle's fixed
+/// defaults are pinned here (`hullwhite.rs:839-844`): `strike = None` (struck at
+/// the forward), `ShiftedLognormal` volatility with zero shift, the index's own
+/// settlement days, and `Compound` averaging. Held as `SharedMut` so a
+/// calibration can install the Jamshidian engine on it and upcast it to
+/// `SharedMut<dyn CalibrationHelper>`.
+#[pyclass(name = "SwaptionHelper", unsendable)]
+pub struct PySwaptionHelper {
+    inner: SharedMut<SwaptionHelper>,
+}
+
+#[pymethods]
+impl PySwaptionHelper {
+    #[new]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        maturity: &PyPeriod,
+        length: &PyPeriod,
+        volatility: f64,
+        index: &PyEuribor,
+        fixed_leg_tenor: &PyPeriod,
+        fixed_leg_day_counter: &PyDayCounter,
+        floating_leg_day_counter: &PyDayCounter,
+        curve: &PyFlatForward,
+        error_type: &PyCalibrationErrorType,
+        nominal: f64,
+    ) -> Self {
+        let vol = Handle::new(shared(SimpleQuote::new(volatility)) as Shared<dyn Quote>);
+        PySwaptionHelper {
+            inner: shared_mut(SwaptionHelper::new(
+                maturity.inner(),
+                length.inner(),
+                vol,
+                index.inner(),
+                fixed_leg_tenor.inner(),
+                fixed_leg_day_counter.inner(),
+                floating_leg_day_counter.inner(),
+                curve.handle(),
+                error_type.inner(),
+                None,
+                nominal,
+                VolatilityType::ShiftedLognormal,
+                0.0,
+                None,
+                RateAveraging::Compound,
+            )),
+        }
+    }
+
+    /// The calibration error under the helper's error type, after a calibration
+    /// has installed a pricing engine on it.
+    fn calibration_error(&mut self) -> PyResult<f64> {
+        Ok(self
+            .inner
+            .borrow_mut()
+            .calibration_error()
+            .map_err(PyQlError::from)?)
     }
 }

--- a/crates/itofin-py/src/lib.rs
+++ b/crates/itofin-py/src/lib.rs
@@ -17,7 +17,7 @@ mod time;
 use calibration::{PyCalibrationErrorType, PyEndCriteria, PyLevenbergMarquardt};
 use curve::PyFlatForward;
 use heston::{PyHestonModel, PyHestonModelHelper, PyHestonProcess};
-use hullwhite::{PyEuribor, PyHullWhite};
+use hullwhite::{PyEuribor, PyHullWhite, PySwaptionHelper};
 use libitofin::errors::QlError;
 use market::{PyBlackScholesProcess, PySimpleQuote};
 use option::{PyOptionType, PyVanillaOption};
@@ -70,6 +70,7 @@ fn itofin(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyHestonModelHelper>()?;
     m.add_class::<PyHullWhite>()?;
     m.add_class::<PyEuribor>()?;
+    m.add_class::<PySwaptionHelper>()?;
     m.add_class::<PyLevenbergMarquardt>()?;
     m.add_class::<PyEndCriteria>()?;
     m.add_class::<PyCalibrationErrorType>()?;

--- a/crates/itofin-py/src/time.rs
+++ b/crates/itofin-py/src/time.rs
@@ -8,6 +8,7 @@ use libitofin::time::daycounter::DayCounter;
 use libitofin::time::daycounters::actual360::Actual360;
 use libitofin::time::daycounters::actual365fixed::Actual365Fixed;
 use libitofin::time::daycounters::actualactual::{ActualActual, Convention};
+use libitofin::time::daycounters::thirty360::{Convention as Thirty360Convention, Thirty360};
 use libitofin::time::period::Period;
 use libitofin::time::timeunit::TimeUnit;
 use pyo3::prelude::*;
@@ -153,6 +154,15 @@ impl PyDayCounter {
     fn actual_actual_isda() -> Self {
         PyDayCounter {
             inner: ActualActual::with_convention(Convention::ISDA),
+        }
+    }
+
+    /// `Thirty360(Thirty360::BondBasis)`: the fixed-leg day count the Hull-White
+    /// swaption-calibration oracle anchors on (`hullwhite.rs:835`).
+    #[staticmethod]
+    fn thirty360_bond_basis() -> Self {
+        PyDayCounter {
+            inner: Thirty360::with_convention(Thirty360Convention::BondBasis),
         }
     }
 

--- a/crates/itofin-py/tests/test_hullwhite_calibration.py
+++ b/crates/itofin-py/tests/test_hullwhite_calibration.py
@@ -1,0 +1,115 @@
+import itofin
+import pytest
+
+# ORACLE testCachedHullWhite (shortratemodels.cpp:83-153, mirrored by the Rust
+# oracle calibrate_cached_hull_white in hullwhite.rs:793-912): calibrate
+# Hull-White to five co-terminal swaptions through the analytic Jamshidian engine
+# via Levenberg-Marquardt and reproduce the cached a/sigma to 1.3e-5.
+#
+# The C++/Rust oracle gates the cached values on usingAtParCoupons: the par arm
+# (usingAtParCoupons == true) yields a = 0.0464041, sigma = 0.00579912. `true` is
+# the Settings default (settings.rs Default), so a plain itofin.Settings() hits
+# the par arm without any further wiring. The evaluation date is 15-Feb-2002 on
+# Settings, while the flat curve is referenced at the SETTLEMENT date 19-Feb-2002;
+# these differ by design (a FlatForward with an explicit reference date is not
+# tied to the evaluation date), so both are set independently below.
+TODAY = (15, 2, 2002)
+SETTLEMENT = (19, 2, 2002)
+CURVE_RATE = 0.04875825
+
+# maturity years, length years, Black volatility (shortratemodels.cpp:96-102).
+SWAPTIONS = [
+    (1, 5, 0.1148),
+    (2, 4, 0.1108),
+    (3, 3, 0.1070),
+    (4, 2, 0.1021),
+    (5, 1, 0.1000),
+]
+
+
+def _fixture_settings():
+    settings = itofin.Settings()
+    settings.set_evaluation_date(itofin.Date(*TODAY))
+    return settings
+
+
+def _fixture_curve():
+    return itofin.FlatForward(
+        itofin.Date(*SETTLEMENT), CURVE_RATE, itofin.DayCounter.actual365_fixed()
+    )
+
+
+def _build_helpers(curve, index):
+    fixed_dc = itofin.DayCounter.thirty360_bond_basis()
+    float_dc = itofin.DayCounter.actual360()
+    fixed_tenor = itofin.Period(1, "Years")
+    helpers = []
+    for maturity, length, vol in SWAPTIONS:
+        helpers.append(
+            itofin.SwaptionHelper(
+                itofin.Period(maturity, "Years"),
+                itofin.Period(length, "Years"),
+                vol,
+                index,
+                fixed_tenor,
+                fixed_dc,
+                float_dc,
+                curve,
+                itofin.CalibrationErrorType.RelativePriceError,
+                1.0,
+            )
+        )
+    return helpers
+
+
+def test_hullwhite_calibrates_to_the_cached_swaption_values():
+    settings = _fixture_settings()
+    curve = _fixture_curve()
+    model = itofin.HullWhite(curve, 0.1, 0.01)
+    index = itofin.Euribor.six_months(curve, settings)
+    helpers = _build_helpers(curve, index)
+
+    method = itofin.LevenbergMarquardt(1e-8, 1e-8, 1e-8, False)
+    end_criteria = itofin.EndCriteria(10000, 100, 1e-6, 1e-8, 1e-8)
+    model.calibrate(helpers, method, end_criteria, False)
+
+    assert model.a() == pytest.approx(0.0464041, abs=1.3e-5)
+    assert model.sigma() == pytest.approx(0.00579912, abs=1.3e-5)
+
+    # A 2-parameter fit to 5 swaptions is not exact; the per-helper relative-price
+    # errors are NOT tiny here (the RSS residual is ~0.1158). Pin only that each
+    # helper's error is finite, i.e. the engine priced and the fit converged.
+    for helper in helpers:
+        error = helper.calibration_error()
+        assert error == error
+        assert abs(error) < float("inf")
+
+
+def test_hullwhite_calibrates_with_fixed_reversion():
+    # Optional second arm (shortratemodels.cpp:155-227, hullwhite.rs:1036-1044):
+    # pin the mean reversion a at 0.05 and free only sigma. This arm uses a
+    # DIFFERENT EndCriteria(1000, 500, ...) than the par arm; a must stay exactly
+    # 0.05 (the fixed parameter must not move), and sigma fits to 0.00585858.
+    settings = _fixture_settings()
+    curve = _fixture_curve()
+    model = itofin.HullWhite(curve, 0.05, 0.01)
+    index = itofin.Euribor.six_months(curve, settings)
+    helpers = _build_helpers(curve, index)
+
+    method = itofin.LevenbergMarquardt(1e-8, 1e-8, 1e-8, False)
+    end_criteria = itofin.EndCriteria(1000, 500, 1e-8, 1e-8, 1e-8)
+    model.calibrate(helpers, method, end_criteria, True)
+
+    assert model.a() == pytest.approx(0.05, abs=1e-15)
+    assert model.sigma() == pytest.approx(0.00585858, abs=1e-5)
+
+
+def test_calibrate_with_no_helpers_raises():
+    settings = _fixture_settings()
+    curve = _fixture_curve()
+    model = itofin.HullWhite(curve, 0.1, 0.01)
+    itofin.Euribor.six_months(curve, settings)
+    method = itofin.LevenbergMarquardt(1e-8, 1e-8, 1e-8, False)
+    end_criteria = itofin.EndCriteria(10000, 100, 1e-6, 1e-8, 1e-8)
+    with pytest.raises(itofin.ItofinError):
+        model.calibrate([], method, end_criteria, False)


### PR DESCRIPTION
- **feat(python): add HestonProcess, HestonModel and the analytic Heston engine wiring (#495)**
- **feat(python): add HestonModelHelper and Heston flat-vol calibration (#496)**
- **feat(python): add HullWhite model and Euribor index facades (#497)**
- **feat(itofin-py): add Hull-White swaption calibration bindings**

close #498