### PR TITLE
ci(release): disable success and failure comments on github

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -64,7 +64,9 @@
     [
       "@semantic-release/github",
       {
-        "githubUrl": "https://api.github.com"
+        "failComment": false,
+        "githubUrl": "https://api.github.com",
+        "successComment": false
       }
     ]
   ],


### PR DESCRIPTION
Configure semantic-release to suppress automated success and failure
comments on GitHub issues and pull requests.
