### PR TITLE
feat(itofin-py): expose Monte Carlo American engine bindings

### DIFF
--- a/crates/itofin-py/python/itofin/instruments.pyi
+++ b/crates/itofin-py/python/itofin/instruments.pyi
@@ -9,6 +9,7 @@ from itofin.pricingengines import (
     BlackCapFloorEngine,
     BlackSwaptionEngine,
     DiscountingSwapEngine,
+    MCAmericanEngine,
     MCEuropeanEngine,
     MCEuropeanHestonEngine,
     MidPointCdsEngine,
@@ -31,15 +32,32 @@ class OptionType:
     Put: OptionType
 
 class VanillaOption:
-    """A single-asset European option."""
+    """A single-asset vanilla option: European by construction, American
+    through the american classmethod."""
 
     def __init__(
         self, option_type: OptionType, strike: float, expiry: Date, settings: Settings
     ) -> None: ...
+    @classmethod
+    def american(
+        cls,
+        option_type: OptionType,
+        strike: float,
+        earliest: Date,
+        latest: Date,
+        settings: Settings,
+    ) -> VanillaOption:
+        """The option exercisable at any time over [earliest, latest], paying on
+        exercise. Raises ItofinError when earliest is after latest."""
+        ...
     def set_engine(self, process: BlackScholesProcess) -> None: ...
     def set_heston_engine(self, model: HestonModel, integration_order: int) -> None: ...
     def set_mc_engine(self, engine: MCEuropeanEngine) -> None: ...
     def set_mc_heston_engine(self, engine: MCEuropeanHestonEngine) -> None: ...
+    def set_mc_american_engine(self, engine: MCAmericanEngine) -> None:
+        """Attaches the Monte Carlo American engine. A European-exercise option
+        raises ItofinError ("wrong exercise given") when priced on it."""
+        ...
     def npv(self) -> float: ...
     def delta(self) -> float: ...
     def gamma(self) -> float: ...
@@ -50,6 +68,11 @@ class VanillaOption:
     def error_estimate(self) -> float:
         """The standard error on the present value. Raises ItofinError on the
         engines that do not produce one, which is every analytic engine here."""
+        ...
+    def exercise_probability(self) -> float:
+        """The fraction of simulated paths exercised before expiry. Raises
+        ItofinError on every engine that does not report it - only
+        MCAmericanEngine does."""
         ...
 
 class SwapType:

--- a/crates/itofin-py/python/itofin/pricingengines.pyi
+++ b/crates/itofin-py/python/itofin/pricingengines.pyi
@@ -163,3 +163,36 @@ class MCEuropeanHestonEngine:
         """Raises ItofinError when neither or both of steps / steps_per_year are
         given, and when both samples and absolute_tolerance are given."""
         ...
+
+class MCAmericanEngine:
+    """The Longstaff-Schwartz least-squares Monte Carlo engine for American
+    payoffs, over the pseudo-random RNG policy. The low-discrepancy policy is
+    not exposed (#454), and the Monomial regression basis is not selectable
+    (#453).
+
+    The option priced must come from VanillaOption.american(...): a
+    European-exercise option raises ItofinError ("wrong exercise given") when
+    priced here.
+
+    Pricing is seeded and deterministic: the same seed reproduces the NPV
+    bitwise, the standard error is read back through
+    VanillaOption.error_estimate() and the early-exercise fraction through
+    VanillaOption.exercise_probability()."""
+
+    def __init__(
+        self,
+        process: BlackScholesProcess,
+        steps: int | None = None,
+        steps_per_year: int | None = None,
+        samples: int | None = None,
+        absolute_tolerance: float | None = None,
+        max_samples: int | None = None,
+        seed: int | None = None,
+        antithetic: bool | None = None,
+        polynomial_order: int | None = None,
+        calibration_samples: int | None = None,
+    ) -> None:
+        """Raises ItofinError when neither or both of steps / steps_per_year are
+        given, and when both samples and absolute_tolerance are given. The
+        polynomial order defaults to 2 and the calibration samples to 2048."""
+        ...

--- a/crates/itofin-py/src/lib.rs
+++ b/crates/itofin-py/src/lib.rs
@@ -59,7 +59,7 @@ use inflation::{
 };
 use libitofin::errors::QlError;
 use market::{PyBlackScholesProcess, PySimpleQuote};
-use mcengine::{PyMCEuropeanEngine, PyMCEuropeanHestonEngine};
+use mcengine::{PyMCAmericanEngine, PyMCEuropeanEngine, PyMCEuropeanHestonEngine};
 use option::{PyOptionType, PyVanillaOption};
 use optionletvol::{
     PyConstantOptionletVolatility, PyOptionletStripper1, PyOptionletVolatilityStructure,
@@ -233,6 +233,7 @@ fn itofin(m: &Bound<'_, PyModule>) -> PyResult<()> {
     pricingengines.add_class::<PyDiscountingSwapEngine>()?;
     pricingengines.add_class::<PyMCEuropeanEngine>()?;
     pricingengines.add_class::<PyMCEuropeanHestonEngine>()?;
+    pricingengines.add_class::<PyMCAmericanEngine>()?;
 
     let optimization = PyModule::new(py, "optimization")?;
     optimization.add_class::<PyLevenbergMarquardt>()?;

--- a/crates/itofin-py/src/mcengine.rs
+++ b/crates/itofin-py/src/mcengine.rs
@@ -1,5 +1,5 @@
-//! Facades for the Monte Carlo European pricing engines:
-//! [`PyMCEuropeanEngine`] and [`PyMCEuropeanHestonEngine`].
+//! Facades for the Monte Carlo pricing engines: [`PyMCEuropeanEngine`],
+//! [`PyMCEuropeanHestonEngine`] and [`PyMCAmericanEngine`].
 //!
 //! The core engines are generic over their RNG policy, which does not cross FFI
 //! (D7), so the facades pin `PseudoRandom` - the policy that carries an error
@@ -14,7 +14,8 @@ use crate::market::PyBlackScholesProcess;
 use libitofin::math::randomnumbers::rngtraits::PseudoRandom;
 use libitofin::pricingengine::PricingEngine;
 use libitofin::pricingengines::vanilla::{
-    MCEuropeanEngine, MCEuropeanHestonEngine, MakeMcEuropeanEngine, MakeMcEuropeanHestonEngine,
+    MCAmericanEngine, MCEuropeanEngine, MCEuropeanHestonEngine, MakeMcAmericanEngine,
+    MakeMcEuropeanEngine, MakeMcEuropeanHestonEngine,
 };
 use libitofin::shared::{SharedMut, shared_mut};
 use pyo3::prelude::*;
@@ -175,6 +176,101 @@ impl PyMCEuropeanHestonEngine {
 }
 
 impl PyMCEuropeanHestonEngine {
+    /// The erased engine the instrument facades install via `set_pricing_engine`.
+    pub(crate) fn engine(&self) -> SharedMut<dyn PricingEngine> {
+        SharedMut::clone(&self.inner) as SharedMut<dyn PricingEngine>
+    }
+}
+
+/// Python `MCAmericanEngine`: the Longstaff-Schwartz least-squares Monte Carlo
+/// engine for American payoffs (`pricingengines::vanilla::MCAmericanEngine`),
+/// built through the core's `MakeMcAmericanEngine` factory.
+///
+/// Same optional-argument contract as [`PyMCEuropeanEngine`], plus the two
+/// regression settings: `polynomial_order` (default 2) and
+/// `calibration_samples` (default 2048). The basis family is `Monomial` and is
+/// not selectable (#453). The antithetic variate is supported here, and the
+/// core oracle prices with it on.
+///
+/// The option this engine prices must carry an American exercise that does not
+/// pay at expiry - `VanillaOption.american(...)` builds exactly that. Pricing a
+/// European-exercise option on this engine raises `ItofinError` ("wrong
+/// exercise given").
+///
+/// Pricing is seeded and deterministic: the same `seed` reproduces the NPV
+/// bitwise. The standard error is read back through
+/// `VanillaOption.error_estimate()` and the fraction of paths exercised early
+/// through `VanillaOption.exercise_probability()`.
+#[pyclass(name = "MCAmericanEngine", unsendable)]
+pub struct PyMCAmericanEngine {
+    inner: SharedMut<MCAmericanEngine<PseudoRandom>>,
+}
+
+#[pymethods]
+impl PyMCAmericanEngine {
+    /// An engine over `process`, configured through the core factory.
+    #[new]
+    #[pyo3(signature = (
+        process,
+        steps = None,
+        steps_per_year = None,
+        samples = None,
+        absolute_tolerance = None,
+        max_samples = None,
+        seed = None,
+        antithetic = None,
+        polynomial_order = None,
+        calibration_samples = None,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        process: &PyBlackScholesProcess,
+        steps: Option<usize>,
+        steps_per_year: Option<usize>,
+        samples: Option<usize>,
+        absolute_tolerance: Option<f64>,
+        max_samples: Option<usize>,
+        seed: Option<u32>,
+        antithetic: Option<bool>,
+        polynomial_order: Option<usize>,
+        calibration_samples: Option<usize>,
+    ) -> PyResult<Self> {
+        let mut maker = MakeMcAmericanEngine::<PseudoRandom>::new(process.inner());
+        if let Some(steps) = steps {
+            maker = maker.with_steps(steps);
+        }
+        if let Some(steps_per_year) = steps_per_year {
+            maker = maker.with_steps_per_year(steps_per_year);
+        }
+        if let Some(samples) = samples {
+            maker = maker.with_samples(samples);
+        }
+        if let Some(tolerance) = absolute_tolerance {
+            maker = maker.with_absolute_tolerance(tolerance);
+        }
+        if let Some(max_samples) = max_samples {
+            maker = maker.with_max_samples(max_samples);
+        }
+        if let Some(seed) = seed {
+            maker = maker.with_seed(seed);
+        }
+        if let Some(antithetic) = antithetic {
+            maker = maker.with_antithetic_variate(antithetic);
+        }
+        if let Some(order) = polynomial_order {
+            maker = maker.with_polynomial_order(order);
+        }
+        if let Some(samples) = calibration_samples {
+            maker = maker.with_calibration_samples(samples);
+        }
+        let engine = maker.build().map_err(PyQlError::from)?;
+        Ok(PyMCAmericanEngine {
+            inner: shared_mut(engine),
+        })
+    }
+}
+
+impl PyMCAmericanEngine {
     /// The erased engine the instrument facades install via `set_pricing_engine`.
     pub(crate) fn engine(&self) -> SharedMut<dyn PricingEngine> {
         SharedMut::clone(&self.inner) as SharedMut<dyn PricingEngine>

--- a/crates/itofin-py/src/option.rs
+++ b/crates/itofin-py/src/option.rs
@@ -3,10 +3,10 @@
 use crate::PyQlError;
 use crate::heston::PyHestonModel;
 use crate::market::PyBlackScholesProcess;
-use crate::mcengine::{PyMCEuropeanEngine, PyMCEuropeanHestonEngine};
+use crate::mcengine::{PyMCAmericanEngine, PyMCEuropeanEngine, PyMCEuropeanHestonEngine};
 use crate::settings::PySettings;
 use crate::time::PyDate;
-use libitofin::exercise::{EuropeanExercise, Exercise};
+use libitofin::exercise::{AmericanExercise, EuropeanExercise, Exercise};
 use libitofin::instrument::Instrument;
 use libitofin::instruments::{PlainVanillaPayoff, StrikedTypePayoff, VanillaOption};
 use libitofin::option::OptionType;
@@ -14,7 +14,9 @@ use libitofin::pricingengine::PricingEngine;
 use libitofin::pricingengines::AnalyticEuropeanEngine;
 use libitofin::pricingengines::vanilla::analytichestonengine::AnalyticHestonEngine;
 use libitofin::shared::{Shared, SharedMut, shared, shared_mut};
+use libitofin::types::Real;
 use pyo3::prelude::*;
+use pyo3::types::PyType;
 
 /// Python `OptionType`: the call/put flag (core `option::OptionType`).
 ///
@@ -38,8 +40,11 @@ impl PyOptionType {
     }
 }
 
-/// Python `VanillaOption`: a single-asset European option (core
+/// Python `VanillaOption`: a single-asset vanilla option (core
 /// `instruments::VanillaOption`, an alias of `OneAssetOption`).
+///
+/// The constructor builds the European-exercise option; the `american`
+/// classmethod builds the American-exercise one.
 ///
 /// Holds the option by value so the lazily-computed results can be produced
 /// through `&mut self` accessors; the inner instrument is `Rc`/`RefCell`-based
@@ -59,6 +64,32 @@ impl PyVanillaOption {
         PyVanillaOption {
             inner: VanillaOption::new(payoff, exercise, settings.inner()),
         }
+    }
+
+    /// The same option struck at `strike` but exercisable at any time over
+    /// `[earliest, latest]`, paying on exercise rather than at expiry.
+    ///
+    /// This is the exercise the Monte Carlo American engine requires; the
+    /// analytic European engine rejects it.
+    ///
+    /// Raises `ItofinError` when `earliest` is after `latest`.
+    #[classmethod]
+    fn american(
+        _cls: &Bound<'_, PyType>,
+        option_type: PyOptionType,
+        strike: f64,
+        earliest: &PyDate,
+        latest: &PyDate,
+        settings: &PySettings,
+    ) -> PyResult<Self> {
+        let payoff = shared(PlainVanillaPayoff::new(option_type.inner(), strike))
+            as Shared<dyn StrikedTypePayoff>;
+        let exercise = shared(
+            AmericanExercise::over(earliest.inner(), latest.inner()).map_err(PyQlError::from)?,
+        ) as Shared<dyn Exercise>;
+        Ok(PyVanillaOption {
+            inner: VanillaOption::new(payoff, exercise, settings.inner()),
+        })
     }
 
     /// Attaches an analytic European engine built on `process`, threading in
@@ -101,6 +132,16 @@ impl PyVanillaOption {
         self.inner.base_mut().set_pricing_engine(engine.engine());
     }
 
+    /// Attaches the Monte Carlo American engine `engine`, which already holds
+    /// the process it prices on.
+    ///
+    /// The option must have been built through `american`: pricing a
+    /// European-exercise option on this engine raises `ItofinError` ("wrong
+    /// exercise given") from `npv()`.
+    fn set_mc_american_engine(&mut self, engine: &PyMCAmericanEngine) {
+        self.inner.base_mut().set_pricing_engine(engine.engine());
+    }
+
     /// The present value, erroring when no evaluation date or engine is set.
     fn npv(&mut self) -> PyResult<f64> {
         Ok(self.inner.npv().map_err(PyQlError::from)?)
@@ -140,5 +181,15 @@ impl PyVanillaOption {
     /// engines that do not produce one (every analytic engine here).
     fn error_estimate(&mut self) -> PyResult<f64> {
         Ok(self.inner.error_estimate().map_err(PyQlError::from)?)
+    }
+
+    /// The fraction of simulated paths exercised before expiry, raising
+    /// `ItofinError` on every engine that does not report it - only the Monte
+    /// Carlo American engine does.
+    fn exercise_probability(&mut self) -> PyResult<f64> {
+        Ok(self
+            .inner
+            .result::<Real>("exerciseProbability")
+            .map_err(PyQlError::from)?)
     }
 }

--- a/crates/itofin-py/tests/test_mc_american.py
+++ b/crates/itofin-py/tests/test_mc_american.py
@@ -1,0 +1,137 @@
+"""Oracle for the Python MCAmericanEngine facade and the American VanillaOption.
+
+Mirrors the core oracle in
+crates/libitofin/src/pricingengines/vanilla/mcamericanengine.rs:762-812, itself
+a port of test-suite/americanoption.cpp: the 36-strike American put on a flat
+Actual365Fixed market, priced with withSteps(75).withAntitheticVariate(true)
+.withAbsoluteTolerance(0.02).withSeed(42).withPolynomialOrder(3). The reference
+2.054422273006143 is the value a locally-built QuantLib 1.43 produces for this
+exact configuration, banded by the engine's own error estimate.
+"""
+
+import pytest
+
+from itofin import ItofinError, Settings
+from itofin.instruments import OptionType, VanillaOption
+from itofin.pricingengines import MCAmericanEngine
+from itofin.processes import BlackScholesProcess
+from itofin.time import Date, DayCounter
+
+TODAY = Date(15, 5, 1998)
+SETTLEMENT = Date(17, 5, 1998)
+MATURITY = Date(17, 5, 1999)
+
+UNDERLYING = 36.0
+STRIKE = 36.0
+RISK_FREE_RATE = 0.06
+DIVIDEND_YIELD = 0.0
+VOLATILITY = 0.20
+
+QUANTLIB_MC_VALUE = 2.054422273006143
+EXPECTED_EXERCISE_PROBABILITY = 0.48013
+
+
+def _market():
+    settings = Settings()
+    settings.set_evaluation_date(TODAY)
+    process = BlackScholesProcess(
+        UNDERLYING,
+        RISK_FREE_RATE,
+        DIVIDEND_YIELD,
+        VOLATILITY,
+        SETTLEMENT,
+        DayCounter.actual365_fixed(),
+    )
+    return settings, process
+
+
+def _american_option(settings):
+    return VanillaOption.american(
+        OptionType.Put, STRIKE, earliest=SETTLEMENT, latest=MATURITY, settings=settings
+    )
+
+
+def _milestone_engine(process, seed=42, antithetic=True):
+    return MCAmericanEngine(
+        process,
+        steps=75,
+        antithetic=antithetic,
+        absolute_tolerance=0.02,
+        seed=seed,
+        polynomial_order=3,
+    )
+
+
+def test_american_put_reproduces_the_quantlib_price_and_exercise_probability():
+    settings, process = _market()
+    option = _american_option(settings)
+    option.set_mc_american_engine(_milestone_engine(process))
+
+    npv = option.npv()
+    error_estimate = option.error_estimate()
+    exercise_probability = option.exercise_probability()
+
+    european = VanillaOption(OptionType.Put, STRIKE, MATURITY, settings)
+    european.set_engine(process)
+    european_npv = european.npv()
+
+    assert abs(npv - QUANTLIB_MC_VALUE) < 2.34 * error_estimate
+    assert abs(exercise_probability - EXPECTED_EXERCISE_PROBABILITY) < 0.015
+    assert npv > european_npv
+
+
+def test_european_exercise_is_rejected_by_the_american_engine():
+    settings, process = _market()
+    option = VanillaOption(OptionType.Put, STRIKE, MATURITY, settings)
+    option.set_mc_american_engine(_milestone_engine(process))
+
+    with pytest.raises(ItofinError, match="wrong exercise given"):
+        option.npv()
+
+
+def test_exercise_probability_is_unavailable_on_the_analytic_engine():
+    settings, process = _market()
+    option = VanillaOption(OptionType.Put, STRIKE, MATURITY, settings)
+    option.set_engine(process)
+
+    with pytest.raises(ItofinError, match="exerciseProbability"):
+        option.exercise_probability()
+
+
+def _fixed_sample_npv(
+    seed=42, antithetic=True, polynomial_order=3, calibration_samples=None
+):
+    settings, process = _market()
+    option = _american_option(settings)
+    option.set_mc_american_engine(
+        MCAmericanEngine(
+            process,
+            steps=75,
+            antithetic=antithetic,
+            samples=2048,
+            seed=seed,
+            polynomial_order=polynomial_order,
+            calibration_samples=calibration_samples,
+        )
+    )
+    return option.npv()
+
+
+def test_same_seed_reproduces_bitwise_and_another_seed_differs():
+    first = _fixed_sample_npv(42, True)
+    second = _fixed_sample_npv(42, True)
+    other = _fixed_sample_npv(43, True)
+
+    assert first == second
+    assert first != other
+
+
+def test_antithetic_flag_reaches_the_core():
+    assert _fixed_sample_npv(42, True) != _fixed_sample_npv(42, False)
+
+
+def test_regression_settings_reach_the_core():
+    baseline = _fixed_sample_npv()
+
+    assert baseline != _fixed_sample_npv(polynomial_order=4)
+    assert baseline != _fixed_sample_npv(calibration_samples=1024)


### PR DESCRIPTION
This pull request adds Python bindings for the Longstaff-Schwartz least-squares Monte Carlo engine for American payoffs, along with the option construction and result accessors it requires.

**American option support:**
* Added a `VanillaOption.american(...)` classmethod that builds an American-exercise option struck at a given strike, exercisable at any time over `[earliest, latest]` and paying on exercise, raising `ItofinError` when `earliest` is after `latest`.
* Added `VanillaOption.set_mc_american_engine(...)` to attach the new engine, and `VanillaOption.exercise_probability()` to read back the fraction of simulated paths exercised before expiry.

**MCAmericanEngine facade:**
* Added `PyMCAmericanEngine`, a facade over the core `MakeMcAmericanEngine` factory pinned to the `PseudoRandom` RNG policy, sharing the optional-argument contract of the European engine plus `polynomial_order` (default 2) and `calibration_samples` (default 2048).
* Registered the new engine class in the `pricingengines` module.

**Type stubs:**
* Updated `instruments.pyi` and `pricingengines.pyi` with the new classmethod, engine setter, result accessor, and `MCAmericanEngine` signature.

Closes #771
