### PR TITLE
feat(itofin-py): add interpolated yield curve bindings

### DIFF
--- a/crates/itofin-py/python/itofin/termstructures.pyi
+++ b/crates/itofin-py/python/itofin/termstructures.pyi
@@ -36,6 +36,40 @@ class FlatForward(YieldTermStructure):
 
     def __init__(self, reference_date: Date, rate: float, day_counter: DayCounter) -> None: ...
 
+class ZeroCurve(YieldTermStructure):
+    """A yield curve interpolating continuously-compounded zero rates linearly
+    between nodes. The first date is the reference date; finite in time."""
+
+    def __init__(
+        self,
+        dates: list[Date],
+        yields: list[float],
+        day_counter: DayCounter,
+    ) -> None: ...
+
+class DiscountCurve(YieldTermStructure):
+    """A yield curve interpolating discount factors log-linearly (piecewise-constant
+    forwards). The first date is the reference date and its discount must be 1.0."""
+
+    def __init__(
+        self,
+        dates: list[Date],
+        discounts: list[float],
+        day_counter: DayCounter,
+        calendar: Calendar | None = None,
+    ) -> None: ...
+
+class ForwardCurve(YieldTermStructure):
+    """A yield curve interpolating instantaneous forward rates backward-flat.
+    The first date is the reference date; finite in time."""
+
+    def __init__(
+        self,
+        dates: list[Date],
+        forwards: list[float],
+        day_counter: DayCounter,
+    ) -> None: ...
+
 class BlackConstantVol(BlackVolTermStructure):
     """A flat Black volatility, constant in strike and time."""
 

--- a/crates/itofin-py/src/curve.rs
+++ b/crates/itofin-py/src/curve.rs
@@ -2,11 +2,13 @@
 //! base and the concrete [`PyFlatForward`] curve.
 
 use crate::PyQlError;
-use crate::time::{PyDate, PyDayCounter};
+use crate::time::{PyCalendar, PyDate, PyDayCounter};
 use libitofin::handle::Handle;
 use libitofin::interestrate::Compounding;
+use libitofin::math::interpolations::flat::BackwardFlat;
+use libitofin::math::interpolations::linear::Linear;
 use libitofin::shared::{Shared, shared};
-use libitofin::termstructures::yields::FlatForward;
+use libitofin::termstructures::yields::{DiscountCurve, FlatForward, ForwardCurve, ZeroCurve};
 use libitofin::termstructures::yieldtermstructure::YieldTermStructure;
 use libitofin::time::frequency::Frequency;
 use pyo3::prelude::*;
@@ -167,5 +169,102 @@ impl PyFlatForward {
             inner: Handle::new(curve),
         })
         .add_subclass(PyFlatForward)
