### PR TITLE
feat(crates): support first curve node preceding the reference date

### DIFF
--- a/crates/libitofin/src/termstructures/inflation/inflationhelpers.rs
+++ b/crates/libitofin/src/termstructures/inflation/inflationhelpers.rs
@@ -242,36 +242,73 @@ mod tests {
         accepts_driver_helper::<dyn ZeroInflationHelper>();
     }
 
-    /// Every driver-facing method routes through the trait, so a concrete
-    /// helper's overrides run. Short-circuiting to the base would leave a
-    /// helper pricing off an unlinked handle and would silently swap its
-    /// quote error for the default one. The curve is bound to a local because
-    /// the base holds it weakly and never owns it.
+    /// What a driver sees of a helper.
+    struct DriverView {
+        quote_value: Real,
+        quote_error: Real,
+        pillar_date: Date,
+        latest_relevant_date: Date,
+        maturity_date: Date,
+    }
+
+    /// Exercises the helper the way
+    /// [`IterativeBootstrap::calculate`](crate::termstructures::iterativebootstrap::IterativeBootstrap::calculate)
+    /// does: through a type parameter bounded by [`BootstrapHelperShared`], so
+    /// only that impl's methods are in scope.
+    ///
+    /// Reaching the bound through a type parameter is what makes the assertions
+    /// below bite. Calling the same method names straight on a
+    /// `Shared<dyn ZeroInflationHelper>` resolves to [`ZeroInflationHelper`]
+    /// instead and never enters the impl under test, which would leave the
+    /// routing claim untested.
+    fn drive<H>(helper: &Shared<H>, curve: &Shared<dyn ZeroInflationTermStructure>) -> DriverView
+    where
+        H: BootstrapHelperShared<TS = dyn ZeroInflationTermStructure> + ?Sized,
+    {
+        helper.set_term_structure(curve);
+        DriverView {
+            quote_value: helper.quote_value().unwrap(),
+            quote_error: helper.quote_error().unwrap(),
+            pillar_date: helper.pillar_date(),
+            latest_relevant_date: helper.latest_relevant_date(),
+            maturity_date: helper.maturity_date(),
+        }
+    }
+
+    /// Every driver-facing method routes through the [`ZeroInflationHelper`]
+    /// trait, so a concrete helper's overrides run. Short-circuiting the impl
+    /// to the base would leave a helper pricing off an unlinked handle and
+    /// would silently swap its quote error for the default one - here, the
+    /// stub's `-1.0` would become the default `0.03 - 0.01`. The curve is bound
+    /// to a local because the base holds it weakly and never owns it.
     #[test]
     fn the_driver_bound_routes_through_the_trait_so_overrides_run() {
         let helper = StubHelper::new();
         let driver: Shared<dyn ZeroInflationHelper> = Shared::clone(&helper) as _;
-
         let curve = curve();
-        driver.set_term_structure(&curve);
-        assert!(helper.curve_set.get());
-        assert!(helper.base.term_structure().is_ok());
 
-        assert_eq!(driver.quote_error().unwrap(), -1.0);
-        assert!(helper.error_called.get());
-        assert_eq!(driver.quote_value().unwrap(), 0.03);
+        let view = drive(&driver, &curve);
+
+        assert!(
+            helper.curve_set.get(),
+            "set_term_structure override skipped"
+        );
+        assert!(helper.base.term_structure().is_ok());
+        assert!(helper.error_called.get(), "quote_error override skipped");
+        assert_eq!(view.quote_error, -1.0);
+        assert_eq!(view.quote_value, 0.03);
     }
 
     #[test]
     fn the_driver_bound_reports_the_bases_dates() {
         let helper = StubHelper::new();
         let driver: Shared<dyn ZeroInflationHelper> = Shared::clone(&helper) as _;
+        let curve = curve();
 
-        assert_eq!(driver.pillar_date(), Date::new(1, Month::June, 2030));
-        assert_eq!(
-            driver.latest_relevant_date(),
-            Date::new(1, Month::July, 2030)
-        );
-        assert_eq!(driver.maturity_date(), Date::new(1, Month::June, 2030));
+        let view = drive(&driver, &curve);
+
+        assert_eq!(view.pillar_date, Date::new(1, Month::June, 2030));
+        assert_eq!(view.latest_relevant_date, Date::new(1, Month::July, 2030));
+        assert_eq!(view.maturity_date, Date::new(1, Month::June, 2030));
     }
 }

