### PR TITLE
feat(inflation): port seasonality to zero inflation curves


### DIFF
--- a/crates/itofin-py/src/inflation.rs
+++ b/crates/itofin-py/src/inflation.rs
@@ -403,6 +403,7 @@ impl PyInterpolatedZeroInflationCurve {
                 frequency.inner(),
                 day_counter.inner(),
                 Linear,
+                None,
             )
             .map_err(PyQlError::from)?,
         );
@@ -647,6 +648,7 @@ impl PyPiecewiseZeroInflationCurve {
             frequency.inner(),
             day_counter.inner(),
             instruments,
+            None,
         )
         .map_err(PyQlError::from)?;
         let erased = Shared::clone(&concrete) as Shared<dyn ZeroInflationTermStructure>;

--- a/crates/libitofin/src/indexes/inflationindex.rs
+++ b/crates/libitofin/src/indexes/inflationindex.rs
@@ -1126,6 +1126,7 @@ mod tests {
                 Frequency::Monthly,
                 Actual360::new(),
                 Linear,
+                None,
             )
             .expect("a well-formed zero inflation curve"),
         )

--- a/crates/libitofin/src/instruments/zerocouponinflationswap.rs
+++ b/crates/libitofin/src/instruments/zerocouponinflationswap.rs
@@ -515,6 +515,7 @@ mod tests {
                 Frequency::Monthly,
                 Actual360::new(),
                 Linear,
+                None,
             )
             .expect("a well-formed zero inflation curve"),
         );

--- a/crates/libitofin/src/termstructures/inflation/inflationhelpers.rs
+++ b/crates/libitofin/src/termstructures/inflation/inflationhelpers.rs
@@ -504,6 +504,7 @@ mod tests {
             Frequency::Monthly,
             Actual360::new(),
             crate::math::interpolations::linear::Linear,
+            None,
         )
         .unwrap();
         shared(curve) as Shared<dyn ZeroInflationTermStructure>
@@ -660,6 +661,7 @@ mod tests {
                     Frequency::Monthly,
                     Actual360::new(),
                     Linear,
+                    None,
                 )
                 .expect("a well-formed zero inflation curve"),
             ) as Shared<dyn ZeroInflationTermStructure>

--- a/crates/libitofin/src/termstructures/inflation/inflationtermstructure.rs
+++ b/crates/libitofin/src/termstructures/inflation/inflationtermstructure.rs
@@ -25,15 +25,22 @@
 //!   live two-argument overload, which delegates with a zero lag and no
 //!   forced interpolation (`inflationtermstructure.cpp:134-138`), so it takes
 //!   the `else` branch only.
-//! - Seasonality (`seasonality_`, `setSeasonality`, `seasonality()`,
-//!   `hasSeasonality()` and the `correctZeroRate` fold at
-//!   `inflationtermstructure.cpp:170-172`) is not ported. Every use of it in
-//!   this file is guarded by `hasSeasonality()`, which is false for a curve
-//!   built without one, so the omission is behaviour-free for the curves
-//!   landing now; it follows with the seasonality classes in EPIC Inflation
-//!   (#705). The accessors are omitted rather than stubbed to a constant
-//!   `false`, so a curve needing seasonality fails to compile instead of
-//!   silently skipping the correction.
+//! - C++ gates [`Seasonality::is_consistent`] inside the three
+//!   `InflationTermStructure` constructors, against a partially constructed
+//!   `*this` (`inflationtermstructure.cpp:34-38,57-61,79-83`). A Rust holder
+//!   is not the curve and cannot produce the `&dyn InflationTermStructure`
+//!   that check needs, so the gate moves *out* to the concrete curve
+//!   constructors, which run
+//!   [`check_seasonality`](InflationTermStructure::check_seasonality) once
+//!   they have a whole curve. The holder still stores whatever it is given.
+//! - C++'s `setSeasonality` closes with a call to the virtual `update()`
+//!   (`inflationtermstructure.cpp:87`); the Rust equivalent is
+//!   [`update_after_seasonality_change`](InflationTermStructure::update_after_seasonality_change),
+//!   a separate overridable hook, because the notification a bootstrapped
+//!   curve owes its observers also has to invalidate its own cache.
+//! - The seasonality is held in a [`RefCell`] rather than as a plain field:
+//!   C++ `setSeasonality` is non-const and called on the concrete curve, which
+//!   here lives behind a [`Shared`] that hands out only shared references.
 //! - C++'s `checkRange` overloads *hide* `TermStructure::checkRange`; Rust
 //!   traits have no name hiding, so they are ported under distinct names
 //!   ([`check_inflation_range_date`](InflationTermStructure::check_inflation_range_date)
@@ -44,10 +51,13 @@
 //! - C++ overloads on `Date`/`Time` become distinct method names, the `_date`
 //!   suffix taking dates.
 
+use std::cell::RefCell;
+
 use crate::errors::QlResult;
 use crate::indexes::inflationindex::inflation_period;
 use crate::settings::Settings;
 use crate::shared::Shared;
+use crate::termstructures::inflation::seasonality::Seasonality;
 use crate::termstructures::{TermStructure, TermStructureBase};
 use crate::time::calendar::Calendar;
 use crate::time::date::Date;
