### PR TITLE
ci(pre-commit): allow incompat type in commit message validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         name: commit message is valid
         args:
           - --negate
-        entry: ^(build|ci|docs|feat|fix|perf|refactor|style|test|revert|hotfix|ops|chore)\([\w,\.,\-,\(,\),\/,\#]+\)(!?)(:)\s{1}([\w,\W,:]+)$
+        entry: ^(build|ci|docs|feat|fix|perf|refactor|style|test|revert|hotfix|ops|chore|incompat)\([\w,\.,\-,\(,\),\/,\#]+\)(!?)(:)\s{1}([\w,\W,:]+)$
         language: pygrep
         stages:
           - commit-msg


### PR DESCRIPTION
- **feat(crates)!: organize Python bindings into ql-faithful submodules**
- **refactor(py): reorganize public API into QuantLib-style submodules**
- **feat(itofin-py): add type stubs and configure python source layout (#520)**
- **ci(pre-commit): allow incompat type in commit message pattern**
