### PR TITLE
feat(itofin-py): add Python bindings for vanilla swap

### DIFF
--- a/crates/itofin-py/src/lib.rs
+++ b/crates/itofin-py/src/lib.rs
@@ -12,6 +12,7 @@ mod hullwhite;
 mod market;
 mod option;
 mod settings;
+mod swap;
 mod time;
 
 use calibration::{PyCalibrationErrorType, PyEndCriteria, PyLevenbergMarquardt};
@@ -25,6 +26,7 @@ use pyo3::create_exception;
 use pyo3::exceptions::PyException;
 use pyo3::prelude::*;
 use settings::PySettings;
+use swap::{PySwapType, PyVanillaSwap};
 use time::{
     PyBusinessDayConvention, PyCalendar, PyDate, PyDayCounter, PyFrequency, PyPeriod, PySchedule,
 };
@@ -79,5 +81,7 @@ fn itofin(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyLevenbergMarquardt>()?;
     m.add_class::<PyEndCriteria>()?;
     m.add_class::<PyCalibrationErrorType>()?;
+    m.add_class::<PySwapType>()?;
+    m.add_class::<PyVanillaSwap>()?;
     Ok(())
 }

--- a/crates/itofin-py/src/swap.rs
+++ b/crates/itofin-py/src/swap.rs
@@ -1,0 +1,149 @@
+//! Facades for the plain-vanilla swap stack: [`PySwapType`] and
+//! [`PyVanillaSwap`].
+//!
+//! [`PyVanillaSwap`] wraps a `SharedMut<FixedVsFloatingSwap>` (the shape a
+//! swaption underlying needs, X3) and is priced with a [`DiscountingSwapEngine`]
+//! attached through [`set_engine`](PyVanillaSwap::set_engine), so the facade
+//! pins a real number rather than a construction-only object.
+
+use crate::PyQlError;
+use crate::curve::PyFlatForward;
+use crate::hullwhite::PyEuribor;
+use crate::settings::PySettings;
+use crate::time::{PyDayCounter, PySchedule};
+use libitofin::instrument::Instrument;
+use libitofin::instruments::{FixedVsFloatingSwap, SwapType, VanillaSwap};
+use libitofin::pricingengine::PricingEngine;
+use libitofin::pricingengines::DiscountingSwapEngine;
+use libitofin::shared::{SharedMut, shared_mut};
+use pyo3::prelude::*;
+
+/// Python `SwapType`: which side of the named leg the swap is seen from
+/// (`instruments::swap::SwapType`, re-exported as `instruments::SwapType`).
+///
+/// A fieldless pyo3 enum exposing `SwapType.Payer` / `SwapType.Receiver`; the
+/// signed `+1`/`-1` leg multiplier stays in the core.
+#[pyclass(name = "SwapType", eq, eq_int, from_py_object)]
+#[derive(Clone, Copy, PartialEq)]
+pub enum PySwapType {
+    Payer,
+    Receiver,
+}
+
+impl PySwapType {
+    /// The core [`SwapType`] this variant stands for.
+    fn inner(&self) -> SwapType {
+        match self {
+            PySwapType::Payer => SwapType::Payer,
+            PySwapType::Receiver => SwapType::Receiver,
+        }
+    }
+}
+
+/// Python `VanillaSwap`: a fixed-vs-Ibor interest-rate swap
+/// (`instruments::vanillaswap::VanillaSwap`).
+///
+/// Built with [`VanillaSwap::new`] and immediately lowered to its
+/// [`FixedVsFloatingSwap`] base via `into_fixed_vs_floating` (the shape X3's
+/// swaption consumes), held behind a `SharedMut`. The ctor is fallible
+/// (`vanillaswap.rs:88`): it builds the floating [`IborLeg`], so a degenerate
+/// leg surfaces as an `ItofinError`. Pricing needs an engine: call
+/// [`set_engine`](Self::set_engine) before [`fair_rate`](Self::fair_rate) or
+/// [`npv`](Self::npv).
+#[pyclass(name = "VanillaSwap", unsendable)]
+pub struct PyVanillaSwap {
+    inner: SharedMut<FixedVsFloatingSwap>,
+}
+
+#[pymethods]
+impl PyVanillaSwap {
+    #[new]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        swap_type: &PySwapType,
+        nominal: f64,
+        fixed_schedule: &PySchedule,
+        fixed_rate: f64,
+        fixed_day_count: &PyDayCounter,
+        float_schedule: &PySchedule,
+        ibor_index: &PyEuribor,
+        spread: f64,
+        floating_day_count: &PyDayCounter,
+        settings: &PySettings,
+    ) -> PyResult<Self> {
+        let swap = VanillaSwap::new(
+            swap_type.inner(),
+            nominal,
+            fixed_schedule.inner(),
+            fixed_rate,
+            fixed_day_count.inner(),
+            float_schedule.inner(),
+            ibor_index.inner(),
+            spread,
+            floating_day_count.inner(),
+            None,
+            settings.inner(),
+        )
+        .map_err(PyQlError::from)?;
+        Ok(PyVanillaSwap {
+            inner: shared_mut(swap.into_fixed_vs_floating()),
+        })
+    }
+
+    /// Attaches a [`DiscountingSwapEngine`] over `curve` so the swap prices.
+    ///
+    /// The engine is built with the settings-driven flow defaults
+    /// (`include_settlement_date_flows`, `settlement_date`, `npv_date` all
+    /// unset) and installed on the swap's [`InstrumentBase`] via
+    /// `set_pricing_engine`.
+    fn set_engine(&mut self, curve: &PyFlatForward, settings: &PySettings) {
+        let engine = shared_mut(DiscountingSwapEngine::new(
+            curve.handle(),
+            None,
+            None,
+            None,
+            settings.inner(),
+        )) as SharedMut<dyn PricingEngine>;
+        self.inner
+            .borrow_mut()
+            .base_mut()
+            .set_pricing_engine(engine);
+    }
+
+    /// The fair fixed rate that zeroes the swap NPV (`fairRate()`).
+    ///
+    /// Fallible: an engine must be attached and the swap non-expired.
+    fn fair_rate(&mut self) -> PyResult<f64> {
+        Ok(self
+            .inner
+            .borrow_mut()
+            .fair_rate()
+            .map_err(PyQlError::from)?)
+    }
+
+    /// The swap NPV under the attached engine.
+    ///
+    /// Fallible: an engine must be attached (`set_engine`).
+    fn npv(&mut self) -> PyResult<f64> {
+        Ok(self.inner.borrow_mut().npv().map_err(PyQlError::from)?)
+    }
+
+    /// The swap nominal (`nominal()`).
+    fn nominal(&self) -> PyResult<f64> {
+        Ok(self.inner.borrow().nominal().map_err(PyQlError::from)?)
+    }
+
+    /// The fixed-leg rate (`fixedRate()`).
+    fn fixed_rate(&self) -> f64 {
+        self.inner.borrow().fixed_rate()
+    }
+}
+
+impl PyVanillaSwap {
+    /// A clone of the inner swap for the swaption facade (X3), which takes the
+    /// underlying as a `SharedMut<FixedVsFloatingSwap>`.
+    #[allow(dead_code)]
+    pub(crate) fn inner(&self) -> SharedMut<FixedVsFloatingSwap> {
+        SharedMut::clone(&self.inner)
+    }
+}