--- a/crates/libitofin/src/termstructures/inflation/inflationhelpers.rs
+++ b/crates/libitofin/src/termstructures/inflation/inflationhelpers.rs
@@ -1,0 +1,277 @@
+//! Bootstrap helpers for zero-inflation term structures.
+//!
+//! Port of the helper base `ZeroCouponInflationSwapHelper` derives from
+//! (`ql/termstructures/inflation/inflationhelpers.hpp:36-37`, a
+//! `RelativeDateBootstrapHelper<ZeroInflationTermStructure>`) together with the
+//! plain `BootstrapHelper<ZeroInflationTermStructure>` the traits name as their
+//! helper type (`inflationtraits.hpp:43`). They are the inflation twins of
+//! [`RateHelper`](crate::termstructures::bootstraphelper::RateHelper) and
+//! [`DefaultProbabilityHelper`](crate::termstructures::credit::defaultprobabilityhelpers::DefaultProbabilityHelper),
+//! and they carry no behaviour of their own: everything is inherited from the
+//! shared [`BootstrapHelperBase`], instantiated here over
+//! [`ZeroInflationTermStructure`].
+//!
+//! Where C++ gets every family from one class template, this port needs one
+//! trait per family, because a trait generic over its term structure cannot be
+//! made into the bare trait object the curves are typed on. The shared driver
+//! reaches all three through [`BootstrapHelperShared`], implemented below on
+//! `dyn ZeroInflationHelper`.
+//!
+//! The concrete `ZeroCouponInflationSwapHelper` (`inflationhelpers.hpp:35`)
+//! follows within EPIC Inflation (#705); this module is the base it plugs into.
+
+use crate::errors::QlResult;
+use crate::handle::Handle;
+use crate::patterns::observable::AsObservable;
+use crate::quotes::Quote;
+use crate::shared::Shared;
+use crate::termstructures::bootstraphelper::{BootstrapHelperBase, BootstrapHelperShared};
+use crate::termstructures::inflation::inflationtermstructure::ZeroInflationTermStructure;
+use crate::time::date::Date;
+use crate::types::Real;
+
+/// The shared state of an inflation bootstrap helper: a
+/// [`BootstrapHelperBase`] whose back-pointer is a zero-inflation curve.
+pub type ZeroInflationHelperBase = BootstrapHelperBase<dyn ZeroInflationTermStructure>;
+
+/// Bootstrap helper for the zero-inflation-curve bootstrap
+/// (`BootstrapHelper<ZeroInflationTermStructure>`).
+///
+/// Mirrors [`RateHelper`](crate::termstructures::bootstraphelper::RateHelper)
+/// exactly, over [`ZeroInflationTermStructure`]: a concrete helper embeds a
+/// [`ZeroInflationHelperBase`], returns it from [`base`](Self::base) and
+/// supplies [`implied_quote`](Self::implied_quote); the rest of the interface
+/// is derived from the base. The same ownership contract holds - the curve is
+/// held [`Weak`](std::rc::Weak) and never observed - since it is the one base
+/// that enforces it.
+pub trait ZeroInflationHelper: AsObservable {
+    /// The embedded shared state.
+    fn base(&self) -> &ZeroInflationHelperBase;
+
+    /// The quote implied by the current curve, computed by the concrete helper.
+    ///
+    /// The helper does not observe the curve, so this must force any
+    /// recalculation it needs itself rather than trusting a cached value.
+    fn implied_quote(&self) -> QlResult<Real>;
+
+    /// The market quote the helper fits the curve to.
+    fn quote(&self) -> &Handle<dyn Quote> {
+        self.base().quote()
+    }
+
+    /// The bootstrap's root: market quote minus implied quote, driven to zero.
+    fn quote_error(&self) -> QlResult<Real> {
+        Ok(self.base().quote_value()? - self.implied_quote()?)
+    }
+
+    /// Sets the curve being bootstrapped (non-owning, unobserved).
+    ///
+    /// A concrete helper that hands the curve to an instrument overrides this
+    /// to relink that handle first, then delegates here.
+    fn set_term_structure(&self, term_structure: &Shared<dyn ZeroInflationTermStructure>) {
+        self.base().set_term_structure(term_structure);
+    }
+
+    /// The earliest date data are needed at.
+    fn earliest_date(&self) -> Date {
+        self.base().earliest_date()
+    }
+
+    /// The instrument's maturity date.
+    fn maturity_date(&self) -> Date {
+        self.base().maturity_date()
+    }
+
+    /// The latest date data are needed at.
+    fn latest_relevant_date(&self) -> Date {
+        self.base().latest_relevant_date()
+    }
+
+    /// The pillar date, at which the curve node this helper sets sits.
+    fn pillar_date(&self) -> Date {
+        self.base().pillar_date()
+    }
+
+    /// The latest date, equal to the pillar date.
+    fn latest_date(&self) -> Date {
+        self.base().latest_date()
+    }
+}
+
+/// Inflation bootstrap helper whose date schedule is relative to the
+/// evaluation date (`RelativeDateBootstrapHelper<ZeroInflationTermStructure>`).
+///
+/// `ZeroCouponInflationSwapHelper` derives from this
+/// (`inflationhelpers.hpp:36-37`): its swap schedule is rebuilt whenever the
+/// evaluation date moves. The concrete helper builds its base with
+/// [`BootstrapHelperBase::new_relative`], passing a closure that calls
+/// [`initialize_dates`](Self::initialize_dates).
+pub trait RelativeDateZeroInflationHelper: ZeroInflationHelper {
+    /// Rebuilds the helper's date schedule off the current evaluation date.
+    fn initialize_dates(&self);
+}
+
+/// The inflation half of the driver bound. Like the yield and credit impls,
+/// every method routes through the [`ZeroInflationHelper`] trait rather than
+/// straight to the base, so a concrete helper's override still runs -
+/// `set_term_structure` in particular, which a helper overrides to relink its
+/// own pricing handle before recording the curve.
+impl BootstrapHelperShared for dyn ZeroInflationHelper {
+    type TS = dyn ZeroInflationTermStructure;
+
+    fn set_term_structure(&self, term_structure: &Shared<dyn ZeroInflationTermStructure>) {
+        ZeroInflationHelper::set_term_structure(self, term_structure);
+    }
+
+    fn quote_value(&self) -> QlResult<Real> {
+        self.base().quote_value()
+    }
+
+    fn quote_error(&self) -> QlResult<Real> {
+        ZeroInflationHelper::quote_error(self)
+    }
+
+    fn pillar_date(&self) -> Date {
+        ZeroInflationHelper::pillar_date(self)
+    }
+
+    fn latest_relevant_date(&self) -> Date {
+        ZeroInflationHelper::latest_relevant_date(self)
+    }
+
+    fn maturity_date(&self) -> Date {
+        ZeroInflationHelper::maturity_date(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use super::*;
+    use crate::patterns::observable::Observable;
+    use crate::quotes::SimpleQuote;
+    use crate::shared::shared;
+    use crate::termstructures::inflation::interpolatedzeroinflationcurve::ZeroInflationCurve;
+    use crate::time::date::Month;
+    use crate::time::daycounters::actual360::Actual360;
+    use crate::time::frequency::Frequency;
+
+    /// A helper that overrides both hooks a concrete helper overrides, and
+    /// records that each ran. Its quote is 0.03 and its implied quote 0.01, so
+    /// the default `quote_error` would be 0.02 - a value the overridden one
+    /// deliberately does not return.
+    struct StubHelper {
+        base: ZeroInflationHelperBase,
+        curve_set: Cell<bool>,
+        error_called: Cell<bool>,
+    }
+
+    impl StubHelper {
+        fn new() -> Shared<StubHelper> {
+            let quote = shared(SimpleQuote::new(Some(0.03)));
+            let base = ZeroInflationHelperBase::new(Handle::new(quote));
+            base.set_pillar_date(Date::new(1, Month::June, 2030));
+            base.set_latest_relevant_date(Date::new(1, Month::July, 2030));
+            base.set_maturity_date(Date::new(1, Month::June, 2030));
+            shared(StubHelper {
+                base,
+                curve_set: Cell::new(false),
+                error_called: Cell::new(false),
+            })
+        }
+    }
+
+    impl AsObservable for StubHelper {
+        fn observable(&self) -> &Observable {
+            self.base.observable()
+        }
+    }
+
+    impl ZeroInflationHelper for StubHelper {
+        fn base(&self) -> &ZeroInflationHelperBase {
+            &self.base
+        }
+
+        fn implied_quote(&self) -> QlResult<Real> {
+            Ok(0.01)
+        }
+
+        fn quote_error(&self) -> QlResult<Real> {
+            self.error_called.set(true);
+            Ok(-1.0)
+        }
+
+        fn set_term_structure(&self, term_structure: &Shared<dyn ZeroInflationTermStructure>) {
+            self.curve_set.set(true);
+            self.base.set_term_structure(term_structure);
+        }
+    }
+
+    fn curve() -> Shared<dyn ZeroInflationTermStructure> {
+        let reference = Date::new(27, Month::January, 2026);
+        let dates = vec![
+            Date::new(1, Month::December, 2025),
+            Date::new(1, Month::December, 2030),
+        ];
+        let curve = ZeroInflationCurve::new(
+            reference,
+            dates,
+            vec![0.02, 0.02],
+            Frequency::Monthly,
+            Actual360::new(),
+            crate::math::interpolations::linear::Linear,
+        )
+        .unwrap();
+        shared(curve) as Shared<dyn ZeroInflationTermStructure>
+    }
+
+    /// The inflation family satisfies the bound the bootstrap driver puts on
+    /// `PiecewiseCurve::Helper`, so a piecewise zero-inflation curve can name
+    /// `dyn ZeroInflationHelper` there against a
+    /// `dyn ZeroInflationTermStructure` curve. The two associated types must
+    /// agree, which is the whole point of the generalization, and only a paired
+    /// instantiation checks it.
+    #[test]
+    fn inflation_helpers_satisfy_the_driver_bound() {
+        fn accepts_driver_helper<H>()
+        where
+            H: BootstrapHelperShared<TS = dyn ZeroInflationTermStructure> + ?Sized,
+        {
+        }
+        accepts_driver_helper::<dyn ZeroInflationHelper>();
+    }
+
+    /// Every driver-facing method routes through the trait, so a concrete
+    /// helper's overrides run. Short-circuiting to the base would leave a
+    /// helper pricing off an unlinked handle and would silently swap its
+    /// quote error for the default one. The curve is bound to a local because
+    /// the base holds it weakly and never owns it.
+    #[test]
+    fn the_driver_bound_routes_through_the_trait_so_overrides_run() {
+        let helper = StubHelper::new();
+        let driver: Shared<dyn ZeroInflationHelper> = Shared::clone(&helper) as _;
+
+        let curve = curve();
+        driver.set_term_structure(&curve);
+        assert!(helper.curve_set.get());
+        assert!(helper.base.term_structure().is_ok());
+
+        assert_eq!(driver.quote_error().unwrap(), -1.0);
+        assert!(helper.error_called.get());
+        assert_eq!(driver.quote_value().unwrap(), 0.03);
+    }
+
+    #[test]
+    fn the_driver_bound_reports_the_bases_dates() {
+        let helper = StubHelper::new();
+        let driver: Shared<dyn ZeroInflationHelper> = Shared::clone(&helper) as _;
+
+        assert_eq!(driver.pillar_date(), Date::new(1, Month::June, 2030));
+        assert_eq!(
+            driver.latest_relevant_date(),
+            Date::new(1, Month::July, 2030)
+        );
+        assert_eq!(driver.maturity_date(), Date::new(1, Month::June, 2030));
+    }
+}

--- a/crates/libitofin/src/termstructures/inflation/inflationtraits.rs
+++ b/crates/libitofin/src/termstructures/inflation/inflationtraits.rs
@@ -1,0 +1,222 @@
+//! Inflation bootstrap traits.
+//!
+//! Port of the `ZeroInflationTraits` class in
+//! `ql/termstructures/inflation/inflationtraits.hpp:41-115`.
+//!
+//! ## Why this is not the zero-rate trait
+//!
+//! An inflation rate and a zero yield are both rates stored one per pillar,
+//! which makes it tempting to alias
+//! [`ZeroYield`](crate::termstructures::bootstraptraits::ZeroYield). C++ keeps
+//! them as separate structs and the numbers differ in four places, so this
+//! port transcribes rather than aliases: the average rate is `0.02` and not
+//! `0.05`, the fresh-curve guess is that average at *every* pillar rather than
+//! the previous node from the second one on, the fresh-curve bracket is
+//! `+/-0.5` and not `+/-1.0`, and the iteration cap is `40` and not `100`.
+//!
+//! ## Where `initialDate` went
+//!
+//! C++'s `ZeroInflationTraits::initialDate` returns the curve's `baseDate()`
+//! (`inflationtraits.hpp:46-48`), which is what puts the first bootstrap node
+//! *before* the reference date. In this port that decision belongs to the
+//! curve, as
+//! [`PiecewiseCurve::initial_date`](crate::termstructures::iterativebootstrap::PiecewiseCurve::initial_date),
+//! not to the traits: the driver reads it off the curve it is bootstrapping, so
+//! a piecewise zero-inflation curve overrides that method with its base date.
+//!
+//! ## Only the core trait
+//!
+//! [`ZeroInflationTraits`] implements
+//! [`BootstrapTraits`] and deliberately does not implement
+//! [`YieldBootstrapTraits`](crate::termstructures::bootstraptraits::YieldBootstrapTraits):
+//! the nodes *are* the zero-inflation rates, and there is no discount factor to
+//! convert them into. C++'s `transformDirect`/`transformInverse`
+//! (`inflationtraits.hpp:105-112`) are not ported either: both are the
+//! identity, they exist for an unconstrained-optimization path this port does
+//! not have, and the bootstrap driver never calls them.
+//!
+//! `YoYInflationTraits` (`inflationtraits.hpp:117-198`) is a documented
+//! deferral within EPIC Inflation (#705): it seeds from the curve's base rate
+//! and has no node-0 mirror, so it is a separate transcription rather than a
+//! variation on this one.
+
+use crate::termstructures::bootstraptraits::BootstrapTraits;
+use crate::types::{Real, Size, Time};
+
+/// The average and maximum inflation rate the bracket/guess formulas assume
+/// (`detail::avgInflation` / `detail::maxInflation`,
+/// `inflationtraits.hpp:36-37`). Both are inflation-local: the yield `AVG_RATE`
+/// is more than twice as large and its `MAX_RATE` is double this.
+const AVG_INFLATION: Real = 0.02;
+const MAX_INFLATION: Real = 0.5;
+
+/// Zero-inflation bootstrap traits (`class ZeroInflationTraits`,
+/// `inflationtraits.hpp:41`). The curve nodes are zero-coupon inflation rates,
+/// the base-date node holds a dummy average rate, and the bracket is a wide
+/// band that admits deflation.
+pub struct ZeroInflationTraits;
+
+impl BootstrapTraits for ZeroInflationTraits {
+    /// The dummy value at the first node (`initialValue`, `:50-53`). The C++
+    /// comment is explicit that it "will be overwritten during bootstrap":
+    /// node 0 sits at the base date and carries no information of its own -
+    /// `update_guess` overwrites it with the first solved pillar.
+    fn initial_value() -> Real {
+        AVG_INFLATION
+    }
+
+    /// The per-node guess (`guess`, `:56-68`): the stored node when a previous
+    /// solution seeds the pass, otherwise the average inflation rate.
+    ///
+    /// This is where the convention parts company with every rate-storing yield
+    /// trait. Those return the average only at `i == 1` and extrapolate the
+    /// previous node from there on; this one has no such branch and seeds every
+    /// fresh pillar at the same `0.02`. The guess only seeds a bracketed solver
+    /// whose converged root is independent of it, so the difference is benign,
+    /// but it is the C++ behaviour and is transcribed as such.
+    fn guess(i: Size, _times: &[Time], data: &[Real], valid_data: bool) -> Real {
+        if valid_data {
+            return data[i];
+        }
+        AVG_INFLATION
+    }
+
+    /// The lower bracket (`minValueAfter`, `:71-82`): on a seeded pass, the
+    /// smallest node doubled when negative and halved when positive - the sign
+    /// branch widening the bracket either way - otherwise `-maxInflation`.
+    ///
+    /// The fresh-curve floor is negative, unlike the credit
+    /// [`HazardRate`](crate::termstructures::credit::probabilitytraits::HazardRate)
+    /// floor: deflation is a real state of the world, a negative default
+    /// intensity is not.
+    fn min_value_after(_i: Size, _times: &[Time], data: &[Real], valid_data: bool) -> Real {
+        if valid_data {
+            let r = data.iter().copied().fold(Real::INFINITY, Real::min);
+            return if r < 0.0 { r * 2.0 } else { r / 2.0 };
+        }
+        -MAX_INFLATION
+    }
+
+    /// The upper bracket (`maxValueAfter`, `:84-97`): the largest node halved
+    /// when negative and doubled when positive, otherwise `maxInflation` - a
+    /// value the C++ comment calls "very unlikely to be exceeded" rather than a
+    /// real constraint.
+    fn max_value_after(_i: Size, _times: &[Time], data: &[Real], valid_data: bool) -> Real {
+        if valid_data {
+            let r = data.iter().copied().fold(Real::NEG_INFINITY, Real::max);
+            return if r < 0.0 { r / 2.0 } else { r * 2.0 };
+        }
+        MAX_INFLATION
+    }
+
+    /// Writes a solved rate back (`updateGuess`, `:100-102`): node `i` takes
+    /// the rate, and the base-date node mirrors the first pillar so the segment
+    /// from the base date to the first pillar is not left at the dummy
+    /// `initial_value`.
+    fn update_guess(data: &mut [Real], value: Real, i: Size) {
+        data[i] = value;
+        if i == 1 {
+            data[0] = value;
+        }
+    }
+
+    /// The convergence-loop cap (`maxIterations`, `:114`). Inflation pillars
+    /// are solved in fewer passes than yield pillars, which allow `100`.
+    fn max_iterations() -> Size {
+        40
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::termstructures::bootstraptraits::ZeroYield;
+
+    #[test]
+    fn initial_value_is_the_average_inflation_rate_not_the_average_yield() {
+        assert_eq!(ZeroInflationTraits::initial_value(), 0.02);
+        assert_ne!(
+            ZeroInflationTraits::initial_value(),
+            ZeroYield::initial_value()
+        );
+    }
+
+    #[test]
+    fn max_iterations_is_forty_not_the_yield_hundred() {
+        assert_eq!(ZeroInflationTraits::max_iterations(), 40);
+        assert_ne!(
+            ZeroInflationTraits::max_iterations(),
+            ZeroYield::max_iterations()
+        );
+    }
+
+    #[test]
+    fn every_fresh_pillar_guesses_the_average_rate_where_the_yield_trait_extrapolates() {
+        let times = [0.0, 1.0, 2.0];
+        let data = [0.02, 0.03, 0.02];
+
+        assert_eq!(ZeroInflationTraits::guess(1, &times, &data, false), 0.02);
+        assert_eq!(ZeroInflationTraits::guess(2, &times, &data, false), 0.02);
+        assert_ne!(
+            ZeroInflationTraits::guess(2, &times, &data, false),
+            ZeroYield::guess(2, &times, &data, false)
+        );
+    }
+
+    #[test]
+    fn valid_data_guess_reuses_the_stored_node() {
+        let times = [0.0, 1.0, 2.0];
+        let data = [0.02, 0.02, 0.035];
+        assert_eq!(ZeroInflationTraits::guess(2, &times, &data, true), 0.035);
+    }
+
+    #[test]
+    fn fresh_curve_bracket_is_the_half_percent_band_around_zero() {
+        let times = [0.0, 1.0, 2.0];
+        let data = [0.02, 0.03, 0.02];
+        let min = ZeroInflationTraits::min_value_after(2, &times, &data, false);
+        let max = ZeroInflationTraits::max_value_after(2, &times, &data, false);
+
+        assert_eq!(min, -0.5);
+        assert_eq!(max, 0.5);
+        assert!(min < 0.0, "the bracket must admit deflation");
+        assert_ne!(min, ZeroYield::min_value_after(2, &times, &data, false));
+        assert_ne!(max, ZeroYield::max_value_after(2, &times, &data, false));
+    }
+
+    #[test]
+    fn valid_data_bracket_halves_a_positive_minimum_and_doubles_a_positive_maximum() {
+        let times = [0.0, 1.0, 2.0];
+        let data = [0.02, 0.02, 0.05];
+        assert!(
+            (ZeroInflationTraits::min_value_after(2, &times, &data, true) - 0.01).abs() < 1e-15
+        );
+        assert!(
+            (ZeroInflationTraits::max_value_after(2, &times, &data, true) - 0.10).abs() < 1e-15
+        );
+    }
+
+    #[test]
+    fn valid_data_bracket_flips_the_branches_on_negative_nodes() {
+        let times = [0.0, 1.0, 2.0];
+        let data = [-0.02, -0.02, -0.01];
+        let min = ZeroInflationTraits::min_value_after(2, &times, &data, true);
+        let max = ZeroInflationTraits::max_value_after(2, &times, &data, true);
+
+        assert!((min - (-0.04)).abs() < 1e-15);
+        assert!((max - (-0.005)).abs() < 1e-15);
+        assert!(min < max);
+    }
+
+    #[test]
+    fn update_guess_writes_the_node_and_mirrors_the_base_date_node() {
+        let mut data = [0.02, 0.02, 0.02];
+        ZeroInflationTraits::update_guess(&mut data, 0.03, 1);
+        assert_eq!(data[1], 0.03);
+        assert_eq!(data[0], 0.03);
+
+        ZeroInflationTraits::update_guess(&mut data, 0.04, 2);
+        assert_eq!(data[2], 0.04);
+        assert_eq!(data[0], 0.03);
+    }
+}

--- a/crates/libitofin/src/termstructures/inflation/mod.rs
+++ b/crates/libitofin/src/termstructures/inflation/mod.rs
@@ -8,4 +8,5 @@
 //! classes that build on it follow within EPIC Inflation (#705).
 
 pub mod inflationtermstructure;
+pub mod inflationtraits;
 pub mod interpolatedzeroinflationcurve;

--- a/crates/libitofin/src/termstructures/inflation/mod.rs
+++ b/crates/libitofin/src/termstructures/inflation/mod.rs
@@ -7,6 +7,7 @@
 //! interpolated curves, the year-on-year structures and the seasonality
 //! classes that build on it follow within EPIC Inflation (#705).
 
+pub mod inflationhelpers;
 pub mod inflationtermstructure;
 pub mod inflationtraits;
 pub mod interpolatedzeroinflationcurve;

--- a/crates/libitofin/src/termstructures/iterativebootstrap.rs
+++ b/crates/libitofin/src/termstructures/iterativebootstrap.rs
@@ -95,8 +95,22 @@ pub trait PiecewiseCurve {
     /// The stopping accuracy for the per-node root search.
     fn accuracy(&self) -> Real;
 
-    /// The curve's reference date (the first curve node).
+    /// The curve's reference date.
     fn reference_date(&self) -> QlResult<Date>;
+
+    /// The date of the first curve node (`Traits::initialDate`).
+    ///
+    /// C++ takes this from the traits struct, which for every yield and credit
+    /// convention returns the term structure's reference date - hence the
+    /// default here. An inflation curve overrides it with its base date, which
+    /// *precedes* the reference date, so its first node sits at a negative
+    /// time. The driver takes all three of its date decisions from this - the
+    /// expired-instrument threshold, the first-alive scan and node 0
+    /// (`iterativebootstrap.hpp:161-182`) - while `time_from_reference` stays
+    /// anchored to the reference date.
+    fn initial_date(&self) -> QlResult<Date> {
+        self.reference_date()
+    }
 
     /// The year fraction from the reference date to `date`.
     fn time_from_reference(&self, date: Date) -> QlResult<Time>;
@@ -139,7 +153,7 @@ impl IterativeBootstrap {
         require!(n > 0, "no bootstrap helpers given");
         sort_by_pillar_date(&mut helpers);
 
-        let first_date = curve.reference_date()?;
+        let first_date = curve.initial_date()?;
         require!(
             helpers[n - 1].pillar_date() > first_date,
             "all instruments expired"
@@ -312,10 +326,29 @@ mod tests {
         interpolator: LogLinear,
         data: RefCell<CurveData<LogLinear>>,
         self_weak: Weak<dyn YieldTermStructure>,
+        initial_date: Option<Date>,
     }
 
     impl StubCurve {
         fn new(reference: Date, instruments: Vec<Shared<dyn RateHelper>>) -> Shared<StubCurve> {
+            StubCurve::build(reference, instruments, None)
+        }
+
+        /// A curve whose first node sits at `initial_date` rather than at the
+        /// reference date, the way an inflation curve's base date does.
+        fn with_initial_date(
+            reference: Date,
+            instruments: Vec<Shared<dyn RateHelper>>,
+            initial_date: Date,
+        ) -> Shared<StubCurve> {
+            StubCurve::build(reference, instruments, Some(initial_date))
+        }
+
+        fn build(
+            reference: Date,
+            instruments: Vec<Shared<dyn RateHelper>>,
+            initial_date: Option<Date>,
+        ) -> Shared<StubCurve> {
             Shared::new_cyclic(|weak: &Weak<StubCurve>| {
                 let self_weak: Weak<dyn YieldTermStructure> = weak.clone();
                 StubCurve {
@@ -328,6 +361,7 @@ mod tests {
                     interpolator: LogLinear,
                     data: RefCell::new(CurveData::new()),
                     self_weak,
+                    initial_date,
                 }
             })
         }
@@ -385,6 +419,13 @@ mod tests {
             self.base.reference_date()
         }
 
+        fn initial_date(&self) -> QlResult<Date> {
+            match self.initial_date {
+                Some(date) => Ok(date),
+                None => self.base.reference_date(),
+            }
+        }
+
         fn time_from_reference(&self, date: Date) -> QlResult<Time> {
             TermStructure::time_from_reference(self, date)
         }
@@ -438,6 +479,44 @@ mod tests {
         IterativeBootstrap::new().calculate(curve.as_ref()).unwrap();
 
         for helper in [&h3, &h6, &h9] {
+            let error = helper.quote_error().unwrap();
+            assert!(error.abs() < 1.0e-12, "deposit quote error {error}");
+        }
+    }
+
+    /// The first node is laid down at the curve's `initial_date`, not at its
+    /// reference date, and its time is still measured from the reference - so a
+    /// curve whose first node precedes the reference (an inflation base date)
+    /// gets `times[0] < 0`. Without this the regression suites would not move:
+    /// the default `initial_date` makes the two dates equal everywhere else.
+    #[test]
+    fn the_first_node_sits_at_the_initial_date_which_may_precede_the_reference() {
+        let today = Date::new(15, Month::June, 2026);
+        let settings = settings_on(today);
+
+        let three_m = euribor(Period::new(3, TimeUnit::Months), settings.clone());
+        let six_m = euribor(Period::new(6, TimeUnit::Months), settings.clone());
+
+        let h3 = DepositRateHelper::from_rate(0.04557, &three_m);
+        let h6 = DepositRateHelper::from_rate(0.04496, &six_m);
+
+        let reference = h3.earliest_date();
+        let base_date = reference - 90;
+        let instruments: Vec<Shared<dyn RateHelper>> = vec![
+            Shared::clone(&h3) as Shared<dyn RateHelper>,
+            Shared::clone(&h6) as Shared<dyn RateHelper>,
+        ];
+
+        let curve = StubCurve::with_initial_date(reference, instruments, base_date);
+        IterativeBootstrap::new().calculate(curve.as_ref()).unwrap();
+
+        let data = curve.data.borrow();
+        assert_eq!(data.dates()[0], base_date);
+        assert!(data.times()[0] < 0.0, "times[0] = {}", data.times()[0]);
+        assert_eq!(data.times()[0], -90.0 / 360.0);
+        drop(data);
+
+        for helper in [&h3, &h6] {
             let error = helper.quote_error().unwrap();
             assert!(error.abs() < 1.0e-12, "deposit quote error {error}");
         }


### PR DESCRIPTION
- **feat(crates): support first curve node preceding the reference date**
- **feat(inflation): add inflation traits module**
- **feat(inflation): add inflation helpers module**
- **test(crates): drive inflation helpers through the bootstrap bound**
