### PR TITLE
feat(finitedifferences): add boundary and step condition scaffolding

### DIFF
--- a/crates/libitofin/src/methods/finitedifferences/boundarycondition.rs
+++ b/crates/libitofin/src/methods/finitedifferences/boundarycondition.rs
@@ -1,0 +1,62 @@
+//! Boundary conditions for finite-difference operators.
+//!
+//! Port of `ql/methods/finitedifferences/boundarycondition.hpp:35`.
+//!
+//! The header's `NeumannBC` (`:71`) and `DirichletBC` (`:90`) are not ported:
+//! both are `BoundaryCondition<TridiagonalOperator>` classes of the old FD
+//! framework and carry an upstream `[[deprecated]]` marker as of QuantLib
+//! 1.42. They are dropped, not deferred - the FDM path uses the
+//! `BoundaryCondition<FdmLinearOp>` family instead.
+
+use crate::math::array::Array;
+use crate::methods::finitedifferences::operators::FdmLinearOp;
+use crate::types::Time;
+
+/// The grid edge a boundary condition acts on (`boundarycondition.hpp:41`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BoundarySide {
+    /// No side selected.
+    None,
+    /// The upper end of the direction.
+    Upper,
+    /// The lower end of the direction.
+    Lower,
+}
+
+/// A condition the grid values and the operator must satisfy at a boundary.
+///
+/// C++ templates this on the operator (`boundarycondition.hpp:34`). Of its two
+/// instantiations only `BoundaryCondition<FdmLinearOp>` is live - it is what
+/// `OperatorTraits<FdmLinearOp>::bc_set` (`operatortraits.hpp:38`) and every
+/// `Fdm*Boundary` use - while `BoundaryCondition<TridiagonalOperator>` belongs
+/// to the deprecated pair above. The Rust trait therefore fixes the operator to
+/// [`FdmLinearOp`] and takes no type parameter, which also keeps it usable as
+/// `dyn BoundaryCondition` in [`FdmBoundaryConditionSet`].
+///
+/// [`FdmBoundaryConditionSet`]: crate::methods::finitedifferences::utilities::FdmBoundaryConditionSet
+///
+/// C++ declares `setTime` non-const (`:62`); the Rust method takes `&self`
+/// because the set holds each condition as a [`Shared`], which yields no
+/// `&mut`. Time-dependent conditions keep their state behind interior
+/// mutability, as [`FdmInnerValueCalculator`] already does for its cache.
+///
+/// [`Shared`]: crate::shared::Shared
+/// [`FdmInnerValueCalculator`]: crate::methods::finitedifferences::utilities::FdmInnerValueCalculator
+pub trait BoundaryCondition {
+    /// Modifies the operator `op` before it is applied, so that the result of
+    /// applying it satisfies the condition.
+    fn apply_before_applying(&self, op: &mut dyn FdmLinearOp);
+
+    /// Modifies the grid values `a` so that they satisfy the condition.
+    fn apply_after_applying(&self, a: &mut Array);
+
+    /// Modifies the operator `op` and the right-hand side `rhs` before the
+    /// linear system is solved, so that its solution satisfies the condition.
+    fn apply_before_solving(&self, op: &mut dyn FdmLinearOp, rhs: &mut Array);
+
+    /// Modifies the solution `a` so that it satisfies the condition.
+    fn apply_after_solving(&self, a: &mut Array);
+
+    /// Sets the current time for time-dependent conditions.
+    fn set_time(&self, t: Time);
+}

--- a/crates/libitofin/src/methods/finitedifferences/mod.rs
+++ b/crates/libitofin/src/methods/finitedifferences/mod.rs
@@ -2,9 +2,16 @@
 //!
 //! Port of `ql/methods/finitedifferences/`. The operator layer lands first,
 //! then the meshers that give its index space a geometry, then the utilities
-//! that compute over a finished grid; the schemes and solvers stack on all
-//! three in later tickets.
+//! that compute over a finished grid, then the conditions a step must respect;
+//! the schemes and solvers stack on all of them in later tickets.
+
+mod boundarycondition;
+mod stepcondition;
 
 pub mod meshers;
 pub mod operators;
+pub mod schemes;
 pub mod utilities;
+
+pub use boundarycondition::{BoundaryCondition, BoundarySide};
+pub use stepcondition::{NullCondition, StepCondition};

