### PR TITLE
feat(currency): add GBP currency and region module

### DIFF
--- a/crates/libitofin/src/currency.rs
+++ b/crates/libitofin/src/currency.rs
@@ -5,8 +5,8 @@
 //! fractionary parts per unit. It is a value type, exercised through the indexes
 //! and (later) money rather than by any dedicated numeric test.
 //!
-//! Only [`Currency::eur`] is provided here, as the [`IborIndex`] slice (Euribor)
-//! needs it. The full `ql/currencies/*` catalogue is deferred to a later ticket.
+//! Only the currencies the ported indexes need are provided here. The full
+//! `ql/currencies/*` catalogue is deferred to a later ticket.
 //!
 //! ## Divergences from QuantLib
 //!
@@ -82,6 +82,16 @@ impl Currency {
         Currency::new("U.S. dollar", "USD", 840, "$", "\u{a2}", 100)
     }
 
+    /// The British pound sterling (ISO code `GBP`, numeric `826`, 100 pence
+    /// per unit).
+    ///
+    /// Values match `GBPCurrency` in QuantLib's `ql/currencies/europe.cpp`
+    /// (`:106-109`). Its default `Rounding()` convention is dropped along with
+    /// the `rounding` field (see the module divergences).
+    pub fn gbp() -> Self {
+        Currency::new("British pound sterling", "GBP", 826, "\u{a3}", "p", 100)
+    }
+
     /// Currency name, e.g. `"European Euro"`.
     pub fn name(&self) -> &str {
         &self.name
@@ -151,6 +161,17 @@ mod tests {
         assert_eq!(usd.symbol(), "$");
         assert_eq!(usd.fraction_symbol(), "\u{a2}");
         assert_eq!(usd.fractions_per_unit(), 100);
+    }
+
+    #[test]
+    fn gbp_fields_match_quantlib() {
+        let gbp = Currency::gbp();
+        assert_eq!(gbp.name(), "British pound sterling");
+        assert_eq!(gbp.code(), "GBP");
+        assert_eq!(gbp.numeric_code(), 826);
+        assert_eq!(gbp.symbol(), "\u{a3}");
+        assert_eq!(gbp.fraction_symbol(), "p");
+        assert_eq!(gbp.fractions_per_unit(), 100);
     }
 
     #[test]

--- a/crates/libitofin/src/indexes/mod.rs
+++ b/crates/libitofin/src/indexes/mod.rs
@@ -9,10 +9,12 @@ pub mod ibor;
 pub mod iborindex;
 pub mod index;
 pub mod interestrateindex;
+pub mod region;
 pub mod swapindex;
 
 pub use ibor::{Estr, Euribor, Sofr};
 pub use iborindex::{IborIndex, OvernightIndex};
 pub use index::Index;
 pub use interestrateindex::{InterestRateIndex, InterestRateIndexBase};
+pub use region::Region;
 pub use swapindex::SwapIndex;

--- a/crates/libitofin/src/indexes/region.rs
+++ b/crates/libitofin/src/indexes/region.rs
@@ -1,0 +1,116 @@
+//! Region, i.e. geographical area, specification.
+//!
+//! Port of `ql/indexes/region.{hpp,cpp}`. A [`Region`] carries a name and a
+//! code, and exists for inflation applicability: an inflation index name is
+//! `region.name() + " " + family_name`, which is in turn the D11 fixing-store
+//! key (`"UK RPI"`, `"EU HICP"`). Exercised through the inflation indexes
+//! rather than by any dedicated numeric test.
+//!
+//! ## Divergences from QuantLib
+//!
+//! - **No `shared_ptr<Data>` indirection.** QuantLib's `Region` holds an
+//!   `ext::shared_ptr<Data>` (`region.hpp:44-53`) that each concrete
+//!   constructor points at a function-local `static`, so every `UKRegion`
+//!   shares one allocation. That is a C++ allocation optimisation with no
+//!   Rust counterpart worth carrying: this port stores the name and code
+//!   inline. Behaviour is unchanged, since QuantLib compares regions by name
+//!   (`region.hpp:121-127`), not by data pointer.
+//! - **No abstract base.** QuantLib models the concretes as subclasses whose
+//!   only content is the constructor. Rust gets associated constructor
+//!   functions on the one concrete [`Region`] type instead; nothing in the
+//!   library upcasts a region, so the subclass hierarchy buys nothing.
+//! - **Only the regions batch 1 needs.** `AustraliaRegion`, `FranceRegion`,
+//!   `USRegion` and `ZARegion` (`region.cpp:31-59`) are deliberately not
+//!   ported yet; they arrive with the inflation indexes that use them.
+//!   [`Region::new`] ports `CustomRegion` and can express any of them
+//!   meanwhile.
+
+/// Geographical or economic region, used for inflation applicability.
+///
+/// Two regions are equal iff they share the same [`name`](Region::name),
+/// matching QuantLib's `operator==`.
+#[derive(Clone, Debug)]
+pub struct Region {
+    name: String,
+    code: String,
+}
+
+impl Region {
+    /// Builds a region from its name and code.
+    ///
+    /// Ports `CustomRegion` (`region.hpp:67-71`), which exists so that a
+    /// one-off region needs no new class.
+    pub fn new(name: impl Into<String>, code: impl Into<String>) -> Self {
+        Region {
+            name: name.into(),
+            code: code.into(),
+        }
+    }
+
+    /// The European Union as a region (name and code both `"EU"`).
+    ///
+    /// Values match `EURegion` in `ql/indexes/region.cpp:36-39`.
+    pub fn eu() -> Self {
+        Region::new("EU", "EU")
+    }
+
+    /// The United Kingdom as a region (name and code both `"UK"`).
+    ///
+    /// Values match `UKRegion` in `ql/indexes/region.cpp:46-49`.
+    pub fn uk() -> Self {
+        Region::new("UK", "UK")
+    }
+
+    /// Region name, e.g. `"UK"`.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Region code, e.g. `"UK"`.
+    pub fn code(&self) -> &str {
+        &self.code
+    }
+}
+
+impl PartialEq for Region {
+    fn eq(&self, other: &Region) -> bool {
+        self.name == other.name
+    }
+}
+
+impl Eq for Region {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uk_fields_match_quantlib() {
+        let uk = Region::uk();
+        assert_eq!(uk.name(), "UK");
+        assert_eq!(uk.code(), "UK");
+    }
+
+    #[test]
+    fn eu_fields_match_quantlib() {
+        let eu = Region::eu();
+        assert_eq!(eu.name(), "EU");
+        assert_eq!(eu.code(), "EU");
+    }
+
+    #[test]
+    fn accessors_round_trip_construction() {
+        let france = Region::new("France", "FR");
+        assert_eq!(france.name(), "France");
+        assert_eq!(france.code(), "FR");
+    }
+
+    #[test]
+    fn equality_is_by_name() {
+        assert_eq!(Region::uk(), Region::uk());
+        assert_ne!(Region::uk(), Region::eu());
+
+        let same_name_other_code = Region::new("UK", "GB");
+        assert_eq!(Region::uk(), same_name_other_code);
+    }
+}


### PR DESCRIPTION
This change introduces support for the British pound sterling and adds a
new region module to the indexes package.

**Currency additions:**
* Added `Currency::gbp` constructor for the British pound sterling (ISO
  code `GBP`, numeric `826`, 100 pence per unit), matching `GBPCurrency`
  in QuantLib's `ql/currencies/europe.cpp`.
* Added `gbp_fields_match_quantlib` test verifying the new currency's
  fields.
* Updated the module docs to note that only the currencies the ported
  indexes need are provided.

**Indexes module:**
* Added a new `region` module and re-exported `Region` from
  `indexes/mod.rs`.

Closes #706
