### PR TITLE
feat(itofin-py): expose Black volatility term structures

### DIFF
--- a/crates/itofin-py/python/itofin/processes.pyi
+++ b/crates/itofin-py/python/itofin/processes.pyi
@@ -1,10 +1,11 @@
 # Hand-written stubs for itofin.processes; sync manually with src/market.rs and
 # src/heston.rs (#517).
 
+from itofin.termstructures import BlackVolTermStructure, YieldTermStructure
 from itofin.time import Date, DayCounter
 
 class BlackScholesProcess:
-    """A flat-market generalized Black-Scholes process."""
+    """A generalized Black-Scholes process, built from scalars or curve objects."""
 
     def __init__(
         self,
@@ -15,6 +16,13 @@ class BlackScholesProcess:
         reference_date: Date,
         day_counter: DayCounter,
     ) -> None: ...
+    @staticmethod
+    def from_curves(
+        spot: float,
+        risk_free: YieldTermStructure,
+        dividend: YieldTermStructure,
+        vol: BlackVolTermStructure,
+    ) -> BlackScholesProcess: ...
     def risk_free_rate(self) -> float: ...
     def dividend_yield(self) -> float: ...
 

--- a/crates/itofin-py/python/itofin/termstructures.pyi
+++ b/crates/itofin-py/python/itofin/termstructures.pyi
@@ -1,6 +1,6 @@
 # Hand-written stubs for itofin.termstructures; sync manually with src/curve.rs and src/vol.rs (#517).
 
-from itofin.time import Date, DayCounter
+from itofin.time import Calendar, Date, DayCounter
 
 class YieldTermStructure:
     """Shared base for every yield curve: discount factors, zero and forward rates."""
@@ -35,3 +35,41 @@ class FlatForward(YieldTermStructure):
     """A flat continuously-compounded yield curve behind a Handle."""
 
     def __init__(self, reference_date: Date, rate: float, day_counter: DayCounter) -> None: ...
+
+class BlackConstantVol(BlackVolTermStructure):
+    """A flat Black volatility, constant in strike and time."""
+
+    def __init__(
+        self,
+        reference_date: Date,
+        volatility: float,
+        day_counter: DayCounter,
+        calendar: Calendar | None = None,
+    ) -> None: ...
+
+class BlackVarianceCurve(BlackVolTermStructure):
+    """A term structure of Black volatility (no strike dimension), interpolating
+    linearly on variance. Finite in time: enable extrapolation past the last date."""
+
+    def __init__(
+        self,
+        reference_date: Date,
+        dates: list[Date],
+        black_vol_curve: list[float],
+        day_counter: DayCounter,
+        force_monotone_variance: bool,
+    ) -> None: ...
+
+class BlackVarianceSurface(BlackVolTermStructure):
+    """A Black volatility surface in strike and expiry, interpolating bilinearly
+    on variance. black_vol_matrix has one row per strike and one column per date."""
+
+    def __init__(
+        self,
+        reference_date: Date,
+        dates: list[Date],
+        strikes: list[float],
+        black_vol_matrix: list[list[float]],
+        day_counter: DayCounter,
+        calendar: Calendar | None = None,
+    ) -> None: ...

