### PR TITLE
feat(itofin-py): expose Schedule and coupon enums to Python

### DIFF
--- a/crates/itofin-py/src/lib.rs
+++ b/crates/itofin-py/src/lib.rs
@@ -25,7 +25,9 @@ use pyo3::create_exception;
 use pyo3::exceptions::PyException;
 use pyo3::prelude::*;
 use settings::PySettings;
-use time::{PyCalendar, PyDate, PyDayCounter, PyPeriod};
+use time::{
+    PyBusinessDayConvention, PyCalendar, PyDate, PyDayCounter, PyFrequency, PyPeriod, PySchedule,
+};
 
 create_exception!(itofin, ItofinError, PyException);
 
@@ -60,6 +62,9 @@ fn itofin(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyDayCounter>()?;
     m.add_class::<PyCalendar>()?;
     m.add_class::<PyPeriod>()?;
+    m.add_class::<PyFrequency>()?;
+    m.add_class::<PyBusinessDayConvention>()?;
+    m.add_class::<PySchedule>()?;
     m.add_class::<PySimpleQuote>()?;
     m.add_class::<PyBlackScholesProcess>()?;
     m.add_class::<PyFlatForward>()?;

--- a/crates/itofin-py/src/time.rs
+++ b/crates/itofin-py/src/time.rs
@@ -1,6 +1,7 @@
 //! Facades for the time primitives: [`PyDate`], [`PyDayCounter`], [`PyCalendar`].
 
 use crate::ItofinError;
+use libitofin::time::businessdayconvention::BusinessDayConvention;
 use libitofin::time::calendar::Calendar;
 use libitofin::time::calendars::{NullCalendar, Target};
 use libitofin::time::date::{Date, Month};
@@ -9,7 +10,9 @@ use libitofin::time::daycounters::actual360::Actual360;
 use libitofin::time::daycounters::actual365fixed::Actual365Fixed;
 use libitofin::time::daycounters::actualactual::{ActualActual, Convention};
 use libitofin::time::daycounters::thirty360::{Convention as Thirty360Convention, Thirty360};
+use libitofin::time::frequency::Frequency;
 use libitofin::time::period::Period;
+use libitofin::time::schedule::{MakeSchedule, Schedule};
 use libitofin::time::timeunit::TimeUnit;
 use pyo3::prelude::*;
 
@@ -251,6 +254,131 @@ impl PyCalendar {
 impl PyCalendar {
     /// The wrapped core [`Calendar`] (cheap `Rc` clone).
     pub(crate) fn inner(&self) -> Calendar {
+        self.inner.clone()
+    }
+}
+
+/// Python `Frequency`: the coupon frequencies the swaption fixture needs.
+///
+/// A fieldless pyo3 enum exposing `Frequency.Annual` / `Frequency.Semiannual`;
+/// only the variants the Jamshidian fixture uses are surfaced.
+#[pyclass(name = "Frequency", eq, eq_int, from_py_object)]
+#[derive(Clone, Copy, PartialEq)]
+pub enum PyFrequency {
+    Annual,
+    Semiannual,
+}
+
+impl PyFrequency {
+    /// The core [`Frequency`] this variant stands for.
+    fn inner(&self) -> Frequency {
+        match self {
+            PyFrequency::Annual => Frequency::Annual,
+            PyFrequency::Semiannual => Frequency::Semiannual,
+        }
+    }
+}
+
+/// Python `BusinessDayConvention`: the holiday-rolling rules the fixture needs.
+///
+/// A fieldless pyo3 enum exposing the `Following`, `ModifiedFollowing` and
+/// `Unadjusted` variants; the adjustment logic itself lives in the core
+/// calendar.
+#[pyclass(name = "BusinessDayConvention", eq, eq_int, from_py_object)]
+#[derive(Clone, Copy, PartialEq)]
+pub enum PyBusinessDayConvention {
+    ModifiedFollowing,
+    Following,
+    Unadjusted,
+}
+
+impl PyBusinessDayConvention {
+    /// The core [`BusinessDayConvention`] this variant stands for.
+    fn inner(&self) -> BusinessDayConvention {
+        match self {
+            PyBusinessDayConvention::ModifiedFollowing => BusinessDayConvention::ModifiedFollowing,
+            PyBusinessDayConvention::Following => BusinessDayConvention::Following,
+            PyBusinessDayConvention::Unadjusted => BusinessDayConvention::Unadjusted,
+        }
+    }
+}
+
+/// Python `Schedule`: a sequence of coupon dates built through `MakeSchedule`.
+///
+/// The core `Schedule::new` (via `MakeSchedule::build`) `panic!`s on degenerate
+/// input - a null date or an effective date not strictly before the termination
+/// date - and a panic unwinding across the PyO3 boundary is an abort/UB hazard.
+/// The constructor supplies every builder input, so the `build`-level checks are
+/// unreachable; the date ordering is the one piece of user input, so it is
+/// validated first and returns [`struct@ItofinError`] before the core is
+/// touched. `date` likewise bounds-checks the index the core would otherwise
+/// panic on.
+#[pyclass(name = "Schedule", unsendable)]
+pub struct PySchedule {
+    inner: Schedule,
+}
+
+#[pymethods]
+impl PySchedule {
+    #[new]
+    fn new(
+        start: &PyDate,
+        end: &PyDate,
+        frequency: &PyFrequency,
+        calendar: &PyCalendar,
+        convention: &PyBusinessDayConvention,
+    ) -> PyResult<Self> {
+        if start.inner() >= end.inner() {
+            return Err(ItofinError::new_err(format!(
+                "schedule start ({}) is not strictly before end ({})",
+                start.inner(),
+                end.inner()
+            )));
+        }
+        let convention = convention.inner();
+        let inner = MakeSchedule::new()
+            .from(start.inner())
+            .to(end.inner())
+            .with_frequency(frequency.inner())
+            .with_calendar(calendar.inner())
+            .with_convention(convention)
+            .with_termination_date_convention(convention)
+            .forwards()
+            .build();
+        Ok(PySchedule { inner })
+    }
+
+    /// The number of dates in the schedule (one more than the period count).
+    fn size(&self) -> usize {
+        self.inner.dates().len()
+    }
+
+    /// The `i`-th date, erroring when `i` is out of range.
+    fn date(&self, i: usize) -> PyResult<PyDate> {
+        let dates = self.inner.dates();
+        if i >= dates.len() {
+            return Err(ItofinError::new_err(format!(
+                "schedule date index {i} out of range [0, {})",
+                dates.len()
+            )));
+        }
+        Ok(PyDate { inner: dates[i] })
+    }
+
+    /// All the schedule dates, as a Python list.
+    fn dates(&self) -> Vec<PyDate> {
+        self.inner
+            .dates()
+            .iter()
+            .map(|&inner| PyDate { inner })
+            .collect()
+    }
+}
+
+impl PySchedule {
+    /// The wrapped core [`Schedule`] (clone), for the swap facades in X2.
+    #[allow(dead_code)]
+    pub(crate) fn inner(&self) -> Schedule {
         self.inner.clone()
     }
 }

--- a/crates/itofin-py/tests/test_schedule.py
+++ b/crates/itofin-py/tests/test_schedule.py
@@ -1,0 +1,96 @@
+"""Oracle for the Schedule facade (issue #499).
+
+The expected dates were pinned against an independently-run Rust ``MakeSchedule``
+probe (a throwaway ``cargo test`` that printed ``schedule.dates()`` and was then
+reverted). Both endpoints matter: 15-Jan-2028 and 15-Jan-2033 are Saturdays, so
+under TARGET + ModifiedFollowing they roll forward to Monday 17-Jan. The oracle
+therefore pins 17-Jan, not the naive 15th quoted in the issue body.
+"""
+
+import pytest
+
+from itofin import (
+    BusinessDayConvention,
+    Calendar,
+    Date,
+    Frequency,
+    ItofinError,
+    Schedule,
+)
+
+START = Date(15, 1, 2028)
+END = Date(15, 1, 2033)
+
+
+def _fixed_leg():
+    return Schedule(
+        START,
+        END,
+        Frequency.Annual,
+        Calendar.target(),
+        BusinessDayConvention.ModifiedFollowing,
+    )
+
+
+def test_fixed_leg_size_and_endpoints():
+    sched = _fixed_leg()
+    # 5 annual periods -> 6 dates.
+    assert sched.size() == 6
+    # 15-Jan-2028 (Sat) and 15-Jan-2033 (Sat) both roll to Mon 17-Jan.
+    assert sched.date(0) == Date(17, 1, 2028)
+    assert sched.date(5) == Date(17, 1, 2033)
+
+
+def test_fixed_leg_all_dates():
+    sched = _fixed_leg()
+    expected = [
+        Date(17, 1, 2028),
+        Date(15, 1, 2029),
+        Date(15, 1, 2030),
+        Date(15, 1, 2031),
+        Date(15, 1, 2032),
+        Date(17, 1, 2033),
+    ]
+    assert sched.dates() == expected
+
+
+def test_float_leg_has_twice_the_periods():
+    fixed = _fixed_leg()
+    floating = Schedule(
+        START,
+        END,
+        Frequency.Semiannual,
+        Calendar.target(),
+        BusinessDayConvention.ModifiedFollowing,
+    )
+    # Semiannual over the same span: 10 periods (11 dates) vs the fixed leg's 5.
+    assert floating.size() == 11
+    assert (floating.size() - 1) == 2 * (fixed.size() - 1)
+
+
+def test_start_after_end_raises_not_panics():
+    with pytest.raises(ItofinError):
+        Schedule(
+            END,
+            START,
+            Frequency.Annual,
+            Calendar.target(),
+            BusinessDayConvention.ModifiedFollowing,
+        )
+
+
+def test_zero_length_span_raises():
+    with pytest.raises(ItofinError):
+        Schedule(
+            START,
+            START,
+            Frequency.Annual,
+            Calendar.target(),
+            BusinessDayConvention.ModifiedFollowing,
+        )
+
+
+def test_date_index_out_of_range_raises():
+    sched = _fixed_leg()
+    with pytest.raises(ItofinError):
+        sched.date(6)


### PR DESCRIPTION
Add PyFrequency, PyBusinessDayConvention, and PySchedule facades so
Python callers can build coupon schedules via MakeSchedule. The schedule
constructor validates that the start date is strictly before the end
date and the date accessor bounds-checks its index, returning
ItofinError instead of letting the core panic unwind across the PyO3
boundary. The new classes are registered in the module and covered by
tests in test_schedule.py.

close #499