+    }
+}
+
+/// Python `ZeroCurve`: a yield curve built from (date, continuously-compounded
+/// zero-rate) nodes, interpolating linearly in zero-rate space
+/// (`termstructures::yields::ZeroCurve = InterpolatedZeroCurve<Linear>`).
+///
+/// Extends [`PyYieldTermStructure`]; the first date is the reference date and
+/// the query surface is inherited. Finite in time: queries past the last node
+/// require `enable_extrapolation()` or `extrapolate=True`.
+#[pyclass(name = "ZeroCurve", extends = PyYieldTermStructure, unsendable)]
+pub struct PyZeroCurve;
+
+#[pymethods]
+impl PyZeroCurve {
+    #[new]
+    fn new(
+        dates: Vec<PyRef<PyDate>>,
+        yields: Vec<f64>,
+        day_counter: &PyDayCounter,
+    ) -> PyResult<PyClassInitializer<Self>> {
+        let dates: Vec<_> = dates.iter().map(|d| d.inner()).collect();
+        let curve = shared(
+            ZeroCurve::new(dates, yields, day_counter.inner(), Linear).map_err(PyQlError::from)?,
+        ) as Shared<dyn YieldTermStructure>;
+        Ok(PyClassInitializer::from(PyYieldTermStructure {
+            inner: Handle::new(curve),
+        })
+        .add_subclass(PyZeroCurve))
+    }
+}
+
+/// Python `DiscountCurve`: a yield curve built from (date, discount-factor)
+/// nodes, interpolating log-linearly for piecewise-constant forwards
+/// (`termstructures::yields::DiscountCurve = InterpolatedDiscountCurve<LogLinear>`).
+///
+/// Extends [`PyYieldTermStructure`]; the first date is the reference date and
+/// its discount must be 1.0. Unlike the other two curves this constructor
+/// accepts an optional calendar. Finite in time: queries past the last node
+/// require `enable_extrapolation()` or `extrapolate=True`.
+#[pyclass(name = "DiscountCurve", extends = PyYieldTermStructure, unsendable)]
+pub struct PyDiscountCurve;
+
+#[pymethods]
+impl PyDiscountCurve {
+    #[new]
+    #[pyo3(signature = (dates, discounts, day_counter, calendar = None))]
+    fn new(
+        dates: Vec<PyRef<PyDate>>,
+        discounts: Vec<f64>,
+        day_counter: &PyDayCounter,
+        calendar: Option<&PyCalendar>,
+    ) -> PyResult<PyClassInitializer<Self>> {
+        let dates: Vec<_> = dates.iter().map(|d| d.inner()).collect();
+        let curve = shared(
+            DiscountCurve::new(
+                dates,
+                discounts,
+                day_counter.inner(),
+                calendar.map(PyCalendar::inner),
+            )
+            .map_err(PyQlError::from)?,
+        ) as Shared<dyn YieldTermStructure>;
+        Ok(PyClassInitializer::from(PyYieldTermStructure {
+            inner: Handle::new(curve),
+        })
+        .add_subclass(PyDiscountCurve))
+    }
+}
+
+/// Python `ForwardCurve`: a yield curve built from (date, instantaneous
+/// forward-rate) nodes, interpolating backward-flat
+/// (`termstructures::yields::ForwardCurve = InterpolatedForwardCurve<BackwardFlat>`).
+///
+/// Extends [`PyYieldTermStructure`]; the first date is the reference date and
+/// the query surface is inherited. Finite in time: queries past the last node
+/// require `enable_extrapolation()` or `extrapolate=True`.
+#[pyclass(name = "ForwardCurve", extends = PyYieldTermStructure, unsendable)]
+pub struct PyForwardCurve;
+
+#[pymethods]
+impl PyForwardCurve {
+    #[new]
+    fn new(
+        dates: Vec<PyRef<PyDate>>,
+        forwards: Vec<f64>,
+        day_counter: &PyDayCounter,
+    ) -> PyResult<PyClassInitializer<Self>> {
+        let dates: Vec<_> = dates.iter().map(|d| d.inner()).collect();
+        let curve = shared(
+            ForwardCurve::new(dates, forwards, day_counter.inner(), BackwardFlat)
+                .map_err(PyQlError::from)?,
+        ) as Shared<dyn YieldTermStructure>;
+        Ok(PyClassInitializer::from(PyYieldTermStructure {
+            inner: Handle::new(curve),
+        })
+        .add_subclass(PyForwardCurve))
     }
 }

--- a/crates/itofin-py/src/lib.rs
+++ b/crates/itofin-py/src/lib.rs
@@ -18,7 +18,7 @@ mod time;
 mod vol;
 
 use calibration::{PyCalibrationErrorType, PyEndCriteria, PyLevenbergMarquardt};
-use curve::{PyFlatForward, PyYieldTermStructure};
+use curve::{PyDiscountCurve, PyFlatForward, PyForwardCurve, PyYieldTermStructure, PyZeroCurve};
 use heston::{PyHestonModel, PyHestonModelHelper, PyHestonProcess};
 use hullwhite::{PyEuribor, PyHullWhite, PySwaptionHelper};
 use libitofin::errors::QlError;