--- a/crates/libitofin/src/methods/finitedifferences/schemes/boundaryconditionschemehelper.rs
+++ b/crates/libitofin/src/methods/finitedifferences/schemes/boundaryconditionschemehelper.rs
@@ -1,0 +1,249 @@
+//! Fans a step's boundary-condition calls over the whole set.
+//!
+//! Port of `ql/methods/finitedifferences/schemes/boundaryconditionschemehelper.hpp:32`.
+
+use crate::math::array::Array;
+use crate::methods::finitedifferences::operators::FdmLinearOp;
+use crate::methods::finitedifferences::utilities::FdmBoundaryConditionSet;
+use crate::types::Time;
+
+/// The boundary conditions of a scheme, applied as one.
+///
+/// Every method forwards to each condition in the set, in order, and is a
+/// no-op on an empty set - the European path. C++ holds the helper by value as
+/// a `const` member of each scheme (`expliciteulerscheme.hpp:57`), so all
+/// methods take `&self`.
+pub struct BoundaryConditionSchemeHelper {
+    bc_set: FdmBoundaryConditionSet,
+}
+
+impl BoundaryConditionSchemeHelper {
+    /// Builds the helper over `bc_set`.
+    pub fn new(bc_set: FdmBoundaryConditionSet) -> Self {
+        Self { bc_set }
+    }
+
+    /// Applies each condition to `op` before the operator is applied.
+    pub fn apply_before_applying(&self, op: &mut dyn FdmLinearOp) {
+        for bc in &self.bc_set {
+            bc.apply_before_applying(op);
+        }
+    }
+
+    /// Applies each condition to `op` and `a` before the system is solved.
+    pub fn apply_before_solving(&self, op: &mut dyn FdmLinearOp, a: &mut Array) {
+        for bc in &self.bc_set {
+            bc.apply_before_solving(op, a);
+        }
+    }
+
+    /// Applies each condition to `a` after the operator has been applied.
+    pub fn apply_after_applying(&self, a: &mut Array) {
+        for bc in &self.bc_set {
+            bc.apply_after_applying(a);
+        }
+    }
+
+    /// Applies each condition to `a` after the system has been solved.
+    pub fn apply_after_solving(&self, a: &mut Array) {
+        for bc in &self.bc_set {
+            bc.apply_after_solving(a);
+        }
+    }
+
+    /// Sets the current time on each condition.
+    pub fn set_time(&self, t: Time) {
+        for bc in &self.bc_set {
+            bc.set_time(t);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::cell::RefCell;
+
+    use crate::methods::finitedifferences::BoundaryCondition;
+    use crate::shared::{Shared, SharedMut, shared, shared_mut};
+    use crate::types::Real;
+
+    struct ScaleOp {
+        factor: Real,
+    }
+
+    impl FdmLinearOp for ScaleOp {
+        fn apply(&self, r: &Array) -> Array {
+            r.iter().map(|x| x * self.factor).collect()
+        }
+    }
+
+    struct Recorder {
+        id: Real,
+        log: Shared<RefCell<Vec<String>>>,
+    }
+
+    impl Recorder {
+        fn record(&self, call: &str) {
+            self.log.borrow_mut().push(format!("{call}:{}", self.id));
+        }
+
+        fn record_op(&self, call: &str, op: &dyn FdmLinearOp) {
+            let probe = op.apply(&Array::from([1.0]))[0];
+            self.log
+                .borrow_mut()
+                .push(format!("{call}:{}:{probe}", self.id));
+        }
+    }
+
+    impl BoundaryCondition for Recorder {
+        fn apply_before_applying(&self, op: &mut dyn FdmLinearOp) {
+            self.record_op("before_applying", op);
+        }
+
+        fn apply_after_applying(&self, a: &mut Array) {
+            self.record("after_applying");
+            a[0] = a[0] * 10.0 + self.id;
+        }
+
+        fn apply_before_solving(&self, op: &mut dyn FdmLinearOp, rhs: &mut Array) {
+            self.record_op("before_solving", op);
+            rhs[0] = rhs[0] * 10.0 + self.id;
+        }
+
+        fn apply_after_solving(&self, a: &mut Array) {
+            self.record("after_solving");
+            a[0] = a[0] * 10.0 + self.id;
+        }
+
+        fn set_time(&self, t: Time) {
+            self.log
+                .borrow_mut()
+                .push(format!("set_time:{}:{t}", self.id));
+        }
+    }
+
+    struct Silent;
+
+    impl BoundaryCondition for Silent {
+        fn apply_before_applying(&self, _op: &mut dyn FdmLinearOp) {}
+        fn apply_after_applying(&self, _a: &mut Array) {}
+        fn apply_before_solving(&self, _op: &mut dyn FdmLinearOp, _rhs: &mut Array) {}
+        fn apply_after_solving(&self, _a: &mut Array) {}
+        fn set_time(&self, _t: Time) {}
+    }
+
+    fn recorders(log: &Shared<RefCell<Vec<String>>>) -> BoundaryConditionSchemeHelper {
+        BoundaryConditionSchemeHelper::new(vec![
+            shared(Recorder {
+                id: 1.0,
+                log: Shared::clone(log),
+            }),
+            shared(Recorder {
+                id: 2.0,
+                log: Shared::clone(log),
+            }),
+        ])
+    }
+
+    #[test]
+    fn every_method_is_a_no_op_on_an_empty_set() {
+        let helper = BoundaryConditionSchemeHelper::new(Vec::new());
+        let mut op = ScaleOp { factor: 3.0 };
+        let mut values = Array::from([1.5, -2.0, 4.0]);
+        let before = values.clone();
+
+        helper.set_time(0.5);
+        helper.apply_before_applying(&mut op);
+        helper.apply_after_applying(&mut values);
+        helper.apply_before_solving(&mut op, &mut values);
+        helper.apply_after_solving(&mut values);
+
+        assert_eq!(values, before);
+        assert_eq!(op.factor, 3.0);
+    }
+
+    #[test]
+    fn operator_calls_reach_every_condition_in_order() {
+        let log = shared(RefCell::new(Vec::new()));
+        let helper = recorders(&log);
+        let mut op = ScaleOp { factor: 7.0 };
+        let mut values = Array::from([0.0]);
+
+        helper.apply_before_applying(&mut op);
+        helper.apply_before_solving(&mut op, &mut values);
+
+        assert_eq!(
+            *log.borrow(),
+            vec![
+                "before_applying:1:7".to_string(),
+                "before_applying:2:7".to_string(),
+                "before_solving:1:7".to_string(),
+                "before_solving:2:7".to_string(),
+            ]
+        );
+        assert_eq!(values[0], 12.0);
+    }
+
+    #[test]
+    fn array_calls_compose_over_the_set_in_order() {
+        let log = shared(RefCell::new(Vec::new()));
+        let helper = recorders(&log);
+        let mut applied = Array::from([0.0]);
+        let mut solved = Array::from([0.0]);
+
+        helper.apply_after_applying(&mut applied);
+        helper.apply_after_solving(&mut solved);
+        helper.set_time(0.25);
+
+        assert_eq!(applied[0], 12.0);
+        assert_eq!(solved[0], 12.0);
+        assert_eq!(
+            *log.borrow(),
+            vec![
+                "after_applying:1".to_string(),
+                "after_applying:2".to_string(),
+                "after_solving:1".to_string(),
+                "after_solving:2".to_string(),
+                "set_time:1:0.25".to_string(),
+                "set_time:2:0.25".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn the_set_holds_distinct_condition_types() {
+        let log = shared(RefCell::new(Vec::new()));
+        let helper = BoundaryConditionSchemeHelper::new(vec![
+            shared(Recorder {
+                id: 1.0,
+                log: Shared::clone(&log),
+            }),
+            shared(Silent),
+        ]);
+        let mut values = Array::from([0.0]);
+
+        helper.apply_after_applying(&mut values);
+
+        assert_eq!(*log.borrow(), vec!["after_applying:1".to_string()]);
+        assert_eq!(values[0], 1.0);
+    }
+
+    #[test]
+    fn a_shared_operator_reaches_the_conditions() {
+        let log = shared(RefCell::new(Vec::new()));
+        let helper = recorders(&log);
+        let op: SharedMut<ScaleOp> = shared_mut(ScaleOp { factor: 5.0 });
+
+        helper.apply_before_applying(&mut *op.borrow_mut());
+
+        assert_eq!(
+            *log.borrow(),
+            vec![
+                "before_applying:1:5".to_string(),
+                "before_applying:2:5".to_string(),
+            ]
+        );
+    }
+}

--- a/crates/libitofin/src/methods/finitedifferences/schemes/mod.rs
+++ b/crates/libitofin/src/methods/finitedifferences/schemes/mod.rs
@@ -1,0 +1,9 @@
+//! Time-stepping schemes for the finite-difference solver.
+//!
+//! Port of `ql/methods/finitedifferences/schemes/`. The boundary-condition
+//! helper the schemes all hold lands first; the schemes themselves follow in
+//! the next batch.
+
+mod boundaryconditionschemehelper;
+
+pub use boundaryconditionschemehelper::BoundaryConditionSchemeHelper;

--- a/crates/libitofin/src/methods/finitedifferences/stepcondition.rs
+++ b/crates/libitofin/src/methods/finitedifferences/stepcondition.rs
@@ -1,0 +1,41 @@
+//! Conditions applied to the grid values at every time step.
+//!
+//! Port of `ql/methods/finitedifferences/stepcondition.hpp:35,45`.
+
+use crate::math::array::Array;
+use crate::types::Time;
+
+/// A condition the backward solver applies to the grid values after each step.
+///
+/// C++ templates this on `array_type` (`stepcondition.hpp:34`); the whole
+/// finite-difference path instantiates it only with `Array`, so the Rust trait
+/// takes the concrete [`Array`] (D10: concrete over generic at the boundary).
+pub trait StepCondition {
+    /// Applies the condition to the grid values `a` at time `t`.
+    fn apply_to(&self, a: &mut Array, t: Time);
+}
+
+/// The step condition that does nothing.
+///
+/// Port of `NullCondition` (`stepcondition.hpp:45`).
+#[derive(Clone, Copy, Debug, Default)]
+pub struct NullCondition;
+
+impl StepCondition for NullCondition {
+    fn apply_to(&self, _a: &mut Array, _t: Time) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn null_condition_leaves_the_array_unchanged() {
+        let mut values = Array::from([1.0, -2.5, 0.0, 7.25]);
+        let before = values.clone();
+
+        NullCondition.apply_to(&mut values, 0.75);
+
+        assert_eq!(values, before);
+    }
+}

--- a/crates/libitofin/src/methods/finitedifferences/utilities/fdmboundaryconditionset.rs
+++ b/crates/libitofin/src/methods/finitedifferences/utilities/fdmboundaryconditionset.rs
@@ -1,0 +1,22 @@
+//! The set of boundary conditions a finite-difference scheme applies.
+//!
+//! Port of `ql/methods/finitedifferences/utilities/fdmboundaryconditionset.hpp:32`.
+//!
+//! The alias is what `OperatorTraits<FdmLinearOp>::bc_set`
+//! (`operatortraits.hpp:38`) expands to. The rest of that C++ type bundle
+//! collapses to concrete Rust types and needs no aliases of its own:
+//! `operator_type` is [`FdmLinearOp`], `array_type` is [`Array`], and
+//! `condition_type` is [`StepCondition`], which already fixes the array type.
+//!
+//! [`FdmLinearOp`]: crate::methods::finitedifferences::operators::FdmLinearOp
+//! [`Array`]: crate::math::array::Array
+//! [`StepCondition`]: crate::methods::finitedifferences::StepCondition
+
+use crate::methods::finitedifferences::BoundaryCondition;
+use crate::shared::Shared;
+
+/// The boundary conditions applied over one step, in order.
+///
+/// Empty on the plain European path, where the grid needs no boundary
+/// treatment.
+pub type FdmBoundaryConditionSet = Vec<Shared<dyn BoundaryCondition>>;

--- a/crates/libitofin/src/methods/finitedifferences/utilities/mod.rs
+++ b/crates/libitofin/src/methods/finitedifferences/utilities/mod.rs
@@ -2,9 +2,11 @@
 //!
 //! Port of `ql/methods/finitedifferences/utilities/`.
 
+mod fdmboundaryconditionset;
 mod fdminnervaluecalculator;
 mod fdmmesherintegral;
 
+pub use fdmboundaryconditionset::FdmBoundaryConditionSet;
 pub use fdminnervaluecalculator::{
     FdmCellAveragingInnerValue, FdmInnerValueCalculator, GridMapping, fdm_log_inner_value,
 };


### PR DESCRIPTION
This change introduces the boundary condition, step condition, and
scheme building blocks for the finite-difference method module.

**New condition primitives:**
* Added `boundarycondition.rs` exposing `BoundaryCondition` and `BoundarySide`.
* Added `stepcondition.rs` exposing `StepCondition` and `NullCondition`.
* Wired both into the `finitedifferences` module exports.

**Scheme and utility support:**
* Added a new `schemes` module with a boundary condition scheme helper.
* Added `FdmBoundaryConditionSet` under utilities and exported it.

Closes #648
