### PR TITLE
feat(instruments): expose cds_maturity for public use

### DIFF
--- a/crates/libitofin/src/instruments/creditdefaultswap.rs
+++ b/crates/libitofin/src/instruments/creditdefaultswap.rs
@@ -63,8 +63,7 @@
 //! ignored:
 //!
 //! - `impliedHazardRate`, `conventionalSpread` and their objective function
-//!   (`creditdefaultswap.cpp:315-428`), and `cdsMaturity`
-//!   (`creditdefaultswap.cpp:479-506`).
+//!   (`creditdefaultswap.cpp:315-428`).
 //! - `protectionEndDate` (`creditdefaultswap.cpp:430-432`), which reads the
 //!   accrual end of the last coupon through the `coupon_cast` that
 //!   [`CashFlow::as_coupon`](crate::cashflow::CashFlow::as_coupon) ports.
@@ -85,11 +84,12 @@ use crate::pricingengine::{Arguments, GenericEngine, Results};
 use crate::settings::Settings;
 use crate::shared::{Shared, shared};
 use crate::time::businessdayconvention::BusinessDayConvention;
-use crate::time::date::Date;
+use crate::time::date::{Date, Month};
 use crate::time::dategenerationrule::DateGeneration;
 use crate::time::daycounter::DayCounter;
 use crate::time::frequency::Frequency;
-use crate::time::schedule::Schedule;
+use crate::time::period::Period;
+use crate::time::schedule::{Schedule, previous_twentieth};
 use crate::time::timeunit::TimeUnit;
 use crate::types::{Integer, Natural, Rate, Real};
 use crate::{fail, require};
@@ -814,6 +814,62 @@ impl Instrument for CreditDefaultSwap {
     }
 }
 