--- a/crates/itofin-py/tests/test_vanilla_swap.py
+++ b/crates/itofin-py/tests/test_vanilla_swap.py
@@ -1,0 +1,126 @@
+"""Oracle for the VanillaSwap facade (issue #500).
+
+The Jamshidian-fixture 5Y swap: nominal 100, fixed leg annual
+15-Jan-2028 -> 15-Jan-2033 at 3% on Thirty360(BondBasis), floating leg
+semiannual Euribor6M on Actual360 with zero spread, Payer, priced with a
+``DiscountingSwapEngine`` on a flat 3% curve (Actual365Fixed, continuous,
+referenced 15-Jan-2026).
+
+The expected ``fair_rate`` and ``npv`` were pinned against an independently
+constructed Rust probe (a throwaway ``cargo test`` that built the identical
+fixture through ``VanillaSwap::new(...).into_fixed_vs_floating()`` with a
+``DiscountingSwapEngine`` and printed the results to 17 significant digits;
+reverted, not committed):
+
+    PROBE_FAIR      = 0.03048844643136293
+    PROBE_NPV       = 0.21033895380698553   (Payer)
+    PROBE_RECV_NPV  = -0.21033895380698553  (Receiver)
+
+The schedule endpoints 15-Jan-2028 and 15-Jan-2033 are both Saturdays and roll
+to Monday 17-Jan under TARGET + ModifiedFollowing; the facade Schedule
+reproduces the core exactly, so the fixture stays apples-to-apples.
+"""
+
+import pytest
+
+from itofin import (
+    BusinessDayConvention,
+    Calendar,
+    Date,
+    DayCounter,
+    Euribor,
+    FlatForward,
+    Frequency,
+    ItofinError,
+    Schedule,
+    Settings,
+    SwapType,
+    VanillaSwap,
+)
+
+PROBE_FAIR = 0.03048844643136293
+PROBE_NPV = 0.21033895380698553
+
+REF = Date(15, 1, 2026)
+START = Date(15, 1, 2028)
+END = Date(15, 1, 2033)
+
+
+def _fixture():
+    settings = Settings()
+    settings.set_evaluation_date(REF)
+    curve = FlatForward(REF, 0.03, DayCounter.actual365_fixed())
+    fixed = Schedule(
+        START,
+        END,
+        Frequency.Annual,
+        Calendar.target(),
+        BusinessDayConvention.ModifiedFollowing,
+    )
+    floating = Schedule(
+        START,
+        END,
+        Frequency.Semiannual,
+        Calendar.target(),
+        BusinessDayConvention.ModifiedFollowing,
+    )
+    index = Euribor.six_months(curve, settings)
+    return settings, curve, fixed, floating, index
+
+
+def _swap(swap_type):
+    settings, curve, fixed, floating, index = _fixture()
+    swap = VanillaSwap(
+        swap_type,
+        100.0,
+        fixed,
+        0.03,
+        DayCounter.thirty360_bond_basis(),
+        floating,
+        index,
+        0.0,
+        DayCounter.actual360(),
+        settings,
+    )
+    swap.set_engine(curve, settings)
+    return swap
+
+
+def test_fair_rate_matches_rust_probe():
+    swap = _swap(SwapType.Payer)
+    assert swap.fair_rate() == pytest.approx(PROBE_FAIR, abs=1e-10)
+
+
+def test_npv_matches_rust_probe():
+    swap = _swap(SwapType.Payer)
+    assert swap.npv() == pytest.approx(PROBE_NPV, abs=1e-10)
+
+
+def test_payer_receiver_npv_are_opposite():
+    payer = _swap(SwapType.Payer)
+    receiver = _swap(SwapType.Receiver)
+    assert receiver.npv() == pytest.approx(-payer.npv(), abs=1e-10)
+
+
+def test_nominal_and_fixed_rate_round_trip():
+    swap = _swap(SwapType.Payer)
+    assert swap.nominal() == pytest.approx(100.0, abs=1e-12)
+    assert swap.fixed_rate() == pytest.approx(0.03, abs=1e-12)
+
+
+def test_price_without_engine_raises_not_panics():
+    settings, curve, fixed, floating, index = _fixture()
+    swap = VanillaSwap(
+        SwapType.Payer,
+        100.0,
+        fixed,
+        0.03,
+        DayCounter.thirty360_bond_basis(),
+        floating,
+        index,
+        0.0,
+        DayCounter.actual360(),
+        settings,
+    )
+    with pytest.raises(ItofinError):
+        swap.fair_rate()


### PR DESCRIPTION
Expose swap functionality to the Python API by adding the new `swap`
module and registering the `PySwapType` and `PyVanillaSwap` classes in
the library entrypoint.

**New swap bindings:**
* Added `crates/itofin-py/src/swap.rs` defining `PySwapType` and
  `PyVanillaSwap` for constructing and pricing vanilla swaps from Python.
* Registered the new classes in `lib.rs` so they are available in the
  Python module.

**Testing:**
* Added `crates/itofin-py/tests/test_vanilla_swap.py` to verify the new
  vanilla swap bindings behave as expected.

Closes #500
