### PR TITLE
test(credit): assert CDS reference date uses evaluation date


### DIFF
--- a/crates/itofin-py/src/credithelpers.rs
+++ b/crates/itofin-py/src/credithelpers.rs
@@ -77,11 +77,10 @@ impl PyDefaultProbabilityHelper {
 /// `set_value` re-drives the bootstrap, and it observes `discount_curve`.
 ///
 /// Fallible, unlike the [`PyFlatHazardRate`](crate::credit::PyFlatHazardRate)
-/// chain it otherwise mirrors: the core rejects the three post-Big-Bang rules
-/// (`DateGeneration.OldCDS` / `.CDS` / `.CDS2015`), whose maturity comes from an
-/// unported `cdsMaturity` (`defaultprobabilityhelpers.rs:314-319`). Passing one
-/// raises [`struct@crate::ItofinError`] instead of building a schedule that ends
-/// on the wrong date.
+/// chain it otherwise mirrors: under the three post-Big-Bang rules
+/// (`DateGeneration.OldCDS` / `.CDS` / `.CDS2015`) the maturity is rolled by
+/// `cdsMaturity`, which raises [`struct@crate::ItofinError`] on a tenor it
+/// cannot roll rather than building a schedule that ends on the wrong date.
 #[pyclass(name = "SpreadCdsHelper", extends = PyDefaultProbabilityHelper, unsendable)]
 pub struct PySpreadCdsHelper;
 

--- a/crates/itofin-py/tests/test_credit_helper.py
+++ b/crates/itofin-py/tests/test_credit_helper.py
@@ -12,14 +12,16 @@ repricing oracle would not discriminate:
   ``forwards()`` is ``with_rule(DateGeneration::Forward)`` (schedule.rs:852-853),
   so the two are identical by construction; this pins the default at the Python
   boundary.
-* ``SpreadCdsHelper`` builds under a CDS rule and rejects the three
-  post-Big-Bang ones, whose maturity rule the core has not ported.
+* ``SpreadCdsHelper`` builds under every date-generation rule the core takes,
+  and the three post-Big-Bang ones reach ``cdsMaturity``: their pillar is the
+  hand-derived CDS roll date, which a helper that had dropped the rule would
+  miss by a quarter.
 * ``Settings.include_todays_cash_flows`` round-trips its three states. Whether
   the flag moves a price is A5's.
 """
 
 import pytest
-from itofin import ItofinError, Settings
+from itofin import Settings
 from itofin.quotes import SimpleQuote
 from itofin.termstructures import FlatForward, SpreadCdsHelper
 from itofin.time import (
@@ -112,9 +114,11 @@ def test_a_spread_helper_builds_under_the_twentieth_imm_rule():
 @pytest.mark.parametrize(
     "rule", [DateGeneration.OldCDS, DateGeneration.CDS, DateGeneration.CDS2015]
 )
-def test_the_post_big_bang_rules_are_refused_rather_than_mispriced(rule):
-    with pytest.raises(ItofinError):
-        Market().helper(rule)
+def test_the_post_big_bang_rules_roll_the_maturity_to_a_cds_date(rule):
+    """Five years quoted on 15 May 2007 rolls to the twentieth of the IMM month
+    a quarter past the anniversary of the previous roll date, which is a
+    different date from the 15 May 2012 a dropped rule would produce."""
+    assert Market().helper(rule).latest_date() == Date(20, 6, 2012)
 
 
 def test_include_todays_cash_flows_round_trips_its_three_states():

--- a/crates/libitofin/src/instruments/creditdefaultswap.rs
+++ b/crates/libitofin/src/instruments/creditdefaultswap.rs
@@ -66,8 +66,9 @@
 //! Within EPIC Credit (#676), and each omitted visibly rather than accepted and
 //! ignored:
 //!
-//! - `conventionalSpread` (`creditdefaultswap.cpp:383-428`), whose only caller
-//!   anywhere in `ql/` is the upfront rate helper it ships with (#782).
+//! - `conventionalSpread` (`creditdefaultswap.cpp:383-428`), which has no
+//!   caller anywhere in `ql/` - not even the upfront rate helper it ships
+//!   with, which quotes `fairUpfront` instead (#790).
 //! - The [`PricingModel::Isda`] branch of [`implied_hazard_rate`]
 //!   (`creditdefaultswap.cpp:361-368`), which prices on the `IsdaCdsEngine`
 //!   (#783); until that engine lands the branch is a typed error rather than a

--- a/crates/libitofin/src/termstructures/credit/defaultprobabilityhelpers.rs
+++ b/crates/libitofin/src/termstructures/credit/defaultprobabilityhelpers.rs
@@ -22,18 +22,17 @@
 //! bootstrap is driven by. `UpfrontCdsHelper` (`defaultprobabilityhelpers.hpp:170`)
 //! is not here yet and follows within EPIC Credit (#676).
 
-use std::cell::{Cell, RefCell};
+use std::cell::{Cell, Ref, RefCell};
 use std::rc::Weak;
 
 use crate::errors::{QlError, QlResult};
 use crate::handle::{Handle, RelinkableHandle};
 use crate::instrument::Instrument;
-use crate::instruments::{CdsTerms, CreditDefaultSwap, ProtectionSide};
+use crate::instruments::{CdsTerms, CreditDefaultSwap, PricingModel, ProtectionSide, cds_maturity};
 use crate::patterns::observable::{AsObservable, Observable};
 use crate::pricingengine::PricingEngine;
 use crate::pricingengines::credit::MidPointCdsEngine;
 use crate::quotes::Quote;
-use crate::require;
 use crate::settings::Settings;
 use crate::shared::{Shared, SharedMut, shared_mut};
 use crate::termstructures::bootstraphelper::{BootstrapHelperBase, BootstrapHelperShared};
@@ -48,6 +47,7 @@ use crate::time::frequency::Frequency;
 use crate::time::period::Period;
 use crate::time::schedule::{MakeSchedule, Schedule};
 use crate::types::{Integer, Real};
+use crate::{fail, require};
 
 /// The shared state of a credit bootstrap helper: a
 /// [`BootstrapHelperBase`] whose back-pointer is a default-probability curve.
@@ -126,7 +126,15 @@ pub trait DefaultProbabilityHelper: AsObservable {
 /// [`initialize_dates`](Self::initialize_dates).
 pub trait RelativeDateDefaultProbabilityHelper: DefaultProbabilityHelper {
     /// Rebuilds the helper's date schedule off the current evaluation date.
-    fn initialize_dates(&self);
+    ///
+    /// Fallible where the yield family's is not: a CDS schedule's maturity
+    /// comes from [`cds_maturity`], which rejects a tenor it cannot roll, and
+    /// the bootstrap must carry that out rather than unwrap it (D4).
+    ///
+    /// # Errors
+    ///
+    /// As the concrete helper's date rule.
+    fn initialize_dates(&self) -> QlResult<()>;
 }
 
 /// The credit half of the driver bound. Like the yield impl, every method
@@ -160,15 +168,14 @@ impl BootstrapHelperShared for dyn DefaultProbabilityHelper {
     }
 }
 
-/// The terms a [`SpreadCdsHelper`] defaults when they are not quoted.
+/// The terms a CDS bootstrap helper defaults when they are not quoted.
 ///
 /// One field per defaulted argument of the C++ `CdsHelper` constructor
-/// (`defaultprobabilityhelpers.hpp:90-94`); [`Default`] carries their C++
-/// values. The `model` argument has no field: only
-/// [`Midpoint`](crate::pricingengines::credit::MidPointCdsEngine) is ported, the
-/// ISDA arm of `resetEngine` (`defaultprobabilityhelpers.cpp:143-148`) staying
-/// deferred within EPIC Credit (#676).
+/// (`defaultprobabilityhelpers.hpp:90-95`); [`Default`] carries their C++
+/// values.
 pub struct CdsHelperTerms {
+    /// The model the helper prices its contract under.
+    pub model: PricingModel,
     /// Whether the accrued coupon is due on a default.
     pub settles_accrual: bool,
     /// Whether a default pays at default time rather than at the end of the
@@ -186,6 +193,7 @@ pub struct CdsHelperTerms {
 impl Default for CdsHelperTerms {
     fn default() -> CdsHelperTerms {
         CdsHelperTerms {
+            model: PricingModel::Midpoint,
             settles_accrual: true,
             pays_at_default_time: true,
             start_date: None,
@@ -195,23 +203,15 @@ impl Default for CdsHelperTerms {
     }
 }
 
-/// A spread-quoted CDS as a credit bootstrap helper (`SpreadCdsHelper`,
-/// `defaultprobabilityhelpers.hpp:128`).
+/// The state and dates every CDS bootstrap helper shares (`CdsHelper`,
+/// `defaultprobabilityhelpers.hpp:48-128`).
 ///
-/// The helper prices a par CDS on its own schedule against the curve being
-/// bootstrapped and reports that contract's fair spread as
-/// [`implied_quote`](DefaultProbabilityHelper::implied_quote); the bootstrap
-/// drives `quoted spread - fair spread` to zero.
-///
-/// The C++ `CdsHelper` base (`defaultprobabilityhelpers.hpp:47-126`) has no
-/// separate type here. It exists in C++ only to share state and
-/// `initializeDates` with `UpfrontCdsHelper`, and that sibling is deferred
-/// (#676), so its state and `initializeDates` live directly in this struct.
-/// Porting `UpfrontCdsHelper` means factoring out the fields below plus
-/// [`initialize_dates`](RelativeDateDefaultProbabilityHelper::initialize_dates)
-/// and [`set_term_structure`](DefaultProbabilityHelper::set_term_structure),
-/// leaving only `reset_engine` and `implied_quote` per subclass.
-pub struct SpreadCdsHelper {
+/// C++ makes this an abstract class between the relative-date helper and the
+/// two quoted contracts; here it is the state those contracts embed. A concrete
+/// helper holds one, reports its [`base`](CdsHelperBase::base) as its own, and
+/// supplies the two members C++ leaves virtual: the contract `reset_engine`
+/// builds and [`implied_quote`](DefaultProbabilityHelper::implied_quote).
+pub struct CdsHelperBase {
     base: DefaultProbabilityHelperBase,
     tenor: Period,
     settlement_days: Integer,
@@ -227,6 +227,7 @@ pub struct SpreadCdsHelper {
     start_date: Option<Date>,
     last_period_day_counter: Option<DayCounter>,
     rebates_accrual: bool,
+    model: PricingModel,
     settings: Shared<Settings<Date>>,
     schedule: RefCell<Schedule>,
     protection_start: Cell<Date>,
@@ -242,6 +243,234 @@ fn engine_not_reset() -> QlError {
         file!(),
         line!(),
     )
+}
+
+impl CdsHelperBase {
+    /// The C++ `CdsHelper` constructor (`defaultprobabilityhelpers.cpp:32-58`),
+    /// less the `initializeDates` its callers run once the concrete helper
+    /// exists to hold this.
+    ///
+    /// `on_eval_change` is the rebuild the base runs when the evaluation date
+    /// moves; it reaches the concrete helper, since the contract it rebuilds is
+    /// the subclass's to build.
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        quote: Handle<dyn Quote>,
+        tenor: Period,
+        settlement_days: Integer,
+        calendar: Calendar,
+        frequency: Frequency,
+        payment_convention: BusinessDayConvention,
+        rule: DateGeneration,
+        day_counter: DayCounter,
+        recovery_rate: Real,
+        discount_curve: Handle<dyn YieldTermStructure>,
+        terms: CdsHelperTerms,
+        settings: Shared<Settings<Date>>,
+        on_eval_change: Box<dyn Fn()>,
+    ) -> CdsHelperBase {
+        let base = BootstrapHelperBase::new_relative(
+            quote,
+            Shared::clone(&settings),
+            true,
+            on_eval_change,
+        );
+        discount_curve.register_observer(&base.observer());
+        CdsHelperBase {
+            base,
+            tenor,
+            settlement_days,
+            calendar,
+            frequency,
+            payment_convention,
+            rule,
+            day_counter,
+            recovery_rate,
+            discount_curve,
+            settles_accrual: terms.settles_accrual,
+            pays_at_default_time: terms.pays_at_default_time,
+            start_date: terms.start_date,
+            last_period_day_counter: terms.last_period_day_counter,
+            rebates_accrual: terms.rebates_accrual,
+            model: terms.model,
+            settings,
+            schedule: RefCell::new(Schedule::from_dates(Vec::new())),
+            protection_start: Cell::new(Date::null()),
+            probability: RelinkableHandle::empty(),
+            swap: RefCell::new(Err(engine_not_reset())),
+        }
+    }
+
+    /// The embedded bootstrap-helper state.
+    pub fn base(&self) -> &DefaultProbabilityHelperBase {
+        &self.base
+    }
+
+    /// The contract the helper prices (`swap()`, `hpp:98-100`), or the reason
+    /// it could not be built.
+    pub fn swap(&self) -> Ref<'_, QlResult<CreditDefaultSwap>> {
+        self.swap.borrow()
+    }
+
+    /// The schedule the contract pays on (`schedule_`, `hpp:126`).
+    pub fn schedule(&self) -> Ref<'_, Schedule> {
+        self.schedule.borrow()
+    }
+
+    /// The date protection starts, `settlement_days` past the evaluation date
+    /// (`cpp:79`).
+    pub fn protection_start(&self) -> Date {
+        self.protection_start.get()
+    }
+
+    /// The evaluation date the schedule is measured from.
+    fn evaluation_date(&self) -> Date {
+        self.base
+            .evaluation_date()
+            .expect("a relative-date helper always tracks an evaluation date")
+    }
+
+    /// Stores the rebuilt contract, or the reason it could not be built.
+    fn set_swap(&self, swap: QlResult<CreditDefaultSwap>) {
+        *self.swap.borrow_mut() = swap;
+    }
+
+    /// Records the curve and hands it to the engine (`setTermStructure`,
+    /// `cpp:60-68`), leaving the contract rebuild to the caller.
+    ///
+    /// The engine's handle is linked weakly, the port of the C++
+    /// `linkTo(..., false)` at `cpp:63-65`: the curve owns this helper, which
+    /// owns the contract, which owns the engine, and a strong link would close
+    /// that ring.
+    fn set_term_structure(&self, term_structure: &Shared<dyn DefaultProbabilityTermStructure>) {
+        self.base.set_term_structure(term_structure);
+        self.probability
+            .link_to_weak(Shared::downgrade(term_structure));
+    }
+
+    /// The terms the priced contract inherits from the helper.
+    ///
+    /// The trade date is the evaluation date, as C++ passes it
+    /// (`cpp:141` and `cpp:201`), rather than the contract's own deduction: it
+    /// is what the accrual rebate accrues to, so leaving it to the contract
+    /// would rebate a different amount than the quoted market convention.
+    fn contract_terms(&self) -> CdsTerms {
+        CdsTerms {
+            settles_accrual: self.settles_accrual,
+            pays_at_default_time: self.pays_at_default_time,
+            protection_start: Some(self.protection_start.get()),
+            last_period_day_counter: self.last_period_day_counter.clone(),
+            rebates_accrual: self.rebates_accrual,
+            trade_date: Some(self.evaluation_date()),
+            ..CdsTerms::default()
+        }
+    }
+
+    /// Installs the model's engine over the helper's own probability handle
+    /// (`resetEngine`'s switch, `cpp:143-153`).
+    ///
+    /// # Errors
+    ///
+    /// [`PricingModel::Isda`] needs the `IsdaCdsEngine` deferred to #783; the
+    /// arm is refused rather than silently priced on the mid-point engine.
+    fn install_engine(&self, swap: &mut CreditDefaultSwap) -> QlResult<()> {
+        require!(
+            self.model == PricingModel::Midpoint,
+            "the ISDA arm of resetEngine (defaultprobabilityhelpers.cpp:143-148) needs the \
+             IsdaCdsEngine, which is not ported yet (#783)"
+        );
+        let engine = MidPointCdsEngine::new(
+            self.probability.handle(),
+            self.recovery_rate,
+            self.discount_curve.clone(),
+            None,
+            Shared::clone(&self.settings),
+        );
+        swap.base_mut()
+            .set_pricing_engine(shared_mut(engine) as SharedMut<dyn PricingEngine>);
+        Ok(())
+    }
+
+    /// Rebuilds the schedule off the current evaluation date (`initializeDates`,
+    /// `cpp:75-108`).
+    ///
+    /// Protection starts `settlement_days` past the evaluation date and, absent
+    /// an explicit start, the schedule starts there too, rolled to a business
+    /// day for every rule but the two post-Big-Bang ones. The maturity has two
+    /// arms: the three CDS rules roll it off [`cds_maturity`] measured from the
+    /// evaluation date (`cpp:86-88`), every other rule measures a tenor from the
+    /// protection start (`cpp:90-92`) - a different reference date, not just a
+    /// different roll.
+    ///
+    /// The earliest date is the schedule's first date and the latest its last,
+    /// rolled, plus the day the ISDA model adds (`cpp:105-106`).
+    ///
+    /// # Errors
+    ///
+    /// If [`cds_maturity`] refuses the tenor, or rolls it to a contract that has
+    /// already matured.
+    fn initialize_dates(&self) -> QlResult<()> {
+        let evaluation_date = self.evaluation_date();
+        let protection_start = evaluation_date + self.settlement_days;
+        self.protection_start.set(protection_start);
+
+        let mut start_date = self.start_date.unwrap_or(protection_start);
+        if self.rule != DateGeneration::CDS && self.rule != DateGeneration::CDS2015 {
+            start_date = self.calendar.adjust(start_date, self.payment_convention);
+        }
+
+        let end_date = if matches!(
+            self.rule,
+            DateGeneration::CDS2015 | DateGeneration::CDS | DateGeneration::OldCDS
+        ) {
+            let reference_date = self.start_date.unwrap_or(evaluation_date);
+            match cds_maturity(reference_date, self.tenor, self.rule)? {
+                Some(date) => date,
+                None => fail!(
+                    "the CDS2015 contract quoted at a zero tenor on {reference_date} has already \
+                     matured (creditdefaultswap.cpp:494)"
+                ),
+            }
+        } else {
+            let reference_date = match self.start_date {
+                Some(date) => date + self.settlement_days,
+                None => protection_start,
+            };
+            reference_date + self.tenor
+        };
+
+        let schedule = MakeSchedule::new()
+            .from(start_date)
+            .to(end_date)
+            .with_frequency(self.frequency)
+            .with_calendar(self.calendar.clone())
+            .with_convention(self.payment_convention)
+            .with_termination_date_convention(BusinessDayConvention::Unadjusted)
+            .with_rule(self.rule)
+            .build();
+
+        let mut latest_date = self
+            .calendar
+            .adjust(schedule.date(schedule.len() - 1), self.payment_convention);
+        if self.model == PricingModel::Isda {
+            latest_date += 1;
+        }
+        self.base.set_earliest_date(schedule.date(0));
+        self.base.set_latest_date(latest_date);
+        *self.schedule.borrow_mut() = schedule;
+        Ok(())
+    }
+}
+
+/// A spread-quoted CDS as a credit bootstrap helper (`SpreadCdsHelper`,
+/// `defaultprobabilityhelpers.hpp:129`).
+///
+/// The helper prices a par CDS on its own schedule against the curve being
+/// bootstrapped and reports that contract's fair spread as
+/// [`implied_quote`](DefaultProbabilityHelper::implied_quote); the bootstrap
+/// drives `quoted spread - fair spread` to zero.
+pub struct SpreadCdsHelper {
+    cds: CdsHelperBase,
 }
 
 impl SpreadCdsHelper {
@@ -292,10 +521,8 @@ impl SpreadCdsHelper {
     ///
     /// # Errors
     ///
-    /// Rejects the three CDS date-generation rules. Their maturity comes from
-    /// `cdsMaturity` (`cpp:87`), which is not ported, and taking the other arm
-    /// for them would silently produce a schedule ending on the wrong date; that
-    /// branch is deferred within EPIC Credit (#676).
+    /// If the date rule cannot roll the tenor to a maturity
+    /// ([`initialize_dates`](CdsHelperBase::initialize_dates)).
     #[allow(clippy::too_many_arguments)]
     pub fn with_terms(
         running_spread: Handle<dyn Quote>,
@@ -311,60 +538,42 @@ impl SpreadCdsHelper {
         terms: CdsHelperTerms,
         settings: Shared<Settings<Date>>,
     ) -> QlResult<Shared<SpreadCdsHelper>> {
-        require!(
-            !matches!(
-                rule,
-                DateGeneration::CDS | DateGeneration::CDS2015 | DateGeneration::OldCDS
-            ),
-            "the post-Big-Bang date-generation rules need cdsMaturity, which is not ported yet \
-             (defaultprobabilityhelpers.cpp:85-88)"
-        );
-        Ok(Shared::new_cyclic(|weak: &Weak<SpreadCdsHelper>| {
+        let helper = Shared::new_cyclic(|weak: &Weak<SpreadCdsHelper>| {
             let weak = weak.clone();
             let on_eval_change = Box::new(move || {
                 if let Some(helper) = weak.upgrade() {
-                    helper.initialize_dates();
-                    helper.reset_engine();
+                    match helper.cds.initialize_dates() {
+                        Ok(()) => helper.reset_engine(),
+                        Err(error) => helper.cds.set_swap(Err(error)),
+                    }
                 }
             });
-            let base = BootstrapHelperBase::new_relative(
-                running_spread,
-                Shared::clone(&settings),
-                true,
-                on_eval_change,
-            );
-            discount_curve.register_observer(&base.observer());
-            let helper = SpreadCdsHelper {
-                base,
-                tenor,
-                settlement_days,
-                calendar,
-                frequency,
-                payment_convention,
-                rule,
-                day_counter,
-                recovery_rate,
-                discount_curve,
-                settles_accrual: terms.settles_accrual,
-                pays_at_default_time: terms.pays_at_default_time,
-                start_date: terms.start_date,
-                last_period_day_counter: terms.last_period_day_counter,
-                rebates_accrual: terms.rebates_accrual,
-                settings,
-                schedule: RefCell::new(Schedule::from_dates(Vec::new())),
-                protection_start: Cell::new(Date::null()),
-                probability: RelinkableHandle::empty(),
-                swap: RefCell::new(Err(engine_not_reset())),
-            };
-            helper.initialize_dates();
-            helper
-        }))
+            SpreadCdsHelper {
+                cds: CdsHelperBase::new(
+                    running_spread,
+                    tenor,
+                    settlement_days,
+                    calendar,
+                    frequency,
+                    payment_convention,
+                    rule,
+                    day_counter,
+                    recovery_rate,
+                    discount_curve,
+                    terms,
+                    settings,
+                    on_eval_change,
+                ),
+            }
+        });
+        helper.cds.initialize_dates()?;
+        Ok(helper)
     }
 
     /// The date protection starts, `settlement_days` past the evaluation date
     /// (`cpp:79`).
     pub fn protection_start(&self) -> Date {
-        self.protection_start.get()
+        self.cds.protection_start()
     }
 
     /// Rebuilds the priced contract and its engine (`resetEngine`, `cpp:137-153`).
@@ -387,61 +596,37 @@ impl SpreadCdsHelper {
     /// [`implied_quote`](DefaultProbabilityHelper::implied_quote), since the C++
     /// signature this mirrors returns nothing.
     fn reset_engine(&self) {
-        *self.swap.borrow_mut() = self.build_swap();
+        self.cds.set_swap(self.build_swap());
     }
 
     /// The par contract the helper prices: a protection-buyer CDS on a notional
     /// of 100 paying a 1% running spread (`cpp:138-141`), under a fresh midpoint
     /// engine over the helper's own probability handle (`cpp:151-152`).
-    ///
-    /// C++ passes its `evaluationDate_` as the contract's trade date; this
-    /// leaves the trade date to the contract, which deduces `protection start -
-    /// 1` for a pre-Big-Bang rule (`creditdefaultswap.rs:365-371`). The two
-    /// differ only when `settlement_days` is zero, and only in the accrual
-    /// rebate and upfront payment, both zero-amount flows on a contract with no
-    /// upfront: the deduced date keeps the helper clear of the rebate
-    /// arithmetic deferred by #689, which the C++ date would enter with nothing
-    /// to show for it.
     fn build_swap(&self) -> QlResult<CreditDefaultSwap> {
         let mut swap = CreditDefaultSwap::with_terms(
             ProtectionSide::Buyer,
             100.0,
             0.01,
-            self.schedule.borrow().clone(),
-            self.payment_convention,
-            self.day_counter.clone(),
-            CdsTerms {
-                settles_accrual: self.settles_accrual,
-                pays_at_default_time: self.pays_at_default_time,
-                protection_start: Some(self.protection_start.get()),
-                last_period_day_counter: self.last_period_day_counter.clone(),
-                rebates_accrual: self.rebates_accrual,
-                ..CdsTerms::default()
-            },
-            Shared::clone(&self.settings),
+            self.cds.schedule().clone(),
+            self.cds.payment_convention,
+            self.cds.day_counter.clone(),
+            self.cds.contract_terms(),
+            Shared::clone(&self.cds.settings),
         )?;
-        let engine = MidPointCdsEngine::new(
-            self.probability.handle(),
-            self.recovery_rate,
-            self.discount_curve.clone(),
-            None,
-            Shared::clone(&self.settings),
-        );
-        swap.base_mut()
-            .set_pricing_engine(shared_mut(engine) as SharedMut<dyn PricingEngine>);
+        self.cds.install_engine(&mut swap)?;
         Ok(swap)
     }
 }
 
 impl AsObservable for SpreadCdsHelper {
     fn observable(&self) -> &Observable {
-        self.base.observable()
+        self.cds.base.observable()
     }
 }
 
 impl DefaultProbabilityHelper for SpreadCdsHelper {
     fn base(&self) -> &DefaultProbabilityHelperBase {
-        &self.base
+        self.cds.base()
     }
 
     /// The contract's fair spread (`impliedQuote`, `cpp:132-135`).
@@ -451,7 +636,7 @@ impl DefaultProbabilityHelper for SpreadCdsHelper {
     /// bootstrap has just moved does not notify the contract, and a plain
     /// `fair_spread` would answer from the previous iteration's results.
     fn implied_quote(&self) -> QlResult<Real> {
-        let mut swap = self.swap.borrow_mut();
+        let mut swap = self.cds.swap.borrow_mut();
         let swap = swap.as_mut().map_err(|error| error.clone())?;
         swap.recalculate()?;
         swap.fair_spread()
@@ -459,66 +644,15 @@ impl DefaultProbabilityHelper for SpreadCdsHelper {
 
     /// Records the curve, hands it to the engine, and rebuilds the contract
     /// (`setTermStructure`, `cpp:60-68`).
-    ///
-    /// The engine's handle is linked weakly, the port of the C++
-    /// `linkTo(..., false)` at `cpp:63-65`: the curve owns this helper, which
-    /// owns the contract, which owns the engine, and a strong link would close
-    /// that ring.
     fn set_term_structure(&self, term_structure: &Shared<dyn DefaultProbabilityTermStructure>) {
-        self.base.set_term_structure(term_structure);
-        self.probability
-            .link_to_weak(Shared::downgrade(term_structure));
+        self.cds.set_term_structure(term_structure);
         self.reset_engine();
     }
 }
 
 impl RelativeDateDefaultProbabilityHelper for SpreadCdsHelper {
-    /// Rebuilds the schedule off the current evaluation date (`initializeDates`,
-    /// `cpp:75-108`).
-    ///
-    /// Protection starts `settlement_days` past the evaluation date and, absent
-    /// an explicit start, the schedule starts there too, rolled to a business
-    /// day. The maturity is the tenor past that same reference date - the
-    /// `cdsMaturity` arm above it (`cpp:86-88`) covers only the three CDS rules,
-    /// which the constructor rejects; `TwentiethIMM` takes this arm.
-    ///
-    /// The earliest date is the schedule's first date and the latest its last,
-    /// rolled. C++ then adds a day under the ISDA model (`cpp:105-106`); the
-    /// midpoint model, the only one ported, does not.
-    fn initialize_dates(&self) {
-        let evaluation_date = self
-            .base
-            .evaluation_date()
-            .expect("a relative-date helper always tracks an evaluation date");
-        let protection_start = evaluation_date + self.settlement_days;
-        self.protection_start.set(protection_start);
-
-        let mut start_date = self.start_date.unwrap_or(protection_start);
-        if self.rule != DateGeneration::CDS && self.rule != DateGeneration::CDS2015 {
-            start_date = self.calendar.adjust(start_date, self.payment_convention);
-        }
-        let reference_date = match self.start_date {
-            Some(date) => date + self.settlement_days,
-            None => protection_start,
-        };
-        let end_date = reference_date + self.tenor;
-
-        let schedule = MakeSchedule::new()
-            .from(start_date)
-            .to(end_date)
-            .with_frequency(self.frequency)
-            .with_calendar(self.calendar.clone())
-            .with_convention(self.payment_convention)
-            .with_termination_date_convention(BusinessDayConvention::Unadjusted)
-            .with_rule(self.rule)
-            .build();
-
-        self.base.set_earliest_date(schedule.date(0));
-        self.base.set_latest_date(
-            self.calendar
-                .adjust(schedule.date(schedule.len() - 1), self.payment_convention),
-        );
-        *self.schedule.borrow_mut() = schedule;
+    fn initialize_dates(&self) -> QlResult<()> {
+        self.cds.initialize_dates()
     }
 }
 
@@ -708,35 +842,54 @@ mod tests {
         );
     }
 
-    /// The three CDS rules need `cdsMaturity`, which is not ported; taking the
-    /// other arm for them would build a schedule ending on the wrong date, so
-    /// they are refused rather than silently mispriced (#676).
+    /// The `cdsMaturity` arm of `initializeDates` (`cpp:85-88`): under the three
+    /// post-Big-Bang rules the maturity is rolled off the *evaluation date*,
+    /// where the other arm measures a tenor from the protection start, and the
+    /// schedule runs from the previous IMM twentieth to it.
+    ///
+    /// Every date here is derived by hand from the rule - the twentieth of
+    /// March, June, September or December at or before the trade date, plus the
+    /// tenor, plus a quarter - rather than read back from [`cds_maturity`]. The
+    /// helper calls that function itself, so an equality against it would hold
+    /// for whatever maturity it returned. The round-trip bootstrap cannot stand
+    /// in either: it rebuilds its contract on the same conventions, so a shared
+    /// wrong schedule still reprices to the quote.
     #[test]
-    fn the_post_big_bang_rules_are_refused() {
+    fn the_cds_rules_roll_the_maturity_off_the_evaluation_date() {
         let settings = settings_at(today());
-        for rule in [
-            DateGeneration::CDS,
-            DateGeneration::CDS2015,
-            DateGeneration::OldCDS,
+        let calendar = Target::new();
+        let anchor = Date::new(20, Month::March, 2026);
+
+        for (years, maturity) in [
+            (2, Date::new(20, Month::June, 2028)),
+            (3, Date::new(20, Month::June, 2029)),
+            (5, Date::new(20, Month::June, 2031)),
+            (7, Date::new(20, Month::June, 2033)),
         ] {
-            let result = SpreadCdsHelper::new(
+            let helper = SpreadCdsHelper::new(
                 Handle::new(shared(SimpleQuote::new(0.01)) as Shared<dyn Quote>),
-                five_years(),
+                Period::new(years, TimeUnit::Years),
                 1,
-                Target::new(),
+                calendar.clone(),
                 Frequency::Quarterly,
                 BusinessDayConvention::Following,
-                rule,
+                DateGeneration::CDS,
                 Actual360::new(),
                 0.4,
                 discount(today()),
                 Shared::clone(&settings),
+            )
+            .unwrap();
+
+            let schedule = helper.cds.schedule();
+            assert_eq!(schedule.date(0), anchor);
+            assert_eq!(last_date(&schedule), maturity);
+            assert_eq!(helper.earliest_date(), anchor);
+            assert_eq!(
+                helper.latest_date(),
+                calendar.adjust(maturity, BusinessDayConvention::Following)
             );
-            assert!(
-                result
-                    .err()
-                    .is_some_and(|error| { error.message().contains("cdsMaturity") })
-            );
+            assert_eq!(helper.protection_start(), today() + 1);
         }
     }
 
@@ -770,13 +923,7 @@ mod tests {
 
         hazard.set_value(0.05);
         assert!(
-            helper
-                .swap
-                .borrow()
-                .as_ref()
-                .unwrap()
-                .base()
-                .is_calculated(),
+            helper.cds.swap().as_ref().unwrap().base().is_calculated(),
             "the weak link must leave the contract unnotified by the curve"
         );
 
@@ -808,7 +955,7 @@ mod tests {
         settings.set_evaluation_date(moved);
 
         let schedule = expected_schedule(moved + 1, moved + 1 + five_years());
-        let swap = helper.swap.borrow();
+        let swap = helper.cds.swap();
         let swap = swap.as_ref().unwrap();
         assert_eq!(swap.protection_start_date(), moved + 1);
         assert_eq!(swap.maturity(), last_date(&schedule));

--- a/crates/libitofin/src/termstructures/credit/defaultprobabilityhelpers.rs
+++ b/crates/libitofin/src/termstructures/credit/defaultprobabilityhelpers.rs
@@ -18,9 +18,10 @@
 //! shared driver reaches both through [`BootstrapHelperShared`], implemented
 //! below on `dyn DefaultProbabilityHelper`.
 //!
-//! [`SpreadCdsHelper`] follows them: the running-spread CDS helper the credit
-//! bootstrap is driven by. `UpfrontCdsHelper` (`defaultprobabilityhelpers.hpp:170`)
-//! is not here yet and follows within EPIC Credit (#676).
+//! [`CdsHelperBase`] follows them, with the two quoted contracts it serves:
+//! [`SpreadCdsHelper`] and [`UpfrontCdsHelper`]. Only the mid-point model is
+//! ported; the ISDA arm of `resetEngine`
+//! (`defaultprobabilityhelpers.cpp:143-148`) rides the `IsdaCdsEngine` (#783).
 
 use std::cell::{Cell, Ref, RefCell};
 use std::rc::Weak;
@@ -46,7 +47,8 @@ use crate::time::daycounter::DayCounter;
 use crate::time::frequency::Frequency;
 use crate::time::period::Period;
 use crate::time::schedule::{MakeSchedule, Schedule};
-use crate::types::{Integer, Real};
+use crate::time::timeunit::TimeUnit;
+use crate::types::{Integer, Natural, Rate, Real};
 use crate::{fail, require};
 
 /// The shared state of a credit bootstrap helper: a
@@ -656,6 +658,226 @@ impl RelativeDateDefaultProbabilityHelper for SpreadCdsHelper {
     }
 }
 
+/// An upfront-quoted CDS as a credit bootstrap helper (`UpfrontCdsHelper`,
+/// `defaultprobabilityhelpers.hpp:158`).
+///
+/// The market quote is the upfront, paid on a cash-settlement date of its own
+/// while the contract runs at a fixed `running_spread`; the bootstrap drives
+/// `quoted upfront - fair upfront` to zero. The upfront must be quoted in
+/// fractional units (`hpp:159`).
+pub struct UpfrontCdsHelper {
+    cds: CdsHelperBase,
+    running_spread: Rate,
+    upfront_settlement_days: Natural,
+    upfront_date: Cell<Date>,
+}
+
+impl UpfrontCdsHelper {
+    /// A helper on the C++ default terms and cash-settlement lag
+    /// (`defaultprobabilityhelpers.hpp:171-177`).
+    ///
+    /// # Errors
+    ///
+    /// As [`with_terms`](UpfrontCdsHelper::with_terms).
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        upfront: Handle<dyn Quote>,
+        running_spread: Rate,
+        tenor: Period,
+        settlement_days: Integer,
+        calendar: Calendar,
+        frequency: Frequency,
+        payment_convention: BusinessDayConvention,
+        rule: DateGeneration,
+        day_counter: DayCounter,
+        recovery_rate: Real,
+        discount_curve: Handle<dyn YieldTermStructure>,
+        settings: Shared<Settings<Date>>,
+    ) -> QlResult<Shared<UpfrontCdsHelper>> {
+        UpfrontCdsHelper::with_terms(
+            upfront,
+            running_spread,
+            tenor,
+            settlement_days,
+            calendar,
+            frequency,
+            payment_convention,
+            rule,
+            day_counter,
+            recovery_rate,
+            discount_curve,
+            3,
+            CdsHelperTerms::default(),
+            settings,
+        )
+    }
+
+    /// A helper settling its upfront `upfront_settlement_days` past the
+    /// evaluation date, on the given `terms` (`defaultprobabilityhelpers.cpp:159-184`).
+    ///
+    /// # Errors
+    ///
+    /// If the date rule cannot roll the tenor to a maturity
+    /// ([`initialize_dates`](CdsHelperBase::initialize_dates)).
+    #[allow(clippy::too_many_arguments)]
+    pub fn with_terms(
+        upfront: Handle<dyn Quote>,
+        running_spread: Rate,
+        tenor: Period,
+        settlement_days: Integer,
+        calendar: Calendar,
+        frequency: Frequency,
+        payment_convention: BusinessDayConvention,
+        rule: DateGeneration,
+        day_counter: DayCounter,
+        recovery_rate: Real,
+        discount_curve: Handle<dyn YieldTermStructure>,
+        upfront_settlement_days: Natural,
+        terms: CdsHelperTerms,
+        settings: Shared<Settings<Date>>,
+    ) -> QlResult<Shared<UpfrontCdsHelper>> {
+        let helper = Shared::new_cyclic(|weak: &Weak<UpfrontCdsHelper>| {
+            let weak = weak.clone();
+            let on_eval_change = Box::new(move || {
+                if let Some(helper) = weak.upgrade() {
+                    match helper.initialize_dates() {
+                        Ok(()) => helper.reset_engine(),
+                        Err(error) => helper.cds.set_swap(Err(error)),
+                    }
+                }
+            });
+            UpfrontCdsHelper {
+                cds: CdsHelperBase::new(
+                    upfront,
+                    tenor,
+                    settlement_days,
+                    calendar,
+                    frequency,
+                    payment_convention,
+                    rule,
+                    day_counter,
+                    recovery_rate,
+                    discount_curve,
+                    terms,
+                    settings,
+                    on_eval_change,
+                ),
+                running_spread,
+                upfront_settlement_days,
+                upfront_date: Cell::new(Date::null()),
+            }
+        });
+        helper.initialize_dates()?;
+        Ok(helper)
+    }
+
+    /// The date the upfront and the accrual rebate settle on (`upfrontDate`,
+    /// `cpp:186-188`).
+    pub fn upfront_date(&self) -> Date {
+        self.upfront_date.get()
+    }
+
+    /// The fixed coupon the contract runs at, alongside the quoted upfront.
+    pub fn running_spread(&self) -> Rate {
+        self.running_spread
+    }
+
+    /// Rebuilds the priced contract and its engine (`resetEngine`,
+    /// `cpp:195-217`).
+    fn reset_engine(&self) {
+        self.cds.set_swap(self.build_swap());
+    }
+
+    /// The contract the helper prices: the spread helper's par CDS with the
+    /// quoted running spread and its own cash-settlement date (`cpp:196-201`).
+    fn build_swap(&self) -> QlResult<CreditDefaultSwap> {
+        let mut swap = CreditDefaultSwap::with_upfront_and_terms(
+            ProtectionSide::Buyer,
+            100.0,
+            0.01,
+            self.running_spread,
+            self.cds.schedule().clone(),
+            self.cds.payment_convention,
+            self.cds.day_counter.clone(),
+            CdsTerms {
+                upfront_date: Some(self.upfront_date.get()),
+                ..self.cds.contract_terms()
+            },
+            Shared::clone(&self.cds.settings),
+        )?;
+        self.cds.install_engine(&mut swap)?;
+        Ok(swap)
+    }
+
+    /// The contract's fair upfront, off a forced recalculation for the reason
+    /// [`SpreadCdsHelper`]'s is forced.
+    fn fair_upfront(&self) -> QlResult<Real> {
+        let mut swap = self.cds.swap.borrow_mut();
+        let swap = swap.as_mut().map_err(|error| error.clone())?;
+        swap.recalculate()?;
+        swap.fair_upfront()
+    }
+}
+
+impl AsObservable for UpfrontCdsHelper {
+    fn observable(&self) -> &Observable {
+        self.cds.base.observable()
+    }
+}
+
+impl DefaultProbabilityHelper for UpfrontCdsHelper {
+    fn base(&self) -> &DefaultProbabilityHelperBase {
+        self.cds.base()
+    }
+
+    /// The contract's fair upfront, priced with today's cash flows included
+    /// (`impliedQuote`, `cpp:219-224`).
+    ///
+    /// The flag matters because the quote is a cash-settled amount: dropping a
+    /// flow that falls on the evaluation date would leave the bootstrap fitting
+    /// a different contract than the one quoted. C++ forces it through the
+    /// singleton and unwinds with `SavedSettings`; with the flag on a
+    /// [`Settings`] the caller owns (D5), the unwind is explicit and runs on the
+    /// error path too, so a contract that fails to price does not leave the
+    /// caller's flag flipped.
+    fn implied_quote(&self) -> QlResult<Real> {
+        let restore = self.cds.settings.include_todays_cash_flows();
+        self.cds.settings.set_include_todays_cash_flows(Some(true));
+        let quote = self.fair_upfront();
+        self.cds.settings.set_include_todays_cash_flows(restore);
+        quote
+    }
+
+    /// Records the curve, hands it to the engine, and rebuilds the contract
+    /// (`setTermStructure`, `cpp:60-68`).
+    fn set_term_structure(&self, term_structure: &Shared<dyn DefaultProbabilityTermStructure>) {
+        self.cds.set_term_structure(term_structure);
+        self.reset_engine();
+    }
+}
+
+impl RelativeDateDefaultProbabilityHelper for UpfrontCdsHelper {
+    /// The base's dates, then the cash-settlement date they move
+    /// (`initializeDates`, `cpp:190-193`).
+    ///
+    /// The override is what keeps the upfront date on the evaluation date it is
+    /// measured from: the base rebuild alone would leave it at the date the
+    /// helper was built on, and the contract would settle its upfront in the
+    /// past without any of its other dates disagreeing.
+    fn initialize_dates(&self) -> QlResult<()> {
+        self.cds.initialize_dates()?;
+        let upfront_date = self.cds.calendar.advance(
+            self.cds.evaluation_date(),
+            self.upfront_settlement_days as Integer,
+            TimeUnit::Days,
+            self.cds.payment_convention,
+            false,
+        );
+        self.upfront_date.set(upfront_date);
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -677,6 +899,7 @@ mod tests {
         accepts_driver_helper::<dyn DefaultProbabilityHelper>();
     }
 
+    use crate::event::Event;
     use crate::interestrate::Compounding;
     use crate::quotes::SimpleQuote;
     use crate::shared::shared;
@@ -997,6 +1220,126 @@ mod tests {
 
         rate.set_value(0.04);
         assert!(Flag::is_up(&flag));
+    }
+
+    /// An upfront helper on a `lag`-day cash settlement, quoting a 1% upfront
+    /// over a 5% running spread.
+    fn upfront_helper(settings: &Shared<Settings<Date>>, lag: Natural) -> Shared<UpfrontCdsHelper> {
+        UpfrontCdsHelper::with_terms(
+            Handle::new(shared(SimpleQuote::new(0.01)) as Shared<dyn Quote>),
+            0.05,
+            five_years(),
+            1,
+            Target::new(),
+            Frequency::Quarterly,
+            BusinessDayConvention::Following,
+            DateGeneration::CDS,
+            Actual360::new(),
+            0.4,
+            discount(today()),
+            lag,
+            CdsHelperTerms::default(),
+            Shared::clone(settings),
+        )
+        .unwrap()
+    }
+
+    fn hazard_curve() -> Shared<dyn DefaultProbabilityTermStructure> {
+        shared(FlatHazardRate::with_rate(
+            today(),
+            0.02,
+            Actual365Fixed::new(),
+        ))
+    }
+
+    /// `upfrontDate` (`cpp:186-188`) and the contract it reaches (`cpp:199`):
+    /// the upfront settles on the helper's own lag past the evaluation date.
+    ///
+    /// The lag here is five days rather than the C++ default of three, and that
+    /// is the point: the contract deduces its own cash settlement three
+    /// business days past the trade date (`creditdefaultswap.rs:502-509`), so a
+    /// helper that never passed its `upfront_date` down would agree with one
+    /// that did on every three-day fixture - including the bootstrap oracle.
+    #[test]
+    fn the_upfront_settles_on_the_helpers_own_lag() {
+        let settings = settings_at(today());
+        let helper = upfront_helper(&settings, 5);
+        let calendar = Target::new();
+        let expected = calendar.advance(
+            today(),
+            5,
+            TimeUnit::Days,
+            BusinessDayConvention::Following,
+            false,
+        );
+        assert_ne!(
+            expected,
+            calendar.advance(
+                today(),
+                3,
+                TimeUnit::Days,
+                BusinessDayConvention::Following,
+                false
+            ),
+            "the fixture's lag must differ from the contract's own default, or \
+             this pins nothing"
+        );
+        assert_eq!(helper.upfront_date(), expected);
+
+        helper.set_term_structure(&hazard_curve());
+        let swap = helper.cds.swap();
+        let swap = swap.as_ref().unwrap();
+        assert_eq!(swap.upfront_payment().date(), expected);
+        assert_eq!(swap.running_spread(), 0.05);
+        assert_eq!(swap.trade_date(), today());
+    }
+
+    /// The `initializeDates` override (`cpp:190-193`): a moved evaluation date
+    /// carries the upfront date with it, in the contract as well as the helper.
+    ///
+    /// Composition loses the C++ override for free - a rebuild routed at the
+    /// shared base would leave the upfront settling on a date the contract has
+    /// already passed, with every other date in agreement.
+    #[test]
+    fn an_evaluation_date_move_rebuilds_the_upfront_date() {
+        let settings = settings_at(today());
+        let helper = upfront_helper(&settings, 5);
+        helper.set_term_structure(&hazard_curve());
+
+        let moved = Date::new(15, Month::December, 2026);
+        settings.set_evaluation_date(moved);
+
+        let expected = Target::new().advance(
+            moved,
+            5,
+            TimeUnit::Days,
+            BusinessDayConvention::Following,
+            false,
+        );
+        assert_eq!(helper.upfront_date(), expected);
+        assert_eq!(
+            helper.cds.swap().as_ref().unwrap().upfront_payment().date(),
+            expected
+        );
+    }
+
+    /// `impliedQuote`'s `SavedSettings` (`cpp:220-221`) unwinds however the
+    /// pricing ends. The bootstrap oracle only ever exercises the path that
+    /// returns a quote; this is the other one, where a `?` between the write
+    /// and its unwind would leave the caller's flag flipped.
+    #[test]
+    fn the_cash_flow_flag_is_restored_when_the_contract_cannot_price() {
+        let settings = settings_at(today());
+        settings.set_include_todays_cash_flows(Some(false));
+        let helper = upfront_helper(&settings, 3);
+
+        assert!(
+            helper
+                .implied_quote()
+                .err()
+                .is_some_and(|error| error.message().contains("bootstrapping curve is set"))
+        );
+        assert_eq!(settings.include_todays_cash_flows(), Some(false));
     }
 
     /// Before a curve arrives there is no contract to price, where C++ would

--- a/crates/libitofin/src/termstructures/credit/defaultprobabilityhelpers.rs
+++ b/crates/libitofin/src/termstructures/credit/defaultprobabilityhelpers.rs
@@ -1222,6 +1222,68 @@ mod tests {
         assert!(Flag::is_up(&flag));
     }
 
+    /// The roll-off case `cdsMaturity` answers with a null date
+    /// (`creditdefaultswap.cpp:494`): a `CDS2015` contract quoted at a zero
+    /// tenor whose anchor is a June or December twentieth has already matured.
+    ///
+    /// C++ hands that null date to `MakeSchedule` and builds a schedule ending
+    /// nowhere; the port refuses instead (D4), and this is the one input that
+    /// reaches the refusal. The evaluation date is chosen to put the anchor on
+    /// 20 June: `previous_twentieth` rolls any date from that day to the
+    /// September twentieth back onto it.
+    #[test]
+    fn a_matured_zero_tenor_is_refused_rather_than_scheduled() {
+        let settings = settings_at(Date::new(15, Month::July, 2026));
+        let result = SpreadCdsHelper::new(
+            Handle::new(shared(SimpleQuote::new(0.01)) as Shared<dyn Quote>),
+            Period::new(0, TimeUnit::Months),
+            1,
+            Target::new(),
+            Frequency::Quarterly,
+            BusinessDayConvention::Following,
+            DateGeneration::CDS2015,
+            Actual360::new(),
+            0.4,
+            discount(today()),
+            settings,
+        );
+        assert!(
+            result
+                .err()
+                .is_some_and(|error| error.message().contains("has already matured"))
+        );
+    }
+
+    /// The ISDA arm, ported as far as it goes: the pillar takes the extra day
+    /// `initializeDates` adds under that model (`cpp:105-106`), and the engine
+    /// it would price on is the deferral (`cpp:144-148`, #783).
+    ///
+    /// Both are inert on every other test here, which is the reason for this
+    /// one: an omitted `++latestDate` and a silent fall back to the mid-point
+    /// engine would each leave the whole suite green.
+    #[test]
+    fn the_isda_model_moves_the_pillar_and_defers_the_engine() {
+        let settings = settings_at(today());
+        let isda = helper(
+            &settings,
+            CdsHelperTerms {
+                model: PricingModel::Isda,
+                ..CdsHelperTerms::default()
+            },
+        );
+        assert_eq!(
+            isda.latest_date(),
+            helper(&settings, CdsHelperTerms::default()).latest_date() + 1
+        );
+
+        isda.set_term_structure(&hazard_curve());
+        assert!(
+            isda.implied_quote()
+                .err()
+                .is_some_and(|error| error.message().contains("#783"))
+        );
+    }
+
     /// An upfront helper on a `lag`-day cash settlement, quoting a 1% upfront
     /// over a 5% running spread.
     fn upfront_helper(settings: &Shared<Settings<Date>>, lag: Natural) -> Shared<UpfrontCdsHelper> {

--- a/crates/libitofin/src/termstructures/credit/defaultprobabilityhelpers.rs
+++ b/crates/libitofin/src/termstructures/credit/defaultprobabilityhelpers.rs
@@ -1116,6 +1116,52 @@ mod tests {
         }
     }
 
+    /// The date the CDS arm rolls *from* is the evaluation date (`cpp:87`), not
+    /// the protection start the non-CDS arm measures from and the schedule
+    /// starts on.
+    ///
+    /// The two are `settlement_days` apart, and on almost every date they roll
+    /// back to the same twentieth - including the fixture above, where both
+    /// land on 20 March 2026, so swapping one for the other there changes
+    /// nothing. This evaluation date straddles a roll instead: 19 March rolls
+    /// back to the previous December, while the protection start a day later is
+    /// itself the March twentieth. The mis-wire that reads `protection_start`
+    /// here therefore matures on 20 June 2031, a full quarter past the literal
+    /// asserted below.
+    #[test]
+    fn the_cds_reference_date_is_the_evaluation_date_not_the_protection_start() {
+        let evaluation_date = Date::new(19, Month::March, 2026);
+        let calendar = Target::new();
+        let helper = SpreadCdsHelper::new(
+            Handle::new(shared(SimpleQuote::new(0.01)) as Shared<dyn Quote>),
+            five_years(),
+            1,
+            calendar.clone(),
+            Frequency::Quarterly,
+            BusinessDayConvention::Following,
+            DateGeneration::CDS,
+            Actual360::new(),
+            0.4,
+            discount(evaluation_date),
+            settings_at(evaluation_date),
+        )
+        .unwrap();
+
+        let maturity = Date::new(20, Month::March, 2031);
+        assert_eq!(helper.protection_start(), Date::new(20, Month::March, 2026));
+        assert_eq!(last_date(&helper.cds.schedule()), maturity);
+        assert_eq!(
+            helper.latest_date(),
+            calendar.adjust(maturity, BusinessDayConvention::Following)
+        );
+        assert_ne!(
+            helper.latest_date(),
+            Date::new(20, Month::June, 2031),
+            "the maturity rolled off the protection start rather than the \
+             evaluation date"
+        );
+    }
+
     /// `impliedQuote` (`cpp:132-135`) prices the helper's own contract against
     /// the curve it was handed, which `set_term_structure` weak-links into the
     /// engine and rebuilds the contract for (`cpp:60-68`).

--- a/crates/libitofin/src/termstructures/credit/piecewisedefaultcurve.rs
+++ b/crates/libitofin/src/termstructures/credit/piecewisedefaultcurve.rs
@@ -294,9 +294,9 @@ impl<I: Interpolator + 'static> PiecewiseCurve for PiecewiseDefaultCurve<HazardR
 mod tests {
     //! Oracle: `defaultprobabilitycurves.cpp` `testFlatHazardConsistency`
     //! (`:320`) through `testBootstrapFromSpread<HazardRate, BackwardFlat>`
-    //! (`:152-224`), and `testSingleInstrumentBootstrap` (`:344-378`). The
-    //! upfront halves of both cases (`testBootstrapFromUpfront`) need
-    //! `UpfrontCdsHelper`, deferred within EPIC Credit (#676).
+    //! (`:152-224`) and `testBootstrapFromUpfront<HazardRate, BackwardFlat>`
+    //! (`:230-317`), `testSingleInstrumentBootstrap` (`:344-378`) and
+    //! `testUpfrontBootstrap` (`:380-395`).
     //!
     //! The round trip is self-consistent - every helper's own contract is
     //! rebuilt and repriced off the bootstrapped curve and must reproduce its
@@ -315,7 +315,7 @@ mod tests {
     use super::*;
     use crate::handle::Handle;
     use crate::instrument::Instrument;
-    use crate::instruments::{CdsTerms, CreditDefaultSwap, ProtectionSide};
+    use crate::instruments::{CdsTerms, CreditDefaultSwap, ProtectionSide, cds_maturity};
     use crate::interestrate::Compounding;
     use crate::math::interpolations::flat::BackwardFlat;
     use crate::pricingengine::PricingEngine;
@@ -323,7 +323,9 @@ mod tests {
     use crate::quotes::{Quote, SimpleQuote};
     use crate::settings::Settings;
     use crate::shared::shared;
-    use crate::termstructures::credit::defaultprobabilityhelpers::SpreadCdsHelper;
+    use crate::termstructures::credit::defaultprobabilityhelpers::{
+        CdsHelperTerms, SpreadCdsHelper, UpfrontCdsHelper,
+    };
     use crate::termstructures::yields::FlatForward;
     use crate::termstructures::yieldtermstructure::YieldTermStructure;
     use crate::time::businessdayconvention::BusinessDayConvention;
@@ -336,7 +338,7 @@ mod tests {
     use crate::time::period::Period;
     use crate::time::schedule::Schedule;
     use crate::time::timeunit::TimeUnit;
-    use crate::types::Integer;
+    use crate::types::{Integer, Natural, Rate};
 
     const QUOTES: [Real; 4] = [0.005, 0.006, 0.007, 0.009];
     const TENORS: [i32; 4] = [1, 2, 3, 5];
@@ -629,5 +631,190 @@ mod tests {
             second < first,
             "a wider spread must lower the survival probability: {second} vs {first}"
         );
+    }
+
+    const UPFRONT_QUOTES: [Real; 4] = [0.01, 0.02, 0.04, 0.06];
+    const UPFRONT_TENORS: [i32; 4] = [2, 3, 5, 7];
+    const RUNNING_SPREAD: Rate = 0.05;
+    const UPFRONT_SETTLEMENT_DAYS: Natural = 3;
+
+    /// The upfront fixture's conventions (`:234-247`), which differ from the
+    /// spread one's in more than the quotation: the contracts roll on
+    /// `DateGeneration::CDS` under `ModifiedFollowing`, accrue on `Actual360`
+    /// with the last period including its end date, and pay a fixed 5% coupon
+    /// while the quote is the upfront.
+    fn upfront_helper(
+        quote: Real,
+        tenor: Period,
+        discount: &Handle<dyn YieldTermStructure>,
+        settings: &Shared<Settings<Date>>,
+    ) -> Shared<dyn DefaultProbabilityHelper> {
+        UpfrontCdsHelper::with_terms(
+            Handle::new(shared(SimpleQuote::new(quote)) as Shared<dyn Quote>),
+            RUNNING_SPREAD,
+            tenor,
+            SETTLEMENT_DAYS,
+            Target::new(),
+            Frequency::Quarterly,
+            BusinessDayConvention::ModifiedFollowing,
+            DateGeneration::CDS,
+            Actual360::new(),
+            RECOVERY_RATE,
+            discount.clone(),
+            UPFRONT_SETTLEMENT_DAYS,
+            CdsHelperTerms {
+                last_period_day_counter: Some(Actual360::with_last_day(true)),
+                ..CdsHelperTerms::default()
+            },
+            Shared::clone(settings),
+        )
+        .expect("the CDS rule rolls every tenor quoted here")
+            as Shared<dyn DefaultProbabilityHelper>
+    }
+
+    /// The round-trip contract's schedule (`:290-291`), from the protection
+    /// start to the rolled CDS maturity.
+    fn upfront_schedule(today: Date, tenor: Period) -> Schedule {
+        Schedule::new(
+            today + SETTLEMENT_DAYS,
+            cds_maturity(today, tenor, DateGeneration::CDS)
+                .unwrap()
+                .expect("a live CDS maturity"),
+            Period::try_from(Frequency::Quarterly).expect("a quarterly period"),
+            Target::new(),
+            BusinessDayConvention::ModifiedFollowing,
+            BusinessDayConvention::Unadjusted,
+            DateGeneration::CDS,
+            false,
+            Date::null(),
+            Date::null(),
+        )
+    }
+
+    /// The four upfront helpers of `testBootstrapFromUpfront` (`:252-266`) and
+    /// the curve they bootstrap.
+    fn upfront_fixture(settings: &Shared<Settings<Date>>) -> Fixture {
+        let discount = discount_curve(today());
+        let helpers: Vec<Shared<dyn DefaultProbabilityHelper>> = UPFRONT_QUOTES
+            .iter()
+            .zip(UPFRONT_TENORS)
+            .map(|(quote, n)| {
+                upfront_helper(*quote, Period::new(n, TimeUnit::Years), &discount, settings)
+            })
+            .collect();
+        let curve = PiecewiseDefaultCurve::<HazardRate, BackwardFlat>::new(
+            today(),
+            helpers.clone(),
+            day_counter(),
+            BackwardFlat,
+        )
+        .unwrap();
+        Fixture {
+            settings: Shared::clone(settings),
+            discount,
+            helpers,
+            curve,
+        }
+    }
+
+    /// The reprice loop of `testBootstrapFromUpfront` (`:277-315`): each
+    /// pillar's contract, rebuilt from the market conventions and priced off
+    /// the bootstrapped curve, must return its own input upfront.
+    ///
+    /// The `includeTodaysCashFlows` write and its unwind are the C++ block's
+    /// (`:278-281`), kept around the reprice alone so that what the flag holds
+    /// outside it is the caller's business.
+    fn assert_the_upfronts_reproduce(fixture: &Fixture) {
+        let curve: Handle<dyn DefaultProbabilityTermStructure> = Handle::new(Shared::clone(
+            &fixture.curve,
+        )
+            as Shared<dyn DefaultProbabilityTermStructure>);
+        let restore = fixture.settings.include_todays_cash_flows();
+        fixture.settings.set_include_todays_cash_flows(Some(true));
+
+        for (quote, n) in UPFRONT_QUOTES.iter().zip(UPFRONT_TENORS) {
+            let tenor = Period::new(n, TimeUnit::Years);
+            let mut cds = CreditDefaultSwap::with_upfront_and_terms(
+                ProtectionSide::Buyer,
+                1.0,
+                *quote,
+                RUNNING_SPREAD,
+                upfront_schedule(today(), tenor),
+                BusinessDayConvention::ModifiedFollowing,
+                Actual360::new(),
+                CdsTerms {
+                    protection_start: Some(today() + SETTLEMENT_DAYS),
+                    upfront_date: Some(Target::new().advance(
+                        today(),
+                        UPFRONT_SETTLEMENT_DAYS as Integer,
+                        TimeUnit::Days,
+                        BusinessDayConvention::ModifiedFollowing,
+                        false,
+                    )),
+                    last_period_day_counter: Some(Actual360::with_last_day(true)),
+                    trade_date: Some(today()),
+                    ..CdsTerms::default()
+                },
+                Shared::clone(&fixture.settings),
+            )
+            .unwrap();
+            let engine = MidPointCdsEngine::new(
+                curve.clone(),
+                RECOVERY_RATE,
+                fixture.discount.clone(),
+                Some(true),
+                Shared::clone(&fixture.settings),
+            );
+            cds.base_mut()
+                .set_pricing_engine(shared_mut(engine) as SharedMut<dyn PricingEngine>);
+
+            let computed = cds.fair_upfront().unwrap();
+            assert!(
+                (computed - quote).abs() <= TOLERANCE,
+                "failed to reproduce the fair upfront for the {n}Y credit-default swap: \
+                 computed {computed}, input {quote}"
+            );
+        }
+        fixture.settings.set_include_todays_cash_flows(restore);
+    }
+
+    /// `testBootstrapFromUpfront<HazardRate, BackwardFlat>` (`:230-317`).
+    #[test]
+    fn bootstrapped_curve_reproduces_the_input_cds_upfronts() {
+        assert_the_upfronts_reproduce(&upfront_fixture(&settings_at(today())));
+    }
+
+    /// `testUpfrontBootstrap` (`:380-395`): the bootstrap runs with the
+    /// caller's flag switched off and leaves it switched off afterwards.
+    ///
+    /// The bootstrap is forced before the reprice, which runs under a flag of
+    /// its own: a curve first read inside that loop would be bootstrapped under
+    /// the loop's `true`, and the assertion below would pin the loop's unwind
+    /// rather than the helper's. C++ leaves it to the loop, so this is the
+    /// stricter of the two.
+    ///
+    /// What this pins is the unwind, not the write. The C++ comment claims a
+    /// `false` flag "would prevent the upfront from being used", but the flag
+    /// only decides flows dated *on* the evaluation date
+    /// (`cashflow.rs:94-113`), and this fixture has none: the upfront and its
+    /// rebate settle three business days out and the first coupon later still.
+    /// Removing the write from `implied_quote` leaves both upfront tests green.
+    /// The write is ported for fidelity and pinned for its unwind
+    /// (`the_cash_flow_flag_is_restored_when_the_contract_cannot_price`,
+    /// defaultprobabilityhelpers.rs); no oracle here discriminates it.
+    #[test]
+    fn the_upfront_bootstrap_leaves_the_cash_flow_flag_as_it_found_it() {
+        let settings = settings_at(today());
+        settings.set_include_todays_cash_flows(Some(false));
+        let fixture = upfront_fixture(&settings);
+
+        fixture.curve.calculate().unwrap();
+        assert_eq!(
+            settings.include_todays_cash_flows(),
+            Some(false),
+            "the helper's own write must be unwound, not left on the caller's settings"
+        );
+        assert_the_upfronts_reproduce(&fixture);
+        assert_eq!(settings.include_todays_cash_flows(), Some(false));
     }
 }


### PR DESCRIPTION
Add a regression test verifying that the CDS arm rolls from the
evaluation date rather than the protection start. The test straddles a
roll boundary (19 March 2026) where the two dates diverge, so a mis-wire
reading `protection_start` would mature a full quarter late on 20 June
2031 instead of the correct 20 March 2031.

Closes #782
