### PR TITLE
feat(crates)!: organize Python bindings into ql-faithful submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,35 @@ use libitofin::time::Date;
 // and analytic option engines are available today - see docs.rs.
 ```
 
+### Python
+
+The same engine is reachable from Python via [`itofin`](https://pypi.org/project/itofin/)
+(Python 3.13+). The API mirrors QuantLib's `ql/` layout: types live in submodules
+(`itofin.time`, `itofin.instruments`, `itofin.processes`, ...), while `Settings`
+and `ItofinError` stay at the top level.
+
+```sh
+pip install itofin
+```
+
+```python
+from itofin import Settings
+from itofin.instruments import OptionType, VanillaOption
+from itofin.processes import BlackScholesProcess
+from itofin.time import Date, DayCounter
+
+s = Settings()
+s.set_evaluation_date(Date(15, 6, 2026))
+dc = DayCounter.actual360()
+
+process = BlackScholesProcess(60.0, 0.08, 0.0, 0.30, Date(15, 6, 2026), dc)
+option = VanillaOption(OptionType.Call, 65.0, Date(15, 6, 2026) + 90, s)
+option.set_engine(process)
+
+print(f"NPV   {option.npv():.10f}")   # 2.1333684449
+print(f"delta {option.delta():.10f}")  # 0.3724827980
+```
+
 ## Why
 
 QuantLib is ~470k lines of mature, battle-tested C++ across 16 modules. This

--- a/crates/itofin-py/README.md
+++ b/crates/itofin-py/README.md
@@ -2,6 +2,8 @@
 
 Idiomatic Python bindings over the [`libitofin`](https://github.com/benbenbang/libitofin) Rust core, a ground-up port of [QuantLib](https://github.com/lballabio/QuantLib) for pricing, risk, and calibration. The heavy numerics run in Rust; Python drives them. The pricing snippets below reproduce the cached Rust test oracles exactly; the abbreviated calibration snippets converge to the same targets within the tests' calibration tolerance (the full matrices live in `tests/`).
 
+The API mirrors QuantLib's `ql/` layout: types live in submodules (`itofin.time`, `itofin.instruments`, `itofin.models`, ...), while `Settings` and `ItofinError` stay at the top level.
+
 ## Install
 
 ```bash
@@ -13,14 +15,17 @@ Requires Python >= 3.13.
 ## Price a European option and its greeks
 
 ```python
-import itofin
+from itofin import Settings
+from itofin.instruments import OptionType, VanillaOption
+from itofin.processes import BlackScholesProcess
+from itofin.time import Date, DayCounter
 
-s = itofin.Settings()
-s.set_evaluation_date(itofin.Date(15, 6, 2026))
-dc = itofin.DayCounter.actual360()
+s = Settings()
+s.set_evaluation_date(Date(15, 6, 2026))
+dc = DayCounter.actual360()
 
-process = itofin.BlackScholesProcess(60.0, 0.08, 0.0, 0.30, itofin.Date(15, 6, 2026), dc)
-option = itofin.VanillaOption(itofin.OptionType.Call, 65.0, itofin.Date(15, 6, 2026) + 90, s)
+process = BlackScholesProcess(60.0, 0.08, 0.0, 0.30, Date(15, 6, 2026), dc)
+option = VanillaOption(OptionType.Call, 65.0, Date(15, 6, 2026) + 90, s)
 option.set_engine(process)
 
 print(f"NPV   {option.npv():.10f}")
@@ -41,18 +46,22 @@ rho   5.0538998582
 Semi-analytic Heston pricing:
 
 ```python
-import itofin
+from itofin import Settings
+from itofin.instruments import OptionType, VanillaOption
+from itofin.models import HestonModel
+from itofin.processes import HestonProcess
+from itofin.time import Date, DayCounter
 
-s = itofin.Settings()
-s.set_evaluation_date(itofin.Date(27, 12, 2004))
-dc = itofin.DayCounter.actual_actual_isda()
+s = Settings()
+s.set_evaluation_date(Date(27, 12, 2004))
+dc = DayCounter.actual_actual_isda()
 
 # HestonProcess(risk_free, dividend, spot, v0, kappa, theta, sigma, rho, reference_date, day_counter)
