### PR TITLE
refactor(termstructures): move discount conversion into bootstrap traits

### DIFF
--- a/crates/libitofin/src/termstructures/bootstraptraits.rs
+++ b/crates/libitofin/src/termstructures/bootstraptraits.rs
@@ -19,11 +19,9 @@
 //!
 //! ## Scope
 //!
-//! Only the `Discount` traits are ported (`Discount` + `LogLinear`/`Linear`
-//! interpolation is the ticket's scope). `ZeroYield`, `ForwardRate` and
-//! `SimpleZeroYield` are a documented deferral: their `guess`/`initialValue`
-//! differ (they store rates, not discount factors) and need the zero/forward
-//! curve types this layer does not build yet.
+//! The `Discount` and `ZeroYield` traits are ported. `SimpleZeroYield`
+//! (`bootstraptraits.hpp:312`) is a documented deferral: it adds a `-1/t`
+//! rate floor and exp/log transforms this port does not need yet.
 
 use crate::errors::QlResult;
 use crate::math::interpolations::{Interpolation, Interpolator};
@@ -143,6 +141,108 @@ impl BootstrapTraits for Discount {
         let d_max = interpolation.value(t_max)?;
         let inst_fwd_max = -interpolation.derivative(t_max)? / d_max;
         Ok(d_max * (-inst_fwd_max * (t - t_max)).exp())
+    }
+}
+
+/// The per-node guess the rate-storing conventions share (`ZeroYield`/
+/// `ForwardRate` `guess`, `bootstraptraits.hpp:147-163`/`:246-256`). The C++
+/// extrapolation branch reprices the partial curve's own `zeroRate`/
+/// `forwardRate`; the Rust trait only receives the node slices, so this returns
+/// the last solved node instead. That is benign by construction: the guess only
+/// seeds a bracketed solver whose converged root is independent of it, and the
+/// caller already clamps the guess into `[min, max]`
+/// (`iterativebootstrap.rs:182-186`).
+fn rate_guess(i: Size, data: &[Real], valid_data: bool) -> Real {
+    if valid_data {
+        return data[i];
+    }
+    if i == 1 {
+        return AVG_RATE;
+    }
+    data[i - 1]
+}
+
+/// The lower bracket the rate-storing conventions share (`minValueAfter`,
+/// `:167-179`/`:266-278`): half a positive minimum, double a negative one, or
+/// an unconstrained `-maxRate` on a fresh curve.
+fn rate_min_value_after(data: &[Real], valid_data: bool) -> Real {
+    if valid_data {
+        let r = data.iter().copied().fold(Real::INFINITY, Real::min);
+        return if r < 0.0 { r * 2.0 } else { r / 2.0 };
+    }
+    -MAX_RATE
+}
+
+/// The upper bracket the rate-storing conventions share (`maxValueAfter`,
+/// `:180-193`/`:279-292`): double a positive maximum, half a negative one, or
+/// an unconstrained `+maxRate` on a fresh curve.
+fn rate_max_value_after(data: &[Real], valid_data: bool) -> Real {
+    if valid_data {
+        let r = data.iter().copied().fold(Real::NEG_INFINITY, Real::max);
+        return if r < 0.0 { r / 2.0 } else { r * 2.0 };
+    }
+    MAX_RATE
+}
+
+/// The solved-value write the rate-storing conventions share (`updateGuess`,
+/// `:207-214`/`:306-313`): node `i` takes the rate, and the reference node
+/// mirrors the first pillar so the `(0, t1)` segment is not left at
+/// `initial_value`.
+fn rate_update_guess(data: &mut [Real], value: Real, i: Size) {
+    data[i] = value;
+    if i == 1 {
+        data[0] = value;
+    }
+}
+
+/// Zero-yield bootstrap traits (`struct ZeroYield`, `bootstraptraits.hpp:127`).
+/// The curve nodes are continuously compounded zero rates; the reference node
+/// starts at the average rate and the bracket keeps each rate within
+/// `[-maxRate, maxRate]` on a fresh pass.
+pub struct ZeroYield;
+
+impl BootstrapTraits for ZeroYield {
+    fn initial_value() -> Real {
+        AVG_RATE
+    }
+
+    fn guess(i: Size, _times: &[Time], data: &[Real], valid_data: bool) -> Real {
+        rate_guess(i, data, valid_data)
+    }
+
+    fn min_value_after(_i: Size, _times: &[Time], data: &[Real], valid_data: bool) -> Real {
+        rate_min_value_after(data, valid_data)
+    }
+
+    fn max_value_after(_i: Size, _times: &[Time], data: &[Real], valid_data: bool) -> Real {
+        rate_max_value_after(data, valid_data)
+    }
+
+    fn update_guess(data: &mut [Real], value: Real, i: Size) {
+        rate_update_guess(data, value, i);
+    }
+
+    fn max_iterations() -> Size {
+        100
+    }
+
+    /// The node is a zero rate `z(t)`, so the discount factor is `exp(-z*t)`.
+    /// In range the rate is the interpolated value; past the last solved node
+    /// the last instantaneous forward continues flat, mirroring
+    /// `InterpolatedZeroCurve::zeroYieldImpl` (`zerocurve.rs:164-182`).
+    fn discount_from_nodes<I: Interpolation>(
+        interpolation: &I,
+        t: Time,
+    ) -> QlResult<DiscountFactor> {
+        let t_max = interpolation.x_max();
+        let z = if t <= t_max {
+            interpolation.value(t)?
+        } else {
+            let z_max = interpolation.value(t_max)?;
+            let inst_fwd_max = z_max + t_max * interpolation.derivative(t_max)?;
+            (z_max * t_max + inst_fwd_max * (t - t_max)) / t
+        };
+        Ok((-z * t).exp())
     }
 }
 

