### PR TITLE
feat(itofin-py): expose ZeroCouponInflationSwap facade

### DIFF
--- a/crates/itofin-py/python/itofin/indexes.pyi
+++ b/crates/itofin-py/python/itofin/indexes.pyi
@@ -2,7 +2,7 @@
 # src/swapindex.rs and src/inflation.rs (#517).
 
 from itofin import Settings
-from itofin.termstructures import YieldTermStructure
+from itofin.termstructures import YieldTermStructure, ZeroInflationTermStructure
 from itofin.time import (
     BusinessDayConvention,
     Calendar,
@@ -90,9 +90,8 @@ class ZeroInflationIndex:
 
     The curve is reached through a relinkable handle the index owns, so an
     index can be built before the curve it forecasts off exists. The handle
-    starts empty and a forecast before any link raises ItofinError. link_to,
-    which points it at a bootstrapped curve, lands with
-    PiecewiseZeroInflationCurve."""
+    starts empty and a forecast before any link raises ItofinError; link_to
+    fills it."""
 
     @staticmethod
     def uk_rpi(settings: Settings) -> ZeroInflationIndex:
@@ -122,6 +121,15 @@ class ZeroInflationIndex:
     def last_fixing_date(self) -> Date:
         """The first day of the inflation period the latest stored figure
         describes. Raises ItofinError on an index with no history."""
+        ...
+    def link_to(self, curve: ZeroInflationTermStructure) -> None:
+        """Points the index at curve, so every forecast from here on compounds
+        off it.
+
+        Takes the ZeroInflationTermStructure base, so any subclass links. It is
+        the curve behind that facade's handle at call time that is stored, not
+        the handle itself: relinking the facade afterwards leaves this index on
+        the curve it was given, and a later link_to is how it moves."""
         ...
     def needs_forecast(self, fixing_date: Date) -> bool:
         """Whether fixing_date has to be forecast rather than read from

--- a/crates/itofin-py/python/itofin/instruments.pyi
+++ b/crates/itofin-py/python/itofin/instruments.pyi
@@ -1,18 +1,21 @@
 # Hand-written stubs for itofin.instruments; sync manually with src/option.rs,
-# src/swap.rs, src/swaption.rs, src/capfloor.rs and src/credit.rs (#517).
+# src/swap.rs, src/swaption.rs, src/capfloor.rs, src/credit.rs and
+# src/inflation.rs (#517).
 
 from itofin import Settings
-from itofin.indexes import Euribor
+from itofin.indexes import CpiInterpolationType, Euribor, ZeroInflationIndex
 from itofin.models import HestonModel, HullWhite
 from itofin.pricingengines import (
     BlackCapFloorEngine,
     BlackSwaptionEngine,
+    DiscountingSwapEngine,
     MidPointCdsEngine,
 )
 from itofin.processes import BlackScholesProcess
 from itofin.termstructures import YieldTermStructure
 from itofin.time import (
     BusinessDayConvention,
+    Calendar,
     Date,
     DayCounter,
     Period,
@@ -233,3 +236,74 @@ class CreditDefaultSwap:
         ...
     def coupon_leg_npv(self) -> float: ...
     def default_leg_npv(self) -> float: ...
+
+class ZeroCouponInflationSwap:
+    """One fixed flow against one inflation-indexed flow, both exchanged at
+    maturity.
+
+    fixed_rate is the K that at inception matches the inflation growth.
+    SwapType names the inflation leg, so a Payer pays inflation and receives
+    fixed.
+
+    maturity is pre-adjustment: each leg's payment date is it rolled on that
+    leg's calendar and convention, while the year fraction behind the fixed
+    amount stays on the raw date. inflation_calendar and inflation_convention
+    fall back to the fixed-leg ones when None.
+
+    The core omits adjust_inf_obs_dates from its own signature, so there is
+    nothing to expose here; the leg and cash-flow accessors are not surfaced
+    either, there being no cash-flow facade."""
+
+    def __init__(
+        self,
+        swap_type: SwapType,
+        nominal: float,
+        start_date: Date,
+        maturity: Date,
+        fixed_calendar: Calendar,
+        fixed_convention: BusinessDayConvention,
+        day_counter: DayCounter,
+        fixed_rate: float,
+        inflation_index: ZeroInflationIndex,
+        observation_lag: Period,
+        observation_interpolation: CpiInterpolationType,
+        inflation_calendar: Calendar | None,
+        inflation_convention: BusinessDayConvention | None,
+        settings: Settings,
+    ) -> None:
+        """Raises ItofinError when the observation lag is too short for the
+        index to observe fixings that exist."""
+        ...
+    def set_engine(self, engine: DiscountingSwapEngine) -> None:
+        """Price the swap off a discount curve. The engine must resolve its
+        dates against the same Settings object as this swap."""
+        ...
+    def npv(self) -> float:
+        """Raises ItofinError with no engine attached, and with no curve linked
+        into the index."""
+        ...
+    def fair_rate(self) -> float:
+        """The index ratio de-compounded over the swap's own year fraction.
+
+        Needs no engine - it reads the indexed flow rather than any priced
+        result - but does need the index linked to a curve."""
+        ...
+    def fixed_leg_npv(self) -> float: ...
+    def inflation_leg_npv(self) -> float: ...
+    def fixed_leg_bps(self) -> float:
+        """The fixed leg's sensitivity to a basis point on the quoted rate,
+        computed in closed form rather than read off the engine, whose own leg
+        BPS is zero for a non-coupon flow."""
+        ...
+    def maturity_date(self) -> Date:
+        """The contract maturity, raw and pre-adjustment - not either leg's
+        payment date."""
+        ...
+    def obs_date(self) -> Date:
+        """The date the maturity fixing is observed at, maturity less the
+        observation lag, unsnapped."""
+        ...
+    def inflation_fixing_date(self) -> Date:
+        """The same date as obs_date, read off the indexed flow rather than off
+        the swap. Both names are kept because both exist in the core."""
+        ...

--- a/crates/itofin-py/src/inflation.rs
+++ b/crates/itofin-py/src/inflation.rs
@@ -1,7 +1,8 @@
 //! Facades for the inflation slice: the [`PyDiscountingSwapEngine`] every
 //! inflation swap prices through, the [`PyCpiInterpolationType`] observation
-//! flag, the [`PyZeroInflationIndex`] family and the
-//! [`PyZeroInflationTermStructure`] curve hierarchy.
+//! flag, the [`PyZeroInflationIndex`] family, the
+//! [`PyZeroInflationTermStructure`] curve hierarchy and the
+//! [`PyZeroCouponInflationSwap`] the three of them price together.
 //!
 //! The swap engine is generic rather than inflation-specific - it prices any
 //! swap - but is homed here because the inflation tickets are the first to need
@@ -10,11 +11,16 @@
 use crate::PyQlError;
 use crate::curve::PyYieldTermStructure;
 use crate::settings::PySettings;
-use crate::time::{PyDate, PyDayCounter, PyFrequency};
+use crate::swap::PySwapType;
+use crate::time::{
+    PyBusinessDayConvention, PyCalendar, PyDate, PyDayCounter, PyFrequency, PyPeriod,
+};
 use libitofin::handle::{Handle, RelinkableHandle};
 use libitofin::indexes::index::Index;
 use libitofin::indexes::inflation::{EuHicp, UkHicp, UkRpi};
-use libitofin::indexes::inflationindex::ZeroInflationIndex;
+use libitofin::indexes::inflationindex::{CpiInterpolationType, ZeroInflationIndex};
+use libitofin::instrument::Instrument;
+use libitofin::instruments::ZeroCouponInflationSwap;
 use libitofin::math::interpolations::linear::Linear;
 use libitofin::pricingengine::PricingEngine;
 use libitofin::pricingengines::DiscountingSwapEngine;
@@ -65,7 +71,6 @@ impl PyDiscountingSwapEngine {
 impl PyDiscountingSwapEngine {
     /// The erased engine the instrument facades install via
     /// `set_pricing_engine`.
-    #[allow(dead_code)]
     pub(crate) fn engine(&self) -> SharedMut<dyn PricingEngine> {
         SharedMut::clone(&self.inner) as SharedMut<dyn PricingEngine>
     }
@@ -88,6 +93,16 @@ pub enum PyCpiInterpolationType {
     Linear,
 }
 
+impl PyCpiInterpolationType {
+    /// The core [`CpiInterpolationType`] this variant stands for.
+    fn inner(&self) -> CpiInterpolationType {
+        match self {
+            PyCpiInterpolationType::Flat => CpiInterpolationType::Flat,
+            PyCpiInterpolationType::Linear => CpiInterpolationType::Linear,
+        }
+    }
+}
+
 /// Python `ZeroInflationIndex`: a price index publishing one level per period,
 /// reading back either a stored figure or a forecast off its inflation curve
 /// (core `indexes::inflationindex::ZeroInflationIndex`).
@@ -100,9 +115,6 @@ pub enum PyCpiInterpolationType {
 /// choice to `link_to`, which is how the bootstrapped-curve fixtures need it.
 /// The handle starts empty, exactly as the core's own constructor leaves it, so
 /// a forecast before any link raises the empty-handle error.
-///
-/// `link_to`, which points that handle at a bootstrapped curve, lands with
-/// `PiecewiseZeroInflationCurve`: there is no curve facade to link to yet.
 #[pyclass(name = "ZeroInflationIndex", unsendable)]
 pub struct PyZeroInflationIndex {
     inner: Shared<ZeroInflationIndex>,
@@ -183,6 +195,26 @@ impl PyZeroInflationIndex {
         ))
     }
 
+    /// Points the index at `curve`, so every forecast from here on compounds
+    /// off it.
+    ///
+    /// Takes the [`PyZeroInflationTermStructure`] base, so any subclass links:
+    /// the directly-built [`PyInterpolatedZeroInflationCurve`] as much as the
+    /// bootstrapped curves that follow. The base's handle is filled at
+    /// construction, so it always dereferences here.
+    ///
+    /// It is the curve *behind* `curve`'s handle at call time that is stored,
+    /// not the handle itself: relinking the facade afterwards leaves this index
+    /// on the curve it was given, and a later `link_to` is how it moves.
+    ///
+    /// # Errors
+    ///
+    /// Reports the empty-handle error if `curve` somehow carries no link.
+    fn link_to(&self, curve: &PyZeroInflationTermStructure) -> PyResult<()> {
+        self.relink(curve.handle().current_link().map_err(PyQlError::from)?);
+        Ok(())
+    }
+
     /// Whether `fixing_date` has to be forecast rather than read from history,
     /// decided against the latest period that could have been published by the
     /// settings' evaluation date.
@@ -201,15 +233,12 @@ impl PyZeroInflationIndex {
 impl PyZeroInflationIndex {
     /// Points the internal handle at `curve`, so the index forecasts off it.
     ///
-    /// The seam the `link_to` method calls once a zero inflation curve facade
-    /// exists.
-    #[allow(dead_code)]
+    /// The seam [`link_to`](Self::link_to) dereferences a curve facade into.
     pub(crate) fn relink(&self, curve: Shared<dyn ZeroInflationTermStructure>) {
         self.curve.link_to(curve);
     }
 
     /// The wrapped core index, for the coupon and helper facades that take one.
-    #[allow(dead_code)]
     pub(crate) fn shared(&self) -> Shared<ZeroInflationIndex> {
         Shared::clone(&self.inner)
     }
@@ -305,7 +334,6 @@ impl PyZeroInflationTermStructure {
 
     /// A clone of the inner curve handle for the coupon and instrument facades
     /// that take an inflation curve.
-    #[allow(dead_code)]
     pub(crate) fn handle(&self) -> Handle<dyn ZeroInflationTermStructure> {
         self.inner.clone()
     }
@@ -404,5 +432,182 @@ impl PyInterpolatedZeroInflationCurve {
             .into_iter()
             .map(|(date, rate)| (PyDate::from_inner(date), rate))
             .collect()
+    }
+}
+
+/// Python `ZeroCouponInflationSwap`: one fixed flow against one
+/// inflation-indexed flow, both exchanged at maturity
+/// (`instruments::zerocouponinflationswap`).
+///
+/// The quoted `fixed_rate` is the `K` that at inception matches the inflation
+/// growth. [`SwapType`](crate::swap::PySwapType) names the *inflation* leg, so a
+/// `Payer` pays inflation and receives fixed.
+///
+/// `maturity` is pre-adjustment: each leg's payment date is it rolled on that
+/// leg's calendar and convention, while the year fraction behind the fixed
+/// amount stays on the raw date. `inflation_calendar` and
+/// `inflation_convention` fall back to the fixed-leg ones when `None`, and are
+/// stored resolved.
+///
+/// Fallible at construction: the observation lag must let the index observe
+/// fixings that exist, which under
+/// [`Linear`](PyCpiInterpolationType::Linear) costs a further publication
+/// period (`zerocouponinflationswap.rs:156-176`).
+///
+/// Pricing needs an engine: call [`set_engine`](Self::set_engine) before
+/// [`npv`](Self::npv). [`fair_rate`](Self::fair_rate) is the exception - it
+/// reads the indexed flow directly and prices with no engine at all - but it
+/// does need the index linked to a curve.
+///
+/// Deferred (visible): the core omits `adjust_inf_obs_dates` from its own
+/// signature, so there is nothing to expose here; the leg and cash-flow
+/// accessors are not surfaced either, there being no cash-flow facade, and
+/// [`inflation_fixing_date`](Self::inflation_fixing_date) carries the one datum
+/// off the indexed flow that the fixtures read.
+#[pyclass(name = "ZeroCouponInflationSwap", unsendable)]
+pub struct PyZeroCouponInflationSwap {
+    inner: SharedMut<ZeroCouponInflationSwap>,
+}
+
+#[pymethods]
+impl PyZeroCouponInflationSwap {
+    #[new]
+    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (
+        swap_type,
+        nominal,
+        start_date,
+        maturity,
+        fixed_calendar,
+        fixed_convention,
+        day_counter,
+        fixed_rate,
+        inflation_index,
+        observation_lag,
+        observation_interpolation,
+        inflation_calendar,
+        inflation_convention,
+        settings,
+    ))]
+    fn new(
+        swap_type: &PySwapType,
+        nominal: f64,
+        start_date: &PyDate,
+        maturity: &PyDate,
+        fixed_calendar: &PyCalendar,
+        fixed_convention: &PyBusinessDayConvention,
+        day_counter: &PyDayCounter,
+        fixed_rate: f64,
+        inflation_index: &PyZeroInflationIndex,
+        observation_lag: &PyPeriod,
+        observation_interpolation: &PyCpiInterpolationType,
+        inflation_calendar: Option<&PyCalendar>,
+        inflation_convention: Option<PyBusinessDayConvention>,
+        settings: &PySettings,
+    ) -> PyResult<Self> {
+        Ok(PyZeroCouponInflationSwap {
+            inner: shared_mut(
+                ZeroCouponInflationSwap::new(
+                    swap_type.inner(),
+                    nominal,
+                    start_date.inner(),
+                    maturity.inner(),
+                    fixed_calendar.inner(),
+                    fixed_convention.inner(),
+                    day_counter.inner(),
+                    fixed_rate,
+                    inflation_index.shared(),
+                    observation_lag.inner(),
+                    observation_interpolation.inner(),
+                    inflation_calendar.map(PyCalendar::inner),
+                    inflation_convention.map(|convention| convention.inner()),
+                    settings.inner(),
+                )
+                .map_err(PyQlError::from)?,
+            ),
+        })
+    }
+
+    /// Attaches a [`PyDiscountingSwapEngine`] so the swap prices.
+    ///
+    /// The engine must resolve its dates against the same `Settings` object
+    /// this swap was built with.
+    fn set_engine(&mut self, engine: &PyDiscountingSwapEngine) {
+        self.inner
+            .borrow_mut()
+            .base_mut()
+            .set_pricing_engine(engine.engine());
+    }
+
+    /// The swap NPV under the attached engine.
+    ///
+    /// Fallible: with no engine attached the core reports `"null pricing
+    /// engine"`, and with no curve linked into the index the indexed flow
+    /// cannot be forecast.
+    fn npv(&mut self) -> PyResult<f64> {
+        Ok(self.inner.borrow_mut().npv().map_err(PyQlError::from)?)
+    }
+
+    /// The rate that would price the swap at zero: the index ratio
+    /// `I(T)/I(0)` de-compounded over the swap's own year fraction.
+    ///
+    /// Needs no engine - it reads the indexed flow rather than any priced
+    /// result - but does need the index linked, the flow's amount being a
+    /// forecast off the inflation curve.
+    fn fair_rate(&self) -> PyResult<f64> {
+        Ok(self.inner.borrow().fair_rate().map_err(PyQlError::from)?)
+    }
+
+    /// The fixed leg's NPV, priced on demand. Fallible as [`npv`](Self::npv).
+    fn fixed_leg_npv(&mut self) -> PyResult<f64> {
+        Ok(self
+            .inner
+            .borrow_mut()
+            .fixed_leg_npv()
+            .map_err(PyQlError::from)?)
+    }
+
+    /// The inflation leg's NPV, priced on demand. Fallible as
+    /// [`npv`](Self::npv).
+    fn inflation_leg_npv(&mut self) -> PyResult<f64> {
+        Ok(self
+            .inner
+            .borrow_mut()
+            .inflation_leg_npv()
+            .map_err(PyQlError::from)?)
+    }
+
+    /// The fixed leg's sensitivity to a basis point on the quoted rate,
+    /// computed in closed form rather than read off the engine, whose own leg
+    /// BPS is zero for a non-coupon flow.
+    ///
+    /// Fallible as [`npv`](Self::npv): it needs the engine's discount factor at
+    /// the fixed leg's end date.
+    fn fixed_leg_bps(&mut self) -> PyResult<f64> {
+        Ok(self
+            .inner
+            .borrow_mut()
+            .fixed_leg_bps()
+            .map_err(PyQlError::from)?)
+    }
+
+    /// The contract maturity, raw and pre-adjustment - not either leg's
+    /// payment date.
+    fn maturity_date(&self) -> PyDate {
+        PyDate::from_inner(self.inner.borrow().maturity_date())
+    }
+
+    /// The date the maturity fixing is observed at, `maturity` less the
+    /// observation lag, unsnapped.
+    fn obs_date(&self) -> PyDate {
+        PyDate::from_inner(self.inner.borrow().obs_date())
+    }
+
+    /// The same date as [`obs_date`](Self::obs_date), read off the indexed flow
+    /// rather than off the swap: the core's `obs_date()` is that call
+    /// (`zerocouponinflationswap.rs:315-317`). Both names are kept because both
+    /// exist in the core, and the oracle asserts they coincide.
+    fn inflation_fixing_date(&self) -> PyDate {
+        PyDate::from_inner(self.inner.borrow().inflation_cash_flow().fixing_date())
     }
 }

--- a/crates/itofin-py/src/lib.rs
+++ b/crates/itofin-py/src/lib.rs
@@ -53,7 +53,7 @@ use heston::{PyHestonModel, PyHestonModelHelper, PyHestonProcess};
 use hullwhite::{PyEuribor, PyHullWhite, PySwaptionHelper};
 use inflation::{
     PyCpiInterpolationType, PyDiscountingSwapEngine, PyInterpolatedZeroInflationCurve,
-    PyZeroInflationIndex, PyZeroInflationTermStructure,
+    PyZeroCouponInflationSwap, PyZeroInflationIndex, PyZeroInflationTermStructure,
 };
 use libitofin::errors::QlError;
 use market::{PyBlackScholesProcess, PySimpleQuote};
@@ -210,6 +210,7 @@ fn itofin(m: &Bound<'_, PyModule>) -> PyResult<()> {
     instruments.add_class::<PyCapFloor>()?;
     instruments.add_class::<PyProtectionSide>()?;
     instruments.add_class::<PyCreditDefaultSwap>()?;
+    instruments.add_class::<PyZeroCouponInflationSwap>()?;
 
     let models = PyModule::new(py, "models")?;
     models.add_class::<PyHestonModel>()?;

--- a/crates/itofin-py/src/swap.rs
+++ b/crates/itofin-py/src/swap.rs
@@ -38,7 +38,7 @@ pub enum PySwapType {
 
 impl PySwapType {
     /// The core [`SwapType`] this variant stands for.
-    fn inner(&self) -> SwapType {
+    pub(crate) fn inner(&self) -> SwapType {
         match self {
             PySwapType::Payer => SwapType::Payer,
             PySwapType::Receiver => SwapType::Receiver,

--- a/crates/itofin-py/tests/test_zc_inflation_swap.py
+++ b/crates/itofin-py/tests/test_zc_inflation_swap.py
@@ -124,7 +124,8 @@ def test_the_observation_date_lags_the_maturity():
     maturity less the three-month lag, unsnapped to its inflation period, and
     obs_date is the same call on the swap (zerocouponinflationswap.rs:315-317)
     under the flow-level name."""
-    swap = _swap(_settings(), _index(_settings()))
+    settings = _settings()
+    swap = _swap(settings, _index(settings))
 
     assert swap.inflation_fixing_date() == Date(13, 5, 2008)
     assert swap.obs_date() == swap.inflation_fixing_date()
@@ -136,14 +137,21 @@ def test_the_maturity_round_trips_raw():
     Swap's span over the legs. The Saturday fixture that does is in the core
     (`the_raw_dates_override_the_bases_span_of_the_legs`); here it is an input
     round-trip."""
-    assert _swap(_settings(), _index(_settings())).maturity_date() == MATURITY
+    settings = _settings()
+
+    assert _swap(settings, _index(settings)).maturity_date() == MATURITY
 
 
 def test_an_unlinked_index_cannot_price_and_link_to_fixes_it():
     """The pin that makes link_to's wiring observable. The index's handle
     starts empty, so the maturity forecast - and everything downstream of it -
     raises until a curve is linked. Nothing about the swap changes in between:
-    the same object prices afterwards."""
+    the same object prices afterwards.
+
+    It does not show that a relink refreshes an already-priced swap. The failed
+    calculate() left the instrument uncalculated, so the second call simply
+    recomputes; whether a notification reaches a swap that priced successfully
+    is the separate #387 question."""
     settings = _settings()
     index = _index(settings)
     swap = _swap(settings, index)

--- a/crates/itofin-py/tests/test_zc_inflation_swap.py
+++ b/crates/itofin-py/tests/test_zc_inflation_swap.py
@@ -1,0 +1,243 @@
+"""ZeroCouponInflationSwap priced without a bootstrap (#750).
+
+The swap is built over a DIRECTLY-built InterpolatedZeroInflationCurve (#749)
+linked into a UK RPI index (#748) through the new ZeroInflationIndex.link_to,
+and discounted by a flat nominal curve. A directly-built curve does not reprice
+its own swaps to zero, so every number below is a pin taken from a throwaway
+Rust probe over the identical fixture, not a milestone the swap has to hit.
+
+What the pins are for: the 14-argument constructor order, the forecast reaching
+the index through the curve link, and the engine reaching the swap. The core
+numerics are not under test here - crates/libitofin/src/instruments/
+zerocouponinflationswap.rs pins those against hand-derived amounts, including
+the raw-vs-adjusted year fraction that this fixture cannot see.
+
+Fixture. It is 13 August 2007. Two RPI figures are on record: May 2007, which
+the swap's own base observation (13 Aug 2007 less the three-month lag) reads
+from history, and July 2007, the curve's base date, which the forecast
+machinery compounds off (inflationindex.rs:479-498). Both sit at or before the
+publication horizon - 13 Aug less RPI's one-month availability lag puts it in
+July 2007 - so neither is itself forecast. The maturity observation, 13 May
+2008, is well past it and so is forecast off the curve; 1 May 2008 falls
+strictly between the 1 Jan and 1 Jul 2008 nodes, so it reads an interpolated
+rate rather than a node outright.
+"""
+
+import pytest
+from itofin import ItofinError, Settings
+from itofin.indexes import CpiInterpolationType, ZeroInflationIndex
+from itofin.instruments import SwapType, ZeroCouponInflationSwap
+from itofin.pricingengines import DiscountingSwapEngine
+from itofin.termstructures import FlatForward, InterpolatedZeroInflationCurve
+from itofin.time import (
+    BusinessDayConvention,
+    Calendar,
+    Date,
+    DayCounter,
+    Frequency,
+    Period,
+)
+
+TODAY = Date(13, 8, 2007)
+MATURITY = Date(13, 8, 2008)
+CURVE_BASE = Date(1, 7, 2007)
+BASE_OBSERVATION = Date(1, 5, 2007)
+CURVE_DATES = [CURVE_BASE, Date(1, 9, 2007), Date(1, 1, 2008), Date(1, 7, 2008), Date(1, 7, 2009)]
+CURVE_RATES = [0.02, 0.022, 0.025, 0.027, 0.030]
+MAY_2007_FIXING = 205.0
+JULY_2007_FIXING = 207.3
+NOMINAL = 1_000_000.0
+FIXED_RATE = 0.025
+NOMINAL_RATE = 0.05
+
+FAIR_RATE = 0.03336195814008680
+NPV = -7953.05109561582139577
+FIXED_LEG_NPV = 23777.47820061785387225
+INFLATION_LEG_NPV = -31730.52929623367526801
+FIXED_LEG_BPS = 95.10991280246126678
+TOLERANCE = 1e-7
+
+
+def _settings() -> Settings:
+    settings = Settings()
+    settings.set_evaluation_date(TODAY)
+    return settings
+
+
+def _curve() -> InterpolatedZeroInflationCurve:
+    return InterpolatedZeroInflationCurve(
+        TODAY,
+        list(CURVE_DATES),
+        list(CURVE_RATES),
+        Frequency.Monthly,
+        DayCounter.thirty360_bond_basis(),
+    )
+
+
+def _index(settings: Settings) -> ZeroInflationIndex:
+    """UK RPI carrying the two figures the fixture reads from history. No curve
+    is linked yet: link_to is what the tests below exercise."""
+    index = ZeroInflationIndex.uk_rpi(settings)
+    index.add_fixing(BASE_OBSERVATION, MAY_2007_FIXING)
+    index.add_fixing(CURVE_BASE, JULY_2007_FIXING)
+    return index
+
+
+def _swap(settings: Settings, index: ZeroInflationIndex) -> ZeroCouponInflationSwap:
+    """A payer, so the swap pays inflation and receives fixed. Both optional
+    inflation-leg conventions are left None and so resolve to the fixed-leg
+    ones."""
+    return ZeroCouponInflationSwap(
+        SwapType.Payer,
+        NOMINAL,
+        TODAY,
+        MATURITY,
+        Calendar.united_kingdom(),
+        BusinessDayConvention.ModifiedFollowing,
+        DayCounter.thirty360_bond_basis(),
+        FIXED_RATE,
+        index,
+        Period(3, "Months"),
+        CpiInterpolationType.Flat,
+        None,
+        None,
+        settings,
+    )
+
+
+def _engine(settings: Settings) -> DiscountingSwapEngine:
+    nominal = FlatForward(TODAY, NOMINAL_RATE, DayCounter.actual365_fixed())
+    return DiscountingSwapEngine(nominal, settings)
+
+
+def _priced_swap() -> ZeroCouponInflationSwap:
+    settings = _settings()
+    index = _index(settings)
+    index.link_to(_curve())
+    swap = _swap(settings, index)
+    swap.set_engine(_engine(settings))
+    return swap
+
+
+def test_the_observation_date_lags_the_maturity():
+    """The one datum read off the indexed cash flow. 13 May 2008 is the raw
+    maturity less the three-month lag, unsnapped to its inflation period, and
+    obs_date is the same call on the swap (zerocouponinflationswap.rs:315-317)
+    under the flow-level name."""
+    swap = _swap(_settings(), _index(_settings()))
+
+    assert swap.inflation_fixing_date() == Date(13, 5, 2008)
+    assert swap.obs_date() == swap.inflation_fixing_date()
+
+
+def test_the_maturity_round_trips_raw():
+    """13 August 2008 is a Wednesday, so the raw maturity and both adjusted
+    payment dates coincide and this cannot tell the override from the base
+    Swap's span over the legs. The Saturday fixture that does is in the core
+    (`the_raw_dates_override_the_bases_span_of_the_legs`); here it is an input
+    round-trip."""
+    assert _swap(_settings(), _index(_settings())).maturity_date() == MATURITY
+
+
+def test_an_unlinked_index_cannot_price_and_link_to_fixes_it():
+    """The pin that makes link_to's wiring observable. The index's handle
+    starts empty, so the maturity forecast - and everything downstream of it -
+    raises until a curve is linked. Nothing about the swap changes in between:
+    the same object prices afterwards."""
+    settings = _settings()
+    index = _index(settings)
+    swap = _swap(settings, index)
+    swap.set_engine(_engine(settings))
+
+    with pytest.raises(ItofinError, match="empty Handle"):
+        swap.fair_rate()
+    with pytest.raises(ItofinError, match="empty Handle"):
+        swap.npv()
+
+    index.link_to(_curve())
+
+    assert swap.fair_rate() == pytest.approx(FAIR_RATE, abs=TOLERANCE)
+    assert swap.npv() == pytest.approx(NPV, abs=TOLERANCE)
+
+
+def test_the_swap_prices_to_the_probed_values():
+    """The probe pins, leg by leg. The sum identity is what would catch the two
+    leg accessors wired to the wrong index: a swapped pair leaves the total
+    unchanged, but the legs differ in both sign and magnitude - a payer
+    receives the fixed 23777 and pays the inflation 31730."""
+    swap = _priced_swap()
+
+    assert swap.fixed_leg_npv() == pytest.approx(FIXED_LEG_NPV, abs=TOLERANCE)
+    assert swap.inflation_leg_npv() == pytest.approx(INFLATION_LEG_NPV, abs=TOLERANCE)
+    assert swap.npv() == pytest.approx(NPV, abs=TOLERANCE)
+    assert swap.fixed_leg_npv() + swap.inflation_leg_npv() == pytest.approx(
+        swap.npv(), abs=TOLERANCE
+    )
+
+    assert swap.npv() != 0.0
+
+
+def test_the_fixed_leg_bps_reaches_the_engines_discount_factor():
+    """fixed_leg_bps is computed in closed form but still needs the engine, for
+    the discount factor at the fixed leg's end date. It is called here with no
+    prior npv(), which is the load-bearing part: the core's end_discounts
+    prices on demand (swap.rs:307-315)."""
+    swap = _priced_swap()
+
+    assert swap.fixed_leg_bps() == pytest.approx(FIXED_LEG_BPS, abs=TOLERANCE)
+
+
+def test_fair_rate_needs_no_engine_but_npv_does():
+    """fair_rate reads the indexed flow rather than any priced result
+    (zerocouponinflationswap.rs:364), so it answers on an engine-less swap
+    while npv reports the null engine.
+
+    Under Thirty360 BondBasis this maturity is exactly one year out, so the
+    de-compounding is the identity and the fair rate equals the raw index
+    growth. That makes the literal readable but blind to the year fraction;
+    the core pins that separately."""
+    settings = _settings()
+    index = _index(settings)
+    index.link_to(_curve())
+    swap = _swap(settings, index)
+
+    assert swap.fair_rate() == pytest.approx(FAIR_RATE, abs=TOLERANCE)
+    with pytest.raises(ItofinError, match="null pricing engine"):
+        swap.npv()
+
+
+def test_a_lag_the_index_cannot_observe_through_is_rejected():
+    """Construction is fallible. Under Flat the bar is RPI's own one-month
+    availability lag; under Linear the interpolation eats a further publication
+    period, so a one-month lag clears the first and fails the second
+    (zerocouponinflationswap.rs:156-176)."""
+    settings = _settings()
+    month = Period(1, "Months")
+
+    with pytest.raises(ItofinError, match="fixings that do not yet exist"):
+        _build_with_lag(settings, Period(0, "Months"), CpiInterpolationType.Flat)
+    with pytest.raises(ItofinError, match="inconsistency between swap observation lag"):
+        _build_with_lag(settings, month, CpiInterpolationType.Linear)
+
+    assert _build_with_lag(settings, month, CpiInterpolationType.Flat) is not None
+
+
+def _build_with_lag(
+    settings: Settings, lag: Period, interpolation: CpiInterpolationType
+) -> ZeroCouponInflationSwap:
+    return ZeroCouponInflationSwap(
+        SwapType.Payer,
+        NOMINAL,
+        TODAY,
+        MATURITY,
+        Calendar.united_kingdom(),
+        BusinessDayConvention.ModifiedFollowing,
+        DayCounter.thirty360_bond_basis(),
+        FIXED_RATE,
+        _index(settings),
+        lag,
+        interpolation,
+        None,
+        None,
+        settings,
+    )

--- a/crates/itofin-py/tests/test_zc_inflation_swap.py
+++ b/crates/itofin-py/tests/test_zc_inflation_swap.py
@@ -164,8 +164,8 @@ def test_an_unlinked_index_cannot_price_and_link_to_fixes_it():
 
     index.link_to(_curve())
 
-    assert swap.fair_rate() == pytest.approx(FAIR_RATE, abs=TOLERANCE)
-    assert swap.npv() == pytest.approx(NPV, abs=TOLERANCE)
+    assert abs(swap.fair_rate() - FAIR_RATE) <= TOLERANCE
+    assert abs(swap.npv() - NPV) <= TOLERANCE
 
 
 def test_the_swap_prices_to_the_probed_values():
@@ -175,12 +175,10 @@ def test_the_swap_prices_to_the_probed_values():
     receives the fixed 23777 and pays the inflation 31730."""
     swap = _priced_swap()
 
-    assert swap.fixed_leg_npv() == pytest.approx(FIXED_LEG_NPV, abs=TOLERANCE)
-    assert swap.inflation_leg_npv() == pytest.approx(INFLATION_LEG_NPV, abs=TOLERANCE)
-    assert swap.npv() == pytest.approx(NPV, abs=TOLERANCE)
-    assert swap.fixed_leg_npv() + swap.inflation_leg_npv() == pytest.approx(
-        swap.npv(), abs=TOLERANCE
-    )
+    assert abs(swap.fixed_leg_npv() - FIXED_LEG_NPV) <= TOLERANCE
+    assert abs(swap.inflation_leg_npv() - INFLATION_LEG_NPV) <= TOLERANCE
+    assert abs(swap.npv() - NPV) <= TOLERANCE
+    assert abs(swap.fixed_leg_npv() + swap.inflation_leg_npv() - swap.npv()) <= TOLERANCE
 
     assert swap.npv() != 0.0
 
@@ -192,7 +190,7 @@ def test_the_fixed_leg_bps_reaches_the_engines_discount_factor():
     prices on demand (swap.rs:307-315)."""
     swap = _priced_swap()
 
-    assert swap.fixed_leg_bps() == pytest.approx(FIXED_LEG_BPS, abs=TOLERANCE)
+    assert abs(swap.fixed_leg_bps() - FIXED_LEG_BPS) <= TOLERANCE
 
 
 def test_fair_rate_needs_no_engine_but_npv_does():
@@ -209,7 +207,7 @@ def test_fair_rate_needs_no_engine_but_npv_does():
     index.link_to(_curve())
     swap = _swap(settings, index)
 
-    assert swap.fair_rate() == pytest.approx(FAIR_RATE, abs=TOLERANCE)
+    assert abs(swap.fair_rate() - FAIR_RATE) <= TOLERANCE
     with pytest.raises(ItofinError, match="null pricing engine"):
         swap.npv()
 


### PR DESCRIPTION
- **feat(itofin-py): expose ZeroCouponInflationSwap facade**
- **test(itofin-py): add tests for zero-coupon inflation swap**
- **test(crates): reuse settings fixture and clarify relink scope**
- **test(crates): use explicit tolerance checks in inflation swap tests**