+/// The date a standard CDS traded on `trade_date` at a quoted `tenor` matures,
+/// under one of the CDS date-generation rules.
+///
+/// Port of `cdsMaturity` (`creditdefaultswap.cpp:479-506`). The tenor must be
+/// quoted in years or in a whole number of quarters, and `OldCDS` does not
+/// admit a zero tenor.
+///
+/// `Ok(None)` stands for the null `Date` C++ returns in its one such case
+/// (`creditdefaultswap.cpp:494`): a `CDS2015` contract quoted at a zero tenor
+/// whose anchor date is 20 December or 20 June, which has already matured. All
+/// other rejections are `Err` (D4).
+pub fn cds_maturity(
+    trade_date: Date,
+    tenor: Period,
+    rule: DateGeneration,
+) -> QlResult<Option<Date>> {
+    require!(
+        matches!(
+            rule,
+            DateGeneration::CDS2015 | DateGeneration::CDS | DateGeneration::OldCDS
+        ),
+        "cds_maturity should only be used with date generation rule CDS2015, CDS or OldCDS"
+    );
+    require!(
+        tenor.units() == TimeUnit::Years
+            || (tenor.units() == TimeUnit::Months && tenor.length() % 3 == 0),
+        "cds_maturity expects a tenor that is a multiple of 3 months."
+    );
+    if rule == DateGeneration::OldCDS {
+        require!(
+            tenor != Period::new(0, TimeUnit::Months),
+            "A tenor of 0M is not supported for OldCDS."
+        );
+    }
+
+    let mut anchor_date = previous_twentieth(trade_date, rule);
+    if rule == DateGeneration::CDS2015
+        && (anchor_date == Date::new(20, Month::December, anchor_date.year())
+            || anchor_date == Date::new(20, Month::June, anchor_date.year()))
+    {
+        if tenor.length() == 0 {
+            return Ok(None);
+        }
+        anchor_date = anchor_date - Period::new(3, TimeUnit::Months);
+    }
+
+    let maturity = anchor_date + tenor + Period::new(3, TimeUnit::Months);
+    require!(
+        maturity > trade_date,
+        "error calculating CDS maturity. Tenor is {tenor}, trade date is {trade_date} \
+         generating a maturity of {maturity} <= trade date."
+    );
+
+    Ok(Some(maturity))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -823,10 +879,8 @@ mod tests {
     use crate::pricingengine::PricingEngine;
     use crate::shared::{SharedMut, shared_mut};
     use crate::time::calendars::weekendsonly::WeekendsOnly;
-    use crate::time::date::Month;
     use crate::time::daycounters::actual360::Actual360;
     use crate::time::daycounters::actual365fixed::Actual365Fixed;
-    use crate::time::period::Period;
     use crate::time::schedule::MakeSchedule;
 
     const NOTIONAL: Real = 10_000_000.0;
@@ -1524,5 +1578,68 @@ mod tests {
             !cds.base().is_calculated(),
             "an evaluation-date change invalidates the contract"
         );
+    }
+
+    /// The maturity a tenor implies is graded against the CDS date-generation
+    /// grids in `schedule.rs`, which the C++ test suite also keeps in
+    /// `test-suite/schedule.cpp:415` rather than beside the function. What is
+    /// left to pin here is the four rejections those grids never reach.
+    fn rejection(tenor: Period, rule: DateGeneration) -> String {
+        cds_maturity(Date::new(1, Month::March, 2017), tenor, rule)
+            .unwrap_err()
+            .message()
+            .to_string()
+    }
+
+    #[test]
+    fn only_the_three_cds_rules_imply_a_maturity() {
+        let message = rejection(
+            Period::new(5, TimeUnit::Years),
+            DateGeneration::TwentiethIMM,
+        );
+        assert!(message.contains("CDS2015, CDS or OldCDS"), "{message}");
+    }
+
+    #[test]
+    fn a_tenor_that_is_not_a_whole_number_of_quarters_is_rejected() {
+        let message = rejection(Period::new(4, TimeUnit::Months), DateGeneration::CDS2015);
+        assert!(message.contains("multiple of 3 months"), "{message}");
+    }
+
+    /// C++ compares the tenor against `0*Months` through the unit-converting
+    /// `Period::operator==`, so a zero tenor quoted in years is the same zero and
+    /// is rejected too. [`PartialEq`] ports that comparison rather than deriving
+    /// on the unit, which is what keeps the two agreeing.
+    #[test]
+    fn a_zero_tenor_is_rejected_under_the_old_rule_alone() {
+        let zero = Period::new(0, TimeUnit::Months);
+        let message = rejection(zero, DateGeneration::OldCDS);
+        assert!(
+            message.contains("0M is not supported for OldCDS"),
+            "{message}"
+        );
+
+        let message = rejection(Period::new(0, TimeUnit::Years), DateGeneration::OldCDS);
+        assert!(
+            message.contains("0M is not supported for OldCDS"),
+            "a zero tenor quoted in years is the same zero: {message}"
+        );
+
+        let live = cds_maturity(
+            Date::new(1, Month::December, 2016),
+            zero,
+            DateGeneration::CDS2015,
+        );
+        assert_eq!(live.unwrap(), Some(Date::new(20, Month::December, 2016)));
+    }
+
+    /// The guard is out of reach of a forward tenor: the anchor is the latest
+    /// twentieth of an IMM month on or before the trade date, so it sits under
+    /// three months back and the three months the maturity adds carry it past
+    /// the trade date again. A tenor quoted backwards reaches it.
+    #[test]
+    fn a_maturity_on_or_before_the_trade_date_is_rejected() {
+        let message = rejection(Period::new(-1, TimeUnit::Years), DateGeneration::CDS);
+        assert!(message.contains("<= trade date"), "{message}");
     }
 }

