### PR TITLE
feat(finitedifferences): add step conditions module

### DIFF
--- a/crates/libitofin/src/methods/finitedifferences/mod.rs
+++ b/crates/libitofin/src/methods/finitedifferences/mod.rs
@@ -11,6 +11,7 @@ mod stepcondition;
 pub mod meshers;
 pub mod operators;
 pub mod schemes;
+pub mod stepconditions;
 pub mod utilities;
 
 pub use boundarycondition::{BoundaryCondition, BoundarySide};

--- a/crates/libitofin/src/methods/finitedifferences/stepconditions/fdmsnapshotcondition.rs
+++ b/crates/libitofin/src/methods/finitedifferences/stepconditions/fdmsnapshotcondition.rs
@@ -1,0 +1,110 @@
+//! The step condition that records the grid at one time.
+//!
+//! Port of `ql/methods/finitedifferences/stepconditions/fdmsnapshotcondition.hpp:33`
+//! and its `.cpp`.
+
+use std::cell::RefCell;
+
+use crate::math::array::Array;
+use crate::methods::finitedifferences::StepCondition;
+use crate::types::Time;
+
+/// Captures the grid values as the solver rolls past one time.
+///
+/// C++ fills a `mutable Array values_` from a `const applyTo` (`hpp:43`). The
+/// Rust trait takes `&self` and consumers hold the condition as a
+/// [`Shared`](crate::shared::Shared), which yields no `&mut`, so the capture
+/// lives behind a [`RefCell`] - the same shape as
+/// [`FdmCellAveragingInnerValue`](crate::methods::finitedifferences::utilities::FdmCellAveragingInnerValue).
+#[derive(Debug)]
+pub struct FdmSnapshotCondition {
+    t: Time,
+    values: RefCell<Array>,
+}
+
+impl FdmSnapshotCondition {
+    /// Builds a condition that captures at `t` (`cpp:26-28`).
+    pub fn new(t: Time) -> Self {
+        Self {
+            t,
+            values: RefCell::new(Array::new()),
+        }
+    }
+
+    /// The time the capture fires at (`cpp:36-38`).
+    pub fn time(&self) -> Time {
+        self.t
+    }
+
+    /// The captured values, empty until the capture fires.
+    ///
+    /// C++ lends a `const Array&` (`cpp:41-43`); the capture sits behind a
+    /// `RefCell`, so the Rust accessor clones rather than handing out a
+    /// [`Ref`](std::cell::Ref) a caller could hold live across a later
+    /// `apply_to` on a composite holding this condition (the
+    /// [`TreeLattice`](crate::methods::lattices::TreeLattice) accessors do the
+    /// same).
+    pub fn values(&self) -> Array {
+        self.values.borrow().clone()
+    }
+}
+
+impl StepCondition for FdmSnapshotCondition {
+    /// `cpp:31-34`: copies the grid if and only if `t` is exactly the capture
+    /// time. The equality is exact in C++ and stays exact here - a tolerance
+    /// would change which step captures.
+    fn apply_to(&self, a: &mut Array, t: Time) {
+        if t == self.t {
+            *self.values.borrow_mut() = a.clone();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn values_are_empty_before_the_capture_fires() {
+        let condition = FdmSnapshotCondition::new(1.5);
+
+        assert!(condition.values().is_empty());
+        assert_eq!(condition.time(), 1.5);
+    }
+
+    #[test]
+    fn a_time_other_than_the_capture_time_records_nothing() {
+        let condition = FdmSnapshotCondition::new(1.5);
+        let mut values = Array::from([1.0, -2.5, 4.0]);
+        let before = values.clone();
+
+        condition.apply_to(&mut values, 1.25);
+
+        assert_eq!(values, before);
+        assert!(condition.values().is_empty());
+    }
+
+    #[test]
+    fn the_capture_time_records_the_whole_grid_unchanged() {
+        let condition = FdmSnapshotCondition::new(1.5);
+        let mut values = Array::from([1.0, -2.5, 4.0]);
+        let before = values.clone();
+
+        condition.apply_to(&mut values, 1.5);
+
+        assert_eq!(values, before);
+        assert_eq!(condition.values(), before);
+    }
+
+    #[test]
+    fn a_later_time_does_not_overwrite_the_capture() {
+        let condition = FdmSnapshotCondition::new(1.5);
+        let mut captured = Array::from([1.0, -2.5, 4.0]);
+        let mut other = Array::from([9.0, 9.0, 9.0]);
+
+        condition.apply_to(&mut captured, 1.5);
+        condition.apply_to(&mut other, 2.0);
+
+        assert_eq!(condition.values(), Array::from([1.0, -2.5, 4.0]));
+    }
+}

--- a/crates/libitofin/src/methods/finitedifferences/stepconditions/fdmstepconditioncomposite.rs
+++ b/crates/libitofin/src/methods/finitedifferences/stepconditions/fdmstepconditioncomposite.rs
@@ -1,0 +1,193 @@
+//! A step condition that fans out over a list of step conditions.
+//!
+//! Port of `ql/methods/finitedifferences/stepconditions/fdmstepconditioncomposite.hpp:43`
+//! and its `.cpp`.
+
+use super::FdmSnapshotCondition;
+use crate::math::array::Array;
+use crate::methods::finitedifferences::StepCondition;
+use crate::shared::{Shared, shared};
+use crate::types::{Real, Time};
+
+/// The step conditions of one solver, applied in order at every step.
+pub struct FdmStepConditionComposite {
+    stopping_times: Vec<Time>,
+    conditions: Vec<Shared<dyn StepCondition>>,
+}
+
+impl FdmStepConditionComposite {
+    /// Merges the per-condition stopping times into one sorted, unique grid
+    /// (`cpp:36-46`).
+    ///
+    /// C++ funnels the lists through a `std::set<Real>`, which orders and
+    /// deduplicates on exact equality; the Rust sort-and-dedup is exact for the
+    /// same reason, unlike the `close_enough` dedup a
+    /// [`TimeGrid`](crate::math::timegrid::TimeGrid) applies.
+    pub fn new(stopping_times: &[Vec<Time>], conditions: Vec<Shared<dyn StepCondition>>) -> Self {
+        let mut all_stopping_times: Vec<Time> = stopping_times.iter().flatten().copied().collect();
+        all_stopping_times.sort_by(Real::total_cmp);
+        all_stopping_times.dedup();
+
+        Self {
+            stopping_times: all_stopping_times,
+            conditions,
+        }
+    }
+
+    /// The merged stopping times (`cpp:53-55`).
+    pub fn stopping_times(&self) -> &[Time] {
+        &self.stopping_times
+    }
+
+    /// The conditions, in application order (`cpp:48-51`).
+    pub fn conditions(&self) -> &[Shared<dyn StepCondition>] {
+        &self.conditions
+    }
+
+    /// Wraps a snapshot around an existing composite (`cpp:63-78`).
+    ///
+    /// The stopping times are `c2`'s plus `c1`'s capture time, and `c2` enters
+    /// the condition list whole and first, `c1` second: every step applies the
+    /// wrapped composite before the snapshot records the grid.
+    pub fn join_conditions(
+        c1: &Shared<FdmSnapshotCondition>,
+        c2: &Shared<FdmStepConditionComposite>,
+    ) -> Shared<FdmStepConditionComposite> {
+        let stopping_times = [c2.stopping_times().to_vec(), vec![c1.time()]];
+
+        let composite: Shared<dyn StepCondition> = c2.clone();
+        let snapshot: Shared<dyn StepCondition> = c1.clone();
+
+        shared(FdmStepConditionComposite::new(
+            &stopping_times,
+            vec![composite, snapshot],
+        ))
+    }
+}
+
+impl StepCondition for FdmStepConditionComposite {
+    /// `cpp:57-61`: applies every condition in turn.
+    fn apply_to(&self, a: &mut Array, t: Time) {
+        for condition in &self.conditions {
+            condition.apply_to(a, t);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+
+    use super::*;
+
+    struct Recorder {
+        tag: &'static str,
+        scale: Real,
+        offset: Real,
+        log: Shared<RefCell<Vec<String>>>,
+    }
+
+    impl StepCondition for Recorder {
+        fn apply_to(&self, a: &mut Array, t: Time) {
+            self.log.borrow_mut().push(format!("{}:{t}", self.tag));
+            a[0] = a[0] * self.scale + self.offset;
+        }
+    }
+
+    fn recorder(
+        tag: &'static str,
+        scale: Real,
+        offset: Real,
+        log: &Shared<RefCell<Vec<String>>>,
+    ) -> Shared<dyn StepCondition> {
+        shared(Recorder {
+            tag,
+            scale,
+            offset,
+            log: Shared::clone(log),
+        })
+    }
+
+    #[test]
+    fn conditions_are_applied_in_order() {
+        let log = shared(RefCell::new(Vec::new()));
+        let composite = FdmStepConditionComposite::new(
+            &[],
+            vec![
+                recorder("first", 2.0, 1.0, &log),
+                recorder("second", 3.0, 0.0, &log),
+            ],
+        );
+        let mut values = Array::from([1.0]);
+
+        composite.apply_to(&mut values, 0.25);
+
+        assert_eq!(values[0], 9.0);
+        assert_eq!(
+            *log.borrow(),
+            vec!["first:0.25".to_string(), "second:0.25".to_string()]
+        );
+    }
+
+    #[test]
+    fn stopping_times_are_sorted_and_deduplicated_across_the_lists() {
+        let composite = FdmStepConditionComposite::new(
+            &[vec![2.0, 0.5, 1.0], vec![1.0, 0.25], vec![0.5]],
+            Vec::new(),
+        );
+
+        assert_eq!(composite.stopping_times(), &[0.25, 0.5, 1.0, 2.0]);
+    }
+
+    #[test]
+    fn joined_conditions_merge_the_snapshot_time_into_the_stopping_times() {
+        let inner = shared(FdmStepConditionComposite::new(
+            &[vec![0.25, 1.0, 2.0]],
+            Vec::new(),
+        ));
+        let snapshot = shared(FdmSnapshotCondition::new(0.75));
+
+        let joined = FdmStepConditionComposite::join_conditions(&snapshot, &inner);
+
+        assert_eq!(joined.stopping_times(), &[0.25, 0.75, 1.0, 2.0]);
+    }
+
+    #[test]
+    fn joined_conditions_hold_the_composite_first_and_the_snapshot_second() {
+        let log = shared(RefCell::new(Vec::new()));
+        let inner = shared(FdmStepConditionComposite::new(
+            &[vec![1.0]],
+            vec![recorder("inner", 2.0, 1.0, &log)],
+        ));
+        let snapshot = shared(FdmSnapshotCondition::new(1.0));
+
+        let joined = FdmStepConditionComposite::join_conditions(&snapshot, &inner);
+
+        assert_eq!(joined.conditions().len(), 2);
+        let inner_dyn: Shared<dyn StepCondition> = inner.clone();
+        let snapshot_dyn: Shared<dyn StepCondition> = snapshot.clone();
+        assert!(Shared::ptr_eq(&joined.conditions()[0], &inner_dyn));
+        assert!(Shared::ptr_eq(&joined.conditions()[1], &snapshot_dyn));
+
+        let mut values = Array::from([1.0]);
+        joined.apply_to(&mut values, 1.0);
+
+        assert_eq!(*log.borrow(), vec!["inner:1".to_string()]);
+        assert_eq!(snapshot.values(), Array::from([3.0]));
+    }
+
+    #[test]
+    fn a_composite_is_itself_a_step_condition() {
+        let log = shared(RefCell::new(Vec::new()));
+        let composite: Shared<dyn StepCondition> = shared(FdmStepConditionComposite::new(
+            &[vec![0.5]],
+            vec![recorder("only", 2.0, 1.0, &log)],
+        ));
+        let mut values = Array::from([1.0]);
+
+        composite.apply_to(&mut values, 0.5);
+
+        assert_eq!(values[0], 3.0);
+        assert_eq!(*log.borrow(), vec!["only:0.5".to_string()]);
+    }
+}

--- a/crates/libitofin/src/methods/finitedifferences/stepconditions/mod.rs
+++ b/crates/libitofin/src/methods/finitedifferences/stepconditions/mod.rs
@@ -1,0 +1,18 @@
+//! The concrete step conditions a solver applies between steps.
+//!
+//! Port of `ql/methods/finitedifferences/stepconditions/`. C++ keeps the
+//! `StepCondition` trait one level up in `stepcondition.hpp` and its
+//! implementations here, so
+//! [`stepcondition`](super::StepCondition) and this directory coexist by
+//! design.
+//!
+//! `FdmStepConditionComposite::vanillaComposite` (`cpp:80-145`) is deferred to
+//! #636: it is the only site of `FdmDividendHandler` (`cpp:104`),
+//! `FdmAmericanStepCondition` (`cpp:130`) and `FdmBermudanStepCondition`
+//! (`cpp:134`), none of which are ported yet.
+
+mod fdmsnapshotcondition;
+mod fdmstepconditioncomposite;
+
+pub use fdmsnapshotcondition::FdmSnapshotCondition;
+pub use fdmstepconditioncomposite::FdmStepConditionComposite;


### PR DESCRIPTION
This pull request introduces a new `stepconditions` module to the finite differences methods, providing support for step-based conditions during finite difference schemes.

**New step conditions module:**
* Added `stepconditions/mod.rs` to declare and expose the new step conditions submodule.
* Added `stepconditions/fdmsnapshotcondition.rs` implementing a snapshot step condition.
* Added `stepconditions/fdmstepconditioncomposite.rs` implementing a composite step condition for combining multiple conditions.
* Registered the new `stepconditions` module in the finite differences `mod.rs`.

Closes #649