--- a/crates/itofin-py/src/lib.rs
+++ b/crates/itofin-py/src/lib.rs
@@ -34,7 +34,9 @@ use swaption::{PyEuropeanExercise, PySettlementMethod, PySettlementType, PySwapt
 use time::{
     PyBusinessDayConvention, PyCalendar, PyDate, PyDayCounter, PyFrequency, PyPeriod, PySchedule,
 };
-use vol::PyBlackVolTermStructure;
+use vol::{
+    PyBlackConstantVol, PyBlackVarianceCurve, PyBlackVarianceSurface, PyBlackVolTermStructure,
+};
 
 create_exception!(itofin, ItofinError, PyException);
 
@@ -91,6 +93,9 @@ fn itofin(m: &Bound<'_, PyModule>) -> PyResult<()> {
     termstructures.add_class::<PyYieldTermStructure>()?;
     termstructures.add_class::<PyBlackVolTermStructure>()?;
     termstructures.add_class::<PyFlatForward>()?;
+    termstructures.add_class::<PyBlackConstantVol>()?;
+    termstructures.add_class::<PyBlackVarianceCurve>()?;
+    termstructures.add_class::<PyBlackVarianceSurface>()?;
 
     let processes = PyModule::new(py, "processes")?;
     processes.add_class::<PyBlackScholesProcess>()?;

--- a/crates/itofin-py/src/market.rs
+++ b/crates/itofin-py/src/market.rs
@@ -1,7 +1,9 @@
 //! Facades for the market inputs: [`PySimpleQuote`] and [`PyBlackScholesProcess`].
 
 use crate::PyQlError;
+use crate::curve::PyYieldTermStructure;
 use crate::time::{PyDate, PyDayCounter};
+use crate::vol::PyBlackVolTermStructure;
 use libitofin::handle::Handle;
 use libitofin::interestrate::Compounding;
 use libitofin::processes::GeneralizedBlackScholesProcess;
@@ -96,6 +98,30 @@ impl PyBlackScholesProcess {
                 dividend_curve,
                 risk_free_curve,
                 vol,
+            )),
+        }
+    }
+
+    /// Builds a process from term-structure objects instead of scalars: a spot
+    /// level plus the risk-free curve, dividend curve, and Black vol surface.
+    ///
+    /// The three legs are bound by name and placed in the core's
+    /// `(x0, dividend, risk_free, vol)` order at the single call site, the same
+    /// r/q footgun the scalar constructor guards against.
+    #[staticmethod]
+    fn from_curves(
+        spot: f64,
+        risk_free: &PyYieldTermStructure,
+        dividend: &PyYieldTermStructure,
+        vol: &PyBlackVolTermStructure,
+    ) -> Self {
+        let x0 = Handle::new(shared(SimpleQuote::new(spot)) as Shared<dyn Quote>);
+        PyBlackScholesProcess {
+            inner: shared(GeneralizedBlackScholesProcess::new(
+                x0,
+                dividend.handle(),
+                risk_free.handle(),
+                vol.handle(),
             )),
         }
     }

--- a/crates/itofin-py/src/vol.rs
+++ b/crates/itofin-py/src/vol.rs
@@ -2,9 +2,14 @@
 //! [`PyBlackVolTermStructure`].
 
 use crate::PyQlError;
-use crate::time::PyDate;
+use crate::time::{PyCalendar, PyDate, PyDayCounter};
 use libitofin::handle::Handle;
-use libitofin::termstructures::volatility::BlackVolTermStructure;
+use libitofin::math::interpolations::linear::Linear;
+use libitofin::math::matrix::Matrix;
+use libitofin::shared::{Shared, shared};
+use libitofin::termstructures::volatility::{
+    BlackConstantVol, BlackVarianceCurve, BlackVarianceSurface, BlackVolTermStructure,
+};
 use pyo3::prelude::*;
 
 /// Python `BlackVolTermStructure`: the shared base for every Black-volatility
