### PR TITLE
feat(instruments): add Claim and ProtectionSide instruments

### DIFF
--- a/crates/libitofin/src/instruments/claim.rs
+++ b/crates/libitofin/src/instruments/claim.rs
@@ -1,0 +1,88 @@
+//! Default-event claims.
+//!
+//! Port of `ql/instruments/claim.{hpp,cpp}`: the [`Claim`] contract a
+//! credit-default swap settles its protection leg against, plus the
+//! [`FaceValueClaim`] used by every standard contract.
+//!
+//! ## Divergences from QuantLib
+//!
+//! - C++ derives `Claim` from `Observable` and `Observer`, with an `update()`
+//!   that only forwards notifications (`claim.hpp:32-39`). The port drops both
+//!   roles: [`FaceValueClaim`] is stateless, so nothing can change and nothing
+//!   subscribes. The wiring belongs to the one claim that needs it, and can be
+//!   added to that type alone when it lands.
+//! - `FaceValueAccrualClaim` (`claim.hpp:49-57`, `claim.cpp:32-44`) is
+//!   deferred: it reads `accruedAmount(d)` and `notional(d)` off a reference
+//!   [`Bond`](crate::instruments::Bond) and registers with it, so it needs both
+//!   the bond accrual API and the observer wiring dropped above. It is deferred
+//!   within EPIC Credit (#676).
+
+use crate::time::date::Date;
+use crate::types::Real;
+
+/// The amount a default event pays out (`Claim`).
+///
+/// Implementors are held as `Shared<dyn Claim>` by the instruments that settle
+/// against them, so the trait stays dyn-compatible.
+pub trait Claim {
+    /// The claim paid on a default at `default_date`, for a contract of
+    /// `notional` recovering `recovery_rate` of it.
+    fn amount(&self, default_date: &Date, notional: Real, recovery_rate: Real) -> Real;
+}
+
+/// A claim on the notional alone (`FaceValueClaim`).
+///
+/// Pays the non-recovered fraction of the notional, `N (1 - R)`
+/// (`claim.cpp:24-28`).
+#[derive(Debug, Clone, Copy)]
+pub struct FaceValueClaim;
+
+impl Claim for FaceValueClaim {
+    /// Ignores the default date: the face value does not accrue
+    /// (`claim.cpp:24-28`).
+    fn amount(&self, _default_date: &Date, notional: Real, recovery_rate: Real) -> Real {
+        notional * (1.0 - recovery_rate)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::shared::{Shared, shared};
+    use crate::time::date::Month;
+
+    fn a_date() -> Date {
+        Date::new(15, Month::June, 2026)
+    }
+
+    #[test]
+    fn face_value_claim_pays_the_non_recovered_notional() {
+        let claim = FaceValueClaim;
+        assert_eq!(claim.amount(&a_date(), 100.0, 0.5), 50.0);
+        assert_eq!(claim.amount(&a_date(), 1_000_000.0, 0.25), 750_000.0);
+    }
+
+    #[test]
+    fn face_value_claim_at_the_recovery_extremes() {
+        let claim = FaceValueClaim;
+        assert_eq!(claim.amount(&a_date(), 100.0, 0.0), 100.0);
+        assert_eq!(claim.amount(&a_date(), 100.0, 1.0), 0.0);
+    }
+
+    #[test]
+    fn face_value_claim_ignores_the_default_date() {
+        let claim = FaceValueClaim;
+        let early = Date::new(1, Month::January, 2026);
+        let late = Date::new(31, Month::December, 2030);
+        assert_eq!(
+            claim.amount(&early, 100.0, 0.5),
+            claim.amount(&late, 100.0, 0.5)
+        );
+    }
+
+    #[test]
+    fn claim_is_dyn_compatible() {
+        let claim: Shared<dyn Claim> = shared(FaceValueClaim);
+        assert_eq!(claim.amount(&a_date(), 100.0, 0.5), 50.0);
+    }
+}

--- a/crates/libitofin/src/instruments/mod.rs
+++ b/crates/libitofin/src/instruments/mod.rs
@@ -6,6 +6,7 @@
 mod bond;
 mod bonds;
 mod capfloor;
+mod claim;
 mod fixedvsfloatingswap;
 mod futures;
 mod makecapfloor;
@@ -15,6 +16,7 @@ mod makevanillaswap;
 mod oneassetoption;
 mod overnightindexedswap;
 mod payoffs;
+mod protection;
 mod swap;
 mod swaption;
 mod vanillaswap;
@@ -22,6 +24,7 @@ mod vanillaswap;
 pub use bond::{Bond, BondArguments, BondEngine, BondPrice, BondPriceType, BondResults};
 pub use bonds::FixedRateBond;
 pub use capfloor::{CapFloor, CapFloorArguments, CapFloorType};
+pub use claim::{Claim, FaceValueClaim};
 pub use fixedvsfloatingswap::{
     FixedVsFloatingSwap, FixedVsFloatingSwapArguments, FixedVsFloatingSwapEngine,
     FixedVsFloatingSwapResults, FloatingArgumentsFn,
@@ -37,6 +40,7 @@ pub use oneassetoption::{
 };
 pub use overnightindexedswap::OvernightIndexedSwap;
 pub use payoffs::{CashOrNothingPayoff, PlainVanillaPayoff, StrikedTypePayoff, TypePayoff};
+pub use protection::ProtectionSide;
 pub use swap::{Swap, SwapArguments, SwapEngine, SwapResults, SwapType};
 pub use swaption::{
     SettlementMethod, SettlementType, Swaption, SwaptionArguments, SwaptionEngine,

--- a/crates/libitofin/src/instruments/protection.rs
+++ b/crates/libitofin/src/instruments/protection.rs
@@ -1,0 +1,28 @@
+//! Default-protection side.
+//!
+//! Port of `ql/default.hpp:32-34` (`struct Protection { enum Side }`), whose
+//! wrapper struct exists only to scope the enum. The port flattens the two
+//! names into one, following
+//! [`OptionType`](crate::option::OptionType) (`Option::Type`) and
+//! [`FuturesType`](crate::instruments::FuturesType) (`Futures::Type`).
+//!
+//! The side tells a credit-default swap which leg it pays: the buyer pays the
+//! premium and receives the default payment, the seller the reverse.
+//!
+//! ## Divergences from QuantLib
+//!
+//! - No integer discriminants are pinned. QuantLib's own `Protection::Side(-1)`
+//!   "not set" sentinel (`ql/experimental/credit/nthtodefault.hpp:138`) only
+//!   appears in the experimental basket instruments, which are out of scope for
+//!   EPIC Credit (#676); the ported engines switch on the enum by value
+//!   (`ql/pricingengines/credit/midpointcdsengine.cpp:134-138`).
+
+/// Which side of a default-protection contract a party holds
+/// (`Protection::Side`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ProtectionSide {
+    /// Pays the premium leg and receives the default payment.
+    Buyer,
+    /// Receives the premium leg and pays the default payment.
+    Seller,
+}


### PR DESCRIPTION
Add the `claim` module with `Claim` and `FaceValueClaim` types and the
`protection` module with `ProtectionSide`, exposing them through the
instruments module.

Closes #683
