### PR TITLE
docs(readme): remove finite differences pending note from L9 methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ repository's issues (the board is the source of truth, not a checked-in file).
 | **L6** | indexes | `InterestRateIndex`, Ibor family (Euribor / Eonia / €STR / SOFR), `SwapIndex` | 🚧 in progress |
 | **L7** | cashflows | fixed / floating / Ibor / overnight coupons and legs, coupon pricers, duration, capped-floored coupons | 🚧 in progress |
 | **L8** | instruments | fixed-rate bonds, vanilla / OIS swaps, swaptions, caps & floors, vanilla options | 🚧 in progress |
-| **L9** | methods | lattices, trees (trinomial + Hull-White), Monte Carlo (path generators + antithetic) | 🚧 in progress |
+| **L9** | methods | lattices, trees (trinomial + Hull-White), Monte Carlo (path generators + antithetic), finite differences (European Black-Scholes vanilla vs analytic) | 🚧 in progress |
 | **L10** | models | `CalibratedModel` + `calibrate()`, short-rate (Vasicek, CIR, Hull-White), Heston, calibration helpers | 🚧 in progress |
 | **L11** | engines | analytic European & Heston (Fourier), swaption (Black / Bachelier / Jamshidian), discounting swap / bond, Black cap/floor | 🚧 in progress |
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ repository's issues (the board is the source of truth, not a checked-in file).
 | **L6** | indexes | `InterestRateIndex`, Ibor family (Euribor / Eonia / €STR / SOFR), `SwapIndex` | 🚧 in progress |
 | **L7** | cashflows | fixed / floating / Ibor / overnight coupons and legs, coupon pricers, duration, capped-floored coupons | 🚧 in progress |
 | **L8** | instruments | fixed-rate bonds, vanilla / OIS swaps, swaptions, caps & floors, vanilla options | 🚧 in progress |
-| **L9** | methods | lattices, trees (trinomial + Hull-White), Monte Carlo (path generators + antithetic); finite differences pending | 🚧 in progress |
+| **L9** | methods | lattices, trees (trinomial + Hull-White), Monte Carlo (path generators + antithetic) | 🚧 in progress |
 | **L10** | models | `CalibratedModel` + `calibrate()`, short-rate (Vasicek, CIR, Hull-White), Heston, calibration helpers | 🚧 in progress |
 | **L11** | engines | analytic European & Heston (Fourier), swaption (Black / Bachelier / Jamshidian), discounting swap / bond, Black cap/floor | 🚧 in progress |
 


### PR DESCRIPTION
- **docs(readme): remove finite differences pending note from L9 methods**
- **docs(readme): note finite differences support in L9 methods**
