### PR TITLE
feat(montecarlo): allow a shared pricer to drive multiple models

### DIFF
--- a/crates/libitofin/src/methods/montecarlo/earlyexercisepathpricer.rs
+++ b/crates/libitofin/src/methods/montecarlo/earlyexercisepathpricer.rs
@@ -1,0 +1,117 @@
+//! Base trait for early-exercise single-path pricers.
+//!
+//! Port of `ql/methods/montecarlo/earlyexercisepathpricer.hpp:62-76`: the three
+//! things a Longstaff-Schwartz backward induction needs from an instrument at
+//! each exercise date - the intrinsic value of exercising now, the regressor
+//! state to condition the continuation value on, and the basis system to
+//! regress that continuation value against.
+//!
+//! Divergences from `earlyexercisepathpricer.hpp`, all deliberate:
+//! - **`State` is an associated type, not an `EarlyExerciseTraits` lookup**:
+//!   C++ derives `StateType` from the path type through a traits class
+//!   specialized per path (`:34-54`, `Real` for `Path`, `Array` for
+//!   `MultiPath`). Rust states the same fact directly on the implementor, which
+//!   drops the traits indirection and the dummy primary template that fails to
+//!   compile for an unknown path type (`:34-37`).
+//! - **`TimeType` and `ValueType` are fixed to [`Size`] and [`Real`]**: the C++
+//!   template parameters (`:62-63`) default to exactly those and no instrument
+//!   in QuantLib instantiates them otherwise.
+//! - **`operator()` is named `value`**: an exercise value is not a call.
+
+use crate::types::{Real, Size};
+
+/// Values an early-exercisable instrument along a single realized path.
+///
+/// `P` is the path type produced by the generator ([`Path`](super::Path) or
+/// [`MultiPath`](super::MultiPath)); `t` indexes the exercise date within it.
+pub trait EarlyExercisePathPricer<P> {
+    /// The regressor observed at an exercise date: `Real` for a single-factor
+    /// [`Path`](super::Path), an [`Array`](crate::math::array::Array) for a
+    /// basket over a [`MultiPath`](super::MultiPath)
+    /// (`earlyexercisepathpricer.hpp:41,50`).
+    type State;
+
+    /// The intrinsic value of exercising at index `t` along `path`, the C++
+    /// `operator()` (`earlyexercisepathpricer.hpp:68-69`).
+    fn value(&self, path: &P, t: Size) -> Real;
+
+    /// The state to regress the continuation value against at index `t`
+    /// (`earlyexercisepathpricer.hpp:71-72`).
+    fn state(&self, path: &P, t: Size) -> Self::State;
+
+    /// The basis functions spanning the continuation-value regression
+    /// (`earlyexercisepathpricer.hpp:73-75`), typically
+    /// [`LsmBasisSystem::path_basis_system`](super::LsmBasisSystem::path_basis_system).
+    fn basis_system(&self) -> Vec<Box<dyn Fn(Self::State) -> Real>>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::math::array::Array;
+    use crate::math::timegrid::TimeGrid;
+    use crate::methods::montecarlo::{LsmBasisSystem, Path, PolynomialType};
+
+    /// The American-put shape every Longstaff-Schwartz instrument takes: the
+    /// exercise value is the payoff of the spot at `t`, the regressor is that
+    /// same spot, and the basis system is the monomials.
+    struct AmericanPut {
+        strike: Real,
+        order: Size,
+    }
+
+    impl EarlyExercisePathPricer<Path> for AmericanPut {
+        type State = Real;
+
+        fn value(&self, path: &Path, t: Size) -> Real {
+            (self.strike - path[t]).max(0.0)
+        }
+
+        fn state(&self, path: &Path, t: Size) -> Real {
+            path[t]
+        }
+
+        fn basis_system(&self) -> Vec<Box<dyn Fn(Real) -> Real>> {
+            LsmBasisSystem::path_basis_system(self.order, PolynomialType::Monomial)
+        }
+    }
+
+    fn path(values: [Real; 3]) -> Path {
+        let grid = TimeGrid::new(1.0, 2).unwrap();
+        Path::new(grid, Array::from(values)).unwrap()
+    }
+
+    /// The trait is usable as written: an implementor over [`Path`] with
+    /// `State = Real` reports the intrinsic value, the regressor, and a basis
+    /// system whose arity matches the requested order.
+    #[test]
+    fn a_path_implementor_reports_value_state_and_basis() {
+        let pricer = AmericanPut {
+            strike: 40.0,
+            order: 2,
+        };
+        let p = path([36.0, 44.0, 38.0]);
+
+        assert_eq!(pricer.value(&p, 0), 4.0);
+        assert_eq!(
+            pricer.value(&p, 1),
+            0.0,
+            "an out-of-the-money put is worth 0"
+        );
+        assert_eq!(pricer.value(&p, 2), 2.0);
+
+        assert_eq!(pricer.state(&p, 1), 44.0);
+        assert_eq!(pricer.basis_system().len(), 3);
+    }
+
+    /// Object safety: the backward induction holds one pricer behind a pointer,
+    /// so the trait must survive erasure with `State` named.
+    #[test]
+    fn the_trait_is_object_safe() {
+        let pricer: Box<dyn EarlyExercisePathPricer<Path, State = Real>> = Box::new(AmericanPut {
+            strike: 40.0,
+            order: 1,
+        });
+        assert_eq!(pricer.value(&path([36.0, 44.0, 38.0]), 0), 4.0);
+    }
+}

