### PR TITLE
feat(itofin-py): add swaption bindings and exercise types

### DIFF
--- a/crates/itofin-py/src/hullwhite.rs
+++ b/crates/itofin-py/src/hullwhite.rs
@@ -130,7 +130,6 @@ impl PyHullWhite {
 impl PyHullWhite {
     /// A clone of the inner model handle for the calibration (W2) and
     /// Jamshidian-engine (X3) facades, which consume `SharedMut<HullWhite>`.
-    #[allow(dead_code)]
     pub(crate) fn inner(&self) -> SharedMut<HullWhite> {
         SharedMut::clone(&self.inner)
     }

--- a/crates/itofin-py/src/lib.rs
+++ b/crates/itofin-py/src/lib.rs
@@ -13,6 +13,7 @@ mod market;
 mod option;
 mod settings;
 mod swap;
+mod swaption;
 mod time;
 
 use calibration::{PyCalibrationErrorType, PyEndCriteria, PyLevenbergMarquardt};
@@ -27,6 +28,7 @@ use pyo3::exceptions::PyException;
 use pyo3::prelude::*;
 use settings::PySettings;
 use swap::{PySwapType, PyVanillaSwap};
+use swaption::{PyEuropeanExercise, PySettlementMethod, PySettlementType, PySwaption};
 use time::{
     PyBusinessDayConvention, PyCalendar, PyDate, PyDayCounter, PyFrequency, PyPeriod, PySchedule,
 };
@@ -83,5 +85,9 @@ fn itofin(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyCalibrationErrorType>()?;
     m.add_class::<PySwapType>()?;
     m.add_class::<PyVanillaSwap>()?;
+    m.add_class::<PyEuropeanExercise>()?;
+    m.add_class::<PySettlementType>()?;
+    m.add_class::<PySettlementMethod>()?;
+    m.add_class::<PySwaption>()?;
     Ok(())
 }

--- a/crates/itofin-py/src/swap.rs
+++ b/crates/itofin-py/src/swap.rs
@@ -142,7 +142,6 @@ impl PyVanillaSwap {
 impl PyVanillaSwap {
     /// A clone of the inner swap for the swaption facade (X3), which takes the
     /// underlying as a `SharedMut<FixedVsFloatingSwap>`.
-    #[allow(dead_code)]
     pub(crate) fn inner(&self) -> SharedMut<FixedVsFloatingSwap> {
         SharedMut::clone(&self.inner)
     }

--- a/crates/itofin-py/src/swaption.rs
+++ b/crates/itofin-py/src/swaption.rs
@@ -1,0 +1,159 @@
+//! Facades for the European swaption stack: [`PyEuropeanExercise`],
+//! [`PySettlementType`], [`PySettlementMethod`] and [`PySwaption`].
+//!
+//! [`PySwaption`] wraps a [`Swaption`] by value and prices it through the
+//! [`JamshidianSwaptionEngine`] built on a [`PyHullWhite`](crate::hullwhite::PyHullWhite)
+//! model (`set_jamshidian_engine`); the engine reads the swap's arguments, so
+//! the underlying swap needs no discounting engine of its own.
+//!
+//! Deferred (visible): the Bermudan `TreeSwaptionEngine` and a `BermudanExercise`
+//! facade are omitted. `BermudanExercise` has no public constructor on `main`
+//! (the core tree tests build one through a private stub), so there is nothing
+//! to wrap; only the European Jamshidian path is exposed here.
+
+use crate::PyQlError;
+use crate::hullwhite::PyHullWhite;
+use crate::settings::PySettings;
+use crate::swap::PyVanillaSwap;
+use crate::time::PyDate;
+use libitofin::exercise::{EuropeanExercise, Exercise};
+use libitofin::instrument::Instrument;
+use libitofin::instruments::{SettlementMethod, SettlementType, Swaption};
+use libitofin::pricingengine::PricingEngine;
+use libitofin::pricingengines::JamshidianSwaptionEngine;
+use libitofin::shared::{Shared, SharedMut, shared, shared_mut};
+use pyo3::prelude::*;
+
+/// Python `EuropeanExercise`: a single-date exercise schedule
+/// (`exercise::EuropeanExercise`).
+///
+/// Wraps a `Shared<dyn Exercise>` so the [`Swaption`] constructor, which takes
+/// the exercise as a trait object, can hold the same value.
+#[pyclass(name = "EuropeanExercise", unsendable)]
+pub struct PyEuropeanExercise {
+    inner: Shared<dyn Exercise>,
+}
+
+#[pymethods]
+impl PyEuropeanExercise {
+    #[new]
+    fn new(date: &PyDate) -> Self {
+        PyEuropeanExercise {
+            inner: shared(EuropeanExercise::new(date.inner())) as Shared<dyn Exercise>,
+        }
+    }
+}
+
+impl PyEuropeanExercise {
+    /// A clone of the inner exercise for the swaption facade, which takes the
+    /// exercise as a `Shared<dyn Exercise>`.
+    pub(crate) fn inner(&self) -> Shared<dyn Exercise> {
+        Shared::clone(&self.inner)
+    }
+}
+
+/// Python `SettlementType`: how a swaption settles on exercise
+/// (`instruments::swaption::SettlementType`).
+///
+/// A fieldless pyo3 enum exposing `SettlementType.Physical` / `SettlementType.Cash`.
+#[pyclass(name = "SettlementType", eq, eq_int, from_py_object)]
+#[derive(Clone, Copy, PartialEq)]
+pub enum PySettlementType {
+    Physical,
+    Cash,
+}
+
+impl PySettlementType {
+    /// The core [`SettlementType`] this variant stands for.
+    fn inner(&self) -> SettlementType {
+        match self {
+            PySettlementType::Physical => SettlementType::Physical,
+            PySettlementType::Cash => SettlementType::Cash,
+        }
+    }
+}
+
+/// Python `SettlementMethod`: the settlement mechanics under a
+/// [`SettlementType`] (`instruments::swaption::SettlementMethod`).
+///
+/// Physical pairs with `PhysicalOTC` / `PhysicalCleared`; cash pairs with
+/// `CollateralizedCashPrice` / `ParYieldCurve`. The consistency check runs at
+/// pricing time (`SwaptionArguments::validate`), not construction, so a
+/// mismatched pair only surfaces as an `ItofinError` from `npv()`.
+#[pyclass(name = "SettlementMethod", eq, eq_int, from_py_object)]
+#[derive(Clone, Copy, PartialEq)]
+pub enum PySettlementMethod {
+    PhysicalOTC,
+    PhysicalCleared,
+    CollateralizedCashPrice,
+    ParYieldCurve,
+}
+
+impl PySettlementMethod {
+    /// The core [`SettlementMethod`] this variant stands for.
+    fn inner(&self) -> SettlementMethod {
+        match self {
+            PySettlementMethod::PhysicalOTC => SettlementMethod::PhysicalOTC,
+            PySettlementMethod::PhysicalCleared => SettlementMethod::PhysicalCleared,
+            PySettlementMethod::CollateralizedCashPrice => {
+                SettlementMethod::CollateralizedCashPrice
+            }
+            PySettlementMethod::ParYieldCurve => SettlementMethod::ParYieldCurve,
+        }
+    }
+}
+
+/// Python `Swaption`: a European option to enter a [`VanillaSwap`](PyVanillaSwap)
+/// (`instruments::swaption::Swaption`).
+///
+/// Built with [`Swaption::new`] (infallible): it registers with the underlying
+/// swap and the settings evaluation date (D5). Pricing needs an engine: call
+/// [`set_jamshidian_engine`](Self::set_jamshidian_engine) before [`npv`](Self::npv).
+/// The (settlement type, method) consistency check runs at pricing time, so a
+/// mismatched pair surfaces as an `ItofinError` from `npv()`, not the ctor.
+#[pyclass(name = "Swaption", unsendable)]
+pub struct PySwaption {
+    inner: Swaption,
+}
+
+#[pymethods]
+impl PySwaption {
+    #[new]
+    fn new(
+        swap: &PyVanillaSwap,
+        exercise: &PyEuropeanExercise,
+        settlement_type: &PySettlementType,
+        settlement_method: &PySettlementMethod,
+        settings: &PySettings,
+    ) -> Self {
+        PySwaption {
+            inner: Swaption::new(
+                swap.inner(),
+                exercise.inner(),
+                settlement_type.inner(),
+                settlement_method.inner(),
+                settings.inner(),
+            ),
+        }
+    }
+
+    /// Attaches a [`JamshidianSwaptionEngine`] built on `model` so the swaption
+    /// prices analytically off the Hull-White dynamics.
+    ///
+    /// The engine (`jamshidianswaptionengine.rs:92`, infallible) is European-only:
+    /// a non-European exercise errors at pricing time. It is installed on the
+    /// swaption's [`InstrumentBase`](libitofin::instrument) via `set_pricing_engine`.
+    fn set_jamshidian_engine(&mut self, model: &PyHullWhite) {
+        let engine = shared_mut(JamshidianSwaptionEngine::new(model.inner()))
+            as SharedMut<dyn PricingEngine>;
+        self.inner.base_mut().set_pricing_engine(engine);
+    }
+
+    /// The swaption NPV under the attached engine.
+    ///
+    /// Fallible: an engine must be attached ([`set_jamshidian_engine`](Self::set_jamshidian_engine))
+    /// and the (settlement type, method) pair consistent.
+    fn npv(&mut self) -> PyResult<f64> {
+        Ok(self.inner.npv().map_err(PyQlError::from)?)
+    }
+}

--- a/crates/itofin-py/tests/test_swaption.py
+++ b/crates/itofin-py/tests/test_swaption.py
@@ -1,0 +1,139 @@
+"""Oracle for the Swaption + Jamshidian-engine facade (issue #501).
+
+Reproduces the Rust cached Jamshidian European-swaption pin
+(``jamshidianswaptionengine.rs:509-522``): eval 15-Jan-2026; a flat 3%
+Actual365Fixed continuous/annual curve referenced 15-Jan-2026;
+``HullWhite(curve, a=0.05, sigma=0.01)``; the 5Y Jamshidian-fixture swap
+(nominal 100, fixed annual 15-Jan-2028 -> 15-Jan-2033 at 3% Thirty360(BondBasis)
+vs semiannual Euribor6M/Actual360, zero spread); ``EuropeanExercise(15-Jan-2027)``;
+Physical/PhysicalOTC.
+
+The schedules use ``Unadjusted``, matching the cached-value fixture
+(``jamshidianswaptionengine.rs:283``), so the 15-Jan-2028 / 15-Jan-2033 Saturday
+endpoints stay put. This differs from the ``VanillaSwap`` oracle (#500), which
+pins a separate ``ModifiedFollowing`` probe that rolls those endpoints to Monday
+the 17th; the two are not the same swap fixture.
+
+The underlying swap carries no discounting engine: the Jamshidian engine reads
+the swap's arguments and prices off the Hull-White dynamics, matching the Rust
+fixture (``jamshidianswaptionengine.rs:344``, which never attaches a swap engine).
+
+    PAYER_NPV    = 1.5666103955750414   (jamshidianswaptionengine.rs:511)
+    RECEIVER_NPV = 1.3562383202325612   (jamshidianswaptionengine.rs:517)
+"""
+
+import pytest
+
+from itofin import (
+    BusinessDayConvention,
+    Calendar,
+    Date,
+    DayCounter,
+    EuropeanExercise,
+    Euribor,
+    FlatForward,
+    Frequency,
+    HullWhite,
+    ItofinError,
+    Schedule,
+    SettlementMethod,
+    SettlementType,
+    Settings,
+    Swaption,
+    SwapType,
+    VanillaSwap,
+)
+
+PAYER_NPV = 1.5666103955750414
+RECEIVER_NPV = 1.3562383202325612
+
+REF = Date(15, 1, 2026)
+START = Date(15, 1, 2028)
+END = Date(15, 1, 2033)
+EXERCISE = Date(15, 1, 2027)
+
+
+def _fixture():
+    settings = Settings()
+    settings.set_evaluation_date(REF)
+    curve = FlatForward(REF, 0.03, DayCounter.actual365_fixed())
+    fixed = Schedule(
+        START,
+        END,
+        Frequency.Annual,
+        Calendar.target(),
+        BusinessDayConvention.Unadjusted,
+    )
+    floating = Schedule(
+        START,
+        END,
+        Frequency.Semiannual,
+        Calendar.target(),
+        BusinessDayConvention.Unadjusted,
+    )
+    index = Euribor.six_months(curve, settings)
+    return settings, curve, fixed, floating, index
+
+
+def _swap(swap_type, settings, curve, fixed, floating, index):
+    return VanillaSwap(
+        swap_type,
+        100.0,
+        fixed,
+        0.03,
+        DayCounter.thirty360_bond_basis(),
+        floating,
+        index,
+        0.0,
+        DayCounter.actual360(),
+        settings,
+    )
+
+
+def _swaption(swap_type, settlement_type, settlement_method, attach_engine=True):
+    settings, curve, fixed, floating, index = _fixture()
+    swap = _swap(swap_type, settings, curve, fixed, floating, index)
+    swaption = Swaption(
+        swap,
+        EuropeanExercise(EXERCISE),
+        settlement_type,
+        settlement_method,
+        settings,
+    )
+    if attach_engine:
+        model = HullWhite(curve, 0.05, 0.01)
+        swaption.set_jamshidian_engine(model)
+    return swaption
+
+
+def test_payer_npv_matches_rust_cached_value():
+    swaption = _swaption(
+        SwapType.Payer, SettlementType.Physical, SettlementMethod.PhysicalOTC
+    )
+    assert swaption.npv() == pytest.approx(PAYER_NPV, abs=1e-8)
+
+
+def test_receiver_npv_matches_rust_cached_value():
+    swaption = _swaption(
+        SwapType.Receiver, SettlementType.Physical, SettlementMethod.PhysicalOTC
+    )
+    assert swaption.npv() == pytest.approx(RECEIVER_NPV, abs=1e-8)
+
+
+def test_npv_without_engine_raises_not_panics():
+    swaption = _swaption(
+        SwapType.Payer,
+        SettlementType.Physical,
+        SettlementMethod.PhysicalOTC,
+        attach_engine=False,
+    )
+    with pytest.raises(ItofinError):
+        swaption.npv()
+
+
+def test_settlement_type_method_mismatch_raises_at_pricing():
+    swaption = _swaption(
+        SwapType.Payer, SettlementType.Cash, SettlementMethod.PhysicalOTC
+    )
+    with pytest.raises(ItofinError):
+        swaption.npv()


### PR DESCRIPTION
This adds Python bindings for swaption pricing to the itofin-py crate,
exposing the swaption facade and its supporting types.

**New swaption bindings:**
* Added `crates/itofin-py/src/swaption.rs` defining `PySwaption` along with `PyEuropeanExercise`, `PySettlementType`, and `PySettlementMethod`.
* Registered the new classes in `lib.rs` and wired up the `swaption` module.
* Added `tests/test_swaption.py` covering the new bindings.

**Cleanup:**
* Removed the now-unused `#[allow(dead_code)]` attributes from `PyHullWhite::inner` and `PyVanillaSwap::inner`, which are consumed by the swaption facade.

close #501
