### PR TITLE
revert(git): disable success and failure comments on github

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -64,9 +64,7 @@
     [
       "@semantic-release/github",
       {
-        "failComment": false,
-        "githubUrl": "https://api.github.com",
-        "successComment": false
+        "githubUrl": "https://api.github.com"
       }
     ]
   ],


### PR DESCRIPTION
This reverts commit https://github.com/benbenbang/libitofin/commit/1b727a323ef3f9297ff369bf1f997b069595389c.