--- a/crates/libitofin/src/instruments/mod.rs
+++ b/crates/libitofin/src/instruments/mod.rs
@@ -27,7 +27,9 @@ pub use bond::{Bond, BondArguments, BondEngine, BondPrice, BondPriceType, BondRe
 pub use bonds::FixedRateBond;
 pub use capfloor::{CapFloor, CapFloorArguments, CapFloorType};
 pub use claim::{Claim, FaceValueClaim};
-pub use creditdefaultswap::{CdsArguments, CdsEngine, CdsResults, CdsTerms, CreditDefaultSwap};
+pub use creditdefaultswap::{
+    CdsArguments, CdsEngine, CdsResults, CdsTerms, CreditDefaultSwap, cds_maturity,
+};
 pub use fixedvsfloatingswap::{
     FixedVsFloatingSwap, FixedVsFloatingSwapArguments, FixedVsFloatingSwapEngine,
     FixedVsFloatingSwapResults, FloatingArgumentsFn,

--- a/crates/libitofin/src/time/schedule.rs
+++ b/crates/libitofin/src/time/schedule.rs
@@ -980,6 +980,7 @@ fn is_imm_date(d: Date) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::instruments::cds_maturity;
     use crate::time::calendars::japan::Japan;
     use crate::time::calendars::target::Target;
     use crate::time::calendars::unitedstates::{Market, UnitedStates};
@@ -1000,33 +1001,6 @@ mod tests {
             .with_termination_date_convention(BusinessDayConvention::Unadjusted)
             .with_rule(rule)
             .build()
-    }
-
-    fn cds_maturity(trade_date: Date, tenor: Period, rule: DateGeneration) -> Option<Date> {
-        assert!(matches!(
-            rule,
-            DateGeneration::CDS2015 | DateGeneration::CDS | DateGeneration::OldCDS
-        ));
-        assert!(
-            tenor.units() == TimeUnit::Years
-                || (tenor.units() == TimeUnit::Months && tenor.length() % 3 == 0)
-        );
-        if rule == DateGeneration::OldCDS {
-            assert!(tenor != Period::new(0, TimeUnit::Months));
-        }
-        let mut anchor_date = previous_twentieth(trade_date, rule);
-        if rule == DateGeneration::CDS2015
-            && (anchor_date == d(20, Month::December, anchor_date.year())
-                || anchor_date == d(20, Month::June, anchor_date.year()))
-        {
-            if tenor.length() == 0 {
-                return None;
-            }
-            anchor_date = anchor_date - Period::new(3, TimeUnit::Months);
-        }
-        let maturity = anchor_date + tenor + Period::new(3, TimeUnit::Months);
-        assert!(maturity > trade_date, "error calculating CDS maturity");
-        Some(maturity)
     }
 
     fn check_dates(s: &Schedule, expected: &[Date]) {
@@ -1502,7 +1476,9 @@ mod tests {
             let exp_start = d(sd, Month::from_ordinal(sm), sy);
             let exp_end = d(ed, Month::from_ordinal(em), ey);
 
-            let maturity = cds_maturity(from, tenor, rule).expect("live CDS maturity");
+            let maturity = cds_maturity(from, tenor, rule)
+                .unwrap()
+                .expect("live CDS maturity");
             assert_eq!(maturity, exp_end, "maturity from {from}, tenor {tenor}");
 
             let s = make_cds_schedule(from, maturity, rule);
@@ -1740,7 +1716,9 @@ mod tests {
         let tenor = Period::new(5, TimeUnit::Years);
 
         let trade_date = d(12, Month::December, 2016);
-        let maturity = cds_maturity(trade_date, tenor, rule).unwrap();
+        let maturity = cds_maturity(trade_date, tenor, rule)
+            .unwrap()
+            .expect("live CDS maturity");
         let exp_start = d(20, Month::September, 2016);
         let exp_maturity = d(20, Month::December, 2021);
         assert_eq!(maturity, exp_maturity);
@@ -1754,7 +1732,9 @@ mod tests {
         assert_eq!(s.end_date(), exp_maturity);
 
         let trade_date = d(1, Month::March, 2017);
-        let maturity = cds_maturity(trade_date, tenor, rule).unwrap();
+        let maturity = cds_maturity(trade_date, tenor, rule)
+            .unwrap()
+            .expect("live CDS maturity");
         assert_eq!(maturity, exp_maturity);
         let s = make_cds_schedule(trade_date, maturity, rule);
         let exp_start = d(20, Month::December, 2016);
@@ -1767,7 +1747,9 @@ mod tests {
         assert_eq!(s.end_date(), d(20, Month::March, 2022));
 
         let trade_date = d(20, Month::March, 2017);
-        let maturity = cds_maturity(trade_date, tenor, rule).unwrap();
+        let maturity = cds_maturity(trade_date, tenor, rule)
+            .unwrap()
+            .expect("live CDS maturity");
         let exp_start = d(20, Month::March, 2017);
         let exp_maturity = d(20, Month::June, 2022);
         assert_eq!(maturity, exp_maturity);
@@ -1782,7 +1764,9 @@ mod tests {
         let tenor = Period::new(1, TimeUnit::Years);
 
         let trade_date = d(18, Month::September, 2015);
-        let maturity = cds_maturity(trade_date, tenor, rule).unwrap();
+        let maturity = cds_maturity(trade_date, tenor, rule)
+            .unwrap()
+            .expect("live CDS maturity");
         let s = make_cds_schedule(trade_date, maturity, rule);
         let mut exp_dates = vec![
             d(22, Month::June, 2015),
@@ -1794,19 +1778,25 @@ mod tests {
         check_dates(&s, &exp_dates);
 
         let trade_date = d(19, Month::September, 2015);
-        let maturity = cds_maturity(trade_date, tenor, rule).unwrap();
+        let maturity = cds_maturity(trade_date, tenor, rule)
+            .unwrap()
+            .expect("live CDS maturity");
         let s = make_cds_schedule(trade_date, maturity, rule);
         check_dates(&s, &exp_dates);
 
         let trade_date = d(20, Month::September, 2015);
-        let maturity = cds_maturity(trade_date, tenor, rule).unwrap();
+        let maturity = cds_maturity(trade_date, tenor, rule)
+            .unwrap()
+            .expect("live CDS maturity");
         let s = make_cds_schedule(trade_date, maturity, rule);
         exp_dates.push(d(20, Month::September, 2016));
         exp_dates.push(d(20, Month::December, 2016));
         check_dates(&s, &exp_dates);
 
         let trade_date = d(21, Month::September, 2015);
-        let maturity = cds_maturity(trade_date, tenor, rule).unwrap();
+        let maturity = cds_maturity(trade_date, tenor, rule)
+            .unwrap()
+            .expect("live CDS maturity");
         let s = make_cds_schedule(trade_date, maturity, rule);
         exp_dates.remove(0);
         check_dates(&s, &exp_dates);
@@ -1838,7 +1828,9 @@ mod tests {
         let tenor = Period::new(1, TimeUnit::Years);
 
         let trade_date = d(18, Month::September, 2015);
-        let maturity = cds_maturity(trade_date, tenor, rule).unwrap();
+        let maturity = cds_maturity(trade_date, tenor, rule)
+            .unwrap()
+            .expect("live CDS maturity");
         let s = make_cds_schedule(trade_date, maturity, rule);
         let mut exp_dates = vec![
             d(22, Month::June, 2015),
@@ -1851,18 +1843,24 @@ mod tests {
         check_dates(&s, &exp_dates);
 
         let trade_date = d(19, Month::September, 2015);
-        let maturity = cds_maturity(trade_date, tenor, rule).unwrap();
+        let maturity = cds_maturity(trade_date, tenor, rule)
+            .unwrap()
+            .expect("live CDS maturity");
         let s = make_cds_schedule(trade_date, maturity, rule);
         check_dates(&s, &exp_dates);
 
         let trade_date = d(20, Month::September, 2015);
-        let maturity = cds_maturity(trade_date, tenor, rule).unwrap();
+        let maturity = cds_maturity(trade_date, tenor, rule)
+            .unwrap()
+            .expect("live CDS maturity");
         let s = make_cds_schedule(trade_date, maturity, rule);
         exp_dates.push(d(20, Month::December, 2016));
         check_dates(&s, &exp_dates);
 
         let trade_date = d(21, Month::September, 2015);
-        let maturity = cds_maturity(trade_date, tenor, rule).unwrap();
+        let maturity = cds_maturity(trade_date, tenor, rule)
+            .unwrap()
+            .expect("live CDS maturity");
         let s = make_cds_schedule(trade_date, maturity, rule);
         exp_dates.remove(0);
         check_dates(&s, &exp_dates);
@@ -1894,7 +1892,9 @@ mod tests {
         let tenor = Period::new(1, TimeUnit::Years);
 
         let mut trade_date_plus_one = d(18, Month::September, 2015);
-        let maturity = cds_maturity(trade_date_plus_one, tenor, rule).unwrap();
+        let maturity = cds_maturity(trade_date_plus_one, tenor, rule)
+            .unwrap()
+            .expect("live CDS maturity");
         let s = make_cds_schedule(trade_date_plus_one, maturity, rule);
         let mut exp_dates = vec![
             d(18, Month::September, 2015),
@@ -1907,20 +1907,26 @@ mod tests {
 
         trade_date_plus_one = d(19, Month::September, 2015);
         exp_dates[0] = trade_date_plus_one;
-        let maturity = cds_maturity(trade_date_plus_one, tenor, rule).unwrap();
+        let maturity = cds_maturity(trade_date_plus_one, tenor, rule)
+            .unwrap()
+            .expect("live CDS maturity");
         let s = make_cds_schedule(trade_date_plus_one, maturity, rule);
         check_dates(&s, &exp_dates);
 
         trade_date_plus_one = d(20, Month::September, 2015);
         exp_dates[0] = trade_date_plus_one;
-        let maturity = cds_maturity(trade_date_plus_one, tenor, rule).unwrap();
+        let maturity = cds_maturity(trade_date_plus_one, tenor, rule)
+            .unwrap()
+            .expect("live CDS maturity");
         let s = make_cds_schedule(trade_date_plus_one, maturity, rule);
         exp_dates.push(d(20, Month::December, 2016));
         check_dates(&s, &exp_dates);
 
         trade_date_plus_one = d(21, Month::September, 2015);
         exp_dates[0] = trade_date_plus_one;
-        let maturity = cds_maturity(trade_date_plus_one, tenor, rule).unwrap();
+        let maturity = cds_maturity(trade_date_plus_one, tenor, rule)
+            .unwrap()
+            .expect("live CDS maturity");
         let s = make_cds_schedule(trade_date_plus_one, maturity, rule);
         check_dates(&s, &exp_dates);
 
@@ -1957,7 +1963,11 @@ mod tests {
         ];
 
         for input in inputs {
-            assert_eq!(cds_maturity(input, tenor, rule), None, "at {input}");
+            assert_eq!(
+                cds_maturity(input, tenor, rule).unwrap(),
+                None,
+                "at {input}"
+            );
         }
     }
 


### PR DESCRIPTION
Move `cdsMaturity` out of the schedule test module and into the
`creditdefaultswap` module as a public `cds_maturity` function, so
callers can compute the maturity of a standard CDS from a trade date
and quoted tenor.

**Public API:**
* Added `cds_maturity` to `creditdefaultswap.rs`, ported from the C++
  `cdsMaturity`, returning `QlResult<Option<Date>>`: `Ok(None)` for the
  one CDS2015 zero-tenor case that has already matured, and `Err` for
  all other rejections (unsupported rule, non-quarter tenor, zero tenor
  under OldCDS, or a maturity on or before the trade date).
* Re-exported `cds_maturity` from `instruments/mod.rs`.

**Tests:**
* Added unit tests covering the four rejection paths the schedule grids
  never reach, plus the live CDS2015 zero-tenor maturity.
* Updated the schedule tests to use the shared `cds_maturity` and its
  new `Result`-wrapped return type.

close #778