-process = itofin.HestonProcess(
-    0.0225, 0.02, 1.0, 0.1, 3.16, 0.09, 0.4, -0.2, itofin.Date(27, 12, 2004), dc
+process = HestonProcess(
+    0.0225, 0.02, 1.0, 0.1, 3.16, 0.09, 0.4, -0.2, Date(27, 12, 2004), dc
 )
-model = itofin.HestonModel(process)
-option = itofin.VanillaOption(itofin.OptionType.Call, 1.05, itofin.Date(28, 3, 2005), s)
+model = HestonModel(process)
+option = VanillaOption(OptionType.Call, 1.05, Date(28, 3, 2005), s)
 option.set_heston_engine(model, 64)
 
 print(f"Heston NPV {option.npv():.10f}")
@@ -66,14 +75,20 @@ Calibrating the model to a flat 10% vol surface drives the vol-of-vol `sigma` to
 
 ```python
 import math
-import itofin
 
-s = itofin.Settings()
-s.set_evaluation_date(itofin.Date(15, 1, 2026))
-dc = itofin.DayCounter.actual360()
-ref = itofin.Date(15, 1, 2026)
-risk_free = itofin.FlatForward(ref, 0.04, dc)
-dividend = itofin.FlatForward(ref, 0.50, dc)
+from itofin import Settings
+from itofin.models import CalibrationErrorType, HestonModel, HestonModelHelper
+from itofin.optimization import EndCriteria, LevenbergMarquardt
+from itofin.processes import HestonProcess
+from itofin.termstructures import FlatForward
+from itofin.time import Calendar, Date, DayCounter, Period
+
+s = Settings()
+s.set_evaluation_date(Date(15, 1, 2026))
+dc = DayCounter.actual360()
+ref = Date(15, 1, 2026)
+risk_free = FlatForward(ref, 0.04, dc)
+dividend = FlatForward(ref, 0.50, dc)
 VOL = 0.10
 
 helpers = []
@@ -82,24 +97,24 @@ for n in (1, 2, 3):
     forward = dividend.discount(tau) / risk_free.discount(tau)  # spot = 1.0
     for moneyness in (-1.0, 0.0, 1.0):
         strike = forward * math.exp(-moneyness * VOL * math.sqrt(tau))
-        helpers.append(itofin.HestonModelHelper(
-            itofin.Period(n, "Years"),
-            itofin.Calendar.null_calendar(),
+        helpers.append(HestonModelHelper(
+            Period(n, "Years"),
+            Calendar.null_calendar(),
             1.0,        # spot
             strike,
             VOL,        # 10% flat vol
             0.04,       # risk-free
             0.50,       # dividend yield
-            itofin.CalibrationErrorType.RelativePriceError,
+            CalibrationErrorType.RelativePriceError,
             ref,
             dc,
             s,
         ))
 
-process = itofin.HestonProcess(0.04, 0.50, 1.0, 0.01, 0.2, 0.02, 0.5, -0.75, ref, dc)
-model = itofin.HestonModel(process)
-method = itofin.LevenbergMarquardt(1e-8, 1e-8, 1e-8, False)
-end_criteria = itofin.EndCriteria(400, 40, 1e-8, 1e-8, 1e-8)
+process = HestonProcess(0.04, 0.50, 1.0, 0.01, 0.2, 0.02, 0.5, -0.75, ref, dc)
+model = HestonModel(process)
+method = LevenbergMarquardt(1e-8, 1e-8, 1e-8, False)
+end_criteria = EndCriteria(400, 40, 1e-8, 1e-8, 1e-8)
 model.calibrate(helpers, method, end_criteria, 96)
 
 print(f"sigma {model.sigma():.6f}")
@@ -116,35 +131,40 @@ theta 0.010000
 ## Calibrate Hull-White to a swaption matrix
 
 ```python
-import itofin
+from itofin import Settings
+from itofin.indexes import Euribor
+from itofin.models import CalibrationErrorType, HullWhite, SwaptionHelper
+from itofin.optimization import EndCriteria, LevenbergMarquardt
+from itofin.termstructures import FlatForward
+from itofin.time import Date, DayCounter, Period
 
-s = itofin.Settings()
-s.set_evaluation_date(itofin.Date(15, 2, 2002))
-curve = itofin.FlatForward(itofin.Date(19, 2, 2002), 0.04875825, itofin.DayCounter.actual365_fixed())
+s = Settings()
+s.set_evaluation_date(Date(15, 2, 2002))
+curve = FlatForward(Date(19, 2, 2002), 0.04875825, DayCounter.actual365_fixed())
 
-model = itofin.HullWhite(curve, 0.1, 0.01)
-index = itofin.Euribor.six_months(curve, s)
+model = HullWhite(curve, 0.1, 0.01)
+index = Euribor.six_months(curve, s)
 
 # (option tenor, swap tenor, Black vol); the full co-terminal matrix is in the tests.
 swaptions = [(1, 5, 0.1148), (2, 4, 0.1108), (3, 3, 0.1070), (4, 2, 0.1021), (5, 1, 0.1000)]
 helpers = [
-    itofin.SwaptionHelper(
-        itofin.Period(maturity, "Years"),
-        itofin.Period(length, "Years"),
+    SwaptionHelper(
+        Period(maturity, "Years"),
+        Period(length, "Years"),
         vol,
         index,
-        itofin.Period(1, "Years"),
-        itofin.DayCounter.thirty360_bond_basis(),
-        itofin.DayCounter.actual360(),
+        Period(1, "Years"),
+        DayCounter.thirty360_bond_basis(),
+        DayCounter.actual360(),
         curve,
-        itofin.CalibrationErrorType.RelativePriceError,
+        CalibrationErrorType.RelativePriceError,
         1.0,
     )
     for maturity, length, vol in swaptions
 ]
 
-method = itofin.LevenbergMarquardt(1e-8, 1e-8, 1e-8, False)
-end_criteria = itofin.EndCriteria(10000, 100, 1e-6, 1e-8, 1e-8)
+method = LevenbergMarquardt(1e-8, 1e-8, 1e-8, False)
+end_criteria = EndCriteria(10000, 100, 1e-6, 1e-8, 1e-8)
 model.calibrate(helpers, method, end_criteria, False)  # fix_reversion=False, fit a and sigma
 
 print(f"a     {model.a():.7f}")
@@ -159,34 +179,46 @@ sigma 0.0057992
 ## Price a European swaption with the Jamshidian engine
 
 ```python
-import itofin
+from itofin import Settings
+from itofin.indexes import Euribor
+from itofin.instruments import (
+    EuropeanExercise,
+    SettlementMethod,
+    SettlementType,
+    Swaption,
+    SwapType,
+    VanillaSwap,
+)
+from itofin.models import HullWhite
+from itofin.termstructures import FlatForward
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Frequency, Schedule
 
-s = itofin.Settings()
-s.set_evaluation_date(itofin.Date(15, 1, 2026))
-curve = itofin.FlatForward(itofin.Date(15, 1, 2026), 0.03, itofin.DayCounter.actual365_fixed())
+s = Settings()
+s.set_evaluation_date(Date(15, 1, 2026))
+curve = FlatForward(Date(15, 1, 2026), 0.03, DayCounter.actual365_fixed())
 
-fixed = itofin.Schedule(
-    itofin.Date(15, 1, 2028), itofin.Date(15, 1, 2033),
-    itofin.Frequency.Annual, itofin.Calendar.target(),
-    itofin.BusinessDayConvention.Unadjusted,
+fixed = Schedule(
+    Date(15, 1, 2028), Date(15, 1, 2033),
+    Frequency.Annual, Calendar.target(),
+    BusinessDayConvention.Unadjusted,
 )
-floating = itofin.Schedule(
-    itofin.Date(15, 1, 2028), itofin.Date(15, 1, 2033),
-    itofin.Frequency.Semiannual, itofin.Calendar.target(),
-    itofin.BusinessDayConvention.Unadjusted,
+floating = Schedule(
+    Date(15, 1, 2028), Date(15, 1, 2033),
+    Frequency.Semiannual, Calendar.target(),
+    BusinessDayConvention.Unadjusted,
 )
-index = itofin.Euribor.six_months(curve, s)
+index = Euribor.six_months(curve, s)
 
-swap = itofin.VanillaSwap(
-    itofin.SwapType.Payer, 100.0,
-    fixed, 0.03, itofin.DayCounter.thirty360_bond_basis(),
-    floating, index, 0.0, itofin.DayCounter.actual360(), s,
+swap = VanillaSwap(
+    SwapType.Payer, 100.0,
+    fixed, 0.03, DayCounter.thirty360_bond_basis(),
+    floating, index, 0.0, DayCounter.actual360(), s,
 )
-swaption = itofin.Swaption(
-    swap, itofin.EuropeanExercise(itofin.Date(15, 1, 2027)),
-    itofin.SettlementType.Physical, itofin.SettlementMethod.PhysicalOTC, s,
+swaption = Swaption(
+    swap, EuropeanExercise(Date(15, 1, 2027)),
+    SettlementType.Physical, SettlementMethod.PhysicalOTC, s,
 )
-swaption.set_jamshidian_engine(itofin.HullWhite(curve, 0.05, 0.01))
+swaption.set_jamshidian_engine(HullWhite(curve, 0.05, 0.01))
 
 print(f"payer swaption NPV {swaption.npv():.10f}")
 ```

--- a/crates/itofin-py/src/lib.rs
+++ b/crates/itofin-py/src/lib.rs
@@ -26,6 +26,7 @@ use option::{PyOptionType, PyVanillaOption};
 use pyo3::create_exception;
 use pyo3::exceptions::PyException;
 use pyo3::prelude::*;
+use pyo3::types::PyDict;
 use settings::PySettings;
 use swap::{PySwapType, PyVanillaSwap};
 use swaption::{PyEuropeanExercise, PySettlementMethod, PySettlementType, PySwaption};
@@ -57,37 +58,81 @@ impl From<PyQlError> for PyErr {
     }
 }
 
+/// Registers the eight `ql/`-faithful submodules on `itofin`.
+///
+/// Nested PyO3 modules give attribute access (`itofin.time.Date`) but do not
+/// form a Python package, so `import itofin.time` / `from itofin.time import
+/// Date` fail unless each submodule is also inserted into `sys.modules` under
+/// its dotted name. The loop below does both: `add_submodule` for attribute
+/// access and `sys.modules["itofin.<name>"]` for real imports.
 #[pymodule]
 fn itofin(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    let py = m.py();
+
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
-    m.add("ItofinError", m.py().get_type::<ItofinError>())?;
+    m.add("ItofinError", py.get_type::<ItofinError>())?;
     m.add_class::<PySettings>()?;
-    m.add_class::<PyDate>()?;
-    m.add_class::<PyDayCounter>()?;
-    m.add_class::<PyCalendar>()?;
-    m.add_class::<PyPeriod>()?;
-    m.add_class::<PyFrequency>()?;
-    m.add_class::<PyBusinessDayConvention>()?;
-    m.add_class::<PySchedule>()?;
-    m.add_class::<PySimpleQuote>()?;
-    m.add_class::<PyBlackScholesProcess>()?;
-    m.add_class::<PyFlatForward>()?;
-    m.add_class::<PyOptionType>()?;
-    m.add_class::<PyVanillaOption>()?;
-    m.add_class::<PyHestonProcess>()?;
-    m.add_class::<PyHestonModel>()?;
-    m.add_class::<PyHestonModelHelper>()?;
-    m.add_class::<PyHullWhite>()?;
-    m.add_class::<PyEuribor>()?;
-    m.add_class::<PySwaptionHelper>()?;
-    m.add_class::<PyLevenbergMarquardt>()?;
-    m.add_class::<PyEndCriteria>()?;
-    m.add_class::<PyCalibrationErrorType>()?;
-    m.add_class::<PySwapType>()?;
-    m.add_class::<PyVanillaSwap>()?;
-    m.add_class::<PyEuropeanExercise>()?;
-    m.add_class::<PySettlementType>()?;
-    m.add_class::<PySettlementMethod>()?;
-    m.add_class::<PySwaption>()?;
+
+    let time = PyModule::new(py, "time")?;
+    time.add_class::<PyDate>()?;
+    time.add_class::<PyPeriod>()?;
+    time.add_class::<PyCalendar>()?;
+    time.add_class::<PyDayCounter>()?;
+    time.add_class::<PyFrequency>()?;
+    time.add_class::<PyBusinessDayConvention>()?;
+    time.add_class::<PySchedule>()?;
+
+    let quotes = PyModule::new(py, "quotes")?;
+    quotes.add_class::<PySimpleQuote>()?;
+
+    let termstructures = PyModule::new(py, "termstructures")?;
+    termstructures.add_class::<PyFlatForward>()?;
+
+    let processes = PyModule::new(py, "processes")?;
+    processes.add_class::<PyBlackScholesProcess>()?;
+    processes.add_class::<PyHestonProcess>()?;
+
+    let indexes = PyModule::new(py, "indexes")?;
+    indexes.add_class::<PyEuribor>()?;
+
+    let instruments = PyModule::new(py, "instruments")?;
+    instruments.add_class::<PyOptionType>()?;
+    instruments.add_class::<PyVanillaOption>()?;
+    instruments.add_class::<PySwapType>()?;
+    instruments.add_class::<PyVanillaSwap>()?;
+    instruments.add_class::<PyEuropeanExercise>()?;
+    instruments.add_class::<PySettlementType>()?;
+    instruments.add_class::<PySettlementMethod>()?;
+    instruments.add_class::<PySwaption>()?;
+
+    let models = PyModule::new(py, "models")?;
+    models.add_class::<PyHestonModel>()?;
+    models.add_class::<PyHullWhite>()?;
+    models.add_class::<PyHestonModelHelper>()?;
+    models.add_class::<PySwaptionHelper>()?;
+    models.add_class::<PyCalibrationErrorType>()?;
+
+    let optimization = PyModule::new(py, "optimization")?;
+    optimization.add_class::<PyLevenbergMarquardt>()?;
+    optimization.add_class::<PyEndCriteria>()?;
+
+    let submodules = [
+        ("time", &time),
+        ("quotes", &quotes),
+        ("termstructures", &termstructures),
+        ("processes", &processes),
+        ("indexes", &indexes),
+        ("instruments", &instruments),
+        ("models", &models),
+        ("optimization", &optimization),
+    ];
+
+    let sys_modules = PyModule::import(py, "sys")?.getattr("modules")?;
+    let sys_modules = sys_modules.cast::<PyDict>()?;
+    for (name, submodule) in submodules {
+        m.add_submodule(submodule)?;
+        sys_modules.set_item(format!("itofin.{name}"), submodule)?;
+    }
+
     Ok(())
 }

--- a/crates/itofin-py/tests/test_european_option.py
+++ b/crates/itofin-py/tests/test_european_option.py
@@ -1,17 +1,19 @@
-import itofin
 import pytest
+
+from itofin import ItofinError, Settings
+from itofin.instruments import OptionType, VanillaOption
+from itofin.processes import BlackScholesProcess
+from itofin.time import Date, DayCounter
 
 TOL = 1e-10
 
 
 def _market_row_1():
-    s = itofin.Settings()
-    s.set_evaluation_date(itofin.Date(15, 6, 2026))
-    dc = itofin.DayCounter.actual360()
-    proc = itofin.BlackScholesProcess(60.0, 0.08, 0.0, 0.30, itofin.Date(15, 6, 2026), dc)
-    opt = itofin.VanillaOption(
-        itofin.OptionType.Call, 65.0, itofin.Date(15, 6, 2026) + 90, s
-    )
+    s = Settings()
+    s.set_evaluation_date(Date(15, 6, 2026))
+    dc = DayCounter.actual360()
+    proc = BlackScholesProcess(60.0, 0.08, 0.0, 0.30, Date(15, 6, 2026), dc)
+    opt = VanillaOption(OptionType.Call, 65.0, Date(15, 6, 2026) + 90, s)
     opt.set_engine(proc)
     return s, opt
 
@@ -28,13 +30,11 @@ def test_gate_row_1_npv_and_greeks_match_at_1e_10():
 
 
 def test_gate_row_4_npv_and_greeks_match_at_1e_10():
-    s = itofin.Settings()
-    s.set_evaluation_date(itofin.Date(15, 6, 2026))
-    dc = itofin.DayCounter.actual360()
-    proc = itofin.BlackScholesProcess(100.0, 0.10, 0.10, 0.15, itofin.Date(15, 6, 2026), dc)
-    opt = itofin.VanillaOption(
-        itofin.OptionType.Call, 100.0, itofin.Date(15, 6, 2026) + 36, s
-    )
+    s = Settings()
+    s.set_evaluation_date(Date(15, 6, 2026))
+    dc = DayCounter.actual360()
+    proc = BlackScholesProcess(100.0, 0.10, 0.10, 0.15, Date(15, 6, 2026), dc)
+    opt = VanillaOption(OptionType.Call, 100.0, Date(15, 6, 2026) + 36, s)
     opt.set_engine(proc)
     assert opt.npv() == pytest.approx(1.8733445727649416, abs=TOL)
     assert opt.delta() == pytest.approx(0.5043916397384094, abs=TOL)
@@ -43,13 +43,11 @@ def test_gate_row_4_npv_and_greeks_match_at_1e_10():
 
 
 def test_gate_row_5_put_arm_matches_at_1e_10():
-    s = itofin.Settings()
-    s.set_evaluation_date(itofin.Date(15, 6, 2026))
-    dc = itofin.DayCounter.actual360()
-    proc = itofin.BlackScholesProcess(100.0, 0.10, 0.10, 0.15, itofin.Date(15, 6, 2026), dc)
-    opt = itofin.VanillaOption(
-        itofin.OptionType.Put, 100.0, itofin.Date(15, 6, 2026) + 36, s
-    )
+    s = Settings()
+    s.set_evaluation_date(Date(15, 6, 2026))
+    dc = DayCounter.actual360()
+    proc = BlackScholesProcess(100.0, 0.10, 0.10, 0.15, Date(15, 6, 2026), dc)
+    opt = VanillaOption(OptionType.Put, 100.0, Date(15, 6, 2026) + 36, s)
     opt.set_engine(proc)
     assert opt.npv() == pytest.approx(1.8733445727649416, abs=TOL)
     assert opt.delta() == pytest.approx(-0.4856581940107596, abs=TOL)
@@ -58,12 +56,10 @@ def test_gate_row_5_put_arm_matches_at_1e_10():
 
 
 def test_unset_evaluation_date_raises():
-    s = itofin.Settings()
-    dc = itofin.DayCounter.actual360()
-    proc = itofin.BlackScholesProcess(60.0, 0.08, 0.0, 0.30, itofin.Date(15, 6, 2026), dc)
-    opt = itofin.VanillaOption(
-        itofin.OptionType.Call, 65.0, itofin.Date(15, 6, 2026) + 90, s
-    )
+    s = Settings()
+    dc = DayCounter.actual360()
+    proc = BlackScholesProcess(60.0, 0.08, 0.0, 0.30, Date(15, 6, 2026), dc)
+    opt = VanillaOption(OptionType.Call, 65.0, Date(15, 6, 2026) + 90, s)
     opt.set_engine(proc)
-    with pytest.raises(itofin.ItofinError, match="no evaluation date set"):
+    with pytest.raises(ItofinError, match="no evaluation date set"):
         opt.npv()

--- a/crates/itofin-py/tests/test_heston_calibration.py
+++ b/crates/itofin-py/tests/test_heston_calibration.py
@@ -1,7 +1,13 @@
 import math
 
-import itofin
 import pytest
+
+from itofin import ItofinError, Settings
+from itofin.models import CalibrationErrorType, HestonModel, HestonModelHelper
+from itofin.optimization import EndCriteria, LevenbergMarquardt
+from itofin.processes import HestonProcess
+from itofin.termstructures import FlatForward
+from itofin.time import Calendar, Date, DayCounter, Period
 
 VOL = 0.1
 EXPECTED_VARIANCE = VOL * VOL
@@ -37,8 +43,8 @@ MONEYNESSES = [-1.0, 0.0, 1.0]
 
 
 def _fixture_settings():
-    settings = itofin.Settings()
-    settings.set_evaluation_date(itofin.Date(*REFERENCE))
+    settings = Settings()
+    settings.set_evaluation_date(Date(*REFERENCE))
     return settings
 
 
@@ -51,11 +57,11 @@ def _build_helpers(settings):
     # discounts are read from FlatForward curves that match the helper's own
     # curves exactly, so the mechanism stays live rather than pasting opaque
     # strike constants.
-    ref = itofin.Date(*REFERENCE)
-    dc = itofin.DayCounter.actual360()
-    calendar = itofin.Calendar.null_calendar()
-    risk_free = itofin.FlatForward(ref, 0.04, dc)
-    dividend = itofin.FlatForward(ref, 0.50, dc)
+    ref = Date(*REFERENCE)
+    dc = DayCounter.actual360()
+    calendar = Calendar.null_calendar()
+    risk_free = FlatForward(ref, 0.04, dc)
+    dividend = FlatForward(ref, 0.50, dc)
 
     helpers = []
     for (n, unit), tau in zip(MATURITIES, TAUS):
@@ -63,15 +69,15 @@ def _build_helpers(settings):
         for moneyness in MONEYNESSES:
             strike = forward * math.exp(-moneyness * VOL * math.sqrt(tau))
             helpers.append(
-                itofin.HestonModelHelper(
-                    itofin.Period(n, unit),
+                HestonModelHelper(
+                    Period(n, unit),
                     calendar,
                     1.0,
                     strike,
                     VOL,
                     0.04,
                     0.50,
-                    itofin.CalibrationErrorType.RelativePriceError,
+                    CalibrationErrorType.RelativePriceError,
                     ref,
                     dc,
                     settings,
@@ -87,7 +93,7 @@ def _seed_model():
     # internally with the identical reference date and day counter, so the
     # engine and the helpers price on the same market.
     def build(sigma):
-        process = itofin.HestonProcess(
+        process = HestonProcess(
             0.04,
             0.50,
             1.0,
@@ -96,10 +102,10 @@ def _seed_model():
             0.02,
             sigma,
             -0.75,
-            itofin.Date(*REFERENCE),
-            itofin.DayCounter.actual360(),
+            Date(*REFERENCE),
+            DayCounter.actual360(),
         )
-        return itofin.HestonModel(process)
+        return HestonModel(process)
 
     return build
 
@@ -119,8 +125,8 @@ def test_heston_calibrates_to_a_flat_vol_surface():
 
     for sigma in (0.1, 0.3, 0.5):
         model = build(sigma)
-        method = itofin.LevenbergMarquardt(1e-8, 1e-8, 1e-8, False)
-        end_criteria = itofin.EndCriteria(400, 40, 1e-8, 1e-8, 1e-8)
+        method = LevenbergMarquardt(1e-8, 1e-8, 1e-8, False)
+        end_criteria = EndCriteria(400, 40, 1e-8, 1e-8, 1e-8)
         model.calibrate(helpers, method, end_criteria, 96)
 
         assert model.sigma() < 3e-3, f"sigma {model.sigma()} (start {sigma})"
@@ -134,7 +140,7 @@ def test_heston_calibrates_to_a_flat_vol_surface():
 
 def test_calibrate_with_no_helpers_raises():
     model = _seed_model()(0.5)
-    method = itofin.LevenbergMarquardt(1e-8, 1e-8, 1e-8, False)
-    end_criteria = itofin.EndCriteria(400, 40, 1e-8, 1e-8, 1e-8)
-    with pytest.raises(itofin.ItofinError):
+    method = LevenbergMarquardt(1e-8, 1e-8, 1e-8, False)
+    end_criteria = EndCriteria(400, 40, 1e-8, 1e-8, 1e-8)
+    with pytest.raises(ItofinError):
         model.calibrate([], method, end_criteria, 96)

--- a/crates/itofin-py/tests/test_heston_pricing.py
+++ b/crates/itofin-py/tests/test_heston_pricing.py
@@ -1,12 +1,17 @@
-import itofin
 import pytest
+
+from itofin import ItofinError, Settings
+from itofin.instruments import OptionType, VanillaOption
+from itofin.models import HestonModel
+from itofin.processes import HestonProcess
+from itofin.time import Date, DayCounter
 
 
 def _heston_arm1():
-    s = itofin.Settings()
-    s.set_evaluation_date(itofin.Date(27, 12, 2004))
-    dc = itofin.DayCounter.actual_actual_isda()
-    proc = itofin.HestonProcess(
+    s = Settings()
+    s.set_evaluation_date(Date(27, 12, 2004))
+    dc = DayCounter.actual_actual_isda()
+    proc = HestonProcess(
         0.0225,
         0.02,
         1.0,
@@ -15,11 +20,11 @@ def _heston_arm1():
         0.09,
         0.4,
         -0.2,
-        itofin.Date(27, 12, 2004),
+        Date(27, 12, 2004),
         dc,
     )
-    model = itofin.HestonModel(proc)
-    opt = itofin.VanillaOption(itofin.OptionType.Call, 1.05, itofin.Date(28, 3, 2005), s)
+    model = HestonModel(proc)
+    opt = VanillaOption(OptionType.Call, 1.05, Date(28, 3, 2005), s)
     opt.set_heston_engine(model, 64)
     return opt
 
@@ -32,12 +37,12 @@ def test_arm1_cached_analytic_price_order_64():
 def test_heston_path_greeks_not_provided():
     opt = _heston_arm1()
     opt.npv()
-    with pytest.raises(itofin.ItofinError):
+    with pytest.raises(ItofinError):
         opt.delta()
 
 
 def test_model_constraint_violation_raises():
-    proc = itofin.HestonProcess(
+    proc = HestonProcess(
         0.0225,
         0.02,
         1.0,
@@ -46,8 +51,8 @@ def test_model_constraint_violation_raises():
         0.09,
         0.4,
         -0.2,
-        itofin.Date(27, 12, 2004),
-        itofin.DayCounter.actual_actual_isda(),
+        Date(27, 12, 2004),
+        DayCounter.actual_actual_isda(),
     )
-    with pytest.raises(itofin.ItofinError):
-        itofin.HestonModel(proc)
+    with pytest.raises(ItofinError):
+        HestonModel(proc)

--- a/crates/itofin-py/tests/test_hullwhite_calibration.py
+++ b/crates/itofin-py/tests/test_hullwhite_calibration.py
@@ -1,5 +1,11 @@
-import itofin
 import pytest
+
+from itofin import ItofinError, Settings
+from itofin.indexes import Euribor
+from itofin.models import CalibrationErrorType, HullWhite, SwaptionHelper
+from itofin.optimization import EndCriteria, LevenbergMarquardt
+from itofin.termstructures import FlatForward
+from itofin.time import Date, DayCounter, Period
 
 # ORACLE testCachedHullWhite (shortratemodels.cpp:83-153, mirrored by the Rust
 # oracle calibrate_cached_hull_white in hullwhite.rs:793-912): calibrate
@@ -8,7 +14,7 @@ import pytest
 #
 # The C++/Rust oracle gates the cached values on usingAtParCoupons: the par arm
 # (usingAtParCoupons == true) yields a = 0.0464041, sigma = 0.00579912. `true` is
-# the Settings default (settings.rs Default), so a plain itofin.Settings() hits
+# the Settings default (settings.rs Default), so a plain Settings() hits
 # the par arm without any further wiring. The evaluation date is 15-Feb-2002 on
 # Settings, while the flat curve is referenced at the SETTLEMENT date 19-Feb-2002;
 # these differ by design (a FlatForward with an explicit reference date is not
@@ -28,34 +34,34 @@ SWAPTIONS = [
 
 
 def _fixture_settings():
-    settings = itofin.Settings()
-    settings.set_evaluation_date(itofin.Date(*TODAY))
+    settings = Settings()
+    settings.set_evaluation_date(Date(*TODAY))
     return settings
 
 
 def _fixture_curve():
-    return itofin.FlatForward(
-        itofin.Date(*SETTLEMENT), CURVE_RATE, itofin.DayCounter.actual365_fixed()
+    return FlatForward(
+        Date(*SETTLEMENT), CURVE_RATE, DayCounter.actual365_fixed()
     )
 
 
 def _build_helpers(curve, index):
-    fixed_dc = itofin.DayCounter.thirty360_bond_basis()
-    float_dc = itofin.DayCounter.actual360()
-    fixed_tenor = itofin.Period(1, "Years")
+    fixed_dc = DayCounter.thirty360_bond_basis()
+    float_dc = DayCounter.actual360()
+    fixed_tenor = Period(1, "Years")
     helpers = []
     for maturity, length, vol in SWAPTIONS:
         helpers.append(
-            itofin.SwaptionHelper(
-                itofin.Period(maturity, "Years"),
-                itofin.Period(length, "Years"),
+            SwaptionHelper(
+                Period(maturity, "Years"),
+                Period(length, "Years"),
                 vol,
                 index,
                 fixed_tenor,
                 fixed_dc,
                 float_dc,
                 curve,
-                itofin.CalibrationErrorType.RelativePriceError,
+                CalibrationErrorType.RelativePriceError,
                 1.0,
             )
         )
@@ -65,12 +71,12 @@ def _build_helpers(curve, index):
 def test_hullwhite_calibrates_to_the_cached_swaption_values():
     settings = _fixture_settings()
     curve = _fixture_curve()
-    model = itofin.HullWhite(curve, 0.1, 0.01)
-    index = itofin.Euribor.six_months(curve, settings)
+    model = HullWhite(curve, 0.1, 0.01)
+    index = Euribor.six_months(curve, settings)
     helpers = _build_helpers(curve, index)
 
-    method = itofin.LevenbergMarquardt(1e-8, 1e-8, 1e-8, False)
-    end_criteria = itofin.EndCriteria(10000, 100, 1e-6, 1e-8, 1e-8)
+    method = LevenbergMarquardt(1e-8, 1e-8, 1e-8, False)
+    end_criteria = EndCriteria(10000, 100, 1e-6, 1e-8, 1e-8)
     model.calibrate(helpers, method, end_criteria, False)
 
     assert model.a() == pytest.approx(0.0464041, abs=1.3e-5)
@@ -92,12 +98,12 @@ def test_hullwhite_calibrates_with_fixed_reversion():
     # 0.05 (the fixed parameter must not move), and sigma fits to 0.00585858.
     settings = _fixture_settings()
     curve = _fixture_curve()
-    model = itofin.HullWhite(curve, 0.05, 0.01)
-    index = itofin.Euribor.six_months(curve, settings)
+    model = HullWhite(curve, 0.05, 0.01)
+    index = Euribor.six_months(curve, settings)
     helpers = _build_helpers(curve, index)
 
-    method = itofin.LevenbergMarquardt(1e-8, 1e-8, 1e-8, False)
-    end_criteria = itofin.EndCriteria(1000, 500, 1e-8, 1e-8, 1e-8)
+    method = LevenbergMarquardt(1e-8, 1e-8, 1e-8, False)
+    end_criteria = EndCriteria(1000, 500, 1e-8, 1e-8, 1e-8)
     model.calibrate(helpers, method, end_criteria, True)
 
     assert model.a() == pytest.approx(0.05, abs=1e-15)
@@ -107,9 +113,9 @@ def test_hullwhite_calibrates_with_fixed_reversion():
 def test_calibrate_with_no_helpers_raises():
     settings = _fixture_settings()
     curve = _fixture_curve()
-    model = itofin.HullWhite(curve, 0.1, 0.01)
-    itofin.Euribor.six_months(curve, settings)
-    method = itofin.LevenbergMarquardt(1e-8, 1e-8, 1e-8, False)
-    end_criteria = itofin.EndCriteria(10000, 100, 1e-6, 1e-8, 1e-8)
-    with pytest.raises(itofin.ItofinError):
+    model = HullWhite(curve, 0.1, 0.01)
+    Euribor.six_months(curve, settings)
+    method = LevenbergMarquardt(1e-8, 1e-8, 1e-8, False)
+    end_criteria = EndCriteria(10000, 100, 1e-6, 1e-8, 1e-8)
+    with pytest.raises(ItofinError):
         model.calibrate([], method, end_criteria, False)

--- a/crates/itofin-py/tests/test_hullwhite_model.py
+++ b/crates/itofin-py/tests/test_hullwhite_model.py
@@ -1,14 +1,20 @@
-import itofin
 import pytest
+
+from itofin import ItofinError, Settings
+from itofin.indexes import Euribor
+from itofin.instruments import OptionType
+from itofin.models import HullWhite
+from itofin.termstructures import FlatForward
+from itofin.time import Date, DayCounter
 
 
 def _flat_curve():
-    dc = itofin.DayCounter.actual365_fixed()
-    return itofin.FlatForward(itofin.Date(15, 1, 2026), 0.03, dc)
+    dc = DayCounter.actual365_fixed()
+    return FlatForward(Date(15, 1, 2026), 0.03, dc)
 
 
 def _hull_white():
-    return itofin.HullWhite(_flat_curve(), 0.05, 0.01)
+    return HullWhite(_flat_curve(), 0.05, 0.01)
 
 
 def test_ctor_round_trips_params():
@@ -24,25 +30,25 @@ def test_r0_matches_flat_zero_rate():
 
 def test_discount_bond_option_finite_nonnegative():
     hw = _hull_white()
-    value = hw.discount_bond_option(itofin.OptionType.Call, 0.9, 1.0, 3.0)
+    value = hw.discount_bond_option(OptionType.Call, 0.9, 1.0, 3.0)
     assert value >= 0.0
     assert value == value
 
 
 def test_discount_bond_option_monotone_in_strike():
     hw = _hull_white()
-    itm = hw.discount_bond_option(itofin.OptionType.Call, 0.8, 1.0, 3.0)
-    otm = hw.discount_bond_option(itofin.OptionType.Call, 1.1, 1.0, 3.0)
+    itm = hw.discount_bond_option(OptionType.Call, 0.8, 1.0, 3.0)
+    otm = hw.discount_bond_option(OptionType.Call, 1.1, 1.0, 3.0)
     assert itm > otm
 
 
 def test_constraint_violation_raises():
-    with pytest.raises(itofin.ItofinError):
-        itofin.HullWhite(_flat_curve(), 0.05, -0.01)
+    with pytest.raises(ItofinError):
+        HullWhite(_flat_curve(), 0.05, -0.01)
 
 
 def test_euribor_six_months_builds():
-    settings = itofin.Settings()
-    settings.set_evaluation_date(itofin.Date(15, 1, 2026))
-    index = itofin.Euribor.six_months(_flat_curve(), settings)
+    settings = Settings()
+    settings.set_evaluation_date(Date(15, 1, 2026))
+    index = Euribor.six_months(_flat_curve(), settings)
     assert index is not None

--- a/crates/itofin-py/tests/test_market.py
+++ b/crates/itofin-py/tests/test_market.py
@@ -1,25 +1,28 @@
-import itofin
 import pytest
+
+from itofin.processes import BlackScholesProcess
+from itofin.quotes import SimpleQuote
+from itofin.time import Date, DayCounter
 
 
 def test_simple_quote_holds_and_updates_value():
-    q = itofin.SimpleQuote(60.0)
+    q = SimpleQuote(60.0)
     assert q.value() == 60.0
     q.set_value(61.0)
     assert q.value() == 61.0
 
 
 def test_black_scholes_process_builds_on_gate_row_1_market():
-    ref_date = itofin.Date(15, 6, 2026)
-    dc = itofin.DayCounter.actual360()
-    process = itofin.BlackScholesProcess(60.0, 0.08, 0.0, 0.30, ref_date, dc)
+    ref_date = Date(15, 6, 2026)
+    dc = DayCounter.actual360()
+    process = BlackScholesProcess(60.0, 0.08, 0.0, 0.30, ref_date, dc)
     assert process.risk_free_rate() == pytest.approx(0.08)
     assert process.dividend_yield() == pytest.approx(0.0)
 
 
 def test_arg_order_pins_risk_free_and_dividend_not_swapped():
-    ref_date = itofin.Date(15, 6, 2026)
-    dc = itofin.DayCounter.actual360()
-    process = itofin.BlackScholesProcess(60.0, 0.08, 0.02, 0.30, ref_date, dc)
+    ref_date = Date(15, 6, 2026)
+    dc = DayCounter.actual360()
+    process = BlackScholesProcess(60.0, 0.08, 0.02, 0.30, ref_date, dc)
     assert process.risk_free_rate() == pytest.approx(0.08)
     assert process.dividend_yield() == pytest.approx(0.02)

--- a/crates/itofin-py/tests/test_primitives.py
+++ b/crates/itofin-py/tests/test_primitives.py
@@ -1,9 +1,11 @@
-import itofin
 import pytest
+
+from itofin import ItofinError, Settings
+from itofin.time import Calendar, Date, DayCounter
 
 
 def test_date_constructs_and_accessors_round_trip():
-    d = itofin.Date(15, 6, 2026)
+    d = Date(15, 6, 2026)
     assert d.year == 2026
     assert d.month == 6
     assert d.day == 15
@@ -21,41 +23,41 @@ def test_date_constructs_and_accessors_round_trip():
     ],
 )
 def test_invalid_date_raises_instead_of_panicking(day, month, year):
-    with pytest.raises(itofin.ItofinError):
-        itofin.Date(day, month, year)
+    with pytest.raises(ItofinError):
+        Date(day, month, year)
 
 
 def test_leap_day_constructs_in_leap_year():
-    d = itofin.Date(29, 2, 2024)
+    d = Date(29, 2, 2024)
     assert d.day == 29
     assert d.month == 2
     assert d.year == 2024
 
 
 def test_date_addition_stays_in_range():
-    assert itofin.Date(15, 6, 2026) + 90 == itofin.Date(13, 9, 2026)
+    assert Date(15, 6, 2026) + 90 == Date(13, 9, 2026)
 
 
 def test_date_subtraction():
-    assert itofin.Date(13, 9, 2026) - 90 == itofin.Date(15, 6, 2026)
+    assert Date(13, 9, 2026) - 90 == Date(15, 6, 2026)
 
 
 def test_date_arithmetic_out_of_range_raises():
-    with pytest.raises(itofin.ItofinError):
-        itofin.Date(31, 12, 2199) + 1
+    with pytest.raises(ItofinError):
+        Date(31, 12, 2199) + 1
 
 
 def test_settings_constructs_and_is_reusable():
-    settings = itofin.Settings()
-    settings.set_evaluation_date(itofin.Date(15, 6, 2026))
-    settings.set_evaluation_date(itofin.Date(16, 6, 2026))
+    settings = Settings()
+    settings.set_evaluation_date(Date(15, 6, 2026))
+    settings.set_evaluation_date(Date(16, 6, 2026))
 
 
 def test_daycounter_factories_construct():
-    assert itofin.DayCounter.actual360() is not None
-    assert itofin.DayCounter.actual365_fixed() is not None
+    assert DayCounter.actual360() is not None
+    assert DayCounter.actual365_fixed() is not None
 
 
 def test_calendar_factories_construct():
-    assert itofin.Calendar.target() is not None
-    assert itofin.Calendar.null_calendar() is not None
+    assert Calendar.target() is not None
+    assert Calendar.null_calendar() is not None

--- a/crates/itofin-py/tests/test_schedule.py
+++ b/crates/itofin-py/tests/test_schedule.py
@@ -9,12 +9,12 @@ therefore pins 17-Jan, not the naive 15th quoted in the issue body.
 
 import pytest
 
-from itofin import (
+from itofin import ItofinError
+from itofin.time import (
     BusinessDayConvention,
     Calendar,
     Date,
     Frequency,
-    ItofinError,
     Schedule,
 )
 

--- a/crates/itofin-py/tests/test_shared.py
+++ b/crates/itofin-py/tests/test_shared.py
@@ -1,68 +1,73 @@
 import math
 
-import itofin
 import pytest
+
+from itofin import ItofinError
+from itofin.models import CalibrationErrorType
+from itofin.optimization import EndCriteria, LevenbergMarquardt
+from itofin.termstructures import FlatForward
+from itofin.time import Date, DayCounter, Period
 
 
 def test_period_builds_with_known_unit():
-    p = itofin.Period(6, "Months")
+    p = Period(6, "Months")
     assert repr(p) == "Period(6, Months)"
 
 
 def test_period_rejects_unknown_unit():
-    with pytest.raises(itofin.ItofinError):
-        itofin.Period(1, "Fortnights")
+    with pytest.raises(ItofinError):
+        Period(1, "Fortnights")
 
 
 def test_levenberg_marquardt_builds_with_defaults():
-    itofin.LevenbergMarquardt()
+    LevenbergMarquardt()
 
 
 def test_levenberg_marquardt_accepts_explicit_args():
-    itofin.LevenbergMarquardt(1e-10, 1e-10, 1e-10, True)
+    LevenbergMarquardt(1e-10, 1e-10, 1e-10, True)
 
 
 def test_end_criteria_builds():
-    itofin.EndCriteria(400, 40, 1e-8, 1e-8, 1e-8)
+    EndCriteria(400, 40, 1e-8, 1e-8, 1e-8)
 
 
 def test_end_criteria_rejects_stationary_ge_iterations():
-    with pytest.raises(itofin.ItofinError):
-        itofin.EndCriteria(400, 500, 1e-8, 1e-8, 1e-8)
+    with pytest.raises(ItofinError):
+        EndCriteria(400, 500, 1e-8, 1e-8, 1e-8)
 
 
 def test_end_criteria_rejects_stationary_not_gt_one():
-    with pytest.raises(itofin.ItofinError):
-        itofin.EndCriteria(400, 1, 1e-8, 1e-8, 1e-8)
+    with pytest.raises(ItofinError):
+        EndCriteria(400, 1, 1e-8, 1e-8, 1e-8)
 
 
 def test_end_criteria_requires_all_five_arguments():
     with pytest.raises(TypeError):
-        itofin.EndCriteria(400)
+        EndCriteria(400)
     with pytest.raises(TypeError):
-        itofin.EndCriteria(400, 40, 1e-8, 1e-8)
+        EndCriteria(400, 40, 1e-8, 1e-8)
 
 
 def test_flat_forward_discount_matches_continuous_flat():
-    curve = itofin.FlatForward(
-        itofin.Date(15, 1, 2026), 0.03, itofin.DayCounter.actual365_fixed()
+    curve = FlatForward(
+        Date(15, 1, 2026), 0.03, DayCounter.actual365_fixed()
     )
     assert curve.discount(1.0) == pytest.approx(math.exp(-0.03 * 1.0), abs=1e-12)
     assert curve.discount(0.0) == pytest.approx(1.0, abs=1e-12)
 
 
 def test_flat_forward_zero_rate_is_flat():
-    curve = itofin.FlatForward(
-        itofin.Date(15, 1, 2026), 0.03, itofin.DayCounter.actual365_fixed()
+    curve = FlatForward(
+        Date(15, 1, 2026), 0.03, DayCounter.actual365_fixed()
     )
     assert curve.zero_rate(1.0) == pytest.approx(0.03, abs=1e-12)
 
 
 def test_calibration_error_types_are_constructible():
-    assert itofin.CalibrationErrorType.RelativePriceError is not None
-    assert itofin.CalibrationErrorType.PriceError is not None
-    assert itofin.CalibrationErrorType.ImpliedVolError is not None
+    assert CalibrationErrorType.RelativePriceError is not None
+    assert CalibrationErrorType.PriceError is not None
+    assert CalibrationErrorType.ImpliedVolError is not None
     assert (
-        itofin.CalibrationErrorType.RelativePriceError
-        != itofin.CalibrationErrorType.PriceError
+        CalibrationErrorType.RelativePriceError
+        != CalibrationErrorType.PriceError
     )

--- a/crates/itofin-py/tests/test_swaption.py
+++ b/crates/itofin-py/tests/test_swaption.py
@@ -24,24 +24,25 @@ fixture (``jamshidianswaptionengine.rs:344``, which never attaches a swap engine
 
 import pytest
 
-from itofin import (
+from itofin import ItofinError, Settings
+from itofin.indexes import Euribor
+from itofin.instruments import (
+    EuropeanExercise,
+    SettlementMethod,
+    SettlementType,
+    Swaption,
+    SwapType,
+    VanillaSwap,
+)
+from itofin.models import HullWhite
+from itofin.termstructures import FlatForward
+from itofin.time import (
     BusinessDayConvention,
     Calendar,
     Date,
     DayCounter,
-    EuropeanExercise,
-    Euribor,
-    FlatForward,
     Frequency,
-    HullWhite,
-    ItofinError,
     Schedule,
-    SettlementMethod,
-    SettlementType,
-    Settings,
-    Swaption,
-    SwapType,
-    VanillaSwap,
 )
 
 PAYER_NPV = 1.5666103955750414

--- a/crates/itofin-py/tests/test_vanilla_swap.py
+++ b/crates/itofin-py/tests/test_vanilla_swap.py
@@ -23,19 +23,17 @@ reproduces the core exactly, so the fixture stays apples-to-apples.
 
 import pytest
 
-from itofin import (
+from itofin import ItofinError, Settings
+from itofin.indexes import Euribor
+from itofin.instruments import SwapType, VanillaSwap
+from itofin.termstructures import FlatForward
+from itofin.time import (
     BusinessDayConvention,
     Calendar,
     Date,
     DayCounter,
-    Euribor,
-    FlatForward,
     Frequency,
-    ItofinError,
     Schedule,
-    Settings,
-    SwapType,
-    VanillaSwap,
 )
 
 PROBE_FAIR = 0.03048844643136293


### PR DESCRIPTION
- **feat(crates): organize Python bindings into ql-faithful submodules**
- **refactor(py): reorganize public API into QuantLib-style submodules**

close #516