--- a/crates/libitofin/src/termstructures/bootstraptraits.rs
+++ b/crates/libitofin/src/termstructures/bootstraptraits.rs
@@ -19,9 +19,9 @@
 //!
 //! ## Scope
 //!
-//! The `Discount` and `ZeroYield` traits are ported. `SimpleZeroYield`
-//! (`bootstraptraits.hpp:312`) is a documented deferral: it adds a `-1/t`
-//! rate floor and exp/log transforms this port does not need yet.
+//! The `Discount`, `ZeroYield` and `ForwardRate` traits are ported.
+//! `SimpleZeroYield` (`bootstraptraits.hpp:312`) is a documented deferral: it
+//! adds a `-1/t` rate floor and exp/log transforms this port does not need yet.
 
 use crate::errors::QlResult;
 use crate::math::interpolations::{Interpolation, Interpolator};
@@ -243,6 +243,60 @@ impl BootstrapTraits for ZeroYield {
             (z_max * t_max + inst_fwd_max * (t - t_max)) / t
         };
         Ok((-z * t).exp())
+    }
+}
+
+/// Forward-rate bootstrap traits (`struct ForwardRate`,
+/// `bootstraptraits.hpp:220`). The curve nodes are instantaneous forward rates;
+/// the guess, bracket and update are identical to [`ZeroYield`] (both store
+/// rates), and only the node-to-discount conversion differs - it integrates the
+/// forward instead of scaling a zero rate.
+pub struct ForwardRate;
+
+impl BootstrapTraits for ForwardRate {
+    fn initial_value() -> Real {
+        AVG_RATE
+    }
+
+    fn guess(i: Size, _times: &[Time], data: &[Real], valid_data: bool) -> Real {
+        rate_guess(i, data, valid_data)
+    }
+
+    fn min_value_after(_i: Size, _times: &[Time], data: &[Real], valid_data: bool) -> Real {
+        rate_min_value_after(data, valid_data)
+    }
+
+    fn max_value_after(_i: Size, _times: &[Time], data: &[Real], valid_data: bool) -> Real {
+        rate_max_value_after(data, valid_data)
+    }
+
+    fn update_guess(data: &mut [Real], value: Real, i: Size) {
+        rate_update_guess(data, value, i);
+    }
+
+    fn max_iterations() -> Size {
+        100
+    }
+
+    /// The node is an instantaneous forward `f(t)`, so the discount factor is
+    /// `exp(-int_0^t f)`. The interpolation's antiderivative gives the integral
+    /// in range; past the last solved node the forward continues flat, mirroring
+    /// `InterpolatedForwardCurve::zeroYieldImpl` (`forwardcurve.rs:169-183`).
+    /// At `t = 0` the antiderivative is zero, so the factor is 1 with no special
+    /// case. `LogLinear` has no closed-form primitive and errors here, which is
+    /// why `ForwardRate` is only wired with `Linear`/`BackwardFlat`.
+    fn discount_from_nodes<I: Interpolation>(
+        interpolation: &I,
+        t: Time,
+    ) -> QlResult<DiscountFactor> {
+        let t_max = interpolation.x_max();
+        let integral = if t <= t_max {
+            interpolation.primitive(t)?
+        } else {
+            let last_forward = interpolation.value(t_max)?;
+            interpolation.primitive(t_max)? + last_forward * (t - t_max)
+        };
+        Ok((-integral).exp())
     }
 }
 