@@ -151,8 +156,156 @@ impl PyBlackVolTermStructure {
 
 impl PyBlackVolTermStructure {
     /// A clone of the inner surface handle for the pricing facades.
-    #[allow(dead_code)]
     pub(crate) fn handle(&self) -> Handle<dyn BlackVolTermStructure> {
         self.inner.clone()
     }
+}
+
+/// Python `BlackConstantVol`: a flat Black volatility, constant in strike and
+/// time (`termstructures::volatility::BlackConstantVol`).
+///
+/// Extends [`PyBlackVolTermStructure`] and supplies only the constructor; the
+/// query surface is inherited. Unbounded in both time and strike, so queries
+/// never need extrapolation enabled.
+#[pyclass(name = "BlackConstantVol", extends = PyBlackVolTermStructure, unsendable)]
+pub struct PyBlackConstantVol;
+
+#[pymethods]
+impl PyBlackConstantVol {
+    #[new]
+    #[pyo3(signature = (reference_date, volatility, day_counter, calendar = None))]
+    fn new(
+        reference_date: &PyDate,
+        volatility: f64,
+        day_counter: &PyDayCounter,
+        calendar: Option<&PyCalendar>,
+    ) -> PyClassInitializer<Self> {
+        let structure = shared(BlackConstantVol::new(
+            reference_date.inner(),
+            calendar.map(PyCalendar::inner),
+            volatility,
+            day_counter.inner(),
+        )) as Shared<dyn BlackVolTermStructure>;
+        PyClassInitializer::from(PyBlackVolTermStructure {
+            inner: Handle::new(structure),
+        })
+        .add_subclass(PyBlackConstantVol)
+    }
+}
+
+/// Python `BlackVarianceCurve`: a term structure of Black volatility with no
+/// strike dimension, interpolating linearly on variance
+/// (`termstructures::volatility::BlackVarianceCurve<Linear>`).
+///
+/// Extends [`PyBlackVolTermStructure`]. Finite in time: the last date is the
+/// maximum, so queries past it require `enable_extrapolation()`. The concrete
+/// `Linear` handle is retained alongside the erased base handle for a future
+/// local-volatility curve facade.
+#[pyclass(name = "BlackVarianceCurve", extends = PyBlackVolTermStructure, unsendable)]
+pub struct PyBlackVarianceCurve {
+    #[allow(dead_code)]
+    concrete: Handle<BlackVarianceCurve<Linear>>,
+}
+
+#[pymethods]
+impl PyBlackVarianceCurve {
+    #[new]
+    fn new(
+        reference_date: &PyDate,
+        dates: Vec<PyRef<PyDate>>,
+        black_vol_curve: Vec<f64>,
+        day_counter: &PyDayCounter,
+        force_monotone_variance: bool,
+    ) -> PyResult<PyClassInitializer<Self>> {
+        let dates: Vec<_> = dates.iter().map(|d| d.inner()).collect();
+        let curve = shared(
+            BlackVarianceCurve::new(
+                reference_date.inner(),
+                &dates,
+                &black_vol_curve,
+                day_counter.inner(),
+                force_monotone_variance,
+            )
+            .map_err(PyQlError::from)?,
+        );
+        let concrete = Handle::new(Shared::clone(&curve));
+        let erased = Handle::new(curve as Shared<dyn BlackVolTermStructure>);
+        Ok(
+            PyClassInitializer::from(PyBlackVolTermStructure { inner: erased })
+                .add_subclass(PyBlackVarianceCurve { concrete }),
+        )
+    }
+}
+
+/// Python `BlackVarianceSurface`: a Black volatility surface in strike and
+/// expiry, interpolating bilinearly on variance
+/// (`termstructures::volatility::BlackVarianceSurface`).
+///
+/// Extends [`PyBlackVolTermStructure`]. The `black_vol_matrix` is a
+/// `list[list[float]]` with **one row per strike and one column per date**;
+/// the surface is finite in both time and strike, so out-of-grid queries
+/// require `enable_extrapolation()`.
+#[pyclass(name = "BlackVarianceSurface", extends = PyBlackVolTermStructure, unsendable)]
+pub struct PyBlackVarianceSurface;
+
+#[pymethods]
+impl PyBlackVarianceSurface {
+    #[new]
+    #[pyo3(signature = (reference_date, dates, strikes, black_vol_matrix, day_counter, calendar = None))]
+    fn new(
+        reference_date: &PyDate,
+        dates: Vec<PyRef<PyDate>>,
+        strikes: Vec<f64>,
+        black_vol_matrix: Vec<Vec<f64>>,
+        day_counter: &PyDayCounter,
+        calendar: Option<&PyCalendar>,
+    ) -> PyResult<PyClassInitializer<Self>> {
+        let dates: Vec<_> = dates.iter().map(|d| d.inner()).collect();
+        let matrix = matrix_from_rows(&black_vol_matrix)?;
+        let surface = shared(
+            BlackVarianceSurface::new(
+                reference_date.inner(),
+                calendar.map(PyCalendar::inner),
+                &dates,
+                strikes,
+                &matrix,
+                day_counter.inner(),
+            )
+            .map_err(PyQlError::from)?,
+        ) as Shared<dyn BlackVolTermStructure>;
+        Ok(PyClassInitializer::from(PyBlackVolTermStructure {
+            inner: Handle::new(surface),
+        })
+        .add_subclass(PyBlackVarianceSurface))
+    }
+}
+
+/// Converts a Python `list[list[float]]` (row per strike, column per date)
+/// into a core [`Matrix`], rejecting an empty or ragged grid before it reaches
+/// the surface constructor's dimension checks.
+fn matrix_from_rows(rows: &[Vec<f64>]) -> PyResult<Matrix> {
+    let n_rows = rows.len();
+    if n_rows == 0 {
+        return Err(crate::ItofinError::new_err(
+            "black vol matrix must have at least one row",
+        ));
+    }
+    let n_cols = rows[0].len();
+    if n_cols == 0 {
+        return Err(crate::ItofinError::new_err(
+            "black vol matrix rows must have at least one column",
+        ));
+    }
+    if rows.iter().any(|row| row.len() != n_cols) {
+        return Err(crate::ItofinError::new_err(
+            "black vol matrix rows must all have the same length",
+        ));
+    }
+    let mut matrix = Matrix::with_size(n_rows, n_cols);
+    for (i, row) in rows.iter().enumerate() {
+        for (j, &value) in row.iter().enumerate() {
+            matrix[(i, j)] = value;
+        }
+    }
+    Ok(matrix)
 }

--- a/crates/itofin-py/tests/test_black_vol.py
+++ b/crates/itofin-py/tests/test_black_vol.py
@@ -1,0 +1,133 @@
+import math
+
+import pytest
+
+from itofin import ItofinError
+from itofin.termstructures import (
+    BlackConstantVol,
+    BlackVarianceCurve,
+    BlackVarianceSurface,
+    BlackVolTermStructure,
+)
+from itofin.time import Date, DayCounter
+
+REF = Date(15, 6, 2026)
+
+
+def _curve():
+    """blackvariancecurve.rs:255-265: ref+180/+360/+720, vols 0.20/0.25/0.30,
+    Actual360, force_monotone_variance=True."""
+    dc = DayCounter.actual360()
+    dates = [REF + 180, REF + 360, REF + 720]
+    return BlackVarianceCurve(REF, dates, [0.20, 0.25, 0.30], dc, True)
+
+
+def _surface():
+    """blackvariancesurface.rs:258-282: strikes [90,100,110] x dates
+    [ref+365, ref+730], Actual365Fixed, rows=strikes
+    [[0.20,0.25],[0.18,0.22],[0.16,0.20]]."""
+    dc = DayCounter.actual365_fixed()
+    dates = [REF + 365, REF + 730]
+    strikes = [90.0, 100.0, 110.0]
+    matrix = [[0.20, 0.25], [0.18, 0.22], [0.16, 0.20]]
+    return BlackVarianceSurface(REF, dates, strikes, matrix, dc)
+
+
+def test_constant_vol_extends_base_and_is_flat():
+    """blackconstantvol.rs:126,136,140: unbounded in time and strike."""
+    dc = DayCounter.actual360()
+    bcv = BlackConstantVol(REF, 0.30, dc)
+    assert isinstance(bcv, BlackVolTermStructure)
+    assert bcv.black_vol(1.0, 100.0) == pytest.approx(0.30, abs=1e-15)
+    assert bcv.black_vol(5.0, 50.0) == pytest.approx(0.30, abs=1e-15)
+
+
+def test_curve_extends_base_and_reproduces_nodes():
+    """blackvariancecurve.rs:270-276: node vols round-trip, variances t*vol^2."""
+    curve = _curve()
+    assert isinstance(curve, BlackVolTermStructure)
+    for date, t, vol in [(REF + 180, 0.5, 0.20), (REF + 360, 1.0, 0.25), (REF + 720, 2.0, 0.30)]:
+        assert curve.black_vol_date(date, 100.0) == pytest.approx(vol, abs=1e-15)
+        assert curve.black_variance(t, 100.0) == pytest.approx(t * vol * vol, abs=1e-15)
+    assert curve.black_variance(1.0, 100.0) == pytest.approx(0.0625, abs=1e-15)
+    assert curve.black_variance(2.0, 100.0) == pytest.approx(0.18, abs=1e-15)
+
+
+def test_curve_interpolates_variance_linearly():
+    """blackvariancecurve.rs:283-287: variance(0.75)=0.04125, vol=sqrt(var/t)."""
+    curve = _curve()
+    assert curve.black_variance(0.75, 100.0) == pytest.approx(0.04125, abs=1e-15)
+    assert curve.black_vol(0.75, 100.0) == pytest.approx(math.sqrt(0.04125 / 0.75), abs=1e-15)
+
+
+def test_curve_pins_zero_variance_and_forward_variance():
+    """blackvariancecurve.rs:293 zero at t=0; :429-432 forward variance additive."""
+    curve = _curve()
+    assert curve.black_variance(0.0, 100.0) == 0.0
+    assert curve.black_forward_variance(0.5, 1.0, 100.0) == pytest.approx(0.0425, abs=1e-15)
+
+
+def test_curve_is_finite_in_time_and_extrapolation_is_the_escape_hatch():
+    """blackvariancecurve.rs:343-347,353-356: past the last node raises with
+    extrapolate=False, then flat-vol extrapolation continues past it."""
+    curve = _curve()
+    assert curve.black_vol(2.0, 100.0) == pytest.approx(0.30, abs=1e-15)
+    with pytest.raises(ItofinError):
+        curve.black_vol(2.5, 100.0, False)
+    assert curve.black_variance(3.0, 100.0, True) == pytest.approx(0.27, abs=1e-15)
+    assert curve.black_vol(3.0, 100.0, True) == pytest.approx(0.30, abs=1e-15)
+    curve.enable_extrapolation()
+    assert curve.black_vol(2.5, 100.0, False) == pytest.approx(0.30, abs=1e-15)
+
+
+def test_surface_extends_base_and_reproduces_nodes():
+    """blackvariancesurface.rs:301-308: node variances/vols reproduce exactly."""
+    surface = _surface()
+    assert isinstance(surface, BlackVolTermStructure)
+    assert surface.black_variance(1.0, 100.0) == pytest.approx(0.0324, abs=1e-14)
+    assert surface.black_variance(2.0, 90.0) == pytest.approx(0.125, abs=1e-14)
+    assert surface.black_vol(1.0, 90.0) == pytest.approx(0.20, abs=1e-14)
+    assert surface.black_vol_date(REF + 365, 100.0) == pytest.approx(0.18, abs=1e-14)
+
+
+def test_surface_interpolates_bilinearly():
+    """blackvariancesurface.rs:314-316: variance(0.5,100)=0.0162; the 4-corner
+    mean (0.04+0.0324+0.125+0.0968)/4 = 0.07355 at (1.5, 95)."""
+    surface = _surface()
+    assert surface.black_variance(0.5, 100.0) == pytest.approx(0.0162, abs=1e-14)
+    assert surface.black_variance(1.5, 95.0) == pytest.approx(0.07355, abs=1e-14)
+
+
+def test_surface_grid_bounds_and_time_extrapolation():
+    """blackvariancesurface.rs:332-336 time extrapolation past the last node;
+    :368-370 grid bounds are min/max strike and the last date."""
+    surface = _surface()
+    assert surface.min_strike() == 90.0
+    assert surface.max_strike() == 110.0
+    assert surface.max_date() == REF + 730
+    assert surface.black_variance(4.0, 100.0, True) == pytest.approx(0.1936, abs=1e-14)
+    with pytest.raises(ItofinError):
+        surface.black_variance(4.0, 100.0, False)
+    surface.enable_extrapolation()
+    assert surface.black_variance(4.0, 100.0, False) == pytest.approx(0.1936, abs=1e-14)
+
+
+def test_surface_rejects_transposed_matrix():
+    """The fixture is non-square (3 strikes x 2 dates); a transposed 2x3 matrix
+    trips the core check dates.len()==columns (blackvariancesurface.rs:106-109)."""
+    dc = DayCounter.actual365_fixed()
+    dates = [REF + 365, REF + 730]
+    strikes = [90.0, 100.0, 110.0]
+    transposed = [[0.20, 0.18, 0.16], [0.25, 0.22, 0.20]]
+    with pytest.raises(ItofinError):
+        BlackVarianceSurface(REF, dates, strikes, transposed, dc)
+
+
+def test_surface_rejects_ragged_matrix():
+    """The list->Matrix converter rejects a ragged grid before construction."""
+    dc = DayCounter.actual365_fixed()
+    dates = [REF + 365, REF + 730]
+    strikes = [90.0, 100.0, 110.0]
+    ragged = [[0.20, 0.25], [0.18], [0.16, 0.20]]
+    with pytest.raises(ItofinError):
+        BlackVarianceSurface(REF, dates, strikes, ragged, dc)

--- a/crates/itofin-py/tests/test_black_vol_pricing.py
+++ b/crates/itofin-py/tests/test_black_vol_pricing.py
@@ -1,0 +1,73 @@
+import pytest
+
+from itofin import Settings
+from itofin.instruments import OptionType, VanillaOption
+from itofin.processes import BlackScholesProcess
+from itofin.termstructures import BlackConstantVol, BlackVarianceSurface, FlatForward
+from itofin.time import Date, DayCounter
+
+REF = Date(15, 6, 2026)
+
+
+def _surface():
+    """blackvariancesurface.rs:258-282: strikes [90,100,110] x dates
+    [ref+365, ref+730], Actual365Fixed, rows=strikes
+    [[0.20,0.25],[0.18,0.22],[0.16,0.20]]. Node vol at (strike 100, ref+365)
+    is 0.18 (blackvariancesurface.rs:305)."""
+    dc = DayCounter.actual365_fixed()
+    dates = [REF + 365, REF + 730]
+    strikes = [90.0, 100.0, 110.0]
+    matrix = [[0.20, 0.25], [0.18, 0.22], [0.16, 0.20]]
+    return BlackVarianceSurface(REF, dates, strikes, matrix, dc)
+
+
+def _gate_row_1_npv(proc):
+    s = Settings()
+    s.set_evaluation_date(REF)
+    opt = VanillaOption(OptionType.Call, 65.0, REF + 90, s)
+    opt.set_engine(proc)
+    return opt.npv()
+
+
+def test_from_curves_reproduces_scalar_gate_row_1_npv_bit_for_bit():
+    """The object ctor (two FlatForwards + BlackConstantVol) must reproduce the
+    scalar ctor's GATE row-1 process exactly (test_european_option.py:15,23),
+    pinning the dividend-before-risk-free order on the new constructor. Both are
+    priced live and compared bit-for-bit: the scalar literal 2.1333684449161985
+    is itself 1 ULP off the current build, so the scalar path is the oracle."""
+    dc = DayCounter.actual360()
+    scalar = BlackScholesProcess(60.0, 0.08, 0.0, 0.30, REF, dc)
+    obj = BlackScholesProcess.from_curves(
+        60.0,
+        FlatForward(REF, 0.08, dc),
+        FlatForward(REF, 0.0, dc),
+        BlackConstantVol(REF, 0.30, dc),
+    )
+    assert _gate_row_1_npv(obj) == _gate_row_1_npv(scalar)
+    assert _gate_row_1_npv(obj) == pytest.approx(2.1333684449161985, abs=1e-10)
+
+
+def test_european_prices_off_surface_equal_constant_vol_at_a_grid_node():
+    """A European struck/expiring exactly on the surface grid (strike 100,
+    expiry ref+365, node vol 0.18 at blackvariancesurface.rs:305) prices
+    identically to a BlackConstantVol(0.18) process sharing the same r/q/spot;
+    bilinear interpolation is exact at a node, so the NPVs coincide."""
+    s = Settings()
+    s.set_evaluation_date(REF)
+    dc = DayCounter.actual365_fixed()
+    risk_free = FlatForward(REF, 0.05, dc)
+    dividend = FlatForward(REF, 0.0, dc)
+
+    surface = _surface()
+    surface_proc = BlackScholesProcess.from_curves(100.0, risk_free, dividend, surface)
+    surface_opt = VanillaOption(OptionType.Call, 100.0, REF + 365, s)
+    surface_opt.set_engine(surface_proc)
+
+    const_vol = BlackConstantVol(REF, 0.18, dc)
+    const_proc = BlackScholesProcess.from_curves(100.0, risk_free, dividend, const_vol)
+    const_opt = VanillaOption(OptionType.Call, 100.0, REF + 365, s)
+    const_opt.set_engine(const_proc)
+
+    surface_npv = surface_opt.npv()
+    assert surface_npv > 0.0
+    assert surface_npv == pytest.approx(const_opt.npv(), abs=1e-12)


### PR DESCRIPTION
Add Python facades for the concrete Black-volatility surfaces, so
Black-Scholes pricing can be driven by real curves instead of scalars.

**New volatility facades:**
* Added `BlackConstantVol` for a flat volatility, constant in strike and time.
* Added `BlackVarianceCurve` interpolating linearly on variance with no strike dimension, retaining the concrete `Linear` handle for a future local-vol facade.
* Added `BlackVarianceSurface` for a strike/expiry surface interpolating bilinearly on variance, with a `matrix_from_rows` helper that rejects empty or ragged grids before the core dimension checks.
* Registered the three new classes in the `termstructures` module.

**Process construction from curves:**
* Added `BlackScholesProcess.from_curves`, binding a spot level plus risk-free, dividend, and Black vol handles by name to avoid the r/q ordering footgun.

**Stubs and tests:**
* Updated `processes.pyi` and `termstructures.pyi` stubs for the new classes and constructor.
* Added `test_black_vol.py` and `test_black_vol_pricing.py`.