--- a/crates/libitofin/src/methods/montecarlo/lsmbasissystem.rs
+++ b/crates/libitofin/src/methods/montecarlo/lsmbasissystem.rs
@@ -1,0 +1,128 @@
+//! Basis systems for Longstaff-Schwartz early-exercise Monte Carlo.
+//!
+//! Port of `ql/methods/montecarlo/lsmbasissystem.{hpp,cpp}`: the family of
+//! functions the backward induction regresses the continuation value against.
+//! [`LsmBasisSystem::path_basis_system`] returns the `order + 1` monomials
+//! `{1, x, x^2, ..., x^order}` (`lsmbasissystem.cpp:109-114`).
+//!
+//! Deferred, rejected visibly rather than silently ignored:
+//! - **the Gauss families** (`Laguerre`, `Hermite`, `Hyperbolic`, `Legendre`,
+//!   `Chebyshev`, `Chebyshev2nd` - `lsmbasissystem.hpp:39-41`, built from
+//!   `GaussianQuadrature::weightedValue` at `lsmbasissystem.cpp:116-151`).
+//!   [`PolynomialType`] therefore carries the one ported variant rather than a
+//!   full set with unreachable arms. `MakeMCAmericanEngine` defaults to
+//!   `Monomial` (`mcamericanengine.hpp:136`), and the only test that varies the
+//!   family indexes its array by `0*(i*3+j)%5`
+//!   (`test-suite/mclongstaffschwartzengine.cpp:193`), whose `0*` factor pins
+//!   every iteration to element 0, `Monomial` (`:161-164`). No oracle in this
+//!   stack reaches the others.
+//! - **`multiPathBasisSystem`** (`lsmbasissystem.hpp:46-47`), the tensor
+//!   product over a `MultiPath` for multi-asset early exercise.
+
+use crate::types::{Real, Size};
+
+/// The polynomial family a basis system is built from
+/// (`lsmbasissystem.hpp:38-41`).
+///
+/// Only `Monomial` is ported; see the module docs for the deferred Gauss
+/// families.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PolynomialType {
+    /// `x^i`, the family `MCAmericanEngine` uses.
+    Monomial,
+}
+
+/// `x^order`, evaluated as C++ does by iterated multiplication rather than
+/// `powi` (`lsmbasissystem.cpp:41-50`).
+///
+/// The two agree to the last bit only up to order 3; binary exponentiation
+/// rounds differently above that, and the regression is the oracle's, so this
+/// follows the C++ arithmetic exactly.
+fn monomial(order: Size, x: Real) -> Real {
+    let mut ret = 1.0;
+    for _ in 0..order {
+        ret *= x;
+    }
+    ret
+}
+
+/// The basis systems of `lsmbasissystem.hpp:37-48`.
+pub struct LsmBasisSystem;
+
+impl LsmBasisSystem {
+    /// The `order + 1` basis functions over a single-factor state
+    /// (`lsmbasissystem.cpp:109-114`): for `PolynomialType::Monomial`,
+    /// `{1, x, x^2, ..., x^order}`.
+    pub fn path_basis_system(
+        order: Size,
+        poly_type: PolynomialType,
+    ) -> Vec<Box<dyn Fn(Real) -> Real>> {
+        match poly_type {
+            PolynomialType::Monomial => (0..=order)
+                .map(|i| Box::new(move |x: Real| monomial(i, x)) as Box<dyn Fn(Real) -> Real>)
+                .collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Oracle: `pathBasisSystem(3, Monomial)` is `{1, x, x^2, x^3}`
+    /// (`lsmbasissystem.cpp:109-114` over the `MonomialFct` of `:41-50`).
+    ///
+    /// The expectations are written as repeated multiplication, matching the
+    /// C++ loop, so the comparison is exact rather than one ulp away from
+    /// `powi`.
+    #[test]
+    fn monomials_of_order_three_evaluate_to_the_powers() {
+        let basis = LsmBasisSystem::path_basis_system(3, PolynomialType::Monomial);
+        assert_eq!(basis.len(), 4, "order n yields n+1 functions");
+
+        for x in [0.5, 1.7, -2.0] {
+            let expected = [1.0, x, x * x, x * x * x];
+            for (i, (f, want)) in basis.iter().zip(expected).enumerate() {
+                assert!(
+                    (f(x) - want).abs() <= 1e-15 * want.abs(),
+                    "basis[{i}]({x}) = {}, expected {want}",
+                    f(x)
+                );
+            }
+        }
+    }
+
+    /// The degenerate end of the range: order 0 is the single constant
+    /// function, and it is 1 everywhere rather than the identity. A basis
+    /// built as `{x^1, ..., x^(order+1)}` would pass the order-3 check on
+    /// length but fail here.
+    #[test]
+    fn order_zero_is_the_constant_one() {
+        let basis = LsmBasisSystem::path_basis_system(0, PolynomialType::Monomial);
+        assert_eq!(basis.len(), 1);
+        for x in [0.0, 0.5, -3.25] {
+            assert_eq!(basis[0](x), 1.0);
+        }
+    }
+
+    /// The basis is what [`GeneralLinearLeastSquares`] consumes, so it must
+    /// typecheck as its `&[F] where F: Fn(Real) -> Real` slice and recover the
+    /// coefficients of a polynomial sampled exactly.
+    ///
+    /// [`GeneralLinearLeastSquares`]: crate::math::generallinearleastsquares::GeneralLinearLeastSquares
+    #[test]
+    fn the_basis_drives_a_least_squares_fit() {
+        use crate::math::generallinearleastsquares::GeneralLinearLeastSquares;
+
+        let basis = LsmBasisSystem::path_basis_system(2, PolynomialType::Monomial);
+        let x = [-2.0, -1.0, 0.0, 1.0, 2.0, 3.0];
+        let y: Vec<Real> = x.iter().map(|x| 3.0 - 2.0 * x + 0.5 * x * x).collect();
+
+        let fit = GeneralLinearLeastSquares::new(&x, &y, &basis).unwrap();
+        let c = fit.coefficients();
+
+        assert!((c[0] - 3.0).abs() < 1e-12, "constant term {}", c[0]);
+        assert!((c[1] + 2.0).abs() < 1e-12, "linear term {}", c[1]);
+        assert!((c[2] - 0.5).abs() < 1e-12, "quadratic term {}", c[2]);
+    }
+}

--- a/crates/libitofin/src/methods/montecarlo/mod.rs
+++ b/crates/libitofin/src/methods/montecarlo/mod.rs
@@ -4,6 +4,8 @@
 //! [`Sample`]; the path generators, path pricers, and Monte Carlo model stack
 //! stack on top in later tickets.
 
+mod earlyexercisepathpricer;
+mod lsmbasissystem;
 mod mcsimulation;
 mod montecarlomodel;
 mod multipath;
@@ -13,6 +15,8 @@ mod pathgen;
 mod pathgenerator;
 mod sample;
 
+pub use earlyexercisepathpricer::EarlyExercisePathPricer;
+pub use lsmbasissystem::{LsmBasisSystem, PolynomialType};
 pub use mcsimulation::{DEFAULT_MIN_SAMPLES, McSimulation};
 pub use montecarlomodel::{MonteCarloModel, PathPricer};
 pub use multipath::MultiPath;

--- a/crates/libitofin/src/methods/montecarlo/montecarlomodel.rs
+++ b/crates/libitofin/src/methods/montecarlo/montecarlomodel.rs
@@ -37,6 +37,7 @@
 use crate::errors::QlResult;
 use crate::math::statistics::{GeneralStatistics, Statistics};
 use crate::methods::montecarlo::PathGen;
+use crate::shared::Shared;
 use crate::types::{Real, Size};
 
 /// Maps a realized path of type `P` to its payoff (the C++ `path_pricer_type`,
@@ -53,6 +54,23 @@ pub trait PathPricer<P> {
 impl<P, F: Fn(&P) -> Real> PathPricer<P> for F {
     fn price(&self, path: &P) -> Real {
         self(path)
+    }
+}
+
+/// A [`Shared`] pricer is itself a [`PathPricer`], so ONE calibrated pricer can
+/// drive several models.
+///
+/// [`MonteCarloModel::new`] takes its pricer by value, whereas C++ holds the
+/// Longstaff-Schwartz pricer as a `shared_ptr`
+/// (`mclongstaffschwartzengine.hpp:110-111`), hands that same pointer to the
+/// calibration model (`:194`), calibrates it (`:198`), and then prices through
+/// it again. Cloning the [`Shared`] gives each model a handle to the one
+/// pricer instead of a copy of it. This does not overlap the `Fn` blanket impl
+/// above: [`Shared`] is [`Rc`](std::rc::Rc), which is not callable and cannot
+/// be made callable by any crate.
+impl<P, T: PathPricer<P>> PathPricer<P> for Shared<T> {
+    fn price(&self, path: &P) -> Real {
+        (**self).price(path)
     }
 }
 
@@ -157,6 +175,7 @@ mod tests {
     use crate::time::daycounters::actual360::Actual360;
     use crate::time::frequency::Frequency;
     use crate::types::{Rate, Time, Volatility};
+    use std::cell::RefCell;
 
     const SPOT: Real = 100.0;
     const R: Rate = 0.05;
@@ -473,6 +492,77 @@ mod tests {
             se_plain > 0.01,
             "non-antithetic run must retain material variance: se={se_plain}"
         );
+    }
+
+    /// A pricer whose per-call state survives being priced through, standing in
+    /// for the Longstaff-Schwartz pricer that collects calibration paths from
+    /// its const `operator()` (`longstaffschwartzpathpricer.hpp:61,80`).
+    struct CountingPricer {
+        value: Real,
+        calls: RefCell<Size>,
+    }
+
+    impl PathPricer<Path> for CountingPricer {
+        fn price(&self, _path: &Path) -> Real {
+            *self.calls.borrow_mut() += 1;
+            self.value
+        }
+    }
+
+    /// The bridge is transparent: pricing through a [`Shared`] returns what the
+    /// bare pricer returns.
+    #[test]
+    fn a_shared_pricer_prices_as_the_bare_pricer_does() {
+        const V: Real = 2.75;
+        let grid = TimeGrid::new(1.0, 2).unwrap();
+        let p = Path::new(grid, Array::from([1.0, 2.0, 3.0])).unwrap();
+
+        let bare = CountingPricer {
+            value: V,
+            calls: RefCell::new(0),
+        };
+        let direct = bare.price(&p);
+
+        let wrapped = shared(CountingPricer {
+            value: V,
+            calls: RefCell::new(0),
+        });
+        assert_eq!(PathPricer::price(&wrapped, &p), direct);
+        assert_eq!(direct, V);
+    }
+
+    /// The reason the bridge exists: [`MonteCarloModel::new`] takes its pricer
+    /// BY VALUE, so without it a Longstaff-Schwartz pricer could not be shared
+    /// between the calibration model and the pricing model
+    /// (`mclongstaffschwartzengine.hpp:110-111,194-198`). Two models built from
+    /// clones of ONE [`Shared`] pricer must accumulate their calls on the same
+    /// pricer, not on private copies.
+    ///
+    /// Confirm-by-stubbing: were the bridge to clone the pointee instead of
+    /// dereferencing it, each model would count its own draws and the shared
+    /// total would read `N`, not `2 * N`.
+    #[test]
+    fn one_shared_pricer_drives_two_models() {
+        const N: Size = 8;
+        let pricer = shared(CountingPricer {
+            value: 1.0,
+            calls: RefCell::new(0),
+        });
+
+        let mut calibration = model(Shared::clone(&pricer), 4, 42);
+        calibration.add_samples(N).unwrap();
+        assert_eq!(*pricer.calls.borrow(), N);
+
+        let mut pricing = model(Shared::clone(&pricer), 4, 43);
+        pricing.add_samples(N).unwrap();
+
+        assert_eq!(
+            *pricer.calls.borrow(),
+            2 * N,
+            "both models must price through the same pricer"
+        );
+        assert_eq!(calibration.sample_accumulator().samples(), N);
+        assert_eq!(pricing.sample_accumulator().samples(), N);
     }
 
     #[test]


### PR DESCRIPTION
This change adds a `PathPricer` implementation for `Shared<T>`, so a single calibrated pricer can be handed to several models via cloned handles instead of being copied. This mirrors the C++ Longstaff-Schwartz engine, which holds its pricer as a `shared_ptr` and reuses it across the calibration and pricing models.

**Path pricer sharing:**
* Implemented `PathPricer<P>` for `Shared<T>` in `montecarlomodel.rs`, dereferencing to the inner pricer so pricing is transparent and does not overlap the existing `Fn` blanket impl.

**New module scaffolding:**
* Added `earlyexercisepathpricer` and `lsmbasissystem` modules and re-exported `EarlyExercisePathPricer`, `LsmBasisSystem`, and `PolynomialType` from the montecarlo module.

**Testing:**
* Added tests confirming a shared pricer prices identically to a bare pricer, and that two models built from clones of one shared pricer accumulate their calls on the same pricer.

Closes #759
