### PR TITLE
docs(examples): add Python and Rust usage examples

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,13 @@
+[settings]
+py_version=3
+line_length=120
+sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+ensure_newline_before_comments=True
+known_first_party=itofin
+import_heading_stdlib=standard library
+import_heading_firstparty=itofin library
+import_heading_thirdparty=pypi/conda library

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,45 +1,58 @@
 repos:
-  - repo: https://github.com/benbenbang/pre-commit-rust
-    rev: v1.0.0
-    hooks:
-      - id: fmt
-      - id: check
-      - id: clippy
-      - id: test
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
-    hooks:
-      - id: check-yaml
-        args:
-          - --allow-multiple-documents
-          - --unsafe
-      - id: end-of-file-fixer
-      - id: trailing-whitespace
-      - id: check-added-large-files
-        args:
-          - --maxkb=1024
-        stages:
-          - pre-commit
-      - id: requirements-txt-fixer
-      - id: check-merge-conflict
-      - id: debug-statements
-      - id: pretty-format-json
-        args:
-          - --autofix
-          - --indent=2
-  - repo: local
-    hooks:
-      - id: itofin-submodule-shims
-        name: itofin submodule .py shims in sync with .pyi
-        entry: python3 crates/itofin-py/scripts/gen_submodule_shims.py
-        language: system
-        files: ^crates/itofin-py/python/itofin/.*\.pyi$
-        pass_filenames: false
-      - id: validate-commit-msg
-        name: commit message is valid
-        args:
-          - --negate
-        entry: ^(build|ci|docs|feat|fix|perf|refactor|style|test|revert|hotfix|ops|chore|incompat)\([\w,\.,\-,\(,\),\/,\#]+\)(!?)(:)\s{1}([\w,\W,:]+)$
-        language: pygrep
-        stages:
-          - commit-msg
+    - repo: https://github.com/timothycrosley/isort
+      rev: 9.0.0a3
+      hooks:
+        - id: isort
+          name: isort
+          args:
+            - --settings-path=.isort.cfg
+    - repo: https://github.com/astral-sh/ruff-pre-commit
+      rev: v0.16.1
+      hooks:
+        - id: ruff
+          args:
+            - --fix
+        - id: ruff-format
+    - repo: https://github.com/benbenbang/pre-commit-rust
+      rev: v1.0.0
+      hooks:
+        - id: fmt
+        - id: check
+        - id: clippy
+        - id: test
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v6.0.0
+      hooks:
+        - id: check-yaml
+          args:
+            - --allow-multiple-documents
+            - --unsafe
+        - id: end-of-file-fixer
+        - id: trailing-whitespace
+        - id: check-added-large-files
+          args:
+            - --maxkb=1024
+          stages:
+            - pre-commit
+        - id: requirements-txt-fixer
+        - id: check-merge-conflict
+        - id: debug-statements
+        - id: pretty-format-json
+          args:
+            - --autofix
+            - --indent=2
+    - repo: local
+      hooks:
+        - id: itofin-submodule-shims
+          name: itofin submodule .py shims in sync with .pyi
+          entry: python3 crates/itofin-py/scripts/gen_submodule_shims.py
+          language: system
+          files: ^crates/itofin-py/python/itofin/.*\.pyi$
+        - id: validate-commit-msg
+          name: commit message is valid
+          args:
+            - --negate
+          entry: ^(build|ci|docs|feat|fix|perf|refactor|style|test|revert|hotfix|ops|chore|incompat)\([\w,\.,\-,\(,\),\/,\#]+\)(!?)(:)\s{1}([\w,\W,:]+)$
+          language: pygrep
+          stages:
+            - commit-msg

--- a/example/python/credit_cds.py
+++ b/example/python/credit_cds.py
@@ -1,0 +1,159 @@
+"""Price a credit default swap and bootstrap a default-probability curve.
+
+Two parts:
+
+1. Price a single CDS with `MidPointCdsEngine` off a flat hazard-rate curve.
+   The engine needs a survival (hazard) curve, a recovery rate and a discount
+   curve. This reproduces QuantLib's `creditdefaultswap.cpp` cached value:
+   NPV 295.0153398 and fair spread 0.007517539081.
+
+2. Bootstrap a `PiecewiseDefaultCurve` from `SpreadCdsHelper` quotes (the
+   inverse problem: given market spreads, solve for the hazard curve), then
+   rebuild each pillar's contract on that curve and confirm it reprices to its
+   own input spread. Mirrors `defaultprobabilitycurves.cpp`.
+
+The bootstrap round-trip is exact only when the rebuilt contract matches the
+helper's own conventions to the day, so the schedule construction below is
+copied verbatim from `test_credit_bootstrap.py` (rolled protection start,
+unadjusted maturity, explicit `protection_start`). A "simplified" schedule still
+runs but quietly misses the quotes.
+
+Run it with:
+
+    python example/python/credit_cds.py
+"""
+
+# itofin library
+from itofin import Settings
+from itofin.instruments import CreditDefaultSwap, ProtectionSide
+from itofin.pricingengines import MidPointCdsEngine
+from itofin.quotes import SimpleQuote
+from itofin.termstructures import FlatForward, FlatHazardRate, PiecewiseDefaultCurve, SpreadCdsHelper
+from itofin.time import BusinessDayConvention, Calendar, Date, DateGeneration, DayCounter, Frequency, Period, Schedule
+
+
+def price_single_cds() -> None:
+    """A 10Y CDS on a flat 1.234% hazard rate, discounted at a flat 6%."""
+    today = Date(9, 6, 2006)
+    settings = Settings()
+    settings.set_evaluation_date(today)
+    calendar = Calendar.target()
+    day_counter = DayCounter.actual360()
+
+    hazard = FlatHazardRate.moving(0, calendar, SimpleQuote(0.01234), day_counter, settings)
+    discount = FlatForward(today, 0.06, day_counter)
+
+    schedule = Schedule(
+        Date(9, 6, 2005),  # issue
+        Date(9, 6, 2015),  # maturity
+        Frequency.Semiannual,
+        calendar,
+        BusinessDayConvention.ModifiedFollowing,
+    )
+
+    # `with_terms` is the self-documenting constructor: protection side,
+    # notional, running spread, schedule, then named conventions. Its defaults
+    # reproduce the cached fixture.
+    cds = CreditDefaultSwap.with_terms(
+        ProtectionSide.Seller,
+        10000.0,  # notional
+        0.0120,  # running spread
+        schedule,
+        BusinessDayConvention.ModifiedFollowing,
+        day_counter,
+        settings,
+    )
+    cds.set_engine(MidPointCdsEngine(hazard, 0.4, discount, settings))
+
+    print("10Y CDS (seller, notional 10000, spread 120bp, hazard 1.234%):")
+    print(f"  NPV            = {cds.npv():.7f}")
+    print(f"  fair spread    = {cds.fair_spread():.12f}")
+    print(f"  coupon leg NPV = {cds.coupon_leg_npv():.7f}")
+    print(f"  default leg NPV= {cds.default_leg_npv():.7f}")
+
+
+# --- bootstrap arm -----------------------------------------------------------
+
+TODAY = Date(9, 6, 2006)
+QUOTES = [0.005, 0.006, 0.007, 0.009]
+TENORS = [1, 2, 3, 5]
+RECOVERY_RATE = 0.4
+SETTLEMENT_DAYS = 1
+
+
+def _round_trip_schedule(calendar: Calendar, tenor: int) -> Schedule:
+    """The rebuilt contract's schedule, matching the helper's own conventions:
+    it starts at the rolled protection start and its maturity is left
+    unadjusted. Copied verbatim from the bootstrap oracle."""
+    start = calendar.adjust(TODAY + SETTLEMENT_DAYS, BusinessDayConvention.Following)
+    end = calendar.advance(TODAY, tenor, "Years", BusinessDayConvention.Unadjusted, False)
+    return Schedule(
+        start,
+        end,
+        Frequency.Quarterly,
+        calendar,
+        BusinessDayConvention.Following,
+        DateGeneration.TwentiethIMM,
+        termination_convention=BusinessDayConvention.Unadjusted,
+    )
+
+
+def bootstrap_default_curve() -> None:
+    """Solve a hazard curve from four CDS spreads, then reprice each contract
+    off it and confirm it returns its own input spread."""
+    settings = Settings()
+    settings.set_evaluation_date(TODAY)
+    # The bootstrap is lazy; this flag must be set before the first curve read.
+    settings.set_include_todays_cash_flows(True)
+    calendar = Calendar.target()
+    day_counter = DayCounter.thirty360_bond_basis()
+    discount = FlatForward(TODAY, 0.06, DayCounter.actual360())
+
+    helpers = [
+        SpreadCdsHelper(
+            SimpleQuote(quote),
+            Period(tenor, "Years"),
+            SETTLEMENT_DAYS,
+            calendar,
+            Frequency.Quarterly,
+            BusinessDayConvention.Following,
+            DateGeneration.TwentiethIMM,
+            day_counter,
+            RECOVERY_RATE,
+            discount,
+            settings,
+        )
+        for quote, tenor in zip(QUOTES, TENORS)
+    ]
+
+    curve = PiecewiseDefaultCurve(TODAY, helpers, day_counter)
+
+    print("\nBootstrapped default curve (survival probabilities):")
+    for date in curve.dates():
+        sp = curve.survival_probability_date(date)
+        print(f"  {date}   survival={sp:.6f}")
+
+    print("\nReprice check (rebuilt contract vs input spread):")
+    for quote, tenor in zip(QUOTES, TENORS):
+        swap = CreditDefaultSwap.with_terms(
+            ProtectionSide.Buyer,
+            1.0,
+            quote,
+            _round_trip_schedule(calendar, tenor),
+            BusinessDayConvention.Following,
+            day_counter,
+            settings,
+            protection_start=TODAY + SETTLEMENT_DAYS,
+        )
+        swap.set_engine(MidPointCdsEngine(curve, RECOVERY_RATE, discount, settings))
+        fair = swap.fair_spread()
+        print(f"  {tenor}Y  fair={fair:.10f}  input={quote:.10f}  |diff|={abs(fair - quote):.2e}")
+
+
+def main() -> None:
+    price_single_cds()
+    bootstrap_default_curve()
+
+
+if __name__ == "__main__":
+    main()

--- a/example/python/european_option.py
+++ b/example/python/european_option.py
@@ -1,0 +1,62 @@
+"""Price a European option and read its greeks.
+
+This is the "hello world" of itofin: build a Black-Scholes market, wrap it in a
+`VanillaOption`, attach the analytic engine and read the value plus every greek.
+
+The numbers below reproduce the pricing gate in
+`crates/itofin-py/tests/test_european_option.py` (row 1), so the printed NPV of
+2.1333684449161985 is a self-check: if it drifts, the market was wired wrong.
+
+Run it with:
+
+    python example/python/european_option.py
+"""
+
+# itofin library
+from itofin import Settings
+from itofin.instruments import OptionType, VanillaOption
+from itofin.processes import BlackScholesProcess
+from itofin.time import Date, DayCounter
+
+
+def main() -> None:
+    # D5: one Settings object holds the evaluation date and is threaded into
+    # every instrument. There is no global "today"; an unset date is an error,
+    # not a silent fall back to the system clock.
+    settings = Settings()
+    today = Date(15, 6, 2026)
+    settings.set_evaluation_date(today)
+
+    # A generalized Black-Scholes process from scalar market data:
+    #   spot 60, risk-free 8%, dividend yield 0%, volatility 30%,
+    # all quoted on an Actual/360 day count as of `today`.
+    day_counter = DayCounter.actual360()
+    process = BlackScholesProcess(
+        60.0,  # spot
+        0.08,  # risk-free rate
+        0.0,  # dividend yield
+        0.30,  # volatility
+        today,  # reference date
+        day_counter,
+    )
+
+    # A European call struck at 65, expiring 90 calendar days out.
+    # `Date + int` advances by days (not by a Period).
+    option = VanillaOption(OptionType.Call, 65.0, today + 90, settings)
+
+    # Attaching the process installs the analytic European engine.
+    option.set_engine(process)
+
+    # NPV plus the full greek set. Each read reprices lazily off the process.
+    print("European call, K=65, 90d, spot=60, vol=30%, r=8%")
+    print(f"  NPV          = {option.npv():.10f}")
+    print(f"  delta        = {option.delta():.10f}")
+    print(f"  gamma        = {option.gamma():.10f}")
+    print(f"  theta        = {option.theta():.10f}")
+    print(f"  vega         = {option.vega():.10f}")
+    print(f"  rho          = {option.rho():.10f}")
+    print(f"  dividend_rho = {option.dividend_rho():.10f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/example/python/inflation_swap.py
+++ b/example/python/inflation_swap.py
@@ -1,0 +1,201 @@
+"""Bootstrap a zero-coupon inflation curve and price inflation swaps.
+
+A `ZeroCouponInflationSwap` exchanges one fixed flow for one inflation-indexed
+flow at maturity. Pricing it needs three things wired together:
+
+* a `ZeroInflationIndex` (here UK RPI) loaded with its published fixings,
+* a zero-inflation term structure the index forecasts future fixings off,
+* a nominal discount curve, via a `DiscountingSwapEngine`.
+
+The index reaches the curve through `index.link_to(curve)`. Until that link is
+made, any forecast raises "empty Handle", so it must happen before the swap
+prices.
+
+This example bootstraps a `PiecewiseZeroInflationCurve` from fourteen quoted
+swap rates, then rebuilds each quoted swap standalone on a 5% nominal curve and
+confirms it reprices to (essentially) zero. This mirrors QuantLib's
+`inflation.cpp` `testZeroTermStructure`.
+
+The evaluation date is 13 August 2007 deliberately: it matches QuantLib's
+fixture, whose RPI history runs from January 2005. All 31 fixings are kept
+because `index.last_fixing_date()` (July 2007) becomes the curve's base date;
+trimming the table would silently move it.
+
+Run it with:
+
+    python example/python/inflation_swap.py
+"""
+
+# itofin library
+from itofin import Settings
+from itofin.indexes import CpiInterpolationType, ZeroInflationIndex
+from itofin.instruments import SwapType, ZeroCouponInflationSwap
+from itofin.pricingengines import DiscountingSwapEngine
+from itofin.quotes import SimpleQuote
+from itofin.termstructures import FlatForward, PiecewiseZeroInflationCurve, ZeroCouponInflationSwapHelper
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Frequency, Period
+
+TODAY = Date(13, 8, 2007)
+LAG = Period(3, "Months")
+NOMINAL = 1_000_000.0
+NOMINAL_RATE = 0.05
+
+# 31 monthly UK RPI figures, published from January 2005 (index level, not a
+# rate). The last, 207.3, is the July 2007 period that forecasts compound off.
+FIX_DATA = [
+    189.9,
+    189.9,
+    189.6,
+    190.5,
+    191.6,
+    192.0,
+    192.2,
+    192.2,
+    192.6,
+    193.1,
+    193.3,
+    193.6,
+    194.1,
+    193.4,
+    194.2,
+    195.0,
+    196.5,
+    197.7,
+    198.5,
+    198.5,
+    199.2,
+    200.1,
+    200.4,
+    201.1,
+    202.7,
+    201.6,
+    203.1,
+    204.4,
+    205.4,
+    206.2,
+    207.3,
+]
+
+# (maturity, quoted zero-coupon inflation swap rate in percent).
+ZC_DATA = [
+    (Date(13, 8, 2008), 2.93),
+    (Date(13, 8, 2009), 2.95),
+    (Date(13, 8, 2010), 2.965),
+    (Date(15, 8, 2011), 2.98),
+    (Date(13, 8, 2012), 3.0),
+    (Date(13, 8, 2014), 3.06),
+    (Date(13, 8, 2017), 3.175),
+    (Date(13, 8, 2019), 3.243),
+    (Date(15, 8, 2022), 3.293),
+    (Date(14, 8, 2027), 3.338),
+    (Date(13, 8, 2032), 3.348),
+    (Date(15, 8, 2037), 3.348),
+    (Date(13, 8, 2047), 3.308),
+    (Date(13, 8, 2057), 3.228),
+]
+
+
+def _fixing_date(i: int) -> Date:
+    """The i-th monthly fixing date, walked from 1 January 2005. A monthly index
+    files each figure under the first of its month."""
+    return Date(1, i % 12 + 1, 2005 + i // 12)
+
+
+def build_index(settings: Settings) -> ZeroInflationIndex:
+    index = ZeroInflationIndex.uk_rpi(settings)
+    for i, fixing in enumerate(FIX_DATA):
+        index.add_fixing(_fixing_date(i), fixing)
+    return index
+
+
+def nominal_curve() -> FlatForward:
+    """The 5% discount curve the standalone swaps price on."""
+    return FlatForward(TODAY, NOMINAL_RATE, DayCounter.actual360())
+
+
+def build_helpers(settings, index):
+    return [
+        ZeroCouponInflationSwapHelper(
+            SimpleQuote(rate / 100.0),
+            LAG,
+            maturity,
+            Calendar.united_kingdom(),
+            BusinessDayConvention.ModifiedFollowing,
+            DayCounter.thirty360_bond_basis(),
+            index,
+            CpiInterpolationType.Flat,
+            settings,
+        )
+        for maturity, rate in ZC_DATA
+    ]
+
+
+def build_swap(settings, index, maturity, fixed_rate):
+    """A payer zero-coupon inflation swap: pays inflation, receives fixed.
+
+    Positional constructor (see instruments.pyi): swap type, nominal, start,
+    maturity, fixed calendar, fixed convention, day count, fixed rate, index,
+    observation lag, observation interpolation, then optional inflation-leg
+    calendar and convention (None -> fall back to the fixed-leg ones)."""
+    swap = ZeroCouponInflationSwap(
+        SwapType.Payer,
+        NOMINAL,
+        TODAY,
+        maturity,
+        Calendar.united_kingdom(),
+        BusinessDayConvention.ModifiedFollowing,
+        DayCounter.thirty360_bond_basis(),
+        fixed_rate,
+        index,
+        LAG,
+        CpiInterpolationType.Flat,
+        None,  # inflation calendar -> fixed-leg calendar
+        None,  # inflation convention -> fixed-leg convention
+        settings,
+    )
+    swap.set_engine(DiscountingSwapEngine(nominal_curve(), settings))
+    return swap
+
+
+def main() -> None:
+    # D5: one Settings threaded through index, helpers, swaps and engines.
+    settings = Settings()
+    settings.set_evaluation_date(TODAY)
+
+    index = build_index(settings)
+    print(f"UK RPI last fixing date (curve base) = {index.last_fixing_date()}")
+
+    # Bootstrap the zero-inflation curve from the fourteen quoted swap rates.
+    curve = PiecewiseZeroInflationCurve(
+        TODAY,
+        index.last_fixing_date(),
+        Frequency.Monthly,
+        DayCounter.thirty360_bond_basis(),
+        build_helpers(settings, index),
+    )
+    # Link the index to the solved curve so standalone swaps can forecast off it.
+    index.link_to(curve)
+
+    # Price one swap in detail.
+    maturity, rate = ZC_DATA[4]  # the 5Y-ish 2012 pillar
+    swap = build_swap(settings, index, maturity, rate / 100.0)
+    print(f"\nZero-coupon inflation swap to {maturity} (quote {rate}%):")
+    print(f"  fair rate        = {swap.fair_rate() * 100:.6f}%")
+    print(f"  NPV              = {swap.npv():.4f}")
+    print(f"  fixed leg NPV    = {swap.fixed_leg_npv():.4f}")
+    print(f"  inflation leg NPV= {swap.inflation_leg_npv():.4f}")
+
+    # The milestone: every quoted swap, rebuilt standalone and discounted on the
+    # 5% nominal curve, reprices to essentially nothing off the bootstrapped
+    # inflation curve.
+    print("\nReprice check (quoted swaps off the bootstrapped curve):")
+    worst = 0.0
+    for maturity, rate in ZC_DATA:
+        npv = build_swap(settings, index, maturity, rate / 100.0).npv()
+        worst = max(worst, abs(npv))
+        print(f"  {maturity}  NPV={npv:14.6f}")
+    print(f"  worst |NPV| = {worst:.3e}  (should be ~1e-8 or smaller)")
+
+
+if __name__ == "__main__":
+    main()

--- a/example/python/monte_carlo.py
+++ b/example/python/monte_carlo.py
@@ -1,0 +1,139 @@
+"""Price options by Monte Carlo: European, Heston, and American.
+
+Three different MC engines, attached through three different setters:
+
+* `MCEuropeanEngine`      -> `option.set_mc_engine(...)`
+* `MCEuropeanHestonEngine`-> `option.set_mc_heston_engine(...)`
+* `MCAmericanEngine`      -> `option.set_mc_american_engine(...)` on an option
+  built with `VanillaOption.american(...)`.
+
+Unlike the analytic engine, an MC engine reports a standard error via
+`option.error_estimate()`, and the American engine additionally reports the
+fraction of paths exercised early via `option.exercise_probability()`. Both of
+those raise on the analytic engine, so only call them on the MC options.
+
+Pricing is seeded, so a given seed reproduces bitwise. The European result is
+cross-checked against the analytic engine; the Heston and American results are
+banded against QuantLib's cached values.
+
+Run it with:
+
+    python example/python/monte_carlo.py
+"""
+
+# itofin library
+from itofin import Settings
+from itofin.instruments import OptionType, VanillaOption
+from itofin.pricingengines import MCAmericanEngine, MCEuropeanEngine, MCEuropeanHestonEngine
+from itofin.processes import BlackScholesProcess, HestonProcess
+from itofin.time import Date, DayCounter
+
+
+def mc_european() -> None:
+    """A European call priced by MC and checked against the analytic engine."""
+    settings = Settings()
+    today = Date(15, 6, 2026)
+    settings.set_evaluation_date(today)
+    expiry = today + 360
+    process = BlackScholesProcess(100.0, 0.05, 0.02, 0.20, today, DayCounter.actual360())
+
+    # Analytic reference.
+    analytic = VanillaOption(OptionType.Call, 100.0, expiry, settings)
+    analytic.set_engine(process)
+
+    # MC: single time step is enough for a path-independent European payoff.
+    # NB: MCEuropeanEngine does not accept the antithetic variate.
+    mc = VanillaOption(OptionType.Call, 100.0, expiry, settings)
+    mc.set_mc_engine(MCEuropeanEngine(process, steps=1, samples=40000, seed=42))
+
+    print("MC European call (K=100, 1y, 40000 paths, seed 42):")
+    print(f"  analytic NPV = {analytic.npv():.6f}")
+    print(f"  MC NPV       = {mc.npv():.6f}  +/- {mc.error_estimate():.6f} (std err)")
+
+
+def mc_heston() -> None:
+    """A Heston put priced by MC against QuantLib's cached hestonmodel.cpp
+    fixture (expected value ~0.0633, banded by the standard error)."""
+    settlement = Date(27, 12, 2004)
+    exercise = Date(28, 3, 2005)
+    settings = Settings()
+    settings.set_evaluation_date(settlement)
+
+    # HestonProcess argument order (see processes.pyi): risk-free, dividend,
+    # spot, v0, kappa, theta, sigma, rho, reference date, day count. These are
+    # the cached-test parameters, not everyday market levels.
+    process = HestonProcess(
+        0.7,  # risk-free rate
+        0.4,  # dividend yield
+        1.05,  # spot
+        0.3,  # v0 (initial variance)
+        1.16,  # kappa (mean reversion speed)
+        0.2,  # theta (long-run variance)
+        0.8,  # sigma (vol of vol)
+        0.8,  # rho (spot/vol correlation)
+        settlement,
+        DayCounter.actual_actual_isda(),
+    )
+
+    option = VanillaOption(OptionType.Put, 1.05, exercise, settings)
+    # The Heston MC engine does accept the antithetic variate.
+    option.set_mc_heston_engine(
+        MCEuropeanHestonEngine(process, steps_per_year=11, antithetic=True, samples=50000, seed=1234)
+    )
+
+    print("\nMC Heston put (K=1.05, 50000 paths, antithetic, seed 1234):")
+    print(f"  MC NPV       = {option.npv():.10f}  +/- {option.error_estimate():.2e}")
+    print("  cached value = 0.0632851309  (QuantLib hestonmodel.cpp)")
+
+
+def mc_american() -> None:
+    """An American put by least-squares Monte Carlo (Longstaff-Schwartz).
+
+    Built with `VanillaOption.american(...)`, exercisable at any time over
+    [earliest, latest]. The engine reports both a standard error and the
+    early-exercise probability. Reproduces QuantLib's cached value 2.0544."""
+    settings = Settings()
+    today = Date(15, 5, 1998)
+    settings.set_evaluation_date(today)
+    settlement = Date(17, 5, 1998)
+    maturity = Date(17, 5, 1999)
+    process = BlackScholesProcess(36.0, 0.06, 0.0, 0.20, settlement, DayCounter.actual365_fixed())
+
+    option = VanillaOption.american(
+        OptionType.Put,
+        36.0,
+        earliest=settlement,
+        latest=maturity,
+        settings=settings,
+    )
+    option.set_mc_american_engine(
+        MCAmericanEngine(
+            process,
+            steps=75,
+            antithetic=True,
+            absolute_tolerance=0.02,
+            seed=42,
+            polynomial_order=3,  # basis-polynomial order for the regression
+        )
+    )
+
+    # A European put on the same market is the lower bound: early exercise can
+    # only add value.
+    european = VanillaOption(OptionType.Put, 36.0, maturity, settings)
+    european.set_engine(process)
+
+    print("\nMC American put (K=36, LSM, 75 steps, antithetic, seed 42):")
+    print(f"  American NPV = {option.npv():.6f}  +/- {option.error_estimate():.6f}")
+    print(f"  exercise probability = {option.exercise_probability():.4f}")
+    print(f"  European NPV = {european.npv():.6f}  (early exercise adds value)")
+    print("  cached American value = 2.0544  (QuantLib americanoption.cpp)")
+
+
+def main() -> None:
+    mc_european()
+    mc_heston()
+    mc_american()
+
+
+if __name__ == "__main__":
+    main()

--- a/example/python/vanilla_swap.py
+++ b/example/python/vanilla_swap.py
@@ -1,0 +1,109 @@
+"""Build and price a vanilla fixed-vs-floating interest-rate swap.
+
+Two ways to get the same swap:
+
+* `MakeVanillaSwap` - a builder that fills in the market conventions (fixed-leg
+  tenor and day count, floating leg from the index) from a tenor and an index.
+* `VanillaSwap` - the explicit form, where every schedule and day count is
+  spelled out by hand.
+
+The swap is priced by a `DiscountingSwapEngine`, which here is attached with
+`swap.set_engine(curve, settings)` (the engine discounts both legs off the given
+curve). The fixture is QuantLib's Jamshidian 5Y swap; the fair rate and NPV
+below reproduce the pins in `test_vanilla_swap.py`, so they double as a
+self-check.
+
+Run it with:
+
+    python example/python/vanilla_swap.py
+"""
+
+# itofin library
+from itofin import Settings
+from itofin.indexes import Euribor
+from itofin.instruments import MakeVanillaSwap, SwapType, VanillaSwap
+from itofin.termstructures import FlatForward
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Frequency, Period, Schedule
+
+REF = Date(15, 1, 2026)
+START = Date(15, 1, 2028)
+END = Date(15, 1, 2033)
+
+
+def make_market():
+    settings = Settings()
+    settings.set_evaluation_date(REF)
+    # A flat 3% continuous curve for both forwarding and discounting.
+    curve = FlatForward(REF, 0.03, DayCounter.actual365_fixed())
+    index = Euribor.six_months(curve, settings)
+    return settings, curve, index
+
+
+def priced_with_builder():
+    """A par 5Y payer swap via the builder: `fixed_rate=None` fills the fixed
+    leg with the fair rate, so the swap prices to zero."""
+    settings, _curve, index = make_market()
+    swap = MakeVanillaSwap(
+        Period(5, "Years"),
+        index,
+        settings,
+        fixed_rate=None,
+        effective_date=START,
+        nominal=100.0,
+    ).build()  # MakeVanillaSwap is a builder: .build() returns the swap.
+    return swap
+
+
+def priced_by_hand():
+    """The same swap spelled out: annual fixed leg on 30/360 bond basis,
+    semiannual floating leg on Euribor6M / Actual360, priced at a 3% coupon."""
+    settings, curve, index = make_market()
+    fixed = Schedule(
+        START,
+        END,
+        Frequency.Annual,
+        Calendar.target(),
+        BusinessDayConvention.ModifiedFollowing,
+    )
+    floating = Schedule(
+        START,
+        END,
+        Frequency.Semiannual,
+        Calendar.target(),
+        BusinessDayConvention.ModifiedFollowing,
+    )
+    swap = VanillaSwap(
+        SwapType.Payer,
+        100.0,  # nominal
+        fixed,
+        0.03,  # fixed rate
+        DayCounter.thirty360_bond_basis(),
+        floating,
+        index,
+        0.0,  # floating spread
+        DayCounter.actual360(),
+        settings,
+    )
+    # DiscountingSwapEngine off `curve`: VanillaSwap.set_engine takes the curve
+    # and settings directly, not a separate engine object.
+    swap.set_engine(curve, settings)
+    return swap
+
+
+def main() -> None:
+    par = priced_with_builder()
+    print("MakeVanillaSwap, par 5Y payer (fixed_rate=None):")
+    print(f"  fair_rate = {par.fair_rate() * 100:.6f}%")
+    print(f"  fixed_rate(filled) = {par.fixed_rate() * 100:.6f}%")
+    print(f"  NPV       = {par.npv():.10f}  (par swap -> ~0)")
+
+    hand = priced_by_hand()
+    print("\nHand-built VanillaSwap, 5Y payer at a 3% coupon:")
+    print(f"  nominal   = {hand.nominal():.2f}")
+    print(f"  fixed_rate= {hand.fixed_rate() * 100:.4f}%")
+    print(f"  fair_rate = {hand.fair_rate() * 100:.6f}%")
+    print(f"  NPV       = {hand.npv():.10f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/example/python/yield_curve.py
+++ b/example/python/yield_curve.py
@@ -1,0 +1,103 @@
+"""Bootstrap a yield curve from deposits and swaps, then query it.
+
+`PiecewiseYieldCurve` takes a bundle of rate helpers (each pinning one market
+quote) and solves for the discount factors that reprice all of them at once.
+The curve is lazy: nothing is solved until the first query.
+
+The deposit and swap quotes are transcribed from QuantLib's
+`piecewiseyieldcurve.cpp`. The pedagogical payoff and the self-check are the
+same thing: a FRESH Euribor index laid on the bootstrapped curve must forecast
+back each deposit's own input rate. If it does, the bootstrap is consistent.
+
+Run it with:
+
+    python example/python/yield_curve.py
+"""
+
+# itofin library
+from itofin import Settings
+from itofin.indexes import Euribor
+from itofin.quotes import SimpleQuote
+from itofin.termstructures import DepositRateHelper, PiecewiseYieldCurve, SwapRateHelper
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Frequency
+from itofin.time import Period as P
+
+# (n, unit, rate-in-percent) short-end deposits.
+DEPOSIT_DATA = [
+    (1, "Weeks", 4.559),
+    (1, "Months", 4.581),
+    (3, "Months", 4.557),
+    (6, "Months", 4.496),
+    (9, "Months", 4.490),
+]
+
+# (years, rate-in-percent) par swap rates for the long end.
+SWAP_DATA = [
+    (1, 4.54),
+    (2, 4.63),
+    (3, 4.75),
+    (5, 4.99),
+    (10, 5.47),
+    (20, 5.89),
+    (30, 5.96),
+]
+
+
+def main() -> None:
+    settings = Settings()
+    calendar = Calendar.target()
+    today = calendar.adjust(Date(15, 6, 2026), BusinessDayConvention.Following)
+    settings.set_evaluation_date(today)
+
+    # Settlement is spot: today advanced two business days.
+    settlement = calendar.advance(today, 2, "Days", BusinessDayConvention.Following, False)
+
+    # Deposit helpers: each quotes a Euribor rate over an (as yet unlinked)
+    # forwarding index. The SimpleQuote holds the market rate.
+    deposits = []
+    for n, unit, rate in DEPOSIT_DATA:
+        index = Euribor(P(n, unit), None, settings)
+        deposits.append(DepositRateHelper(SimpleQuote(rate / 100.0), index))
+
+    # Swap helpers: a par swap rate, an annual fixed leg on 30/360 bond basis,
+    # floating off 6M Euribor.
+    swaps = []
+    for n, rate in SWAP_DATA:
+        euribor6m = Euribor(P(6, "Months"), None, settings)
+        swaps.append(
+            SwapRateHelper(
+                SimpleQuote(rate / 100.0),
+                P(n, "Years"),
+                calendar,
+                Frequency.Annual,
+                BusinessDayConvention.Unadjusted,
+                DayCounter.thirty360_bond_basis(),
+                euribor6m,
+            )
+        )
+
+    # Log-linear-on-discount-factors interpolation (the market default).
+    curve = PiecewiseYieldCurve(settlement, deposits + swaps, DayCounter.actual360(), "LogLinear")
+
+    # First query forces the (lazy) bootstrap. Query strictly inside the curve
+    # span; t=0 and points past the last pillar are range-rejected.
+    print("Discount factors and zero rates off the bootstrapped curve:")
+    for t in [0.5, 1.0, 2.0, 5.0, 10.0, 20.0]:
+        df = curve.discount(t)
+        zero = curve.zero_rate(t)
+        print(f"  t={t:5.1f}y   discount={df:.6f}   zero={zero * 100:6.3f}%")
+
+    # Consistency check: a fresh index on the solved curve reforecasts each
+    # deposit's own input rate. This is the bootstrap contract made visible.
+    print("\nDeposit reprice check (fresh index on the curve vs input quote):")
+    for n, unit, rate in DEPOSIT_DATA:
+        index = Euribor(P(n, unit), curve, settings)
+        forecast = index.fixing(today, False)
+        print(
+            f"  {n:2d} {unit:<7} forecast={forecast * 100:6.3f}%   "
+            f"input={rate:6.3f}%   |diff|={abs(forecast - rate / 100.0):.2e}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/example/rust/credit_cds.rs
+++ b/example/rust/credit_cds.rs
@@ -1,0 +1,272 @@
+//! Credit-default swap pricing and credit-curve bootstrapping with `libitofin`.
+//!
+//! Part A prices a 5Y CDS with `MidPointCdsEngine` off a flat hazard-rate
+//! default curve, printing NPV and fair spread.
+//!
+//! Part B bootstraps a `PiecewiseDefaultCurve` from four `SpreadCdsHelper`
+//! CDS quotes, then prints the bootstrapped hazard-rate nodes, the survival
+//! probabilities at each pillar, and the fair spreads a contract rebuilt off
+//! the curve reproduces (each returns its input quote to ~1e-6).
+//!
+//! Every signature below is taken verbatim from the crate's own tests:
+//! `midpointcdsengine.rs` (mod `oracle`) and `piecewisedefaultcurve.rs`
+//! (mod `tests`). Notes on D5 (explicit `Settings`, no global singleton) and
+//! D2 (`Handle`) inline.
+
+use libitofin::errors::QlResult;
+use libitofin::handle::Handle;
+use libitofin::instrument::Instrument; // brings npv(), base_mut(), recalculate()
+use libitofin::instruments::{CdsTerms, CreditDefaultSwap, ProtectionSide};
+use libitofin::interestrate::Compounding;
+use libitofin::math::interpolations::flat::BackwardFlat;
+use libitofin::pricingengine::PricingEngine; // needed for the `as SharedMut<dyn PricingEngine>` cast
+use libitofin::pricingengines::credit::MidPointCdsEngine;
+use libitofin::quotes::{Quote, SimpleQuote};
+use libitofin::settings::Settings;
+use libitofin::shared::{Shared, SharedMut, shared, shared_mut};
+use libitofin::termstructures::credit::defaultprobabilityhelpers::{
+    DefaultProbabilityHelper, SpreadCdsHelper,
+};
+use libitofin::termstructures::credit::defaulttermstructure::DefaultProbabilityTermStructure;
+use libitofin::termstructures::credit::flathazardrate::FlatHazardRate;
+use libitofin::termstructures::credit::piecewisedefaultcurve::PiecewiseDefaultCurve;
+use libitofin::termstructures::credit::probabilitytraits::HazardRate;
+use libitofin::termstructures::yields::FlatForward;
+use libitofin::termstructures::yieldtermstructure::YieldTermStructure;
+use libitofin::time::businessdayconvention::BusinessDayConvention;
+use libitofin::time::calendars::target::Target;
+use libitofin::time::date::{Date, Month};
+use libitofin::time::dategenerationrule::DateGeneration;
+use libitofin::time::daycounters::actual360::Actual360;
+use libitofin::time::daycounters::thirty360::{Convention, Thirty360};
+use libitofin::time::frequency::Frequency;
+use libitofin::time::period::Period;
+use libitofin::time::schedule::{MakeSchedule, Schedule};
+use libitofin::time::timeunit::TimeUnit;
+use libitofin::types::{Integer, Real};
+
+const RECOVERY: Real = 0.4;
+const SETTLEMENT_DAYS: Integer = 1;
+
+fn main() -> QlResult<()> {
+    // A TARGET business day; the evaluation date every curve/contract shares (D5).
+    let today = Date::new(9, Month::June, 2006);
+
+    part_a_price_a_cds(today)?;
+    println!();
+    part_b_bootstrap_a_default_curve(today)?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Part A: price a CDS with MidPointCdsEngine off a FlatHazardRate curve.
+// ---------------------------------------------------------------------------
+fn part_a_price_a_cds(today: Date) -> QlResult<()> {
+    println!("== Part A: MidPointCdsEngine over a flat hazard-rate curve ==");
+
+    // One explicit Settings drives the curves, the contract and the engine (D5).
+    let settings = shared(Settings::<Date>::new());
+    settings.set_evaluation_date(today);
+
+    // Flat 3% discount curve (continuous / annual are the C++ FlatForward defaults),
+    // wrapped in a Handle<dyn YieldTermStructure> (D2).
+    let discount: Handle<dyn YieldTermStructure> = Handle::new(shared(FlatForward::with_rate(
+        today,
+        0.03,
+        Actual360::new(),
+        Compounding::Continuous,
+        Frequency::Annual,
+    ))
+        as Shared<dyn YieldTermStructure>);
+
+    // Flat 2% hazard rate as the default-probability curve (survival = exp(-h t)).
+    let hazard: Handle<dyn DefaultProbabilityTermStructure> = Handle::new(shared(
+        FlatHazardRate::with_rate(today, 0.02, Actual360::new()),
+    )
+        as Shared<dyn DefaultProbabilityTermStructure>);
+
+    // A 5Y semiannual premium schedule. Backward generation keeps it pre-Big-Bang,
+    // so the default trade date is protection_start - 1 and the accrual rebate
+    // (a zero-amount flow here) is allowed.
+    let schedule = MakeSchedule::new()
+        .from(today)
+        .to(today + Period::new(5, TimeUnit::Years))
+        .with_frequency(Frequency::Semiannual)
+        .with_calendar(Target::new())
+        .with_convention(BusinessDayConvention::Following)
+        .with_termination_date_convention(BusinessDayConvention::Unadjusted)
+        .backwards()
+        .build();
+
+    // Protection-buyer CDS, notional 10mm, 1% running spread, ACT/360 premium accrual.
+    // The final two bools are settles_accrual and pays_at_default_time (C++ defaults).
+    let mut cds = CreditDefaultSwap::new(
+        ProtectionSide::Buyer,
+        10_000_000.0,
+        0.01,
+        schedule,
+        BusinessDayConvention::Following,
+        Actual360::new(),
+        true,
+        true,
+        Shared::clone(&settings),
+    )?;
+
+    // MidPointCdsEngine::new(default-prob handle, recovery, discount handle,
+    // include_settlement_date_flows override, settings).
+    let engine = MidPointCdsEngine::new(
+        hazard.clone(),
+        RECOVERY,
+        discount.clone(),
+        None,
+        Shared::clone(&settings),
+    );
+    cds.base_mut()
+        .set_pricing_engine(shared_mut(engine) as SharedMut<dyn PricingEngine>);
+
+    let npv = cds.npv()?;
+    let fair_spread = cds.fair_spread()?;
+    println!("  maturity              : {:?}", cds.maturity());
+    println!("  NPV (buyer)           : {npv:.4}");
+    println!("  fair spread           : {fair_spread:.10}");
+
+    // The default curve can be queried directly through its handle.
+    let survival_to_maturity = hazard
+        .current_link()?
+        .survival_probability_date(cds.maturity(), false)?;
+    println!("  survival to maturity  : {survival_to_maturity:.10}");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Part B: bootstrap a PiecewiseDefaultCurve from SpreadCdsHelper quotes.
+// ---------------------------------------------------------------------------
+fn part_b_bootstrap_a_default_curve(today: Date) -> QlResult<()> {
+    println!("== Part B: PiecewiseDefaultCurve bootstrapped from CDS spreads ==");
+
+    let quotes: [Real; 4] = [0.005, 0.006, 0.007, 0.009];
+    let tenors: [i32; 4] = [1, 2, 3, 5];
+
+    let settings = shared(Settings::<Date>::new());
+    settings.set_evaluation_date(today);
+    // The helpers price their own contracts inside the bootstrap; this flag must
+    // be set before the first read triggers it.
+    settings.set_include_todays_cash_flows(Some(true));
+
+    // 30/360 bond-basis premium accrual; flat 6% discount curve.
+    let day_counter = Thirty360::with_convention(Convention::BondBasis);
+    let discount: Handle<dyn YieldTermStructure> = Handle::new(shared(FlatForward::with_rate(
+        today,
+        0.06,
+        Actual360::new(),
+        Compounding::Continuous,
+        Frequency::Annual,
+    ))
+        as Shared<dyn YieldTermStructure>);
+
+    // One SpreadCdsHelper per quoted CDS spread. Signature:
+    //   SpreadCdsHelper::new(running_spread_handle, tenor, settlement_days,
+    //     calendar, frequency, payment_convention, date_generation_rule,
+    //     day_counter, recovery_rate, discount_handle, settings) -> Shared<SpreadCdsHelper>
+    // TwentiethIMM is the accepted (pre-Big-Bang) rule; the three CDS rules are
+    // rejected (they need the unported cdsMaturity).
+    let helpers: Vec<Shared<dyn DefaultProbabilityHelper>> = quotes
+        .iter()
+        .zip(tenors)
+        .map(|(quote, n)| {
+            SpreadCdsHelper::new(
+                Handle::new(shared(SimpleQuote::new(*quote)) as Shared<dyn Quote>),
+                Period::new(n, TimeUnit::Years),
+                SETTLEMENT_DAYS,
+                Target::new(),
+                Frequency::Quarterly,
+                BusinessDayConvention::Following,
+                DateGeneration::TwentiethIMM,
+                day_counter.clone(),
+                RECOVERY,
+                discount.clone(),
+                Shared::clone(&settings),
+            )
+            .expect("TwentiethIMM is an accepted date-generation rule")
+                as Shared<dyn DefaultProbabilityHelper>
+        })
+        .collect();
+
+    // Bootstrap is lazy: construction lays down no nodes; the first read solves.
+    // Only HazardRate x BackwardFlat is wired (see the module's Scope note).
+    let curve = PiecewiseDefaultCurve::<HazardRate, BackwardFlat>::new(
+        today,
+        helpers.clone(),
+        day_counter.clone(),
+        BackwardFlat,
+    )?;
+
+    // Bootstrapped (date, hazard-rate) nodes. nodes() triggers the bootstrap.
+    println!("  bootstrapped hazard-rate nodes:");
+    for (date, hazard) in curve.nodes()? {
+        println!("    {date:?}  h = {hazard:.10}");
+    }
+
+    // Survival probability at each pillar (the helper's latest/pillar date).
+    println!("  survival probabilities at pillars:");
+    for (helper, n) in helpers.iter().zip(tenors) {
+        let pillar = helper.latest_date();
+        let survival = curve.survival_probability_date(pillar, false)?;
+        println!("    {n}Y  pillar {pillar:?}  S = {survival:.10}");
+    }
+
+    // Round trip: rebuild each pillar's CDS and reprice it off the bootstrapped
+    // curve; the fair spread returns the input quote to ~1e-6.
+    let curve_handle: Handle<dyn DefaultProbabilityTermStructure> =
+        Handle::new(Shared::clone(&curve) as Shared<dyn DefaultProbabilityTermStructure>);
+    println!("  fair spreads reproduced off the curve:");
+    for (quote, n) in quotes.iter().zip(tenors) {
+        let tenor = Period::new(n, TimeUnit::Years);
+        let protection_start = today + SETTLEMENT_DAYS;
+        let mut cds = CreditDefaultSwap::with_terms(
+            ProtectionSide::Buyer,
+            1.0,
+            *quote,
+            round_trip_schedule(today, tenor),
+            BusinessDayConvention::Following,
+            day_counter.clone(),
+            CdsTerms {
+                protection_start: Some(protection_start),
+                ..CdsTerms::default()
+            },
+            Shared::clone(&settings),
+        )?;
+        let engine = MidPointCdsEngine::new(
+            curve_handle.clone(),
+            RECOVERY,
+            discount.clone(),
+            None,
+            Shared::clone(&settings),
+        );
+        cds.base_mut()
+            .set_pricing_engine(shared_mut(engine) as SharedMut<dyn PricingEngine>);
+
+        let fair = cds.fair_spread()?;
+        println!("    {n}Y  input {quote:.6}  ->  fair {fair:.10}");
+    }
+    Ok(())
+}
+
+/// The round-trip contract's schedule: quarterly TwentiethIMM, starting at the
+/// rolled protection start and ending a tenor past `today`.
+fn round_trip_schedule(today: Date, tenor: Period) -> Schedule {
+    let calendar = Target::new();
+    let start_date = calendar.adjust(today + SETTLEMENT_DAYS, BusinessDayConvention::Following);
+    Schedule::new(
+        start_date,
+        today + tenor,
+        Period::try_from(Frequency::Quarterly).expect("a quarterly period"),
+        calendar,
+        BusinessDayConvention::Following,
+        BusinessDayConvention::Unadjusted,
+        DateGeneration::TwentiethIMM,
+        false,
+        Date::null(),
+        Date::null(),
+    )
+}

--- a/example/rust/european_option.rs
+++ b/example/rust/european_option.rs
@@ -1,0 +1,92 @@
+//! Price a European option with the AnalyticEuropeanEngine and print
+//! NPV + greeks (delta, gamma, vega, theta, rho).
+//!
+//! Mirrors the working `mixed_day_counters` M1-slice test in
+//! `crates/libitofin/src/pricingengines/vanilla/mod.rs`. Every construction
+//! step is the same one the crate's own tests exercise.
+
+use libitofin::exercise::EuropeanExercise;
+use libitofin::handle::Handle;
+use libitofin::instrument::Instrument; // brings `npv`, `base_mut` into scope
+use libitofin::instruments::{EuropeanOption, PlainVanillaPayoff};
+use libitofin::interestrate::Compounding;
+use libitofin::option::OptionType;
+use libitofin::pricingengine::PricingEngine;
+use libitofin::pricingengines::AnalyticEuropeanEngine;
+use libitofin::processes::BlackScholesMertonProcess;
+use libitofin::quotes::{Quote, SimpleQuote};
+use libitofin::settings::Settings;
+use libitofin::shared::{Shared, SharedMut, shared, shared_mut};
+use libitofin::termstructures::volatility::{BlackConstantVol, BlackVolTermStructure};
+use libitofin::termstructures::yields::FlatForward;
+use libitofin::termstructures::yieldtermstructure::YieldTermStructure;
+use libitofin::time::date::{Date, Month};
+use libitofin::time::daycounters::actual360::Actual360;
+use libitofin::time::frequency::Frequency;
+use libitofin::types::Real;
+
+fn main() {
+    // --- Market date. D5: the evaluation date is set explicitly on an owned
+    // Settings, not read from a global clock. ---
+    let today = Date::new(15, Month::June, 2026);
+    let expiry = today + 146; // Date + i64 shifts by calendar days
+
+    let spot: Real = 100.0;
+    let strike: Real = 105.0;
+    let q_rate: Real = 0.04; // continuous dividend yield
+    let r_rate: Real = 0.06; // continuous risk-free rate
+    let vol: Real = 0.20; // flat Black vol
+
+    // Settings is shared (Rc) so the option can register against its
+    // evaluation-date observable and recompute if the date changes.
+    let settings = shared(Settings::new());
+    settings.set_evaluation_date(today);
+
+    let dc = Actual360::new(); // DayCounter used for all three curves
+
+    // --- Black-Scholes-Merton process: spot quote + dividend curve +
+    // risk-free curve + Black vol surface, each wrapped in a Handle so it
+    // can be relinked live. The engine discounts on the risk-free curve
+    // embedded here. ---
+    let process = shared(BlackScholesMertonProcess::new(
+        Handle::new(shared(SimpleQuote::new(spot)) as Shared<dyn Quote>),
+        Handle::new(shared(FlatForward::with_rate(
+            today,
+            q_rate,
+            dc.clone(),
+            Compounding::Continuous,
+            Frequency::Annual,
+        )) as Shared<dyn YieldTermStructure>),
+        Handle::new(shared(FlatForward::with_rate(
+            today,
+            r_rate,
+            dc.clone(),
+            Compounding::Continuous,
+            Frequency::Annual,
+        )) as Shared<dyn YieldTermStructure>),
+        Handle::new(shared(BlackConstantVol::new(today, None, vol, dc.clone()))
+            as Shared<dyn BlackVolTermStructure>),
+    ));
+
+    // --- Instrument: a plain-vanilla call struck at 105, European exercise. ---
+    let payoff = shared(PlainVanillaPayoff::new(OptionType::Call, strike));
+    let exercise = shared(EuropeanExercise::new(expiry));
+    let mut option = EuropeanOption::new(payoff, exercise, Shared::clone(&settings));
+
+    // --- Attach the analytic engine. It is a SharedMut (Rc<RefCell<..>>)
+    // because pricing mutates the engine's cached results. `base_mut()` and
+    // `set_pricing_engine` come from the Instrument trait / InstrumentBase. ---
+    let engine = shared_mut(AnalyticEuropeanEngine::new(Shared::clone(&process)));
+    option
+        .base_mut()
+        .set_pricing_engine(engine as SharedMut<dyn PricingEngine>);
+
+    // --- Results. Each accessor triggers `calculate()` lazily and returns a
+    // Result (D4: explicit errors, e.g. if no engine/exercise were set). ---
+    println!("NPV   = {:.6}", option.npv().unwrap());
+    println!("delta = {:.6}", option.delta().unwrap());
+    println!("gamma = {:.6}", option.gamma().unwrap());
+    println!("vega  = {:.6}", option.vega().unwrap());
+    println!("theta = {:.6}", option.theta().unwrap());
+    println!("rho   = {:.6}", option.rho().unwrap());
+}

--- a/example/rust/inflation_swap.rs
+++ b/example/rust/inflation_swap.rs
@@ -1,0 +1,204 @@
+//! Build UK RPI with fixings, bootstrap a PiecewiseZeroInflationCurve, and
+//! price a ZeroCouponInflationSwap off it. Distilled from the reprice oracle in
+//! `crates/libitofin/src/termstructures/inflation/piecewisezeroinflationcurve.rs`
+//! (`mod zero_term_structure_oracle`, the port of inflation.cpp testZeroTermStructure).
+//!
+//! Wiring notes:
+//! - D5: `Settings` is an explicit shared handle, not a global; the eval date is set on it.
+//! - D11: fixings live on the index via `add_fixing` (needs the `Index` trait in scope),
+//!   NOT on a global IndexManager.
+//! - The index is built on an EMPTY `RelinkableHandle` and only relinked to the curve
+//!   once bootstrapped (the standalone swaps forecast through this link).
+//! - The curve's `base_date` is the index's last published period
+//!   (`index.last_fixing_date()`), which precedes the reference/eval date.
+
+use libitofin::handle::{Handle, RelinkableHandle};
+use libitofin::indexes::Index; // brings add_fixing into scope
+use libitofin::indexes::inflation::UkRpi;
+use libitofin::indexes::inflationindex::{CpiInterpolationType, ZeroInflationIndex};
+use libitofin::instrument::Instrument; // npv() and base_mut()
+use libitofin::instruments::{SwapType, ZeroCouponInflationSwap};
+use libitofin::interestrate::Compounding;
+use libitofin::math::interpolations::linear::Linear;
+use libitofin::pricingengine::PricingEngine;
+use libitofin::pricingengines::DiscountingSwapEngine;
+use libitofin::quotes::{Quote, SimpleQuote};
+use libitofin::settings::Settings;
+use libitofin::shared::{Shared, SharedMut, shared, shared_mut};
+use libitofin::termstructures::inflation::inflationhelpers::{
+    ZeroCouponInflationSwapHelper, ZeroInflationHelper,
+};
+use libitofin::termstructures::inflation::inflationtermstructure::ZeroInflationTermStructure;
+use libitofin::termstructures::inflation::piecewisezeroinflationcurve::PiecewiseZeroInflationCurve;
+use libitofin::termstructures::yields::FlatForward;
+use libitofin::termstructures::yieldtermstructure::YieldTermStructure;
+use libitofin::time::businessdayconvention::BusinessDayConvention;
+use libitofin::time::calendar::Calendar;
+use libitofin::time::calendars::unitedkingdom::{Market, UnitedKingdom};
+use libitofin::time::date::Date;
+use libitofin::time::date::Month::{August, January, July};
+use libitofin::time::daycounter::DayCounter;
+use libitofin::time::daycounters::actual360::Actual360;
+use libitofin::time::daycounters::thirty360::{Convention, Thirty360};
+use libitofin::time::frequency::Frequency;
+use libitofin::time::period::Period;
+use libitofin::time::timeunit::TimeUnit;
+use libitofin::types::Rate;
+
+/// UK RPI, published monthly from January 2005 to July 2007 (inflation.cpp:342-348).
+const FIX_DATA: [f64; 31] = [
+    189.9, 189.9, 189.6, 190.5, 191.6, 192.0, 192.2, 192.2, 192.6, 193.1, 193.3, 193.6, 194.1,
+    193.4, 194.2, 195.0, 196.5, 197.7, 198.5, 198.5, 199.2, 200.1, 200.4, 201.1, 202.7, 201.6,
+    203.1, 204.4, 205.4, 206.2, 207.3,
+];
+
+/// The quoted zero-coupon inflation swap rates, in per cent (inflation.cpp:358-373).
+fn zc_data() -> Vec<(Date, Rate)> {
+    vec![
+        (Date::new(13, August, 2008), 2.93),
+        (Date::new(13, August, 2009), 2.95),
+        (Date::new(13, August, 2010), 2.965),
+        (Date::new(15, August, 2011), 2.98),
+        (Date::new(13, August, 2012), 3.0),
+        (Date::new(13, August, 2014), 3.06),
+        (Date::new(13, August, 2017), 3.175),
+        (Date::new(13, August, 2019), 3.243),
+        (Date::new(15, August, 2022), 3.293),
+        (Date::new(14, August, 2027), 3.338),
+        (Date::new(13, August, 2032), 3.348),
+        (Date::new(15, August, 2037), 3.348),
+        (Date::new(13, August, 2047), 3.308),
+        (Date::new(13, August, 2057), 3.228),
+    ]
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let evaluation_date = Date::new(13, August, 2007);
+    let calendar: Calendar = UnitedKingdom::new(Market::Settlement);
+    let day_counter: DayCounter = Thirty360::with_convention(Convention::BondBasis);
+    let observation_lag = Period::new(3, TimeUnit::Months);
+
+    // D5: explicit Settings handle with the evaluation date set on it.
+    let settings = shared(Settings::<Date>::new());
+    settings.set_evaluation_date(evaluation_date);
+
+    // Index on an empty relinkable handle; relinked to the curve once it exists.
+    let hz: RelinkableHandle<dyn ZeroInflationTermStructure> = RelinkableHandle::empty();
+    let index: Shared<ZeroInflationIndex> =
+        shared(UkRpi::new(Shared::clone(&settings)).with_term_structure(hz.handle()));
+
+    // D11: fixings on the index. Monthly schedule from 1 Jan 2005, first-of-month keys.
+    let first_fixing_date = Date::new(1, January, 2005);
+    for (i, fixing) in FIX_DATA.iter().enumerate() {
+        let date = first_fixing_date + Period::new(i as i32, TimeUnit::Months);
+        index.add_fixing(date, *fixing)?;
+    }
+
+    // Flat 5% continuous nominal discount curve (Actual/360).
+    let nominal_ts: Handle<dyn YieldTermStructure> = Handle::new(shared(FlatForward::with_rate(
+        evaluation_date,
+        0.05,
+        Actual360::new(),
+        Compounding::Continuous,
+        Frequency::Annual,
+    ))
+        as Shared<dyn YieldTermStructure>);
+
+    // One zero-coupon inflation swap helper per quoted pillar.
+    let helpers: Vec<Shared<dyn ZeroInflationHelper>> = zc_data()
+        .iter()
+        .map(|(maturity, rate)| {
+            ZeroCouponInflationSwapHelper::new(
+                Handle::new(shared(SimpleQuote::new(Some(rate / 100.0))) as Shared<dyn Quote>),
+                observation_lag,
+                *maturity,
+                calendar.clone(),
+                BusinessDayConvention::ModifiedFollowing,
+                day_counter.clone(),
+                &index, // note: &Shared<ZeroInflationIndex>
+                CpiInterpolationType::Flat,
+                Shared::clone(&settings),
+            )
+            .expect("a three-month lag covers UK RPI's availability")
+                as Shared<dyn ZeroInflationHelper>
+        })
+        .collect();
+
+    // Base date = the last published period; precedes the reference date.
+    let base_date = index.last_fixing_date()?;
+    assert_eq!(base_date, Date::new(1, July, 2007));
+
+    // Bootstrap the curve (lazy: runs on first read). Only Linear is constructible.
+    let curve = PiecewiseZeroInflationCurve::<Linear>::new(
+        evaluation_date,
+        base_date,
+        Frequency::Monthly,
+        day_counter.clone(),
+        helpers,
+    )?;
+
+    // Link the index's forecast handle to the freshly bootstrapped curve.
+    hz.link_to(Shared::clone(&curve) as Shared<dyn ZeroInflationTermStructure>);
+
+    // Price a standalone 5Y swap on the real 5% nominal curve, struck at its quote.
+    let maturity = Date::new(13, August, 2012);
+    let mut swap = ZeroCouponInflationSwap::new(
+        SwapType::Payer,  // Payer = pays inflation, receives fixed
+        1_000_000.0,      // notional
+        evaluation_date,  // start
+        maturity,         // maturity (raw, pre-adjustment)
+        calendar.clone(), // fixed calendar
+        BusinessDayConvention::ModifiedFollowing,
+        day_counter.clone(),
+        3.0 / 100.0, // fixed rate
+        Shared::clone(&index),
+        observation_lag,
+        CpiInterpolationType::Flat,
+        None, // inflation calendar -> fixed leg's
+        None, // inflation convention -> fixed leg's
+        Shared::clone(&settings),
+    )?;
+
+    let engine = DiscountingSwapEngine::new(
+        nominal_ts.clone(),
+        None, // include_settlement_date_flows
+        None, // settlement_date -> curve ref date
+        None, // npv_date -> curve ref date
+        Shared::clone(&settings),
+    );
+    swap.base_mut()
+        .set_pricing_engine(shared_mut(engine) as SharedMut<dyn PricingEngine>);
+
+    println!("5Y ZCIS NPV      = {:.6}", swap.npv()?); // ~0: on-market
+    println!("5Y ZCIS fairRate = {:.6}%", swap.fair_rate()? * 100.0); // 3.0%
+
+    // Off-market strike (2%) to show a real non-zero NPV.
+    let mut off = ZeroCouponInflationSwap::new(
+        SwapType::Payer,
+        1_000_000.0,
+        evaluation_date,
+        maturity,
+        calendar.clone(),
+        BusinessDayConvention::ModifiedFollowing,
+        day_counter.clone(),
+        2.0 / 100.0,
+        Shared::clone(&index),
+        observation_lag,
+        CpiInterpolationType::Flat,
+        None,
+        None,
+        Shared::clone(&settings),
+    )?;
+    let engine2 = DiscountingSwapEngine::new(
+        nominal_ts.clone(),
+        None,
+        None,
+        None,
+        Shared::clone(&settings),
+    );
+    off.base_mut()
+        .set_pricing_engine(shared_mut(engine2) as SharedMut<dyn PricingEngine>);
+    println!("5Y ZCIS @2% NPV  = {:.6}", off.npv()?); // -42823.6725
+
+    Ok(())
+}

--- a/example/rust/monte_carlo.rs
+++ b/example/rust/monte_carlo.rs
@@ -1,0 +1,179 @@
+//! Self-contained `libitofin` example: Monte Carlo option pricing.
+//!
+//! (a) Prices a European call with `MCEuropeanEngine` and compares it to the
+//!     closed-form `AnalyticEuropeanEngine`, checking the MC result lands within
+//!     3 standard errors of the analytic price (the crate's own convergence pin,
+//!     mceuropeanengine.rs:448-471).
+//! (b) Prices an American put with `MCAmericanEngine` (Longstaff-Schwartz),
+//!     printing NPV, error estimate, and exercise probability. The fixture is the
+//!     one from mcamericanengine.rs:640-717 (QuantLib mclongstaffschwartzengine.cpp
+//!     testAmericanOption, i=j=0), so the numbers reproduce ~2.0544 +/- ~0.0178.
+//!
+//! Run as a binary in a crate that depends on `libitofin` (e.g. add
+//! `libitofin = "0.2"` to Cargo.toml).
+
+use libitofin::exercise::{AmericanExercise, EuropeanExercise, Exercise};
+use libitofin::handle::Handle;
+use libitofin::instrument::Instrument;
+use libitofin::instruments::{PlainVanillaPayoff, StrikedTypePayoff, VanillaOption};
+use libitofin::interestrate::Compounding;
+use libitofin::math::randomnumbers::rngtraits::PseudoRandom;
+use libitofin::option::OptionType;
+use libitofin::pricingengine::PricingEngine;
+use libitofin::pricingengines::vanilla::{
+    AnalyticEuropeanEngine, MakeMcAmericanEngine, MakeMcEuropeanEngine,
+};
+use libitofin::processes::GeneralizedBlackScholesProcess;
+use libitofin::quotes::{Quote, SimpleQuote};
+use libitofin::settings::Settings;
+use libitofin::shared::{Shared, SharedMut, shared, shared_mut};
+use libitofin::termstructures::volatility::{BlackConstantVol, BlackVolTermStructure};
+use libitofin::termstructures::yields::FlatForward;
+use libitofin::termstructures::yieldtermstructure::YieldTermStructure;
+use libitofin::time::date::{Date, Month};
+use libitofin::time::daycounters::actual365fixed::Actual365Fixed;
+use libitofin::time::frequency::Frequency;
+use libitofin::types::{Rate, Real, Volatility};
+
+/// A flat continuously-compounded discount curve on Actual/365 Fixed.
+fn flat_curve(reference: Date, rate: Rate) -> Handle<dyn YieldTermStructure> {
+    Handle::new(shared(FlatForward::with_rate(
+        reference,
+        rate,
+        Actual365Fixed::new(),
+        Compounding::Continuous,
+        Frequency::Annual,
+    )) as Shared<dyn YieldTermStructure>)
+}
+
+/// A Black-Scholes-Merton process: spot quote + dividend, risk-free, and vol curves.
+fn bs_process(
+    reference: Date,
+    spot: Real,
+    q: Rate,
+    r: Rate,
+    vol: Volatility,
+) -> Shared<GeneralizedBlackScholesProcess> {
+    let spot = Handle::new(shared(SimpleQuote::new(spot)) as Shared<dyn Quote>);
+    let vol = Handle::new(shared(BlackConstantVol::new(
+        reference,
+        None, // no calendar override
+        vol,
+        Actual365Fixed::new(),
+    )) as Shared<dyn BlackVolTermStructure>);
+    shared(GeneralizedBlackScholesProcess::new(
+        spot,
+        flat_curve(reference, q),
+        flat_curve(reference, r),
+        vol,
+    ))
+}
+
+fn main() {
+    // ==================================================================
+    // (a) European: Monte Carlo vs analytic.
+    // ==================================================================
+    {
+        let today = Date::new(15, Month::June, 2026);
+        let maturity = Date::new(15, Month::June, 2027); // ~1y on Act/365F
+        let settings = shared(Settings::new());
+        settings.set_evaluation_date(today);
+
+        // spot=100, q=2%, r=5%, sigma=20%; ATM call struck at 100.
+        let process = bs_process(today, 100.0, 0.02, 0.05, 0.20);
+        let strike = 100.0;
+
+        // Analytic reference (closed-form Black-Scholes).
+        let mut analytic_opt = VanillaOption::new(
+            shared(PlainVanillaPayoff::new(OptionType::Call, strike))
+                as Shared<dyn StrikedTypePayoff>,
+            shared(EuropeanExercise::new(maturity)) as Shared<dyn Exercise>,
+            Shared::clone(&settings),
+        );
+        analytic_opt
+            .base_mut()
+            .set_pricing_engine(
+                shared_mut(AnalyticEuropeanEngine::new(Shared::clone(&process)))
+                    as SharedMut<dyn PricingEngine>,
+            );
+        let analytic = analytic_opt.npv().unwrap();
+
+        // Monte Carlo engine: 1 time step, 40_000 pseudo-random paths, seed 42
+        // (the oracle's fixture, mceuropeanengine.rs:430-446).
+        let mc_engine = MakeMcEuropeanEngine::<PseudoRandom>::new(Shared::clone(&process))
+            .with_steps(1)
+            .with_samples(40_000)
+            .with_seed(42)
+            .build()
+            .unwrap();
+        let mut mc_opt = VanillaOption::new(
+            shared(PlainVanillaPayoff::new(OptionType::Call, strike))
+                as Shared<dyn StrikedTypePayoff>,
+            shared(EuropeanExercise::new(maturity)) as Shared<dyn Exercise>,
+            Shared::clone(&settings),
+        );
+        mc_opt
+            .base_mut()
+            .set_pricing_engine(shared_mut(mc_engine) as SharedMut<dyn PricingEngine>);
+
+        let mc = mc_opt.npv().unwrap();
+        let se = mc_opt.error_estimate().unwrap();
+
+        println!("=== European call (S=100, K=100, r=5%, q=2%, sigma=20%, T~1y) ===");
+        println!("  analytic NPV       = {analytic:.6}");
+        println!("  MC NPV             = {mc:.6}");
+        println!("  MC error estimate  = {se:.6}");
+        println!(
+            "  |MC - analytic|    = {:.6}  (converged: {})",
+            (mc - analytic).abs(),
+            (mc - analytic).abs() < 3.0 * se
+        );
+    }
+
+    // ==================================================================
+    // (b) American put: Longstaff-Schwartz Monte Carlo.
+    //     Fixture reproduces QuantLib's own MC value on this problem.
+    // ==================================================================
+    {
+        let eval_date = Date::new(15, Month::May, 1998);
+        let settlement = Date::new(17, Month::May, 1998); // curve reference date
+        let maturity = Date::new(17, Month::May, 1999);
+        let settings = shared(Settings::new());
+        settings.set_evaluation_date(eval_date);
+
+        // spot=36, q=0, r=6%, sigma=20%; put struck at 36. Curves referenced to
+        // the settlement date (deliberately != evaluation date, as in the oracle).
+        let process = bs_process(settlement, 36.0, 0.0, 0.06, 0.20);
+
+        let payoff =
+            shared(PlainVanillaPayoff::new(OptionType::Put, 36.0)) as Shared<dyn StrikedTypePayoff>;
+        let exercise =
+            shared(AmericanExercise::over(settlement, maturity).unwrap()) as Shared<dyn Exercise>;
+
+        // 75 steps, antithetic variate, absolute tolerance 0.02, seed 42,
+        // regression order 3 over the Monomial basis, 2048 calibration paths.
+        let engine = MakeMcAmericanEngine::<PseudoRandom>::new(Shared::clone(&process))
+            .with_steps(75)
+            .with_antithetic_variate(true)
+            .with_absolute_tolerance(0.02)
+            .with_seed(42)
+            .with_polynomial_order(3)
+            .build()
+            .unwrap();
+
+        let mut american = VanillaOption::new(payoff, exercise, Shared::clone(&settings));
+        american
+            .base_mut()
+            .set_pricing_engine(shared_mut(engine) as SharedMut<dyn PricingEngine>);
+
+        let npv = american.npv().unwrap();
+        let se = american.error_estimate().unwrap();
+        let exercise_prob = american.result::<Real>("exerciseProbability").unwrap();
+
+        println!();
+        println!("=== American put (S=36, K=36, r=6%, q=0, sigma=20%, T~1y) ===");
+        println!("  MC NPV                = {npv:.6}   (QuantLib ref ~2.054422)");
+        println!("  MC error estimate     = {se:.6}");
+        println!("  exercise probability  = {exercise_prob:.6}");
+    }
+}

--- a/example/rust/vanilla_swap.rs
+++ b/example/rust/vanilla_swap.rs
@@ -1,0 +1,71 @@
+//! Vanilla fixed-vs-float interest-rate swap priced with `DiscountingSwapEngine`.
+//!
+//! Built through `MakeVanillaSwap` (the QuantLib `MakeVanillaSwap` port), which
+//! derives both schedules, calls `VanillaSwap::new`, and attaches a
+//! `DiscountingSwapEngine` over the index's forwarding curve. A 5Y EUR swap:
+//! annual Thirty360(BondBasis) fixed leg (EUR currency default) vs semiannual
+//! Euribor 6M / Actual360 floating leg, both forecasting and discounting off a
+//! flat 2% continuously-compounded curve.
+//!
+//! D5: `Settings` is an explicit `Shared` handle carrying the evaluation date
+//! (no global singleton). D11: because the swap starts on a future effective
+//! date, every floating fixing lies in the future and is forecast off the curve,
+//! so no past fixing needs to be seeded into `Settings`' fixing store.
+
+use libitofin::handle::Handle;
+use libitofin::indexes::IborIndex;
+use libitofin::indexes::ibor::Euribor;
+use libitofin::instrument::Instrument; // brings the `npv()` method into scope
+use libitofin::instruments::MakeVanillaSwap;
+use libitofin::interestrate::Compounding;
+use libitofin::settings::Settings;
+use libitofin::shared::{Shared, shared};
+use libitofin::termstructures::yields::FlatForward;
+use libitofin::termstructures::yieldtermstructure::YieldTermStructure;
+use libitofin::time::date::{Date, Month};
+use libitofin::time::daycounters::actual360::Actual360;
+use libitofin::time::frequency::Frequency;
+use libitofin::time::period::Period;
+use libitofin::time::timeunit::TimeUnit;
+
+fn main() -> libitofin::errors::QlResult<()> {
+    // --- D5: explicit Settings with an evaluation date (no global clock) ---
+    let today = Date::new(7, Month::July, 2026);
+    let settings: Shared<Settings<Date>> = shared(Settings::<Date>::new());
+    settings.set_evaluation_date(today);
+
+    // --- Flat 2% forecasting/discounting curve, wrapped in a Handle ---
+    let curve: Handle<dyn YieldTermStructure> = Handle::new(shared(FlatForward::with_rate(
+        today,
+        0.02,
+        Actual360::new(),
+        Compounding::Continuous,
+        Frequency::Annual,
+    ))
+        as Shared<dyn YieldTermStructure>);
+
+    // --- 6-month Euribor forecasting off that curve ---
+    let index: Shared<IborIndex> = shared(Euribor::six_months(curve, Shared::clone(&settings)));
+
+    // --- Build + price a 5Y payer swap at a fixed 3% via MakeVanillaSwap ---
+    // Effective date after the evaluation date => all fixings are forecast
+    // (no stored past fixing required). build() attaches DiscountingSwapEngine.
+    let mut swap = MakeVanillaSwap::new(
+        Period::new(5, TimeUnit::Years),
+        Shared::clone(&index),
+        Some(0.03),                     // fixed rate; pass None to fill the fair rate
+        Period::new(0, TimeUnit::Days), // no forward start
+        Shared::clone(&settings),
+    )
+    .with_effective_date(Date::new(9, Month::July, 2026))
+    .build()?;
+
+    // npv() (Instrument trait) prices via the attached DiscountingSwapEngine.
+    let npv = swap.npv()?;
+    // fair (par) swap rate is on the FixedVsFloatingSwap base, needs &mut.
+    let fair_rate = swap.fixed_vs_floating_mut().fair_rate()?;
+
+    println!("Swap NPV:  {npv:.6}");
+    println!("Fair rate: {:.6}%", fair_rate * 100.0);
+    Ok(())
+}

--- a/example/rust/yield_curve.rs
+++ b/example/rust/yield_curve.rs
@@ -1,0 +1,153 @@
+//! Bootstrap a `PiecewiseYieldCurve` from deposit + swap rate helpers, then
+//! query discount factors and zero rates off the solved curve.
+//!
+//! The market strip is transcribed from QuantLib's piecewiseyieldcurve.cpp.
+//! D5: the evaluation date is set explicitly on an owned `Settings` (an unset
+//! date is an Err, not a system-clock fallback).
+
+use libitofin::handle::Handle;
+use libitofin::indexes::ibor::euribor::Euribor;
+use libitofin::interestrate::Compounding;
+use libitofin::math::interpolations::loglinear::LogLinear;
+use libitofin::quotes::{Quote, SimpleQuote};
+use libitofin::settings::Settings;
+use libitofin::shared::{Shared, shared};
+use libitofin::termstructures::TermStructure;
+use libitofin::termstructures::bootstraphelper::RateHelper;
+use libitofin::termstructures::bootstraptraits::Discount;
+use libitofin::termstructures::yields::{DepositRateHelper, PiecewiseYieldCurve, SwapRateHelper};
+use libitofin::termstructures::yieldtermstructure::YieldTermStructure;
+use libitofin::time::businessdayconvention::BusinessDayConvention;
+use libitofin::time::calendars::target::Target;
+use libitofin::time::date::{Date, Month};
+use libitofin::time::daycounters::actual360::Actual360;
+use libitofin::time::daycounters::thirty360::{Convention, Thirty360};
+use libitofin::time::frequency::Frequency;
+use libitofin::time::period::Period;
+use libitofin::time::timeunit::TimeUnit;
+use libitofin::types::Rate;
+
+// Market strip transcribed from QuantLib's piecewiseyieldcurve.cpp
+// (deposits :364-378, swaps :379-403). (n, unit, rate-in-percent).
+const DEPOSIT_DATA: [(i32, TimeUnit, f64); 6] = [
+    (1, TimeUnit::Weeks, 4.559),
+    (1, TimeUnit::Months, 4.581),
+    (2, TimeUnit::Months, 4.573),
+    (3, TimeUnit::Months, 4.557),
+    (6, TimeUnit::Months, 4.496),
+    (9, TimeUnit::Months, 4.490),
+];
+
+const SWAP_DATA: [(i32, TimeUnit, f64); 15] = [
+    (1, TimeUnit::Years, 4.54),
+    (2, TimeUnit::Years, 4.63),
+    (3, TimeUnit::Years, 4.75),
+    (4, TimeUnit::Years, 4.86),
+    (5, TimeUnit::Years, 4.99),
+    (6, TimeUnit::Years, 5.11),
+    (7, TimeUnit::Years, 5.23),
+    (8, TimeUnit::Years, 5.33),
+    (9, TimeUnit::Years, 5.41),
+    (10, TimeUnit::Years, 5.47),
+    (12, TimeUnit::Years, 5.60),
+    (15, TimeUnit::Years, 5.75),
+    (20, TimeUnit::Years, 5.89),
+    (25, TimeUnit::Years, 5.95),
+    (30, TimeUnit::Years, 5.96),
+];
+
+fn main() {
+    // --- 1. Settings (D5: explicit, no global singleton) ---------------------
+    // Evaluation date MUST be set before helpers are built; under D5 an unset
+    // date is an Err, not a clock fallback.
+    let calendar = Target::new();
+    let today = calendar.adjust(
+        Date::new(15, Month::June, 2026),
+        BusinessDayConvention::Following,
+    );
+    let settings = shared(Settings::<Date>::new());
+    settings.set_evaluation_date(today);
+
+    // Spot / settlement date = today + 2 business days; this is the curve's
+    // reference date.
+    let settlement = calendar.advance(
+        today,
+        2,
+        TimeUnit::Days,
+        BusinessDayConvention::Following,
+        false,
+    );
+
+    // --- 2. Rate helpers -----------------------------------------------------
+    // Each helper's index takes an EMPTY forwarding handle: the curve links
+    // itself into the helpers during the bootstrap (passing the curve handle
+    // here would create the circular dependency).
+    let mut instruments: Vec<Shared<dyn RateHelper>> = Vec::new();
+
+    // Deposit helpers. Euribor::new rejects TimeUnit::Days tenors, so the
+    // shortest deposit here is 1W.
+    for (n, units, rate) in DEPOSIT_DATA {
+        let quote = Handle::new(shared(SimpleQuote::new(rate / 100.0)) as Shared<dyn Quote>);
+        let index = Euribor::new(Period::new(n, units), Handle::empty(), settings.clone())
+            .expect("deposit tenor is valid");
+        instruments.push(DepositRateHelper::new(quote, &index) as Shared<dyn RateHelper>);
+    }
+
+    // Swap helpers: annual 30/360 fixed leg vs 6M Euribor float leg.
+    for (n, units, rate) in SWAP_DATA {
+        let quote = Handle::new(shared(SimpleQuote::new(rate / 100.0)) as Shared<dyn Quote>);
+        let euribor6m = Euribor::six_months(Handle::empty(), settings.clone());
+        instruments.push(SwapRateHelper::new(
+            quote,
+            Period::new(n, units),
+            calendar.clone(),
+            Frequency::Annual,
+            BusinessDayConvention::Unadjusted,
+            Thirty360::with_convention(Convention::BondBasis),
+            &euribor6m,
+        ) as Shared<dyn RateHelper>);
+    }
+
+    // --- 3. Build the curve --------------------------------------------------
+    // <Discount, LogLinear>: node values are discount factors, log-linearly
+    // interpolated. Construction is cheap; the bootstrap runs lazily on the
+    // first read (discount / max_date / dates).
+    let curve = PiecewiseYieldCurve::<Discount, LogLinear>::new(
+        settlement,
+        instruments,
+        Actual360::new(),
+        LogLinear,
+    )
+    .expect("curve constructed");
+
+    // Forcing the bootstrap (and surfacing any bootstrap error) up front.
+    let nodes = curve.dates().expect("bootstrap succeeds");
+    println!("bootstrapped {} curve nodes", nodes.len());
+
+    // --- 4. Query discount factors and zero rates ----------------------------
+    // Pick a couple of forward dates inside the curve's range (extrapolate =
+    // false): the 5Y and 10Y swap pillars.
+    for years in [5, 10] {
+        let date = settlement + Period::new(years, TimeUnit::Years);
+
+        // discount_date(date): DF from the reference date to `date`.
+        let df = curve
+            .discount_date(date, false)
+            .expect("date within curve range");
+
+        // discount(t): same, but by time measured in the curve's own day count.
+        let t = curve.time_from_reference(date).expect("time");
+        let df_t = curve.discount(t, false).expect("t within range");
+
+        // zero_rate(t): continuously-compounded zero rate for time t.
+        let zero: Rate = curve
+            .zero_rate(t, Compounding::Continuous, Frequency::Annual, false)
+            .expect("zero rate")
+            .rate();
+
+        println!(
+            "{years:>2}Y  t={t:.4}  DF(date)={df:.8}  DF(t)={df_t:.8}  zero(cont)={:.6}%",
+            zero * 100.0
+        );
+    }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,173 @@
+[project]
+name = "ito-fin"
+version = "0.1.0"
+description = "Add your description here"
+readme = "README.md"
+requires-python = ">=3.13"
+dependencies = []
+
+[tool.uv]
+package = true
+
+# optional - choose between tool.uv or build-version
+# [build-system]
+# requires = ["uv_build>=0.8.9,<0.9.0"]
+# build-backend = "uv_build"
+
+[project.scripts]
+# command-name = "project-name.module-name:function-name"
+
+[tool.ruff]
+line-length = 120
+target-version = "py313"
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+[tool.ruff.lint]
+fixable = ["ALL"]
+unfixable = []
+ignore = ["E731"]
+# exclude = ["ALL"]
+# select = ["PL"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+
+[tool.pylint.messages_control]
+disable = ["all"]
+enable = [
+    "consider-using-f-string",
+    "cyclic-import",
+    "deprecated-module",
+    "f-string-without-interpolation",
+    "import-error",
+    "import-self",
+    "undefined-variable",
+    "undefined-all-variable",
+    "unused-format-string-argument",
+    "unused-format-string-key",
+    "unused-import",
+    #   This might be unused but a mandatory signature in airflow runtime
+    #   "unused-argument",
+    "unused-wildcard-import",
+    "unused-variable",
+    "used-before-assignment",
+    "use-list-literal",
+    "raise-missing-from",
+    "simplifiable-condition",
+    "simplify-boolean-expression",
+    "super-with-arguments",
+    "wrong-spelling-in-comment",
+    "wrong-spelling-in-docstring",
+]
+
+[tool.pyright]
+venvPath = "."
+venv = ".venv"
+
+[tool.pytest.ini_options]
+addopts = '--basetemp=/tmp/pytest'
+# switch on `-s` for deep debuging
+# addopts = '-s --basetemp=/tmp/pytest'
+
+filterwarnings = [
+    "ignore:distutils Version classes:DeprecationWarning",
+    "ignore:'contextfilter' is renamed:DeprecationWarning",
+    "ignore:Unbuilt egg for pytest-airflow-utils:UserWarning",
+    "ignore:The 'missing' argument:DeprecationWarning",
+    "ignore:The 'default' argument:DeprecationWarning",
+    "ignore:The field metadata as keyword:DeprecationWarning",
+    "ignore:Passing field metadata:DeprecationWarning",
+    "ignore:.*__new__.*:pytest.PytestCollectionWarning",
+    "ignore:'_request_ctx_stack':DeprecationWarning",
+    "ignore:'_app_ctx_stack':DeprecationWarning",
+    "ignore:'urllib3.contrib.pyopenssl':DeprecationWarning",
+    "ignore:::.*pkg_resources.*:2350",
+    "ignore:::.*pkg_resources.*:2871",
+    "ignore:::.*gunicorn.*",
+    "ignore:::.*grpc_gcp*",
+]
+
+# testpaths = ["tests/project-name"]
+
+markers = [
+    "unittests: run unittests",
+    "integrationtests: run integrationtests",
+]
+
+[tool.mypy]
+ignore_missing_imports = true
+warn_unreachable = true
+
+[tool.black]
+line-length = 120
+exclude = '''
+/(
+  | {{ cookiecutter.* }}
+  | hooks
+  | .venv
+  | .cache
+)/
+'''
+
+[tool.coverage.run]
+omit = [
+    "tests/*",
+    "**/__init__.py",
+    "datamodel/*",
+    "*/sql/*",
+    "*__SQL.py",
+    "*__DAG.py",
+    "*/__init__.py",
+    "*/setup.py",
+    "provider/*",
+]
+source = ["."]
+parallel = true
+
+[tool.coverage.report]
+exclude_lines = ["if TYPE_CHECKING:", '\.\.\.', '...']
+exclude_also = [
+    "# pragma: no cover",
+    "def __repr__",
+    "if self.debug:",
+    "if settings.DEBUG",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if 0:",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+    "class .*\\bProtocol\\):",
+    "@(abc\\.)?abstractmethod",
+    '\.\.\.',
+    '...',
+]


### PR DESCRIPTION
This pull request adds a comprehensive set of example scripts demonstrating usage across multiple financial instruments for both Python and Rust, and updates the pre-commit tooling to support the new Python examples.

**New usage examples:**
* Added Python examples for inflation swaps, credit CDS, Monte Carlo simulation, vanilla swaps, yield curves, and European options.
* Added matching Rust examples for credit CDS, yield curves, inflation swaps, vanilla swaps, European options, and Monte Carlo simulation.

**Tooling updates:**
* Added `pyproject.toml` and `.isort.cfg` for Python project and import sorting configuration.
* Updated `.pre-commit-config.yaml` to include `isort` and `ruff` hooks for linting and formatting the new Python code.