--- a/crates/libitofin/src/termstructures/bootstraptraits.rs
+++ b/crates/libitofin/src/termstructures/bootstraptraits.rs
@@ -306,12 +306,13 @@ impl BootstrapTraits for ForwardRate {
 ///
 /// This is the curve-side half of the mutation decision. The bootstrap holds
 /// it through a `RefCell` on the curve and drives it a node at a time; the
-/// curve's `discount` reads it back. During a bootstrap the interpolation only
-/// spans the solved prefix `[0, upto]`, so [`discount`](Self::discount)
-/// extrapolates past the last solved node with a flat instantaneous forward,
-/// exactly as `InterpolatedDiscountCurve::discountImpl` does past its last
-/// node - which is also why a helper for pillar `i` (whose latest relevant
-/// date is at most `times[i]`) only ever reads in-range values.
+/// curve's discount lookup reads it back through
+/// [`interpolation`](Self::interpolation), handing that to the convention's
+/// [`discount_from_nodes`](BootstrapTraits::discount_from_nodes). During a
+/// bootstrap the interpolation only spans the solved prefix `[0, upto]`, so
+/// that conversion extrapolates past the last solved node with a flat
+/// instantaneous forward - which is also why a helper for pillar `i` (whose
+/// latest relevant date is at most `times[i]`) only ever reads in-range values.
 pub struct CurveData<I: Interpolator> {
     dates: Vec<Date>,
     times: Vec<Time>,

--- a/crates/libitofin/src/termstructures/bootstraptraits.rs
+++ b/crates/libitofin/src/termstructures/bootstraptraits.rs
@@ -63,6 +63,24 @@ pub trait BootstrapTraits {
 
     /// The convergence-loop iteration cap (`Traits::maxIterations`).
     fn max_iterations() -> Size;
+
+    /// Converts an interpolated node at time `t` into a discount factor,
+    /// applying this convention's node meaning (a discount factor for
+    /// `Discount`, `exp(-z*t)` for a zero rate, `exp(-primitive)` for an
+    /// instantaneous forward). This is the seam that lets one `CurveData`
+    /// holder serve every convention: the holder stays convention-agnostic and
+    /// the traits interpret its nodes.
+    ///
+    /// Everything a conversion needs - the last solved node time, its value,
+    /// the derivative and the antiderivative - is carried by the
+    /// [`Interpolation`] the bootstrap rebuilt over the solved prefix
+    /// `[0, upto]`, so `interpolation.x_max()` is that last node's time and
+    /// `value(x_max)` its value; past it every convention extends the last
+    /// instantaneous forward flat.
+    fn discount_from_nodes<I: Interpolation>(
+        interpolation: &I,
+        t: Time,
+    ) -> QlResult<DiscountFactor>;
 }
 
 /// Discount-factor bootstrap traits (`struct Discount`,
@@ -108,6 +126,23 @@ impl BootstrapTraits for Discount {
 
     fn max_iterations() -> Size {
         100
+    }
+
+    /// The nodes are already discount factors, so the value is the discount
+    /// factor directly (in range), and past the last solved node the last
+    /// instantaneous forward continues flat (the port of
+    /// `InterpolatedDiscountCurve::discountImpl`).
+    fn discount_from_nodes<I: Interpolation>(
+        interpolation: &I,
+        t: Time,
+    ) -> QlResult<DiscountFactor> {
+        let t_max = interpolation.x_max();
+        if t <= t_max {
+            return interpolation.value(t);
+        }
+        let d_max = interpolation.value(t_max)?;
+        let inst_fwd_max = -interpolation.derivative(t_max)? / d_max;
+        Ok(d_max * (-inst_fwd_max * (t - t_max)).exp())
     }
 }
 
@@ -231,20 +266,15 @@ impl<I: Interpolator> CurveData<I> {
         Ok(())
     }
 
-    /// The discount factor at time `t`, reading the interpolation and, past its
-    /// last node, extending the last instantaneous forward flat (the port of
-    /// `InterpolatedDiscountCurve::discountImpl`).
-    pub fn discount(&self, t: Time) -> QlResult<DiscountFactor> {
-        let Some(interpolation) = self.interpolation.as_ref() else {
-            fail!("curve not bootstrapped: no interpolation available");
-        };
-        let t_max = interpolation.x_max();
-        if t <= t_max {
-            return interpolation.value(t);
+    /// The interpolation rebuilt over the solved prefix, for a trait's
+    /// [`discount_from_nodes`](BootstrapTraits::discount_from_nodes) to read the
+    /// node value, derivative or antiderivative at a time. Errors before the
+    /// bootstrap has laid one down.
+    pub fn interpolation(&self) -> QlResult<&I::Output> {
+        match self.interpolation.as_ref() {
+            Some(interpolation) => Ok(interpolation),
+            None => fail!("curve not bootstrapped: no interpolation available"),
         }
-        let d_max = interpolation.value(t_max)?;
-        let inst_fwd_max = -interpolation.derivative(t_max)? / d_max;
-        Ok(d_max * (-inst_fwd_max * (t - t_max)).exp())
     }
 
     /// Asserts the holder has been bootstrapped, for inspectors that must not
@@ -331,19 +361,19 @@ mod tests {
         cd.rebuild(&LogLinear, 2).unwrap();
 
         // in range: geometric interpolation of log-linear discounts
-        let mid = cd.discount(1.5).unwrap();
+        let mid = Discount::discount_from_nodes(cd.interpolation().unwrap(), 1.5).unwrap();
         assert!((mid - (0.95_f64 * 0.88).sqrt()).abs() < 1e-12);
 
         // past the last node: flat instantaneous forward continues
         let last_forward = (0.95_f64 / 0.88).ln();
-        let beyond = cd.discount(3.0).unwrap();
+        let beyond = Discount::discount_from_nodes(cd.interpolation().unwrap(), 3.0).unwrap();
         assert!((beyond - 0.88 * (-last_forward * 1.0).exp()).abs() < 1e-12);
     }
 
     #[test]
-    fn curve_data_discount_before_bootstrap_is_an_error() {
+    fn curve_data_interpolation_before_bootstrap_is_an_error() {
         let cd = CurveData::<LogLinear>::new();
-        assert!(cd.discount(1.0).is_err());
+        assert!(cd.interpolation().is_err());
         assert!(cd.require_initialized().is_err());
     }
 }

--- a/crates/libitofin/src/termstructures/iterativebootstrap.rs
+++ b/crates/libitofin/src/termstructures/iterativebootstrap.rs
@@ -7,9 +7,9 @@
 //!
 //! ## What is ported, and what is provably dead for this path
 //!
-//! The ticket's scope is `Discount` traits with `LogLinear`/`Linear`
-//! interpolation, both of which are *local* interpolators (their value at a
-//! point depends only on the bracketing nodes). Several branches of the C++
+//! The wired conventions (`Discount`, `ZeroYield`, `ForwardRate`) all run on
+//! *local* interpolators - `LogLinear`, `Linear`, `BackwardFlat` - whose value
+//! at a point depends only on the bracketing nodes. Several branches of the C++
 //! algorithm exist only for *global* interpolators (splines) and are dead here:
 //!
 //! - **The outer convergence loop** (`iterativebootstrap.hpp:363-387`). It

--- a/crates/libitofin/src/termstructures/iterativebootstrap.rs
+++ b/crates/libitofin/src/termstructures/iterativebootstrap.rs
@@ -321,7 +321,8 @@ mod tests {
 
     impl YieldTermStructure for StubCurve {
         fn discount_impl(&self, t: Time) -> QlResult<DiscountFactor> {
-            self.data.borrow().discount(t)
+            let data = self.data.borrow();
+            Discount::discount_from_nodes(data.interpolation()?, t)
         }
     }
 

--- a/crates/libitofin/src/termstructures/yields/piecewiseyieldcurve.rs
+++ b/crates/libitofin/src/termstructures/yields/piecewiseyieldcurve.rs
@@ -276,12 +276,13 @@ mod tests {
     use crate::indexes::iborindex::IborIndex;
     use crate::indexes::index::Index;
     use crate::instruments::MakeVanillaSwap;
+    use crate::math::interpolations::flat::BackwardFlat;
     use crate::math::interpolations::linear::Linear;
     use crate::math::interpolations::loglinear::LogLinear;
     use crate::quotes::{Quote, SimpleQuote};
     use crate::settings::Settings;
     use crate::shared::shared;
-    use crate::termstructures::bootstraptraits::{Discount, ZeroYield};
+    use crate::termstructures::bootstraptraits::{Discount, ForwardRate, ZeroYield};
     use crate::termstructures::yields::{DepositRateHelper, SwapRateHelper};
     use crate::time::businessdayconvention::BusinessDayConvention;
     use crate::time::calendars::target::Target;
@@ -475,6 +476,34 @@ mod tests {
         assert_eq!(
             data[0], data[1],
             "the reference zero rate must mirror the first solved pillar"
+        );
+    }
+
+    /// `testLinearForwardConsistency` -> `<ForwardRate, Linear>`
+    /// (`piecewiseyieldcurve.cpp:728,735`). The BMA half (`:736`) is skipped.
+    /// The node `[0]` assertion has the same rationale as
+    /// [`linear_zero_consistency`]: `ForwardRate::update_guess` mirrors the
+    /// first solved forward into the reference node and no repriced instrument
+    /// covers `(0, t1)` to catch a missing mirror.
+    #[test]
+    fn linear_forward_consistency() {
+        let curve = check_curve_consistency::<ForwardRate, Linear>();
+        let data = curve.data().unwrap();
+        assert_eq!(
+            data[0], data[1],
+            "the reference forward must mirror the first solved pillar"
+        );
+    }
+
+    /// `testFlatForwardConsistency` -> `<ForwardRate, BackwardFlat>`
+    /// (`piecewiseyieldcurve.cpp:747,754`). The BMA half (`:755`) is skipped.
+    #[test]
+    fn flat_forward_consistency() {
+        let curve = check_curve_consistency::<ForwardRate, BackwardFlat>();
+        let data = curve.data().unwrap();
+        assert_eq!(
+            data[0], data[1],
+            "the reference forward must mirror the first solved pillar"
         );
     }
 

--- a/crates/libitofin/src/termstructures/yields/piecewiseyieldcurve.rs
+++ b/crates/libitofin/src/termstructures/yields/piecewiseyieldcurve.rs
@@ -216,7 +216,8 @@ impl<T: BootstrapTraits + 'static, I: Interpolator + 'static> YieldTermStructure
     }
 
     fn discount_impl(&self, t: Time) -> QlResult<DiscountFactor> {
-        self.data.borrow().discount(t)
+        let data = self.data.borrow();
+        T::discount_from_nodes(data.interpolation()?, t)
     }
 }
 

--- a/crates/libitofin/src/termstructures/yields/piecewiseyieldcurve.rs
+++ b/crates/libitofin/src/termstructures/yields/piecewiseyieldcurve.rs
@@ -25,9 +25,10 @@
 //!
 //! ## Scope and deferrals
 //!
-//! - Generic over the interpolator; the traits are a type parameter. This
-//!   ticket ports `Discount` with `LogLinear`/`Linear`; `ZeroYield`/`ForwardRate`
-//!   and the spline interpolators are deferred with their traits.
+//! - Generic over the interpolator; the traits are a type parameter. The
+//!   `Discount` (`LogLinear`/`Linear`) and `ZeroYield` (`Linear`) conventions
+//!   are wired; the spline interpolators are deferred (they need the global
+//!   convergence loop, unported).
 //! - `MultiCurveBootstrapProvider` (`ql/termstructures/multicurve.hpp:36`), a
 //!   marker base used only for a `dynamic_pointer_cast`, is dropped.
 //! - Jump quotes (`jumps`/`jumpDates`) are not ported, following the
@@ -280,7 +281,7 @@ mod tests {
     use crate::quotes::{Quote, SimpleQuote};
     use crate::settings::Settings;
     use crate::shared::shared;
-    use crate::termstructures::bootstraptraits::Discount;
+    use crate::termstructures::bootstraptraits::{Discount, ZeroYield};
     use crate::termstructures::yields::{DepositRateHelper, SwapRateHelper};
     use crate::time::businessdayconvention::BusinessDayConvention;
     use crate::time::calendars::target::Target;
@@ -381,11 +382,17 @@ mod tests {
         shared(Euribor::six_months(handle, settings))
     }
 
-    /// The port of `testCurveConsistency<Discount, I, IterativeBootstrap>`,
-    /// deposits + swaps only.
-    fn check_curve_consistency<I: Interpolator + Default + 'static>() {
+    /// The port of `testCurveConsistency<Traits, I, IterativeBootstrap>`,
+    /// deposits + swaps only. Generic over the traits so the same round-trip
+    /// checks the `Discount`, `ZeroYield` and `ForwardRate` conventions; the
+    /// bootstrapped curve is returned so a convention that stores rates can
+    /// additionally assert on its solved nodes.
+    fn check_curve_consistency<
+        T: BootstrapTraits + 'static,
+        I: Interpolator + Default + 'static,
+    >() -> Shared<PiecewiseYieldCurve<T, I>> {
         let vars = common_vars();
-        let curve = PiecewiseYieldCurve::<Discount, I>::new(
+        let curve = PiecewiseYieldCurve::<T, I>::new(
             vars.settlement,
             vars.instruments.clone(),
             Actual360::new(),
@@ -433,6 +440,8 @@ mod tests {
                 "{n} {units:?} swap: estimated {estimated} vs expected {expected}"
             );
         }
+
+        curve
     }
 
     /// `testLogLinearDiscountConsistency` -> `<Discount, LogLinear>`
@@ -440,14 +449,33 @@ mod tests {
     /// (`:684`) needs `BMASwapRateHelper` (#343) and is skipped.
     #[test]
     fn log_linear_discount_consistency() {
-        check_curve_consistency::<LogLinear>();
+        check_curve_consistency::<Discount, LogLinear>();
     }
 
     /// `testLinearDiscountConsistency` -> `<Discount, Linear>`
     /// (`piecewiseyieldcurve.cpp:687,694`). The BMA half (`:695`) is skipped.
     #[test]
     fn linear_discount_consistency() {
-        check_curve_consistency::<Linear>();
+        check_curve_consistency::<Discount, Linear>();
+    }
+
+    /// `testLinearZeroConsistency` -> `<ZeroYield, Linear>`
+    /// (`piecewiseyieldcurve.cpp:698,705`). The BMA half (`:706`) is skipped.
+    ///
+    /// The consistency round-trip only prices instruments at exact solved
+    /// nodes, so it cannot see the reference node: `ZeroYield::update_guess`
+    /// mirrors the first solved rate into node `[0]` (the C++ `i==1 -> data[0]`
+    /// write), and no repriced instrument covers the `(0, t1)` segment where
+    /// that node shapes the curve. Assert it directly, or a missing mirror would
+    /// leave node `[0]` at `initial_value` and still pass green.
+    #[test]
+    fn linear_zero_consistency() {
+        let curve = check_curve_consistency::<ZeroYield, Linear>();
+        let data = curve.data().unwrap();
+        assert_eq!(
+            data[0], data[1],
+            "the reference zero rate must mirror the first solved pillar"
+        );
     }
 
     /// Laziness: constructing the curve runs no bootstrap; the first discount


### PR DESCRIPTION
- **refactor(termstructures): move discount conversion into bootstrap traits**
- **feat(termstructures): port ZeroYield bootstrap traits**
- **feat(termstructures): port ForwardRate bootstrap trait**
- **docs(termstructures): update bootstrap docs for wired conventions**

close #540