@@ -66,6 +76,7 @@ pub struct InflationTermStructureBase {
     frequency: Frequency,
     base_rate: Option<Rate>,
     base_date: Date,
+    seasonality: RefCell<Option<Shared<dyn Seasonality>>>,
 }
 
 impl InflationTermStructureBase {
@@ -80,12 +91,14 @@ impl InflationTermStructureBase {
         frequency: Frequency,
         day_counter: Option<DayCounter>,
         base_rate: Option<Rate>,
+        seasonality: Option<Shared<dyn Seasonality>>,
     ) -> InflationTermStructureBase {
         InflationTermStructureBase {
             base: TermStructureBase::new(day_counter),
             frequency,
             base_rate,
             base_date,
+            seasonality: RefCell::new(seasonality),
         }
     }
 
@@ -97,18 +110,21 @@ impl InflationTermStructureBase {
         frequency: Frequency,
         day_counter: Option<DayCounter>,
         base_rate: Option<Rate>,
+        seasonality: Option<Shared<dyn Seasonality>>,
     ) -> InflationTermStructureBase {
         InflationTermStructureBase {
             base: TermStructureBase::with_reference_date(reference_date, None, day_counter),
             frequency,
             base_rate,
             base_date,
+            seasonality: RefCell::new(seasonality),
         }
     }
 
     /// Holder whose reference date moves off the evaluation date
     /// (`inflationtermstructure.cpp:57-70`); the [`Settings`] handle is
     /// explicit per D5.
+    #[allow(clippy::too_many_arguments)]
     pub fn moving(
         settlement_days: Natural,
         calendar: Calendar,
@@ -116,6 +132,7 @@ impl InflationTermStructureBase {
         frequency: Frequency,
         day_counter: Option<DayCounter>,
         base_rate: Option<Rate>,
+        seasonality: Option<Shared<dyn Seasonality>>,
         settings: Shared<Settings<Date>>,
     ) -> InflationTermStructureBase {
         InflationTermStructureBase {
@@ -123,6 +140,7 @@ impl InflationTermStructureBase {
             frequency,
             base_rate,
             base_date,
+            seasonality: RefCell::new(seasonality),
         }
     }
 
@@ -141,6 +159,15 @@ impl InflationTermStructureBase {
 pub trait InflationTermStructure: TermStructure {
     /// The embedded shared holder.
     fn inflation_base(&self) -> &InflationTermStructureBase;
+
+    /// The curve as the trait object a [`Seasonality`] reads it through.
+    ///
+    /// C++ passes `*this` straight into `correctZeroRate`
+    /// (`inflationtermstructure.cpp:171`). A trait's default body cannot
+    /// unsize `&Self` - `Self` is not known to be sized there - so every
+    /// concrete curve supplies the coercion, whose only implementation is
+    /// `self`.
+    fn as_inflation_term_structure(&self) -> &dyn InflationTermStructure;
 
     /// The frequency of the inflation fixings the curve is built on
     /// (`inflationtermstructure.hpp:261-263`).
@@ -163,6 +190,66 @@ pub trait InflationTermStructure: TermStructure {
             Some(rate) => Ok(rate),
             None => fail!("base rate not available"),
         }
+    }
+
+    /// The seasonality correction folded into the rates the curve publishes,
+    /// if any (`inflationtermstructure.hpp:95`).
+    fn seasonality(&self) -> Option<Shared<dyn Seasonality>> {
+        self.inflation_base().seasonality.borrow().clone()
+    }
+
+    /// Whether the curve carries a seasonality correction
+    /// (`inflationtermstructure.hpp:96`).
+    fn has_seasonality(&self) -> bool {
+        self.inflation_base().seasonality.borrow().is_some()
+    }
+
+    /// Installs, replaces or (with `None`) clears the seasonality correction
+    /// (`inflationtermstructure.cpp:76-88`).
+    ///
+    /// The store happens first and unconditionally, as C++'s does; a
+    /// correction that then fails the consistency gate is left in place and
+    /// the notification does not fire.
+    ///
+    /// # Errors
+    ///
+    /// Propagates the consistency gate.
+    fn set_seasonality(&self, seasonality: Option<Shared<dyn Seasonality>>) -> QlResult<()> {
+        *self.inflation_base().seasonality.borrow_mut() = seasonality;
+        self.check_seasonality()?;
+        self.update_after_seasonality_change();
+        Ok(())
+    }
+
+    /// The consistency gate C++ runs from its constructors and its setter
+    /// (`inflationtermstructure.cpp:34-38,84-86`).
+    ///
+    /// A curve without a seasonality passes trivially.
+    ///
+    /// # Errors
+    ///
+    /// Reports the seasonality's own verdict, and any error it raised
+    /// reaching one.
+    fn check_seasonality(&self) -> QlResult<()> {
+        if let Some(seasonality) = self.seasonality() {
+            require!(
+                seasonality.is_consistent(self.as_inflation_term_structure())?,
+                "Seasonality inconsistent with inflation term structure"
+            );
+        }
+        Ok(())
+    }
+
+    /// The notification closing a successful
+    /// [`set_seasonality`](Self::set_seasonality), the port of C++'s
+    /// `update()` call (`inflationtermstructure.cpp:87`).
+    ///
+    /// The default behaves as `TermStructure::update()`: it refreshes a moving
+    /// reference date and broadcasts. A curve that caches anything derived
+    /// from the correction - every bootstrapped one does - overrides this to
+    /// invalidate that cache first.
+    fn update_after_seasonality_change(&self) {
+        self.base().updater().borrow_mut().update();
     }
 
     /// Date-range check (`inflationtermstructure.cpp:91-98`): `date` must not
@@ -234,11 +321,25 @@ pub trait ZeroInflationTermStructure: InflationTermStructure {
     /// before it reaches the curve: an inflation fixing applies to a whole
     /// period, so every date inside one must yield that period's rate. The
     /// range check and the time conversion both use the quantized date.
+    ///
+    /// Any seasonality correction is folded in last
+    /// (`inflationtermstructure.cpp:170-172`). It receives the *original*
+    /// date, as C++ does on this path - the lag it subtracts there is zero -
+    /// and quantizes for itself. This is the only entry point that corrects:
+    /// [`zero_rate`](Self::zero_rate), taking a time, cannot recover the date
+    /// the correction is a function of, and C++ leaves it uncorrected too
+    /// (`inflationtermstructure.cpp:176-180`).
     fn zero_rate_date(&self, date: Date, extrapolate: bool) -> QlResult<Rate> {
         let (period_start, _) = inflation_period(date, self.frequency())?;
         self.check_inflation_range_date(period_start, extrapolate)?;
         let t = self.time_from_reference(period_start)?;
-        self.zero_rate_impl(t)
+        let zero_rate = self.zero_rate_impl(t)?;
+        match self.seasonality() {
+            Some(seasonality) => {
+                seasonality.correct_zero_rate(date, zero_rate, self.as_inflation_term_structure())
+            }
+            None => Ok(zero_rate),
+        }
     }
 
     /// The zero-coupon inflation rate for time `t`
@@ -258,6 +359,8 @@ pub trait ZeroInflationTermStructure: InflationTermStructure {
 mod tests {
     use super::*;
     use crate::patterns::observable::{AsObservable, Observable};
+    use crate::shared::shared;
+    use crate::termstructures::inflation::seasonality::MultiplicativePriceSeasonality;
     use crate::time::date::Month;
     use crate::time::daycounters::actual360::Actual360;
 
@@ -282,6 +385,7 @@ mod tests {
                 frequency,
                 Some(Actual360::new()),
                 base_rate,
+                None,
             ),
             max: Date::new(15, Month::January, 2036),
         }
@@ -310,6 +414,10 @@ mod tests {
     impl InflationTermStructure for TestCurve {
         fn inflation_base(&self) -> &InflationTermStructureBase {
             &self.inflation
+        }
+
+        fn as_inflation_term_structure(&self) -> &dyn InflationTermStructure {
+            self
         }
     }
 
@@ -419,6 +527,66 @@ mod tests {
         let curve = curve(None);
         assert_eq!(curve.zero_rate(0.375, false).unwrap(), 0.375);
         assert_eq!(curve.zero_rate(-0.1, false).unwrap(), -0.1);
+    }
+
+    /// Twelve monthly factors anchored on a month other than the curve's base
+    /// month, so the correction is not the identity; `count` above twelve makes
+    /// it the multi-year case the consistency gate defers.
+    fn a_seasonality(count: usize) -> Shared<dyn Seasonality> {
+        shared(
+            MultiplicativePriceSeasonality::new(
+                Date::new(31, Month::January, 2026),
+                Frequency::Monthly,
+                (0..count).map(|i| 1.0 + i as Rate / 1000.0).collect(),
+            )
+            .expect("a whole multiple of twelve factors"),
+        ) as Shared<dyn Seasonality>
+    }
+
+    /// The correction is folded into the date-taking query and into nothing
+    /// else, and clearing it puts the raw rate back.
+    ///
+    /// [`zero_rate`](ZeroInflationTermStructure::zero_rate) cannot correct: a
+    /// time does not name the date the factors are a function of, and C++
+    /// leaves it alone too.
+    #[test]
+    fn only_the_date_query_folds_the_seasonality_and_clearing_it_undoes_that() {
+        let curve = curve(None);
+        let date = Date::new(15, Month::March, 2026);
+        let raw = curve.zero_rate_date(date, false).unwrap();
+        let seasonality = a_seasonality(12);
+
+        curve
+            .set_seasonality(Some(Shared::clone(&seasonality)))
+            .unwrap();
+        assert!(curve.has_seasonality());
+        let corrected = curve.zero_rate_date(date, false).unwrap();
+        assert_eq!(
+            corrected,
+            seasonality.correct_zero_rate(date, raw, &curve).unwrap()
+        );
+        assert_ne!(corrected, raw, "the fold must move the rate");
+        assert_eq!(
+            curve.zero_rate(raw, false).unwrap(),
+            raw,
+            "the time query stays raw"
+        );
+
+        curve.set_seasonality(None).unwrap();
+        assert!(!curve.has_seasonality());
+        assert_eq!(curve.zero_rate_date(date, false).unwrap(), raw);
+    }
+
+    /// The gate reports the seasonality's verdict, and - as C++ does - stores
+    /// the correction before consulting it.
+    #[test]
+    fn an_inconsistent_seasonality_is_reported_by_the_gate() {
+        let curve = curve(None);
+
+        let err = curve.set_seasonality(Some(a_seasonality(24))).unwrap_err();
+        assert!(err.message().contains("#807"), "{}", err.message());
+        assert!(curve.has_seasonality(), "C++ stores before it checks");
+        assert!(curve.check_seasonality().is_err());
     }
 
     #[test]

--- a/crates/libitofin/src/termstructures/inflation/interpolatedzeroinflationcurve.rs
+++ b/crates/libitofin/src/termstructures/inflation/interpolatedzeroinflationcurve.rs
@@ -18,11 +18,11 @@
 //!
 //! ## Divergences from QuantLib
 //!
-//! - Seasonality is not ported, following the
-//!   [`inflationtermstructure`](super::inflationtermstructure) divergence: the
-//!   constructor argument (`interpolatedzeroinflationcurve.hpp:47`) is omitted
-//!   rather than accepted and ignored, so a curve needing seasonality fails to
-//!   compile.
+//! - The seasonality constructor argument
+//!   (`interpolatedzeroinflationcurve.hpp:47`) is ported, but the consistency
+//!   gate C++ runs from the base constructor runs here from this one, once the
+//!   curve exists; see the
+//!   [`inflationtermstructure`](super::inflationtermstructure) divergences.
 //! - The protected constructor for descendants that cannot supply their nodes
 //!   at construction (`interpolatedzeroinflationcurve.hpp:75-80,116-126`)
 //!   follows with the bootstrapped curves that use it.
@@ -48,9 +48,11 @@ use crate::errors::QlResult;
 use crate::math::interpolations::linear::Linear;
 use crate::math::interpolations::{Interpolation, Interpolator};
 use crate::patterns::observable::{AsObservable, Observable};
+use crate::shared::Shared;
 use crate::termstructures::inflation::inflationtermstructure::{
     InflationTermStructure, InflationTermStructureBase, ZeroInflationTermStructure,
 };
+use crate::termstructures::inflation::seasonality::Seasonality;
 use crate::termstructures::interpolatedcurve::InterpolatedCurve;
 use crate::termstructures::{TermStructure, TermStructureBase};
 use crate::time::date::Date;
@@ -91,6 +93,7 @@ impl<I: Interpolator> InterpolatedZeroInflationCurve<I> {
         frequency: Frequency,
         day_counter: DayCounter,
         interpolator: I,
+        seasonality: Option<Shared<dyn Seasonality>>,
     ) -> QlResult<InterpolatedZeroInflationCurve<I>> {
         require!(dates.len() > 1, "too few dates: {}", dates.len());
         require!(
@@ -115,12 +118,15 @@ impl<I: Interpolator> InterpolatedZeroInflationCurve<I> {
             frequency,
             Some(day_counter),
             None,
+            seasonality,
         );
-        Ok(InterpolatedZeroInflationCurve {
+        let curve = InterpolatedZeroInflationCurve {
             inflation,
             curve,
             dates,
-        })
+        };
+        curve.check_seasonality()?;
+        Ok(curve)
     }
 
     /// The node times, measured from the reference date; the first is
@@ -181,6 +187,10 @@ impl<I: Interpolator> InflationTermStructure for InterpolatedZeroInflationCurve<
     fn inflation_base(&self) -> &InflationTermStructureBase {
         &self.inflation
     }
+
+    fn as_inflation_term_structure(&self) -> &dyn InflationTermStructure {
+        self
+    }
 }
 
 impl<I: Interpolator> ZeroInflationTermStructure for InterpolatedZeroInflationCurve<I> {
@@ -192,6 +202,8 @@ impl<I: Interpolator> ZeroInflationTermStructure for InterpolatedZeroInflationCu
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::shared::shared;
+    use crate::termstructures::inflation::seasonality::MultiplicativePriceSeasonality;
     use crate::time::date::Month;
     use crate::time::daycounters::actual360::Actual360;
     use crate::time::period::Period;
@@ -236,11 +248,51 @@ mod tests {
             Frequency::Monthly,
             Actual360::new(),
             Linear,
+            None,
         )
     }
 
     fn sample() -> ZeroInflationCurve {
         build(sample_dates(), sample_rates()).unwrap()
+    }
+
+    /// A seasonality passed at construction is installed and gated there, where
+    /// C++ gates it in the base constructor: twelve monthly factors are
+    /// consistent with any curve, a twenty-four-factor set is the multi-year
+    /// case this port defers.
+    #[test]
+    fn the_constructor_installs_and_gates_a_seasonality() {
+        fn built(count: usize) -> QlResult<ZeroInflationCurve> {
+            let seasonality = shared(
+                MultiplicativePriceSeasonality::new(
+                    Date::new(31, Month::January, 2022),
+                    Frequency::Monthly,
+                    (0..count).map(|i| 1.0 + i as Rate / 1000.0).collect(),
+                )
+                .expect("a whole multiple of twelve factors"),
+            ) as Shared<dyn Seasonality>;
+            ZeroInflationCurve::new(
+                today(),
+                sample_dates(),
+                sample_rates(),
+                Frequency::Monthly,
+                Actual360::new(),
+                Linear,
+                Some(seasonality),
+            )
+        }
+
+        assert!(built(12).unwrap().has_seasonality());
+        let deferred = match built(24) {
+            Ok(_) => panic!("expected the multi-year seasonality to be rejected"),
+            Err(err) => err,
+        };
+        assert!(
+            deferred.message().contains("#807"),
+            "{}",
+            deferred.message()
+        );
+        assert!(!sample().has_seasonality());
     }
 
     #[test]

--- a/crates/libitofin/src/termstructures/inflation/mod.rs
+++ b/crates/libitofin/src/termstructures/inflation/mod.rs
@@ -4,11 +4,14 @@
 //! under `ql/termstructures/inflation/`. The
 //! [`ZeroInflationTermStructure`](inflationtermstructure::ZeroInflationTermStructure)
 //! trait is the contract every zero-coupon inflation curve plugs into; the
-//! interpolated curves, the year-on-year structures and the seasonality
-//! classes that build on it follow within EPIC Inflation (#705).
+//! interpolated curves and the seasonality corrections build on it; the
+//! year-on-year structures follow within EPIC Inflation (#705).
 
 pub mod inflationhelpers;
 pub mod inflationtermstructure;
 pub mod inflationtraits;
 pub mod interpolatedzeroinflationcurve;
 pub mod piecewisezeroinflationcurve;
+pub mod seasonality;
+
+pub use seasonality::{MultiplicativePriceSeasonality, Seasonality};

--- a/crates/libitofin/src/termstructures/inflation/piecewisezeroinflationcurve.rs
+++ b/crates/libitofin/src/termstructures/inflation/piecewisezeroinflationcurve.rs
@@ -32,10 +32,13 @@
 //!
 //! ## Divergences from QuantLib
 //!
-//! - Seasonality (`:61`) is omitted rather than accepted and ignored, following
-//!   the [`inflationtermstructure`](super::inflationtermstructure) contract: a
-//!   caller needing it fails to compile. It follows with the seasonality
-//!   classes in EPIC Inflation (#705).
+//! - The seasonality argument (`:61`) is ported, and so is C++'s virtual
+//!   `update()` behind
+//!   [`set_seasonality`](InflationTermStructure::set_seasonality): installing
+//!   one invalidates the bootstrap, so the next read re-solves every node
+//!   against the corrected rates. The consistency gate runs from this
+//!   constructor rather than from the base one; see the
+//!   [`inflationtermstructure`](super::inflationtermstructure) divergences.
 //! - The `BaseDateFunc` constructor overload (`:73-90`), whose base date is
 //!   resolved lazily inside `performCalculations` (`:168-169`), is deferred
 //!   with it, and with it its oracle `testZeroTermStructureLazyBaseDate`
@@ -61,6 +64,7 @@ use crate::termstructures::inflation::inflationtermstructure::{
     InflationTermStructure, InflationTermStructureBase, ZeroInflationTermStructure,
 };
 use crate::termstructures::inflation::inflationtraits::ZeroInflationTraits;
+use crate::termstructures::inflation::seasonality::Seasonality;
 use crate::termstructures::iterativebootstrap::{IterativeBootstrap, PiecewiseCurve};
 use crate::termstructures::{TermStructure, TermStructureBase};
 use crate::time::date::Date;
@@ -122,6 +126,7 @@ impl PiecewiseZeroInflationCurve<Linear> {
         frequency: Frequency,
         day_counter: DayCounter,
         instruments: Vec<Shared<dyn ZeroInflationHelper>>,
+        seasonality: Option<Shared<dyn Seasonality>>,
     ) -> QlResult<Shared<PiecewiseZeroInflationCurve<Linear>>> {
         require!(!instruments.is_empty(), "no bootstrap helpers given");
 
@@ -139,6 +144,7 @@ impl PiecewiseZeroInflationCurve<Linear> {
                     frequency,
                     Some(day_counter),
                     None,
+                    seasonality,
                 ),
                 instruments,
                 interpolator: Linear,
@@ -156,6 +162,7 @@ impl PiecewiseZeroInflationCurve<Linear> {
         for helper in &curve.instruments {
             helper.observable().register_observer(&observer);
         }
+        curve.check_seasonality()?;
         Ok(curve)
     }
 }
@@ -238,6 +245,20 @@ impl<I: Interpolator + 'static> TermStructure for PiecewiseZeroInflationCurve<I>
 impl<I: Interpolator + 'static> InflationTermStructure for PiecewiseZeroInflationCurve<I> {
     fn inflation_base(&self) -> &InflationTermStructureBase {
         &self.inflation
+    }
+
+    fn as_inflation_term_structure(&self) -> &dyn InflationTermStructure {
+        self
+    }
+
+    /// Invalidates the bootstrap before broadcasting: a seasonality change
+    /// moves the rates the helpers reprice against, so the solved nodes are
+    /// stale and every one of them has to be solved again. This is the curve's
+    /// own `update()` (`:180-183`), which the base default cannot reach.
+    fn update_after_seasonality_change(&self) {
+        if let Some(update) = LazyObject::deferred_update(&self.lazy) {
+            update.notify_observers();
+        }
     }
 }
 
@@ -401,6 +422,7 @@ mod tests {
             Frequency::Monthly,
             day_counter(),
             helpers.clone(),
+            None,
         )
         .unwrap();
         Fixture {
@@ -498,6 +520,7 @@ mod tests {
             Frequency::Monthly,
             day_counter(),
             vec![Shared::clone(&helper) as Shared<dyn ZeroInflationHelper>],
+            None,
         )
         .unwrap();
 
@@ -523,6 +546,7 @@ mod tests {
             Frequency::Monthly,
             day_counter(),
             Vec::new(),
+            None,
         );
         let err = match built {
             Ok(_) => panic!("expected a construction error"),
@@ -547,10 +571,11 @@ mod zero_term_structure_oracle {
     //! placement, the fixing-period quantization and the forecast formula all
     //! at once, at the C++ tolerance of 1e-7.
     //!
-    //! Phase 3 (`:465-506`), which adds a seasonality correction and reprices
-    //! again, is **omitted**: seasonality is a documented deferral of this port
-    //! (see the module divergences), and the Rust curve takes no seasonality
-    //! argument, so phases 1 and 2 run exactly the numbers C++ runs before it.
+    //! Phase 3 (`:465-506`) installs a twelve-factor monthly price seasonality
+    //! on the bootstrapped curve and reprices the same fourteen swaps. The
+    //! factors are not one, so the corrected rates move and the curve has to
+    //! re-solve every node against them to come back to zero: a curve that
+    //! stored the correction without invalidating its bootstrap fails it.
     //!
     //! `testZeroTermStructureWithNominalCurve` (`:597-763`), which reruns the
     //! same fixture through the deprecated nominal-curve helper constructor, is
@@ -574,6 +599,7 @@ mod zero_term_structure_oracle {
     use crate::settings::Settings;
     use crate::shared::{SharedMut, shared, shared_mut};
     use crate::termstructures::inflation::inflationhelpers::ZeroCouponInflationSwapHelper;
+    use crate::termstructures::inflation::seasonality::MultiplicativePriceSeasonality;
     use crate::termstructures::yields::FlatForward;
     use crate::termstructures::yieldtermstructure::YieldTermStructure;
     use crate::time::businessdayconvention::BusinessDayConvention;
@@ -750,6 +776,7 @@ mod zero_term_structure_oracle {
             Frequency::Monthly,
             day_counter(),
             helpers,
+            None,
         )
         .unwrap();
         hz.link_to(Shared::clone(&curve) as Shared<dyn ZeroInflationTermStructure>);
@@ -809,6 +836,74 @@ mod zero_term_structure_oracle {
         println!("worst |NPV| {worst_npv:e}, worst fixed-leg BPS error {worst_bps:e}");
         assert!(worst_npv < EPS, "worst |NPV| {worst_npv}");
         assert!(worst_bps < EPS, "worst fixed-leg BPS error {worst_bps}");
+    }
+
+    /// The twelve monthly factors phase 3 installs (`:469-483`), anchored on 31
+    /// January of the year the curve's base period ends in (`:467-468`).
+    const SEASONALITY_FACTORS: [Real; 12] = [
+        1.003245, 1.000000, 0.999715, 1.000495, 1.000929, 0.998687, 0.995949, 0.994682, 0.995949,
+        1.000519, 1.003705, 1.004186,
+    ];
+
+    fn a_seasonality(curve: &PiecewiseZeroInflationCurve<Linear>) -> Shared<dyn Seasonality> {
+        let (_, next_base_date) =
+            inflation_period(curve.base_date(), Frequency::Monthly).expect("a monthly curve");
+        shared(
+            MultiplicativePriceSeasonality::new(
+                Date::new(31, January, next_base_date.year()),
+                Frequency::Monthly,
+                SEASONALITY_FACTORS.to_vec(),
+            )
+            .expect("twelve monthly factors"),
+        ) as Shared<dyn Seasonality>
+    }
+
+    /// Phase 3 (`:465-506`): the same fourteen swaps still reprice to zero once
+    /// a non-unit seasonality is installed on the bootstrapped curve.
+    ///
+    /// The direct pin comes first and is what makes the reprice loop mean
+    /// anything. Phase 3 on its own is degenerate: if the correction were
+    /// stored but never folded into the published rate, the re-bootstrap would
+    /// hit the very same nodes off the very same quotes and every swap would
+    /// still come back worth nothing - a false pass. So the index's own
+    /// forecast, which is the path every helper and every swap reaches the
+    /// curve through, is required to *move*. The reprice loop then covers the
+    /// other half: with the correction live, only a bootstrap that re-solved
+    /// against it can return to zero.
+    #[test]
+    fn a_seasonality_moves_the_forecast_and_the_curve_reprices_the_swaps_again() {
+        let fixture = a_fixture();
+        let curve = &fixture.curve;
+        let a_date = Date::new(1, August, 2012);
+
+        let (maturity, rate) = zc_data()[6];
+        let mut held = fixture.a_swap(maturity, rate / 100.0);
+        let held_npv = held.npv().unwrap();
+
+        let before = fixture.index.fixing(a_date, true).unwrap();
+        curve
+            .set_seasonality(Some(a_seasonality(curve.as_ref())))
+            .unwrap();
+        assert_ne!(
+            held.npv().unwrap(),
+            held_npv,
+            "an already-priced swap was never told the curve moved"
+        );
+        let after = fixture.index.fixing(a_date, true).unwrap();
+        println!("forecast at {a_date}: {before} -> {after}");
+        assert!(
+            (after - before).abs() > 1.0e-3,
+            "the seasonality never reached the forecast: {before} vs {after}"
+        );
+        assert!(curve.has_seasonality());
+
+        let mut worst_npv = 0.0_f64;
+        for (maturity, rate) in zc_data() {
+            let mut swap = fixture.a_swap(maturity, rate / 100.0);
+            worst_npv = worst_npv.max(swap.npv().unwrap().abs());
+        }
+        println!("worst |NPV| under seasonality {worst_npv:e}");
+        assert!(worst_npv < EPS, "worst |NPV| {worst_npv}");
     }
 
     /// Phase 2 (`:437-463`): the index, forecasting off the bootstrapped curve,

--- a/crates/libitofin/src/termstructures/inflation/seasonality.rs
+++ b/crates/libitofin/src/termstructures/inflation/seasonality.rs
@@ -1,0 +1,368 @@
+//! Seasonality corrections applied to inflation term structures.
+//!
+//! Port of `ql/termstructures/inflation/seasonality.{hpp,cpp}`:
+//! [`Seasonality`] is the transformation an inflation curve folds into the
+//! rates it publishes, and [`MultiplicativePriceSeasonality`] is the one
+//! implementation QuantLib ships for price indexes (CPI/RPI/HICP), where the
+//! factors multiply the index level itself.
+//!
+//! Seasonality fills in an inflation curve between the integer-year maturities
+//! the market quotes. Stationary (one year of factors) multiplicative price
+//! seasonality moves zero-coupon rates but leaves year-on-year rates alone;
+//! multi-year factor sets move both. The correction is piecewise constant, so
+//! it works with un-interpolated inflation indexes
+//! (`seasonality.hpp:34-53,81-118`).
+//!
+//! ## Divergences from QuantLib
+//!
+//! - `KerkhofSeasonality` (`seasonality.hpp:170-187`,
+//!   `seasonality.cpp:220-277`) is **not ported**. It is a distinct
+//!   cumulative-product subclass, not a parametrization of
+//!   [`MultiplicativePriceSeasonality`], and is out of scope here (#729).
+//! - [`MultiplicativePriceSeasonality::is_consistent`] ports the two
+//!   short-circuits (`seasonality.cpp:69-70`) but **not** the multi-year
+//!   whole-year comparison loop (`seasonality.cpp:72-85`), which returns a
+//!   typed error naming the deferral (#807) rather than a silent `true`. A
+//!   stationary factor set - the same count as the frequency - is unaffected.
+//! - C++'s `set` assigns the fields and *then* validates, leaving an invalid
+//!   object behind on failure; [`MultiplicativePriceSeasonality::set`] builds
+//!   the replacement first, so a rejected input leaves the receiver untouched.
+//! - `iTS.dayCounter()` may be an empty day counter in C++; here it is
+//!   [`TermStructure::require_day_counter`], which errors on a curve carrying
+//!   none (D10).
+//! - The factor lookup, the validation and the corrections all return
+//!   [`QlResult`] where C++ throws, `inflation_period` being fallible.
+
+use crate::errors::QlResult;
+use crate::indexes::inflationindex::inflation_period;
+use crate::termstructures::inflation::inflationtermstructure::InflationTermStructure;
+use crate::time::date::Date;
+use crate::time::daycounter::DayCounter;
+use crate::time::frequency::Frequency;
+use crate::time::period::Period;
+use crate::time::timeunit::TimeUnit;
+use crate::types::{Integer, Rate};
+use crate::{fail, require};
+
+/// A transformation of an existing inflation rate.
+///
+/// Mirrors QuantLib's abstract `Seasonality` (`seasonality.hpp:55-79`): the
+/// two `correctXXXRate` methods return the rate with the correction folded in,
+/// and [`is_consistent`](Self::is_consistent) reports whether the factor set
+/// can coexist with the curve it is given to.
+pub trait Seasonality {
+    /// The zero-coupon inflation rate for `date`, corrected.
+    fn correct_zero_rate(
+        &self,
+        date: Date,
+        rate: Rate,
+        its: &dyn InflationTermStructure,
+    ) -> QlResult<Rate>;
+
+    /// The year-on-year inflation rate for `date`, corrected.
+    fn correct_yoy_rate(
+        &self,
+        date: Date,
+        rate: Rate,
+        its: &dyn InflationTermStructure,
+    ) -> QlResult<Rate>;
+
+    /// Whether the correction is consistent with `its`
+    /// (`seasonality.cpp:29-31`).
+    ///
+    /// Multi-year seasonalities can contradict the quoted instruments a curve
+    /// is built from: for price seasonality the corrections at whole years
+    /// after the curve's base date must agree. Implementing the test is
+    /// optional, and the default reports consistency.
+    fn is_consistent(&self, _its: &dyn InflationTermStructure) -> QlResult<bool> {
+        Ok(true)
+    }
+}
+
+/// Multiplicative seasonality in the price index (CPI/RPI/HICP).
+///
+/// Port of `seasonality.hpp:119-167`. Factors come in whole multiples of the
+/// count the frequency dictates - twelve for [`Monthly`](Frequency::Monthly) -
+/// and are reused as long as needed, so twenty-four monthly factors repeat
+/// every two years and twelve of them are stationary.
+///
+/// The factors are normalized against a reference date rather than used raw:
+/// for a zero-coupon rate that is the curve's true base date, whose fixing is
+/// known and whose factor must therefore divide out to one; for a year-on-year
+/// rate it is always one year earlier.
+///
+/// Multi-year (non-stationary) factor sets are fragile: the corrections at
+/// whole years either side of the curve's base date must match or the curve
+/// contradicts its own quotes. See
+/// [`is_consistent`](MultiplicativePriceSeasonality::is_consistent) for how
+/// much of that check is ported.
+#[derive(Debug)]
+pub struct MultiplicativePriceSeasonality {
+    seasonality_base_date: Date,
+    frequency: Frequency,
+    seasonality_factors: Vec<Rate>,
+}
+
+impl MultiplicativePriceSeasonality {
+    /// The seasonality whose factors start at `seasonality_base_date` and step
+    /// at `frequency` (`seasonality.cpp:91-95`).
+    ///
+    /// # Errors
+    ///
+    /// Rejects a frequency outside semiannual-through-daily, an empty factor
+    /// set, and a factor count that is not a whole multiple of the frequency.
+    pub fn new(
+        seasonality_base_date: Date,
+        frequency: Frequency,
+        seasonality_factors: Vec<Rate>,
+    ) -> QlResult<MultiplicativePriceSeasonality> {
+        let seasonality = MultiplicativePriceSeasonality {
+            seasonality_base_date,
+            frequency,
+            seasonality_factors,
+        };
+        seasonality.validate()?;
+        Ok(seasonality)
+    }
+
+    /// Replaces the whole factor specification (`seasonality.cpp:97-108`),
+    /// leaving the receiver untouched if the new one is rejected.
+    ///
+    /// # Errors
+    ///
+    /// As [`new`](Self::new).
+    pub fn set(
+        &mut self,
+        seasonality_base_date: Date,
+        frequency: Frequency,
+        seasonality_factors: Vec<Rate>,
+    ) -> QlResult<()> {
+        *self = MultiplicativePriceSeasonality::new(
+            seasonality_base_date,
+            frequency,
+            seasonality_factors,
+        )?;
+        Ok(())
+    }
+
+    /// The date the factor set is anchored on (`seasonality.cpp:110-112`).
+    pub fn seasonality_base_date(&self) -> Date {
+        self.seasonality_base_date
+    }
+
+    /// The frequency the factors step at (`seasonality.cpp:114-116`).
+    pub fn frequency(&self) -> Frequency {
+        self.frequency
+    }
+
+    /// The factors, in order from the seasonality base date
+    /// (`seasonality.cpp:118-120`).
+    pub fn seasonality_factors(&self) -> &[Rate] {
+        &self.seasonality_factors
+    }
+
+    /// The factor covering `to`, normalized against nothing at all
+    /// (`seasonality.cpp:145-188`).
+    ///
+    /// The offset from the seasonality base date is counted in whole factor
+    /// periods and wrapped modulo the factor count, so a set shorter than the
+    /// span repeats. For a month-based frequency the offset is *stepped*: the
+    /// first guess is `31 * length` days per period and the loop then advances
+    /// one period at a time until it lands inside `to`'s inflation period,
+    /// which is not the same as advancing by the multiple in one go (month-end
+    /// clamping is not associative).
+    ///
+    /// # Errors
+    ///
+    /// Rejects a year-based factor period, which cannot express seasonality.
+    pub fn seasonality_factor(&self, to: Date) -> QlResult<Rate> {
+        let from = self.seasonality_base_date;
+        let factor_frequency = self.frequency;
+        let n_factors = self.seasonality_factors.len();
+        let factor_period = Period::try_from(factor_frequency)?;
+
+        let which = if from == to {
+            0
+        } else {
+            let diff_days = (to - from).abs();
+            let dir: Integer = if from > to { -1 } else { 1 };
+            let diff = match factor_period.units() {
+                TimeUnit::Days => dir * diff_days,
+                TimeUnit::Weeks => dir * (diff_days / 7),
+                TimeUnit::Months => {
+                    let lim = inflation_period(to, factor_frequency)?;
+                    let mut steps = diff_days / (31 * factor_period.length());
+                    let mut go = from + factor_period * (dir * steps);
+                    while !(lim.0 <= go && go <= lim.1) {
+                        go = go + factor_period * dir;
+                        steps += 1;
+                    }
+                    dir * steps
+                }
+                TimeUnit::Years => fail!(
+                    "seasonality period time unit is not allowed to be : {}",
+                    factor_period.units()
+                ),
+                unit => fail!("Unknown time unit: {unit}"),
+            };
+            if dir == 1 {
+                (diff as usize) % n_factors
+            } else {
+                (n_factors - ((-diff) as usize) % n_factors) % n_factors
+            }
+        };
+
+        Ok(self.seasonality_factors[which])
+    }
+
+    /// The factor set as it applies to `frequency`, rejecting the frequencies
+    /// QuantLib refuses (`seasonality.cpp:36-61`).
+    fn validate(&self) -> QlResult<()> {
+        match self.frequency {
+            Frequency::Semiannual
+            | Frequency::EveryFourthMonth
+            | Frequency::Quarterly
+            | Frequency::Bimonthly
+            | Frequency::Monthly
+            | Frequency::Biweekly
+            | Frequency::Weekly
+            | Frequency::Daily => {
+                require!(
+                    !self.seasonality_factors.is_empty(),
+                    "no seasonality factors given"
+                );
+                let per_year = self.frequency as i16;
+                require!(
+                    self.seasonality_factors
+                        .len()
+                        .is_multiple_of(per_year as usize),
+                    "For frequency {} require multiple of {per_year} factors {} were given.",
+                    self.frequency,
+                    self.seasonality_factors.len()
+                );
+                Ok(())
+            }
+            frequency => fail!(
+                "bad frequency specified: {frequency}, \
+                 only semi-annual through daily permitted."
+            ),
+        }
+    }
+
+    /// `rate` with the correction folded in (`seasonality.cpp:191-217`).
+    ///
+    /// Two factors are needed, not one: the raw factor at `at_date` divided by
+    /// the one at the reference date, which is `curve_base_date` for a zero
+    /// rate (whose fixing is known there, so the correction must be the
+    /// identity) and one year earlier for a year-on-year rate. The zero path
+    /// then spreads the ratio over the time from the curve base to the start
+    /// of `at_date`'s inflation period.
+    ///
+    /// At the curve's own base date that time is zero and the ratio is exactly
+    /// one, so `1.powf(inf)` returns one and the correction is the identity -
+    /// the path every bootstrap takes on its first node. C++ has no guard
+    /// there and neither does this.
+    fn seasonality_correction(
+        &self,
+        rate: Rate,
+        at_date: Date,
+        day_counter: &DayCounter,
+        curve_base_date: Date,
+        is_zero_rate: bool,
+    ) -> QlResult<Rate> {
+        let factor_at = self.seasonality_factor(at_date)?;
+
+        let f = if is_zero_rate {
+            let factor_base = self.seasonality_factor(curve_base_date)?;
+            let seasonality_at = factor_at / factor_base;
+            let (period_start, _) = inflation_period(at_date, self.frequency)?;
+            let time_from_curve_base = day_counter.year_fraction(curve_base_date, period_start);
+            seasonality_at.powf(1.0 / time_from_curve_base)
+        } else {
+            let a_year_before = at_date - Period::new(1, TimeUnit::Years);
+            factor_at / self.seasonality_factor(a_year_before)?
+        };
+
+        Ok((rate + 1.0) * f - 1.0)
+    }
+}
+
+impl Seasonality for MultiplicativePriceSeasonality {
+    /// The zero rate corrected against the curve's *true* base date
+    /// (`seasonality.cpp:123-133`).
+    ///
+    /// The reference is `its.base_date()` itself, not the end of its inflation
+    /// period, and `date` is quantized to the start of its own period, so this
+    /// picks the same base date and effective fixing date
+    /// [`ZeroInflationIndex::forecast_fixing`] does and the input seasonality
+    /// adjustment is recovered by their ratio.
+    ///
+    /// [`ZeroInflationIndex::forecast_fixing`]: crate::indexes::inflationindex::ZeroInflationIndex
+    fn correct_zero_rate(
+        &self,
+        date: Date,
+        rate: Rate,
+        its: &dyn InflationTermStructure,
+    ) -> QlResult<Rate> {
+        let curve_base_date = its.base_date();
+        let (effective_fixing_date, _) = inflation_period(date, its.frequency())?;
+        self.seasonality_correction(
+            rate,
+            effective_fixing_date,
+            &its.require_day_counter()?,
+            curve_base_date,
+            true,
+        )
+    }
+
+    /// The year-on-year rate corrected against one year earlier
+    /// (`seasonality.cpp:136-142`).
+    ///
+    /// The reference here is the *end* of the base date's inflation period,
+    /// and `date` reaches the correction unquantized. A stationary factor set
+    /// leaves the rate alone: the factor a year earlier is the same one.
+    fn correct_yoy_rate(
+        &self,
+        date: Date,
+        rate: Rate,
+        its: &dyn InflationTermStructure,
+    ) -> QlResult<Rate> {
+        let (_, curve_base_date) = inflation_period(its.base_date(), its.frequency())?;
+        self.seasonality_correction(
+            rate,
+            date,
+            &its.require_day_counter()?,
+            curve_base_date,
+            false,
+        )
+    }
+
+    /// Consistency with the curve (`seasonality.cpp:64-88`), as far as it is
+    /// ported.
+    ///
+    /// Daily seasonality is consistent by fiat: weekends, holidays and leap
+    /// years make it otherwise never so (`seasonality.cpp:67-69`). A
+    /// stationary set - one factor per period of the year - is consistent
+    /// because it repeats exactly on whole years (`seasonality.cpp:70`).
+    ///
+    /// # Errors
+    ///
+    /// Any other (multi-year) factor count errors: the whole-year comparison
+    /// loop that decides those (`seasonality.cpp:72-85`) is deferred to #807,
+    /// and reporting consistency without running it would let an inconsistent
+    /// curve through unnoticed.
+    fn is_consistent(&self, _its: &dyn InflationTermStructure) -> QlResult<bool> {
+        if self.frequency == Frequency::Daily {
+            return Ok(true);
+        }
+        if (self.frequency as i16 as usize) == self.seasonality_factors.len() {
+            return Ok(true);
+        }
+        fail!(
+            "multi-year seasonality consistency check is not ported (#807): \
+             {} factors at {} frequency",
+            self.seasonality_factors.len(),
+            self.frequency
+        )
+    }
+}

--- a/crates/libitofin/src/termstructures/inflation/seasonality.rs
+++ b/crates/libitofin/src/termstructures/inflation/seasonality.rs
@@ -411,6 +411,7 @@ mod tests {
             Frequency::Monthly,
             Thirty360::with_convention(Convention::BondBasis),
             Linear,
+            None,
         )
         .expect("two sorted nodes and plausible rates")
     }

--- a/crates/libitofin/src/termstructures/inflation/seasonality.rs
+++ b/crates/libitofin/src/termstructures/inflation/seasonality.rs
@@ -366,3 +366,220 @@ impl Seasonality for MultiplicativePriceSeasonality {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! The factor set is anchored on 31 January 2007 while the curve's base
+    //! date is 1 July 2007, so the two reference factors differ and the
+    //! end-to-end zero correction discriminates which of them divides which.
+
+    use super::*;
+    use crate::math::interpolations::linear::Linear;
+    use crate::termstructures::inflation::interpolatedzeroinflationcurve::ZeroInflationCurve;
+    use crate::time::date::Month::{August, December, January, July};
+    use crate::time::daycounters::thirty360::{Convention, Thirty360};
+
+    /// Readable factors: the value names its own index.
+    fn factors(count: usize) -> Vec<Rate> {
+        (0..count).map(|i| 1.0 + i as Rate / 1000.0).collect()
+    }
+
+    fn seasonality_base_date() -> Date {
+        Date::new(31, January, 2007)
+    }
+
+    fn curve_base_date() -> Date {
+        Date::new(1, July, 2007)
+    }
+
+    fn monthly(count: usize) -> MultiplicativePriceSeasonality {
+        MultiplicativePriceSeasonality::new(
+            seasonality_base_date(),
+            Frequency::Monthly,
+            factors(count),
+        )
+        .expect("a whole multiple of twelve factors")
+    }
+
+    /// A carrier for the three properties a correction reads off a curve: the
+    /// base date, the frequency and the day counter.
+    fn a_curve() -> ZeroInflationCurve {
+        ZeroInflationCurve::new(
+            Date::new(13, August, 2007),
+            vec![curve_base_date(), Date::new(13, August, 2012)],
+            vec![0.02, 0.03],
+            Frequency::Monthly,
+            Thirty360::with_convention(Convention::BondBasis),
+            Linear,
+        )
+        .expect("two sorted nodes and plausible rates")
+    }
+
+    /// The offset is counted in whole months from the seasonality base date
+    /// and wraps modulo twelve, in both directions.
+    ///
+    /// The four dates are hand-counted off 31 January 2007: 1 July 2007 is six
+    /// stepped months later, 1 August 2008 nineteen (so it wraps to seven), 1
+    /// December 2006 one earlier (wrapping to eleven) and 1 December 2005
+    /// thirteen earlier (wrapping past a whole year, to eleven again).
+    #[test]
+    fn the_factor_is_picked_by_stepped_month_offset_and_wraps_both_ways() {
+        let seasonality = monthly(12);
+
+        assert_eq!(
+            seasonality
+                .seasonality_factor(seasonality_base_date())
+                .unwrap(),
+            factors(12)[0]
+        );
+        assert_eq!(
+            seasonality.seasonality_factor(curve_base_date()).unwrap(),
+            factors(12)[6]
+        );
+        assert_eq!(
+            seasonality
+                .seasonality_factor(Date::new(1, August, 2008))
+                .unwrap(),
+            factors(12)[7]
+        );
+        assert_eq!(
+            seasonality
+                .seasonality_factor(Date::new(1, December, 2006))
+                .unwrap(),
+            factors(12)[11]
+        );
+        assert_eq!(
+            seasonality
+                .seasonality_factor(Date::new(1, December, 2005))
+                .unwrap(),
+            factors(12)[11]
+        );
+    }
+
+    /// The year-on-year branch is the plain ratio of the factor at the date to
+    /// the one a year earlier - `curve_base_date` never reaches it - and the
+    /// zero branch spreads its ratio over the time from the curve base.
+    #[test]
+    fn the_correction_is_the_rate_grossed_up_by_the_factor_ratio() {
+        let seasonality = monthly(24);
+        let day_counter = Thirty360::with_convention(Convention::BondBasis);
+        let at = Date::new(1, August, 2008);
+        let rate = 0.03;
+
+        let factor_at = seasonality.seasonality_factor(at).unwrap();
+        let a_year_before = seasonality
+            .seasonality_factor(Date::new(1, August, 2007))
+            .unwrap();
+        assert_ne!(factor_at, a_year_before, "a two-year factor set moves YoY");
+        assert_eq!(
+            seasonality
+                .seasonality_correction(rate, at, &day_counter, Date::null(), false)
+                .unwrap(),
+            (rate + 1.0) * (factor_at / a_year_before) - 1.0
+        );
+
+        let factor_base = seasonality.seasonality_factor(curve_base_date()).unwrap();
+        let f = (factor_at / factor_base).powf(1.0 / (390.0 / 360.0));
+        assert_eq!(
+            seasonality
+                .seasonality_correction(rate, at, &day_counter, curve_base_date(), true)
+                .unwrap(),
+            (rate + 1.0) * f - 1.0
+        );
+    }
+
+    /// The end-to-end zero correction off a real curve, pinned to a factor
+    /// ratio and a year fraction computed by hand.
+    ///
+    /// The reference factor is the one at the curve's base date, 1 July 2007
+    /// (index six), and the corrected factor the one at the start of the
+    /// query's inflation period, 1 August 2008 (index seven). Dividing the
+    /// other way round, or referencing the *end* of the base period
+    /// (31 July 2007, index six as well but a different year fraction),
+    /// changes the answer. `Thirty360(BondBasis)` from 1 July 2007 to 1 August
+    /// 2008 is `(360 + 30) / 360`.
+    #[test]
+    fn the_zero_correction_normalizes_against_the_curves_true_base_date() {
+        let seasonality = monthly(12);
+        let curve = a_curve();
+        let rate = 0.03;
+
+        let expected_f = (factors(12)[7] / factors(12)[6]).powf(1.0 / (390.0 / 360.0));
+        assert_eq!(
+            seasonality
+                .correct_zero_rate(Date::new(15, August, 2008), rate, &curve)
+                .unwrap(),
+            (rate + 1.0) * expected_f - 1.0
+        );
+        assert!(expected_f > 1.0, "the factor set rises over that span");
+        assert_ne!(
+            seasonality
+                .correct_zero_rate(Date::new(15, August, 2008), rate, &curve)
+                .unwrap(),
+            rate,
+            "the correction must move the rate at all"
+        );
+    }
+
+    /// Stationary price seasonality leaves year-on-year rates untouched: the
+    /// factor a year earlier is the very same one, so the ratio is exactly one
+    /// and only the `(rate + 1) * 1 - 1` round trip separates the answer from
+    /// the input.
+    #[test]
+    fn a_stationary_factor_set_does_not_move_a_year_on_year_rate() {
+        let seasonality = monthly(12);
+        let curve = a_curve();
+        let at = Date::new(1, August, 2008);
+
+        assert_eq!(
+            seasonality.seasonality_factor(at).unwrap(),
+            seasonality
+                .seasonality_factor(Date::new(1, August, 2007))
+                .unwrap()
+        );
+        let corrected = seasonality.correct_yoy_rate(at, 0.03, &curve).unwrap();
+        assert!((corrected - 0.03).abs() < 1.0e-15, "moved to {corrected}");
+    }
+
+    /// Twelve monthly factors are consistent with any curve; twenty-four are
+    /// the deferred multi-year branch; thirteen never build at all.
+    #[test]
+    fn consistency_covers_the_stationary_case_and_defers_the_multi_year_one() {
+        let curve = a_curve();
+
+        assert!(monthly(12).is_consistent(&curve).unwrap());
+        let deferred = monthly(24).is_consistent(&curve).unwrap_err();
+        assert!(deferred.message().contains("#807"));
+
+        let rejected = MultiplicativePriceSeasonality::new(
+            seasonality_base_date(),
+            Frequency::Monthly,
+            factors(13),
+        )
+        .unwrap_err();
+        assert!(
+            rejected
+                .message()
+                .contains("require multiple of 12 factors 13 were given")
+        );
+    }
+
+    #[test]
+    fn only_semiannual_through_daily_frequencies_are_accepted() {
+        let annual = MultiplicativePriceSeasonality::new(
+            seasonality_base_date(),
+            Frequency::Annual,
+            factors(1),
+        )
+        .unwrap_err();
+        assert!(annual.message().contains("bad frequency specified"));
+
+        let empty = MultiplicativePriceSeasonality::new(
+            seasonality_base_date(),
+            Frequency::Monthly,
+            vec![],
+        )
+        .unwrap_err();
+        assert!(empty.message().contains("no seasonality factors given"));
+    }
+}


### PR DESCRIPTION
Wire the ported `Seasonality` correction into the inflation term
structure so curves can install, replace, or clear it and fold it into
their published zero rates.

**Seasonality on the base holder:**
* Store the correction in a `RefCell` on `InflationTermStructureBase` and
  expose `seasonality`, `has_seasonality`, and `set_seasonality`.
* Add `check_seasonality`, moving C++'s constructor-time consistency gate
  out to the concrete curve constructors, and `as_inflation_term_structure`
  so a curve can hand itself to the correction as a trait object.
* Fold the correction into `zero_rate_date` only; the time-taking
  `zero_rate` stays raw, matching C++.

**Curve wiring:**
* Accept a seasonality argument on the interpolated and piecewise zero
  inflation curve constructors and run the gate once the curve exists.
* Override `update_after_seasonality_change` on the piecewise curve to
  invalidate the bootstrap so nodes re-solve against the corrected rates.

**Callers and tests:**
* Thread `None` through every existing curve construction site across the
  crates and the Python bindings.
* Add tests covering the date-query fold, clearing, the consistency gate,
  and the QuantLib phase 3 reprice under a non-unit seasonality.

Closes #729