@@ -93,6 +93,9 @@ fn itofin(m: &Bound<'_, PyModule>) -> PyResult<()> {
     termstructures.add_class::<PyYieldTermStructure>()?;
     termstructures.add_class::<PyBlackVolTermStructure>()?;
     termstructures.add_class::<PyFlatForward>()?;
+    termstructures.add_class::<PyZeroCurve>()?;
+    termstructures.add_class::<PyDiscountCurve>()?;
+    termstructures.add_class::<PyForwardCurve>()?;
     termstructures.add_class::<PyBlackConstantVol>()?;
     termstructures.add_class::<PyBlackVarianceCurve>()?;
     termstructures.add_class::<PyBlackVarianceSurface>()?;

--- a/crates/itofin-py/tests/test_interpolated_curves.py
+++ b/crates/itofin-py/tests/test_interpolated_curves.py
@@ -1,0 +1,143 @@
+import math
+
+import pytest
+
+from itofin import ItofinError
+from itofin.termstructures import (
+    DiscountCurve,
+    ForwardCurve,
+    YieldTermStructure,
+    ZeroCurve,
+)
+from itofin.time import Date, DayCounter
+
+REF = Date(15, 6, 2026)
+
+
+def _dates():
+    """zerocurve.rs:201-208 / discountcurve.rs:189-192: ref, +180, +360, +720."""
+    return [REF, REF + 180, REF + 360, REF + 720]
+
+
+def _zero_curve():
+    """zerocurve.rs:210-216: zeros 0.02/0.03/0.04/0.045, Actual360, Linear."""
+    return ZeroCurve(_dates(), [0.02, 0.03, 0.04, 0.045], DayCounter.actual360())
+
+
+def _discount_curve():
+    """discountcurve.rs:194-200: discounts 1.0/0.97/0.94/0.88, Actual360, LogLinear."""
+    return DiscountCurve(_dates(), [1.0, 0.97, 0.94, 0.88], DayCounter.actual360())
+
+
+def _forward_curve():
+    """forwardcurve.rs:328-336: dates ref/+360/+720, forwards 0.03/0.04/0.06,
+    Actual360, BackwardFlat."""
+    return ForwardCurve([REF, REF + 360, REF + 720], [0.03, 0.04, 0.06], DayCounter.actual360())
+
+
+def test_discount_curve_extends_base_and_reproduces_nodes():
+    """discountcurve.rs:203-211: reference date is the first node, max date the
+    last, node discounts round-trip through discount_date @1e-15."""
+    curve = _discount_curve()
+    assert isinstance(curve, YieldTermStructure)
+    assert curve.reference_date() == REF
+    assert curve.max_date() == REF + 720
+    for date, discount in zip(_dates(), [1.0, 0.97, 0.94, 0.88]):
+        assert curve.discount_date(date) == pytest.approx(discount, abs=1e-15)
+
+
+def test_discount_curve_log_linear_midpoint():
+    """discountcurve.rs:217-218: log-linear interpolation is geometric,
+    discount(0.75) == sqrt(0.97 * 0.94)."""
+    curve = _discount_curve()
+    assert curve.discount(0.75) == pytest.approx(math.sqrt(0.97 * 0.94), abs=1e-15)
+
+
+def test_discount_curve_zero_rate_round_trips_the_discount():
+    """discountcurve.rs:256-258: continuously-compounded zero_rate(1.0) == -ln(0.94)."""
+    curve = _discount_curve()
+    assert curve.zero_rate(1.0) == pytest.approx(-math.log(0.94), abs=1e-14)
+
+
+def test_discount_curve_extrapolation_is_the_escape_hatch():
+    """discountcurve.rs:234-245: past the last node discount raises with the
+    default extrapolate=False; both extrapolate=True and enable_extrapolation()
+    continue the last forward flat, expected 0.88 * exp(-ln(0.94/0.88))."""
+    curve = _discount_curve()
+    expected = 0.88 * math.exp(-math.log(0.94 / 0.88))
+    with pytest.raises(ItofinError):
+        curve.discount(3.0, False)
+    assert curve.discount(3.0, True) == pytest.approx(expected, abs=1e-14)
+    curve.enable_extrapolation()
+    assert curve.discount(3.0, False) == pytest.approx(expected, abs=1e-14)
+
+
+def test_discount_curve_constructor_rejects_bad_inputs():
+    """discountcurve.rs:287-333: length mismatch, first discount != 1.0, and
+    unsorted dates each raise ItofinError instead of panicking."""
+    dc = DayCounter.actual360()
+    with pytest.raises(ItofinError):
+        DiscountCurve(_dates(), [1.0, 0.97], dc)
+    with pytest.raises(ItofinError):
+        DiscountCurve(_dates(), [0.99, 0.97, 0.94, 0.88], dc)
+    unsorted = [REF, REF + 360, REF + 180, REF + 720]
+    with pytest.raises(ItofinError):
+        DiscountCurve(unsorted, [1.0, 0.97, 0.94, 0.88], dc)
+
+
+def test_zero_curve_extends_base_and_reproduces_the_zero_rates():
+    """zerocurve.rs:218-229: zero_rate(t) reads back the node rate and
+    discount(t) == exp(-z*t); discount(0.0) is exactly 1.0."""
+    curve = _zero_curve()
+    assert isinstance(curve, YieldTermStructure)
+    for t, z in [(0.5, 0.03), (1.0, 0.04), (2.0, 0.045)]:
+        assert curve.zero_rate(t) == pytest.approx(z, abs=1e-14)
+        assert curve.discount(t) == pytest.approx(math.exp(-z * t), abs=1e-15)
+    assert curve.discount(0.0) == 1.0
+
+
+def test_zero_curve_interpolates_rates_linearly():
+    """zerocurve.rs:238-245: zero_rate(0.75) == 0.035 (midpoint of 0.03/0.04)
+    and discount(1.5) == exp(-0.0425 * 1.5)."""
+    curve = _zero_curve()
+    assert curve.zero_rate(0.75) == pytest.approx(0.035, abs=1e-14)
+    assert curve.discount(1.5) == pytest.approx(math.exp(-0.0425 * 1.5), abs=1e-15)
+
+
+def test_zero_curve_constructor_rejects_bad_inputs():
+    """zerocurve.rs:319-331: length mismatch and unsorted dates raise ItofinError."""
+    dc = DayCounter.actual360()
+    with pytest.raises(ItofinError):
+        ZeroCurve(_dates(), [0.02], dc)
+    unsorted = [REF, REF + 360, REF + 180, REF + 720]
+    with pytest.raises(ItofinError):
+        ZeroCurve(unsorted, [0.02, 0.03, 0.04, 0.045], dc)
+
+
+def test_forward_curve_extends_base_and_discounts_backward_flat():
+    """forwardcurve.rs:347-348: backward-flat forwards 0.04 on (0,1] and 0.06
+    on (1,2] integrate to discount(2.0) == exp(-0.10)."""
+    curve = _forward_curve()
+    assert isinstance(curve, YieldTermStructure)
+    assert curve.reference_date() == REF
+    assert curve.max_date() == REF + 720
+    assert curve.discount(2.0) == pytest.approx(math.exp(-0.10), abs=1e-15)
+
+
+def test_forward_curve_extrapolation_is_the_escape_hatch():
+    """forwardcurve.rs:358-360: discount past the last node raises with the
+    default extrapolate=False, then enable_extrapolation() answers it."""
+    curve = _forward_curve()
+    with pytest.raises(ItofinError):
+        curve.discount(3.0, False)
+    curve.enable_extrapolation()
+    assert curve.discount(3.0, False) > 0.0
+
+
+def test_forward_curve_constructor_rejects_bad_inputs():
+    """forwardcurve.rs:425-455: length mismatch and unsorted dates raise ItofinError."""
+    dc = DayCounter.actual360()
+    with pytest.raises(ItofinError):
+        ForwardCurve([REF, REF + 360], [0.03], dc)
+    with pytest.raises(ItofinError):
+        ForwardCurve([REF + 360, REF], [0.03, 0.04], dc)


### PR DESCRIPTION
Expose three new interpolated yield term-structure curves to Python,
extending the existing `YieldTermStructure` hierarchy.

**New curve bindings:**
* Added `ZeroCurve`, interpolating continuously-compounded zero rates
  linearly between nodes.
* Added `DiscountCurve`, interpolating discount factors log-linearly for
  piecewise-constant forwards, with an optional calendar argument.
* Added `ForwardCurve`, interpolating instantaneous forward rates
  backward-flat between nodes.

**Registration and typing:**
* Registered the new classes in the `termstructures` module and updated
  the type stubs with their constructor signatures.
* Added tests covering the interpolated curve constructors.
