### PR TITLE
feat(src): add cash-or-nothing payoff and digital Black pricing

### DIFF
--- a/crates/libitofin/src/instruments/mod.rs
+++ b/crates/libitofin/src/instruments/mod.rs
@@ -36,7 +36,7 @@ pub use oneassetoption::{
     OneAssetOptionResults, OptionArguments, VanillaOption,
 };
 pub use overnightindexedswap::OvernightIndexedSwap;
-pub use payoffs::{PlainVanillaPayoff, StrikedTypePayoff, TypePayoff};
+pub use payoffs::{CashOrNothingPayoff, PlainVanillaPayoff, StrikedTypePayoff, TypePayoff};
 pub use swap::{Swap, SwapArguments, SwapEngine, SwapResults, SwapType};
 pub use swaption::{
     SettlementMethod, SettlementType, Swaption, SwaptionArguments, SwaptionEngine,

--- a/crates/libitofin/src/instruments/payoffs.rs
+++ b/crates/libitofin/src/instruments/payoffs.rs
@@ -86,7 +86,7 @@ impl StrikedTypePayoff for PlainVanillaPayoff {
 /// Binary cash-or-nothing payoff: a fixed `cash_payoff` when the price ends
 /// strictly beyond the strike, nothing otherwise.
 ///
-/// Ports `CashOrNothingPayoff` (`ql/instruments/payoffs.hpp:148`,
+/// Ports `CashOrNothingPayoff` (`ql/instruments/payoffs.hpp:152`,
 /// `payoffs.cpp:154-163`). The comparison is strict on both sides, so a price
 /// exactly at the strike pays nothing for either option type.
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/crates/libitofin/src/instruments/payoffs.rs
+++ b/crates/libitofin/src/instruments/payoffs.rs
@@ -1,10 +1,10 @@
 //! Payoffs for various options.
 //!
 //! Port of the plain-vanilla subset of `ql/instruments/payoffs.{hpp,cpp}`:
-//! the [`TypePayoff`] and [`StrikedTypePayoff`] intermediate contracts and
-//! the [`PlainVanillaPayoff`]. The remaining payoffs (`NullPayoff`,
-//! `FloatingTypePayoff`, `PercentageStrikePayoff`, `AssetOrNothingPayoff`,
-//! `CashOrNothingPayoff`, `GapPayoff`, `SuperFundPayoff`,
+//! the [`TypePayoff`] and [`StrikedTypePayoff`] intermediate contracts, the
+//! [`PlainVanillaPayoff`] and the [`CashOrNothingPayoff`]. The remaining
+//! payoffs (`NullPayoff`, `FloatingTypePayoff`, `PercentageStrikePayoff`,
+//! `AssetOrNothingPayoff`, `GapPayoff`, `SuperFundPayoff`,
 //! `SuperSharePayoff`) are follow-up work.
 
 use std::any::Any;
@@ -83,6 +83,76 @@ impl StrikedTypePayoff for PlainVanillaPayoff {
     }
 }
 
+/// Binary cash-or-nothing payoff: a fixed `cash_payoff` when the price ends
+/// strictly beyond the strike, nothing otherwise.
+///
+/// Ports `CashOrNothingPayoff` (`ql/instruments/payoffs.hpp:148`,
+/// `payoffs.cpp:154-163`). The comparison is strict on both sides, so a price
+/// exactly at the strike pays nothing for either option type.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct CashOrNothingPayoff {
+    option_type: OptionType,
+    strike: Real,
+    cash_payoff: Real,
+}
+
+impl CashOrNothingPayoff {
+    /// Builds a cash-or-nothing payoff of the given type, strike and cash
+    /// amount.
+    pub fn new(option_type: OptionType, strike: Real, cash_payoff: Real) -> CashOrNothingPayoff {
+        CashOrNothingPayoff {
+            option_type,
+            strike,
+            cash_payoff,
+        }
+    }
+
+    /// The amount paid when the payoff is in the money.
+    pub fn cash_payoff(&self) -> Real {
+        self.cash_payoff
+    }
+}
+
+impl Payoff for CashOrNothingPayoff {
+    fn name(&self) -> String {
+        "CashOrNothing".to_string()
+    }
+
+    fn description(&self) -> String {
+        format!(
+            "{} {}, {} strike, {} cash payoff",
+            self.name(),
+            self.option_type,
+            self.strike,
+            self.cash_payoff
+        )
+    }
+
+    fn value(&self, price: Real) -> Real {
+        let moneyness = match self.option_type {
+            OptionType::Call => price - self.strike,
+            OptionType::Put => self.strike - price,
+        };
+        if moneyness > 0.0 {
+            self.cash_payoff
+        } else {
+            0.0
+        }
+    }
+}
+
+impl TypePayoff for CashOrNothingPayoff {
+    fn option_type(&self) -> OptionType {
+        self.option_type
+    }
+}
+
+impl StrikedTypePayoff for CashOrNothingPayoff {
+    fn strike(&self) -> Real {
+        self.strike
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -133,6 +203,49 @@ mod tests {
         let payoff = PlainVanillaPayoff::new(OptionType::Call, 100.0);
         let dynamic: &dyn StrikedTypePayoff = &payoff;
         assert_eq!(dynamic.value(107.0), 7.0);
+        assert_eq!(dynamic.option_type(), OptionType::Call);
+        assert_eq!(dynamic.strike(), 100.0);
+    }
+
+    #[test]
+    fn digital_pays_the_cash_amount_beyond_the_strike() {
+        let call = CashOrNothingPayoff::new(OptionType::Call, 100.0, 10.0);
+        assert_eq!(call.value(110.0), 10.0);
+        assert_eq!(call.value(90.0), 0.0);
+
+        let put = CashOrNothingPayoff::new(OptionType::Put, 100.0, 10.0);
+        assert_eq!(put.value(90.0), 10.0);
+        assert_eq!(put.value(110.0), 0.0);
+    }
+
+    /// `payoffs.cpp:156,158` compares `> 0.0`, so the strike itself is out of
+    /// the money for both types - a non-strict comparison would pay twice.
+    #[test]
+    fn digital_at_the_strike_pays_nothing_either_way() {
+        let call = CashOrNothingPayoff::new(OptionType::Call, 100.0, 10.0);
+        let put = CashOrNothingPayoff::new(OptionType::Put, 100.0, 10.0);
+        assert_eq!(call.value(100.0), 0.0);
+        assert_eq!(put.value(100.0), 0.0);
+    }
+
+    #[test]
+    fn digital_accessors_and_description_match_quantlib() {
+        let put = CashOrNothingPayoff::new(OptionType::Put, 80.0, 10.0);
+        assert_eq!(put.option_type(), OptionType::Put);
+        assert_eq!(put.strike(), 80.0);
+        assert_eq!(put.cash_payoff(), 10.0);
+        assert_eq!(put.name(), "CashOrNothing");
+        assert_eq!(
+            put.description(),
+            "CashOrNothing Put, 80 strike, 10 cash payoff"
+        );
+    }
+
+    #[test]
+    fn digital_usable_as_trait_object() {
+        let payoff = CashOrNothingPayoff::new(OptionType::Call, 100.0, 10.0);
+        let dynamic: &dyn StrikedTypePayoff = &payoff;
+        assert_eq!(dynamic.value(107.0), 10.0);
         assert_eq!(dynamic.option_type(), OptionType::Call);
         assert_eq!(dynamic.strike(), 100.0);
     }

--- a/crates/libitofin/src/pricingengines/blackcalculator.rs
+++ b/crates/libitofin/src/pricingengines/blackcalculator.rs
@@ -2,9 +2,15 @@
 //!
 //! Port of `ql/pricingengines/blackcalculator.{hpp,cpp}`: a
 //! [`BlackCalculator`] prices a European payoff on a forward and exposes the
-//! full greek set. Only the plain-vanilla payoff is supported; the C++
-//! visitor dispatch on the other striked payoffs follows those payoffs as a
-//! follow-up, as do `strike_gamma`, `vanna` and `volga`.
+//! full greek set. The plain-vanilla and cash-or-nothing payoffs are
+//! supported; the C++ visitor's remaining arms (`AssetOrNothingPayoff`,
+//! `GapPayoff`) follow those payoffs as a follow-up, as do `strike_gamma`,
+//! `vanna` and `volga`.
+//!
+//! Known limitation carried over from the reference: the zero-volatility
+//! branches below return the plain-vanilla ladder, which is meaningless for a
+//! digital payoff. C++ has the same gap - its branches read the option type
+//! off `alpha_ >= 0`, and a digital's `alpha_` is always zero.
 //!
 //! Divergence, throughout: every argument requirement here is QuantLib's own
 //! (`blackcalculator.cpp:66,68,72,74` for the constructor, `:204` and `:316`
@@ -25,9 +31,11 @@
 //! the C++ and return `NaN`, while `value` and the ITM probabilities stay
 //! well-defined; a test locks the artifact.
 
+use std::any::Any;
+
 use crate::errors::QlResult;
 use crate::fail;
-use crate::instruments::{PlainVanillaPayoff, StrikedTypePayoff, TypePayoff};
+use crate::instruments::{CashOrNothingPayoff, PlainVanillaPayoff, StrikedTypePayoff, TypePayoff};
 use crate::math::comparison::close;
 use crate::math::distributions::normal::CumulativeNormalDistribution;
 use crate::option::OptionType;
@@ -50,6 +58,7 @@ pub struct BlackCalculator {
     dbeta_dd2: Real,
     cum_d1: Real,
     cum_d2: Real,
+    n_d2: Real,
     x: Real,
     dx_ds: Real,
     dx_dstrike: Real,
@@ -150,6 +159,7 @@ impl BlackCalculator {
             dbeta_dd2,
             cum_d1,
             cum_d2,
+            n_d2,
             x: strike,
             dx_ds: 0.0,
             dx_dstrike: 1.0,
@@ -170,6 +180,54 @@ impl BlackCalculator {
             std_dev,
             discount,
         )
+    }
+
+    /// Builds a calculator from any striked payoff the C++ visitor handles.
+    ///
+    /// Ports `BlackCalculator::Calculator` (`blackcalculator.cpp:149-174`):
+    /// the coefficients [`BlackCalculator::new`] lays down are the
+    /// plain-vanilla ones and stand as they are, the cash-or-nothing payoff
+    /// replaces them with the digital ones (`:158-174`), and every other
+    /// payoff hits the `visit(Payoff&)` failure (`:152-154`).
+    ///
+    /// # Errors
+    ///
+    /// Errors on the arguments [`BlackCalculator::new`] rejects, and on a
+    /// payoff type the visitor does not handle.
+    pub fn with_striked_payoff(
+        payoff: &dyn StrikedTypePayoff,
+        forward: Real,
+        std_dev: Real,
+        discount: Real,
+    ) -> QlResult<BlackCalculator> {
+        let mut black = BlackCalculator::new(
+            payoff.option_type(),
+            payoff.strike(),
+            forward,
+            std_dev,
+            discount,
+        )?;
+
+        let dynamic = payoff as &dyn Any;
+        if dynamic.is::<PlainVanillaPayoff>() {
+            return Ok(black);
+        }
+        if let Some(digital) = dynamic.downcast_ref::<CashOrNothingPayoff>() {
+            black.alpha = 0.0;
+            black.dalpha_dd1 = 0.0;
+            black.x = digital.cash_payoff();
+            black.dx_dstrike = 0.0;
+            let (beta, dbeta_dd2) = match digital.option_type() {
+                OptionType::Call => (black.cum_d2, black.n_d2),
+                OptionType::Put => (1.0 - black.cum_d2, -black.n_d2),
+            };
+            black.beta = beta;
+            black.dbeta_dd2 = dbeta_dd2;
+            return Ok(black);
+        }
+
+        let name = payoff.name();
+        fail!("unsupported payoff type: {name}");
     }
 
     /// Zero-volatility sensitivities by moneyness, negated for puts;
@@ -418,6 +476,7 @@ fn elasticity_from(value: Real, delta: Real, underlying: Real) -> Real {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::payoff::Payoff;
     use crate::pricingengines::blackformula::black_formula;
 
     use crate::pricingengines::hull_fixture::{DISCOUNT, FORWARD, MATURITY, SPOT, STD_DEV, STRIKE};
@@ -515,6 +574,93 @@ mod tests {
         let from_payoff = BlackCalculator::with_payoff(&payoff, FORWARD, STD_DEV, DISCOUNT)
             .expect("valid inputs");
         assert_close(from_payoff.value(), hull(OptionType::Put).value(), 0.0);
+    }
+
+    #[test]
+    fn striked_payoff_constructor_leaves_the_vanilla_path_alone() {
+        let payoff = PlainVanillaPayoff::new(OptionType::Put, STRIKE);
+        let visited = BlackCalculator::with_striked_payoff(&payoff, FORWARD, STD_DEV, DISCOUNT)
+            .expect("valid inputs");
+        assert_close(visited.value(), hull(OptionType::Put).value(), 0.0);
+        assert_close(
+            visited.strike_sensitivity(),
+            hull(OptionType::Put).strike_sensitivity(),
+            0.0,
+        );
+    }
+
+    /// The digital value is `discount * cash * N(d2)` for a call and
+    /// `discount * cash * N(-d2)` for a put; the coefficient assignment of
+    /// `blackcalculator.cpp:158-174` must reproduce it through the shared
+    /// `value()` formula.
+    #[test]
+    fn digital_coefficients_reproduce_the_closed_form() {
+        let cash = 10.0;
+        let d2 = (FORWARD / STRIKE).ln() / STD_DEV - 0.5 * STD_DEV;
+        let f = CumulativeNormalDistribution::standard();
+        for (option_type, expected) in [
+            (OptionType::Call, DISCOUNT * cash * f.value(d2)),
+            (OptionType::Put, DISCOUNT * cash * f.value(-d2)),
+        ] {
+            let payoff = CashOrNothingPayoff::new(option_type, STRIKE, cash);
+            let black = BlackCalculator::with_striked_payoff(&payoff, FORWARD, STD_DEV, DISCOUNT)
+                .expect("valid inputs");
+            assert_close(black.value(), expected, 1e-14);
+            assert_close(black.alpha(), 0.0, 0.0);
+        }
+    }
+
+    /// `x_` becomes the cash amount and no longer tracks the strike, so
+    /// `DxDstrike_` is reset to zero (`blackcalculator.cpp:161`). The strike
+    /// derivative of `discount * cash * N(-d2)` is
+    /// `discount * cash * n(d2) / (stdDev * strike)`.
+    #[test]
+    fn digital_strike_sensitivity_drops_the_strike_carrying_term() {
+        let cash = 10.0;
+        let d2 = (FORWARD / STRIKE).ln() / STD_DEV - 0.5 * STD_DEV;
+        let f = CumulativeNormalDistribution::standard();
+        let expected = DISCOUNT * cash * f.derivative(d2) / (STD_DEV * STRIKE);
+        let payoff = CashOrNothingPayoff::new(OptionType::Put, STRIKE, cash);
+        let black = BlackCalculator::with_striked_payoff(&payoff, FORWARD, STD_DEV, DISCOUNT)
+            .expect("valid inputs");
+        assert_close(black.strike_sensitivity(), expected, 1e-14);
+    }
+
+    #[test]
+    fn payoffs_outside_the_visitor_are_rejected() {
+        let payoff = PercentageStrikeStub;
+        let error = BlackCalculator::with_striked_payoff(&payoff, FORWARD, STD_DEV, DISCOUNT)
+            .expect_err("the visitor does not handle this payoff");
+        assert_eq!(error.message(), "unsupported payoff type: PercentageStrike");
+    }
+
+    /// Stands in for `PercentageStrikePayoff`, a striked payoff the C++
+    /// visitor genuinely does not handle (`blackcalculator.cpp:25-32` lists
+    /// its arms), so it falls through to `visit(Payoff&)`.
+    struct PercentageStrikeStub;
+
+    impl Payoff for PercentageStrikeStub {
+        fn name(&self) -> String {
+            "PercentageStrike".to_string()
+        }
+        fn description(&self) -> String {
+            self.name()
+        }
+        fn value(&self, price: Real) -> Real {
+            price
+        }
+    }
+
+    impl TypePayoff for PercentageStrikeStub {
+        fn option_type(&self) -> OptionType {
+            OptionType::Call
+        }
+    }
+
+    impl StrikedTypePayoff for PercentageStrikeStub {
+        fn strike(&self) -> Real {
+            STRIKE
+        }
     }
 
     #[test]

--- a/crates/libitofin/src/pricingengines/vanilla/mod.rs
+++ b/crates/libitofin/src/pricingengines/vanilla/mod.rs
@@ -12,10 +12,10 @@
 //! - The C++ second constructor taking a separate discounting curve is
 //!   follow-up work; the risk-free curve embedded in the process is used for
 //!   both forecasting and discounting, as with the C++ default constructor.
-//! - The C++ engine accepts any `StrikedTypePayoff` and lets the calculator
-//!   visit the concrete type; only [`PlainVanillaPayoff`] exists in the crate
-//!   (and the calculator supports nothing else), so any other payoff is an
-//!   explicit error instead of a silently wrong price.
+//! - As in C++, the engine accepts any `StrikedTypePayoff` and lets the
+//!   calculator visit the concrete type; a payoff the calculator's visitor
+//!   does not handle is an explicit error from there rather than a silently
+//!   wrong price.
 
 pub mod analytichestonengine;
 pub mod mceuropeanengine;
@@ -36,7 +36,6 @@ use crate::exercise::ExerciseType;
 use crate::fail;
 use crate::instruments::{
     Greeks, MoreGreeks, OneAssetOptionEngine, OneAssetOptionResults, OptionArguments,
-    PlainVanillaPayoff, StrikedTypePayoff,
 };
 use crate::patterns::observable::{AsObservable, Observable};
 use crate::pricingengine::{Arguments, PricingEngine, Results};
@@ -92,11 +91,7 @@ impl PricingEngine for AnalyticEuropeanEngine {
         let Some(payoff) = &arguments.payoff else {
             fail!("no payoff given");
         };
-        let payoff: &dyn StrikedTypePayoff = &**payoff;
-        let Some(payoff) = (payoff as &dyn Any).downcast_ref::<PlainVanillaPayoff>() else {
-            fail!("only plain-vanilla payoffs are supported");
-        };
-        let payoff = *payoff;
+        let payoff = Shared::clone(payoff);
         let maturity_date = exercise.last_date();
 
         let risk_free = self.process.risk_free_rate().current_link()?;
@@ -113,7 +108,8 @@ impl PricingEngine for AnalyticEuropeanEngine {
         }
         let forward_price = spot * dividend_discount / risk_free_discount;
 
-        let black = BlackCalculator::with_payoff(&payoff, forward_price, variance.sqrt(), df)?;
+        let black =
+            BlackCalculator::with_striked_payoff(&*payoff, forward_price, variance.sqrt(), df)?;
 
         let value = black.value();
         let delta = black.delta(spot)?;
@@ -180,7 +176,7 @@ pub(crate) mod test_market {
     use crate::exercise::EuropeanExercise;
     use crate::handle::Handle;
     use crate::instrument::Instrument;
-    use crate::instruments::{EuropeanOption, PlainVanillaPayoff};
+    use crate::instruments::{EuropeanOption, PlainVanillaPayoff, StrikedTypePayoff};
     use crate::interestrate::Compounding;
     use crate::option::OptionType;
     use crate::pricingengine::PricingEngine;
@@ -231,7 +227,14 @@ pub(crate) mod test_market {
             strike: Real,
             expiry: Date,
         ) -> EuropeanOption {
-            let payoff = shared(PlainVanillaPayoff::new(option_type, strike));
+            self.option_with_payoff(shared(PlainVanillaPayoff::new(option_type, strike)), expiry)
+        }
+
+        pub(crate) fn option_with_payoff(
+            &self,
+            payoff: Shared<dyn StrikedTypePayoff>,
+            expiry: Date,
+        ) -> EuropeanOption {
             let exercise = shared(EuropeanExercise::new(expiry));
             let mut option = EuropeanOption::new(payoff, exercise, Shared::clone(&self.settings));
             let engine = shared_mut(AnalyticEuropeanEngine::new(Shared::clone(&self.process)));
@@ -394,12 +397,17 @@ mod tests {
         );
     }
 
+    /// The engine no longer screens the payoff type: it hands any striked
+    /// payoff to the calculator, so the rejection boundary moved to the
+    /// calculator's `visit(Payoff&)` arm (`blackcalculator.cpp:152-154`).
+    /// `PercentageStrikePayoff` is a real C++ striked payoff the visitor does
+    /// not handle, so it stands in for the unsupported case.
     #[test]
-    fn non_plain_vanilla_payoffs_are_rejected() {
-        struct CashOrNothingStub;
-        impl Payoff for CashOrNothingStub {
+    fn payoffs_the_calculator_cannot_visit_are_rejected() {
+        struct PercentageStrikeStub;
+        impl Payoff for PercentageStrikeStub {
             fn name(&self) -> String {
-                "CashOrNothing".to_string()
+                "PercentageStrike".to_string()
             }
             fn description(&self) -> String {
                 "stub".to_string()
@@ -408,12 +416,12 @@ mod tests {
                 0.0
             }
         }
-        impl TypePayoff for CashOrNothingStub {
+        impl TypePayoff for PercentageStrikeStub {
             fn option_type(&self) -> OptionType {
                 OptionType::Call
             }
         }
-        impl StrikedTypePayoff for CashOrNothingStub {
+        impl StrikedTypePayoff for PercentageStrikeStub {
             fn strike(&self) -> Real {
                 100.0
             }
@@ -421,18 +429,11 @@ mod tests {
 
         let market = market();
         market.set(100.0, 0.04, 0.06, 0.20);
-        let template = market.option(OptionType::Call, 100.0, today() + 360);
-        let mut option = crate::instruments::OneAssetOption::new(
-            crate::shared::shared(CashOrNothingStub),
-            template.exercise().clone(),
-            crate::shared::Shared::clone(&market.settings),
-        );
-        option
-            .base_mut()
-            .set_pricing_engine(template.base().pricing_engine().unwrap().clone());
+        let mut option =
+            market.option_with_payoff(crate::shared::shared(PercentageStrikeStub), today() + 360);
         assert_eq!(
             option.npv().unwrap_err().message(),
-            "only plain-vanilla payoffs are supported"
+            "unsupported payoff type: PercentageStrike"
         );
     }
 }
@@ -891,12 +892,179 @@ mod test_greek_values {
 }
 
 #[cfg(test)]
+mod test_cash_or_nothing {
+    //! The `testCashOrNothingEuropeanValues` oracle of
+    //! `test-suite/digitaloption.cpp:77-129`, plus the finite-difference pins
+    //! the C++ suite gets only from its `testGreeks` digital sweep.
+
+    use super::test_market::{market, time_to_days, today};
+    use crate::instrument::Instrument;
+    use crate::instruments::{CashOrNothingPayoff, EuropeanOption};
+    use crate::option::OptionType::{self, Call, Put};
+    use crate::shared::shared;
+    use crate::types::{Rate, Real, Time, Volatility};
+
+    const CASH: Real = 10.0;
+
+    fn digital(
+        option_type: OptionType,
+        strike: Real,
+        expiry_time: Time,
+        market: &super::test_market::Market,
+    ) -> EuropeanOption {
+        let expiry = today() + time_to_days(expiry_time);
+        market.option_with_payoff(
+            shared(CashOrNothingPayoff::new(option_type, strike, CASH)),
+            expiry,
+        )
+    }
+
+    /// The single row of the C++ fixture (`digitaloption.cpp:82-85`): a Haug
+    /// p.88 put, asserted at the C++ tolerance of 1e-4. The table has exactly
+    /// one row and it is a put; there is no cached call value to port.
+    ///
+    /// As in `test_values`, the published figure is paired with a
+    /// full-precision reference at 1e-12: `discount * cash * N(-d2)`
+    /// evaluated by an independent double-precision transliteration, which
+    /// agrees with the engine to a unit in the last place. The published
+    /// value alone leaves only a 2.2x margin at its own tolerance.
+    #[test]
+    fn value_matches_the_haug_cash_or_nothing_row() {
+        let (strike, spot, q, r, t, vol): (Real, Real, Rate, Rate, Time, Volatility) =
+            (80.0, 100.0, 0.06, 0.06, 0.75, 0.35);
+        let haug: Real = 2.6710;
+        let precise: Real = 2.671045684461348;
+
+        let market = market();
+        market.set(spot, q, r, vol);
+        let mut option = digital(Put, strike, t, &market);
+
+        let calculated = option.npv().unwrap();
+        assert!(
+            (calculated - haug).abs() <= 1.0e-4,
+            "cash-or-nothing put K={strike} S={spot}: {calculated} vs Haug {haug} \
+             (error {})",
+            (calculated - haug).abs()
+        );
+        assert!(
+            (calculated - precise).abs() <= 1.0e-12,
+            "cash-or-nothing put K={strike} S={spot}: {calculated} vs reference {precise} \
+             (error {})",
+            (calculated - precise).abs()
+        );
+    }
+
+    /// Exactly one of the two digitals pays, so together they are a
+    /// zero-coupon bond on the cash amount. The identity is exact - both
+    /// alphas are zero and the betas are `N(d2)` and `1 - N(d2)` - so it
+    /// pins the call arm of the visitor (`blackcalculator.cpp:165-171`)
+    /// without inventing a cached number the C++ suite does not carry.
+    #[test]
+    fn call_and_put_digitals_sum_to_the_discounted_cash() {
+        let market = market();
+        market.set(100.0, 0.04, 0.06, 0.30);
+        let t: Time = 0.5;
+
+        for strike in [80.0, 100.0, 120.0] {
+            let mut call = digital(Call, strike, t, &market);
+            let mut put = digital(Put, strike, t, &market);
+            let discount = (-0.06 * t).exp();
+            let total = call.npv().unwrap() + put.npv().unwrap();
+            assert!(
+                (total - discount * CASH).abs() <= 1.0e-14,
+                "K={strike}: call + put {total} vs discounted cash {}",
+                discount * CASH
+            );
+        }
+    }
+
+    /// Gate F1: the digital delta, gamma and strike sensitivity against
+    /// central differences of the engine's own NPV, on a `q != r` fixture so
+    /// the forward differs from the spot.
+    ///
+    /// The bump is `h = 1e-4` relative to the bumped quantity, which balances
+    /// the two error sources of the second difference: truncation falls as
+    /// `h^2 / 12 * d4V/dS4` while roundoff grows as `4 * eps * value / h^2`,
+    /// bounding them at 3.6e-11 and 2.2e-11 here (truncation alone is 5.4e-7
+    /// at `h = 1e-2` relative). The observed errors are 2.0e-9 for delta,
+    /// 9.5e-12 for gamma and 1.6e-9 for the strike sensitivity - the
+    /// first-difference pair is truncation-dominated at `h^2 / 6 * d3V/dS3` -
+    /// so the tolerance is 1e-7, some fifty times the worst of them.
+    ///
+    /// Analytic gamma is 8.3e-4 on this fixture, four orders above the
+    /// tolerance, and the test asserts it is non-negligible so a
+    /// both-sides-zero result cannot pass. Both option types are swept: the
+    /// value formula reads only `alpha`, `beta` and `x`, so the visitor's
+    /// per-type `dbeta_dd2` (`blackcalculator.cpp:167,170`) is invisible to
+    /// every value-based check and a sign error there survives them all. The
+    /// strike arm is in turn the only check that sees `dx_dstrike` (`:161`):
+    /// leaving it at the base 1.0 adds `discount * beta`, about 0.5 against
+    /// an analytic 0.125.
+    #[test]
+    fn digital_greeks_match_central_differences() {
+        let (strike, spot, q, r, t, vol): (Real, Real, Rate, Rate, Time, Volatility) =
+            (100.0, 100.0, 0.04, 0.06, 0.75, 0.35);
+        let tolerance: Real = 1.0e-7;
+
+        let market = market();
+        market.set(spot, q, r, vol);
+
+        for option_type in [Call, Put] {
+            let mut option = digital(option_type, strike, t, &market);
+
+            let delta = option.delta().unwrap();
+            let gamma = option.gamma().unwrap();
+            let strike_sensitivity = option.strike_sensitivity().unwrap();
+            assert!(
+                gamma.abs() > 1.0e-4,
+                "the fixture must have a gamma worth pinning, got {gamma}"
+            );
+
+            let h = spot * 1.0e-4;
+            market.spot.set_value(spot + h);
+            let value_up = option.npv().unwrap();
+            market.spot.set_value(spot - h);
+            let value_down = option.npv().unwrap();
+            market.spot.set_value(spot);
+            let value = option.npv().unwrap();
+
+            let fd_delta = (value_up - value_down) / (2.0 * h);
+            let fd_gamma = (value_up - 2.0 * value + value_down) / (h * h);
+
+            let hk = strike * 1.0e-4;
+            let fd_strike_sensitivity =
+                (digital(option_type, strike + hk, t, &market).npv().unwrap()
+                    - digital(option_type, strike - hk, t, &market).npv().unwrap())
+                    / (2.0 * hk);
+
+            for (name, analytic, finite_difference) in [
+                ("delta", delta, fd_delta),
+                ("gamma", gamma, fd_gamma),
+                (
+                    "strikeSensitivity",
+                    strike_sensitivity,
+                    fd_strike_sensitivity,
+                ),
+            ] {
+                assert!(
+                    (analytic - finite_difference).abs() <= tolerance,
+                    "{name} of the {option_type:?} digital: analytic {analytic} vs finite \
+                     difference {finite_difference} (error {})",
+                    (analytic - finite_difference).abs()
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
 mod test_greeks {
     //! The `testGreeks` oracle of `test-suite/europeanoption.cpp`: analytic
     //! greeks against central finite differences over the full plain-vanilla
     //! grid, on curves moving off the evaluation date. The C++ test also
-    //! sweeps cash-or-nothing, asset-or-nothing and gap payoffs; those
-    //! payoffs are follow-up work and their sweeps come with them.
+    //! sweeps asset-or-nothing and gap payoffs; those payoffs are follow-up
+    //! work and their sweeps come with them. The cash-or-nothing sweep is
+    //! covered by `test_cash_or_nothing` above.
 
     use super::AnalyticEuropeanEngine;
     use super::test_market::{quote_handle, time_to_days, today};


### PR DESCRIPTION
- **feat(src): add cash-or-nothing payoff and digital Black pricing**
- **feat(crates): support cash-or-nothing payoffs in analytic engine**

close #655