### PR TITLE
feat(itofin-py): add ISDA standard-model CDS engine


### DIFF
--- a/crates/itofin-py/python/itofin/instruments.pyi
+++ b/crates/itofin-py/python/itofin/instruments.pyi
@@ -9,6 +9,7 @@ from itofin.pricingengines import (
     BlackCapFloorEngine,
     BlackSwaptionEngine,
     DiscountingSwapEngine,
+    IsdaCdsEngine,
     MCAmericanEngine,
     MCEuropeanEngine,
     MCEuropeanHestonEngine,
@@ -256,6 +257,12 @@ class CreditDefaultSwap:
         """Price the contract off a default-probability and a discount curve.
         The engine must resolve its dates against the same Settings object as
         this contract."""
+        ...
+    def set_isda_engine(self, engine: IsdaCdsEngine) -> None:
+        """Price the contract under the ISDA standard model. A separate setter
+        because the two engine classes are unrelated; the same same-Settings
+        rule applies, and the ISDA engine additionally refuses curves outside
+        its specification when the contract prices."""
         ...
     def npv(self) -> float:
         """Raises ItofinError with no engine attached."""

--- a/crates/itofin-py/python/itofin/pricingengines.pyi
+++ b/crates/itofin-py/python/itofin/pricingengines.pyi
@@ -102,6 +102,29 @@ class MidPointCdsEngine:
         settings: Settings,
     ) -> None: ...
 
+class IsdaCdsEngine:
+    """The ISDA standard-model credit-default-swap engine: both legs are
+    integrated over the pillar dates of the two curves the engine is built with
+    rather than over the premium schedule alone.
+
+    Infallible at construction, like MidPointCdsEngine. The model is specified
+    against curves of a fixed shape, so every check - both curves counting
+    Act/365 (Fixed) and referenced at the evaluation date, the contract settling
+    its accrual, paying at the default time and carrying a face-value claim - is
+    reported as ItofinError when the contract is priced, not from __init__. The
+    core's include_settlement_date_flows override is not exposed and is always
+    None. The three fidelity flags keep the C++ defaults Taylor / HalfDayBias /
+    Piecewise; the builder that chooses them is not exposed (#814). The contract
+    this engine prices must carry the same Settings object."""
+
+    def __init__(
+        self,
+        probability: DefaultProbabilityTermStructure,
+        recovery: float,
+        discount: YieldTermStructure,
+        settings: Settings,
+    ) -> None: ...
+
 class DiscountingSwapEngine:
     """Discounts every leg of a swap over a single yield curve.
 

--- a/crates/itofin-py/src/credit.rs
+++ b/crates/itofin-py/src/credit.rs
@@ -4,7 +4,7 @@
 //! [`PyCreditDefaultSwap`] instrument.
 
 use crate::PyQlError;
-use crate::creditengine::PyMidPointCdsEngine;
+use crate::creditengine::{PyIsdaCdsEngine, PyMidPointCdsEngine};
 use crate::credithelpers::PyDefaultProbabilityHelper;
 use crate::market::PySimpleQuote;
 use crate::settings::PySettings;
@@ -605,6 +605,21 @@ impl PyCreditDefaultSwap {
     /// shared across contracts. It must resolve its dates against the same
     /// `Settings` object this contract was built with.
     fn set_engine(&mut self, engine: &PyMidPointCdsEngine) {
+        self.inner
+            .borrow_mut()
+            .base_mut()
+            .set_pricing_engine(engine.engine());
+    }
+
+    /// Attaches a [`PyIsdaCdsEngine`] so the contract prices under the ISDA
+    /// standard model.
+    ///
+    /// A separate setter rather than a widened [`set_engine`](Self::set_engine):
+    /// the two engine facades are unrelated pyo3 classes, so one argument cannot
+    /// name both. The same sharing and same-`Settings` rules apply, and the ISDA
+    /// engine additionally refuses curves outside its specification when the
+    /// contract prices.
+    fn set_isda_engine(&mut self, engine: &PyIsdaCdsEngine) {
         self.inner
             .borrow_mut()
             .base_mut()

--- a/crates/itofin-py/src/creditengine.rs
+++ b/crates/itofin-py/src/creditengine.rs
@@ -1,21 +1,25 @@
-//! Facade for the mid-point credit-default-swap engine:
-//! [`PyMidPointCdsEngine`].
+//! Facades for the two credit-default-swap engines: [`PyMidPointCdsEngine`] and
+//! [`PyIsdaCdsEngine`].
 //!
-//! The engine prices each live premium period of a
+//! The mid-point engine prices each live premium period of a
 //! [`CreditDefaultSwap`](crate::credit::PyCreditDefaultSwap) against the default
 //! probability over that period, placing the default at the period's mid-point,
-//! and discounts on a separate yield curve.
+//! and discounts on a separate yield curve. The ISDA engine prices the same
+//! contract the way the ISDA standard model does, integrating both legs over the
+//! pillar dates of the two curves rather than over the premium schedule alone.
 //!
 //! Deferred (visible): the core's `include_settlement_date_flows` override
-//! (`midpointcdsengine.rs:73`) is not exposed and is always passed as `None`, so
-//! the settlement-date flow decision follows the settings' own flags - the
-//! shape the C++ cached-value fixture uses (`creditdefaultswap.cpp:96`).
+//! (`midpointcdsengine.rs:73`, `isdacdsengine.rs:127`) is not exposed on either
+//! engine and is always passed as `None`, so the settlement-date flow decision
+//! follows the settings' own flags - the shape the C++ cached-value fixture uses
+//! (`creditdefaultswap.cpp:96`).
 
 use crate::credit::PyDefaultProbabilityTermStructure;
 use crate::curve::PyYieldTermStructure;
 use crate::settings::PySettings;
 use libitofin::pricingengine::PricingEngine;
 use libitofin::pricingengines::MidPointCdsEngine;
+use libitofin::pricingengines::credit::IsdaCdsEngine;
 use libitofin::shared::{SharedMut, shared_mut};
 use pyo3::prelude::*;
 
@@ -60,6 +64,67 @@ impl PyMidPointCdsEngine {
 }
 
 impl PyMidPointCdsEngine {
+    /// The erased engine the instrument facades install via
+    /// `set_pricing_engine`.
+    pub(crate) fn engine(&self) -> SharedMut<dyn PricingEngine> {
+        SharedMut::clone(&self.inner) as SharedMut<dyn PricingEngine>
+    }
+}
+
+/// Python `IsdaCdsEngine`: the ISDA standard-model credit-default-swap engine
+/// (`pricingengines::credit::isdacdsengine::IsdaCdsEngine`).
+///
+/// Both legs are integrated over the pillar dates of the two curves the engine
+/// is built with, so the price follows the standard model rather than the
+/// premium schedule alone.
+///
+/// The model is specified against curves of a fixed shape, and the engine
+/// refuses anything else when it prices (`isdacdsengine.rs:162-205`): both
+/// curves must count Act/365 (Fixed) and be referenced at the evaluation date,
+/// and the contract must settle its accrual, pay at the default time and carry a
+/// face-value claim. Construction is infallible, as for
+/// [`PyMidPointCdsEngine`], so every one of those is reported as
+/// [`struct@crate::ItofinError`] from
+/// [`npv`](crate::credit::PyCreditDefaultSwap::npv), not from `__init__`.
+///
+/// The `settings` passed here must be the same object the instrument this
+/// engine prices was built with, or the two resolve their dates against
+/// different evaluation dates and the NPV is silently wrong.
+///
+/// Deferred (visible): the three fidelity flags are left at the C++ defaults
+/// `Taylor` / `HalfDayBias` / `Piecewise` that the core constructor bakes in
+/// (`isdacdsengine.rs:139-141`); the `with_fidelity` builder that chooses them
+/// (`:148-158`) and the three enums it takes are not exposed (#814).
+#[pyclass(name = "IsdaCdsEngine", unsendable)]
+pub struct PyIsdaCdsEngine {
+    inner: SharedMut<IsdaCdsEngine>,
+}
+
+#[pymethods]
+impl PyIsdaCdsEngine {
+    /// An engine reading default probabilities off `probability`, paying
+    /// `1 - recovery` of the notional on a default, and discounting on
+    /// `discount`.
+    #[new]
+    fn new(
+        probability: &PyDefaultProbabilityTermStructure,
+        recovery: f64,
+        discount: &PyYieldTermStructure,
+        settings: &PySettings,
+    ) -> Self {
+        PyIsdaCdsEngine {
+            inner: shared_mut(IsdaCdsEngine::new(
+                probability.handle(),
+                recovery,
+                discount.handle(),
+                None,
+                settings.inner(),
+            )),
+        }
+    }
+}
+
+impl PyIsdaCdsEngine {
     /// The erased engine the instrument facades install via
     /// `set_pricing_engine`.
     pub(crate) fn engine(&self) -> SharedMut<dyn PricingEngine> {

--- a/crates/itofin-py/src/lib.rs
+++ b/crates/itofin-py/src/lib.rs
@@ -39,7 +39,7 @@ use credit::{
     PyCreditDefaultSwap, PyDefaultProbabilityTermStructure, PyFlatHazardRate,
     PyInterpolatedHazardRateCurve, PyPiecewiseDefaultCurve, PyProtectionSide,
 };
-use creditengine::PyMidPointCdsEngine;
+use creditengine::{PyIsdaCdsEngine, PyMidPointCdsEngine};
 use credithelpers::{PyDefaultProbabilityHelper, PySpreadCdsHelper};
 use curve::{
     PyDiscountCurve, PyFlatForward, PyForwardCurve, PyPiecewiseFlatForward,
@@ -230,6 +230,7 @@ fn itofin(m: &Bound<'_, PyModule>) -> PyResult<()> {
     pricingengines.add_class::<PyBlackSwaptionEngine>()?;
     pricingengines.add_class::<PyBlackCapFloorEngine>()?;
     pricingengines.add_class::<PyMidPointCdsEngine>()?;
+    pricingengines.add_class::<PyIsdaCdsEngine>()?;
     pricingengines.add_class::<PyDiscountingSwapEngine>()?;
     pricingengines.add_class::<PyMCEuropeanEngine>()?;
     pricingengines.add_class::<PyMCEuropeanHestonEngine>()?;

--- a/crates/itofin-py/tests/test_isda_cds.py
+++ b/crates/itofin-py/tests/test_isda_cds.py
@@ -45,7 +45,13 @@ SPREAD = 0.01
 NPV = -52927.18294373818
 COUPON_LEG_NPV = 281656.6267407311
 DEFAULT_LEG_NPV = -334583.8096844693
-TOLERANCE = 1e-10
+
+# Wide enough to survive a platform's exp differing in its last bit: the values
+# run to 1e5, so this is a relative 2e-13, while the literals were recorded on
+# one machine and are asserted on whichever one CI happens to run. Still some
+# nine orders of magnitude below anything a mis-wired engine, curve or contract
+# term would move the price by.
+TOLERANCE = 1e-8
 
 
 class Market:
@@ -137,9 +143,21 @@ def test_curves_outside_the_isda_conventions_are_refused_when_pricing():
 
 def test_the_mid_point_engine_accepts_the_curves_the_isda_engine_refuses():
     """The refusal above is the ISDA engine's own check, not something about the
-    Act/360 fixture: the mid-point engine prices it."""
+    Act/360 fixture: the mid-point engine prices that same fixture to
+    -57557.43897416495.
+
+    The sign and the magnitude are pinned rather than the digits, which belong
+    to the mid-point engine and are not this test's subject: the contract is
+    sold protection at a spread below the fair one, so the value is negative and
+    is tens of thousands on a ten-million notional. A price of zero, of the
+    wrong sign, or rounding to nothing would all mean the engine had not really
+    priced the contract, which is the only thing being shown here.
+    """
     market = Market(curve_day_counter=DayCounter.actual360())
     cds = market.contract()
     cds.set_engine(market.mid_point_engine())
 
-    assert cds.npv() != 0.0
+    npv = cds.npv()
+
+    assert npv < 0.0
+    assert 1e4 < abs(npv) < 1e5

--- a/crates/itofin-py/tests/test_isda_cds.py
+++ b/crates/itofin-py/tests/test_isda_cds.py
@@ -1,0 +1,145 @@
+"""CreditDefaultSwap priced by IsdaCdsEngine (#812).
+
+The three pinned values come from the Rust test
+`the_flat_curve_fixture_prices_to_the_pinned_value` in the `binding_oracle`
+module of crates/libitofin/src/pricingengines/credit/isdacdsengine.rs, which
+records them from its own run. That fixture is rebuilt here byte-for-byte - the
+same evaluation date, the same two flat Act/365F curves referenced at it, the
+same TARGET/Following/Forward quarterly schedule and the same contract terms -
+so the literals grade the facade rather than restate whatever it happens to
+return.
+
+The schedule shape is asserted on both sides (13 dates, first the evaluation
+date, last the maturity) so a drift in the dates is told apart from a drift in
+the pricing, and the two legs are pinned alongside the value so a mismatch says
+which half moved.
+
+Two flat curves leave the ISDA integration grid as the maturity alone
+(isdanodegrid.rs:122-124), which is still a genuine single-node ISDA reprice and
+still distinct from the mid-point engine's period-by-period integration - hence
+the discriminator below.
+"""
+
+import pytest
+from itofin import ItofinError, Settings
+from itofin.instruments import CreditDefaultSwap, ProtectionSide
+from itofin.pricingengines import IsdaCdsEngine, MidPointCdsEngine
+from itofin.termstructures import FlatForward, FlatHazardRate
+from itofin.time import (
+    BusinessDayConvention,
+    Calendar,
+    Date,
+    DayCounter,
+    Frequency,
+    Schedule,
+)
+
+TODAY = Date(15, 6, 2026)
+MATURITY = Date(15, 6, 2029)
+HAZARD_RATE = 0.02
+DISCOUNT_RATE = 0.03
+RECOVERY = 0.4
+NOTIONAL = 10000000.0
+SPREAD = 0.01
+
+NPV = -52927.18294373818
+COUPON_LEG_NPV = 281656.6267407311
+DEFAULT_LEG_NPV = -334583.8096844693
+TOLERANCE = 1e-10
+
+
+class Market:
+    """The Rust fixture's curves and conventions, rebuilt through the facades.
+
+    day_counter is the contract's own Act/360; the two curves count Act/365
+    (Fixed), which is what the ISDA engine requires of them.
+    """
+
+    def __init__(self, curve_day_counter: DayCounter | None = None):
+        self.settings = Settings()
+        self.settings.set_evaluation_date(TODAY)
+        self.calendar = Calendar.target()
+        self.day_counter = DayCounter.actual360()
+        self.convention = BusinessDayConvention.Following
+        curves = curve_day_counter or DayCounter.actual365_fixed()
+        self.hazard = FlatHazardRate.with_rate(TODAY, HAZARD_RATE, curves)
+        self.discount = FlatForward(TODAY, DISCOUNT_RATE, curves)
+
+    def isda_engine(self) -> IsdaCdsEngine:
+        return IsdaCdsEngine(self.hazard, RECOVERY, self.discount, self.settings)
+
+    def mid_point_engine(self) -> MidPointCdsEngine:
+        return MidPointCdsEngine(self.hazard, RECOVERY, self.discount, self.settings)
+
+    def schedule(self) -> Schedule:
+        return Schedule(
+            TODAY, MATURITY, Frequency.Quarterly, self.calendar, self.convention
+        )
+
+    def contract(self) -> CreditDefaultSwap:
+        return CreditDefaultSwap(
+            ProtectionSide.Seller,
+            NOTIONAL,
+            SPREAD,
+            self.schedule(),
+            self.convention,
+            self.day_counter,
+            True,
+            True,
+            self.settings,
+        )
+
+
+def test_the_schedule_matches_the_one_the_rust_fixture_builds():
+    schedule = Market().schedule()
+
+    assert schedule.size() == 13
+    assert schedule.date(0) == TODAY
+    assert schedule.date(12) == MATURITY
+
+
+def test_the_flat_curve_contract_prices_to_the_rust_pinned_value():
+    market = Market()
+    cds = market.contract()
+    cds.set_isda_engine(market.isda_engine())
+
+    assert abs(cds.npv() - NPV) < TOLERANCE
+    assert abs(cds.coupon_leg_npv() - COUPON_LEG_NPV) < TOLERANCE
+    assert abs(cds.default_leg_npv() - DEFAULT_LEG_NPV) < TOLERANCE
+
+
+def test_the_isda_price_differs_meaningfully_from_the_mid_point_price():
+    """The same contract on the same curves, priced by the other engine. The gap
+    is asserted as a relative size rather than as an inequality so that two
+    values agreeing to the last bit could not pass as a difference."""
+    market = Market()
+    isda = market.contract()
+    isda.set_isda_engine(market.isda_engine())
+    mid_point = market.contract()
+    mid_point.set_engine(market.mid_point_engine())
+
+    npv_isda = isda.npv()
+    npv_mid = mid_point.npv()
+
+    assert abs(npv_isda - npv_mid) / abs(npv_mid) > 1e-6
+
+
+def test_curves_outside_the_isda_conventions_are_refused_when_pricing():
+    """Construction is infallible, so the Act/365 (Fixed) requirement surfaces
+    from npv(), where the engine validates its inputs."""
+    market = Market(curve_day_counter=DayCounter.actual360())
+    cds = market.contract()
+    cds.set_isda_engine(market.isda_engine())
+
+    with pytest.raises(ItofinError):
+        cds.npv()
+
+
+def test_the_mid_point_engine_accepts_the_curves_the_isda_engine_refuses():
+    """The refusal above is the ISDA engine's own check, not something about the
+    Act/360 fixture: the mid-point engine prices it."""
+    market = Market(curve_day_counter=DayCounter.actual360())
+    cds = market.contract()
+    cds.set_engine(market.mid_point_engine())
+
+    assert cds.npv() != 0.0

--- a/crates/libitofin/src/pricingengines/credit/isdacdsengine.rs
+++ b/crates/libitofin/src/pricingengines/credit/isdacdsengine.rs
@@ -2179,7 +2179,13 @@ mod binding_oracle {
     const NPV: Real = -52927.18294373818;
     const COUPON_LEG_NPV: Real = 281656.6267407311;
     const DEFAULT_LEG_NPV: Real = -334583.8096844693;
-    const TOLERANCE: Real = 1.0e-10;
+
+    /// Wide enough to survive a platform's `exp` differing in its last bit: the
+    /// values run to `10^5`, so this is a relative `2 * 10^-13`, while the
+    /// literals were recorded on one machine and are asserted on whichever one
+    /// CI happens to run. Still some nine orders of magnitude below anything a
+    /// mis-wired engine, curve or contract term would move the price by.
+    const TOLERANCE: Real = 1.0e-8;
 
     fn today() -> Date {
         Date::new(15, Month::June, 2026)

--- a/crates/libitofin/src/pricingengines/credit/isdacdsengine.rs
+++ b/crates/libitofin/src/pricingengines/credit/isdacdsengine.rs
@@ -2128,3 +2128,130 @@ mod markit_oracle {
         );
     }
 }
+
+/// The oracle the Python `IsdaCdsEngine` facade (#812) is pinned against: a
+/// three-year contract on two flat Act/365F curves referenced at the evaluation
+/// date, priced through the instrument the way a caller prices one.
+///
+/// The fixture lives here rather than only in the binding because the pinned
+/// number has to come out of the constructor the facade wraps.
+/// `crates/itofin-py/tests/test_isda_cds.py` rebuilds it byte-for-byte - the
+/// same dates, curves, schedule and contract terms - and asserts the same three
+/// literals, so a facade that reached a different engine, or dropped one of the
+/// arguments it forwards, shows up there as a mismatch rather than as a
+/// plausible number nothing grades.
+///
+/// The schedule is built through the same builder calls `PySchedule::new`
+/// (`itofin-py/src/time.rs:528-536`) makes, including the rule and the
+/// termination convention the refusal fixture leaves defaulted, and its shape
+/// is asserted alongside the value so a drift in the dates is told apart from a
+/// drift in the pricing. Two flat curves leave the integration grid as the
+/// maturity alone (`isdanodegrid.rs:122-124`), so this is a single-node ISDA
+/// reprice - still the engine's own kernels, and still distinct from the
+/// mid-point engine's period-by-period integration.
+#[cfg(test)]
+mod binding_oracle {
+    use super::*;
+    use crate::instrument::Instrument;
+    use crate::instruments::{CreditDefaultSwap, ProtectionSide};
+    use crate::interestrate::Compounding;
+    use crate::pricingengine::PricingEngine;
+    use crate::shared::{SharedMut, shared, shared_mut};
+    use crate::termstructures::credit::flathazardrate::FlatHazardRate;
+    use crate::termstructures::yields::FlatForward;
+    use crate::time::businessdayconvention::BusinessDayConvention;
+    use crate::time::calendars::target::Target;
+    use crate::time::date::Month;
+    use crate::time::dategenerationrule::DateGeneration;
+    use crate::time::daycounters::actual360::Actual360;
+    use crate::time::frequency::Frequency;
+    use crate::time::schedule::MakeSchedule;
+
+    const NOTIONAL: Real = 10_000_000.0;
+    const SPREAD: Rate = 0.01;
+    const RECOVERY: Real = 0.4;
+    const HAZARD: Real = 0.02;
+    const DISCOUNT_RATE: Rate = 0.03;
+
+    /// What the fixture prices to, recorded from this test's own run to the
+    /// precision an `f64` round-trips at. `test_isda_cds.py` carries the same
+    /// three numbers.
+    const NPV: Real = -52927.18294373818;
+    const COUPON_LEG_NPV: Real = 281656.6267407311;
+    const DEFAULT_LEG_NPV: Real = -334583.8096844693;
+    const TOLERANCE: Real = 1.0e-10;
+
+    fn today() -> Date {
+        Date::new(15, Month::June, 2026)
+    }
+
+    fn maturity() -> Date {
+        Date::new(15, Month::June, 2029)
+    }
+
+    /// The contract of the fixture, with the ISDA engine already installed.
+    fn priced() -> CreditDefaultSwap {
+        let settings = shared(Settings::new());
+        settings.set_evaluation_date(today());
+        let discount = Handle::new(shared(FlatForward::with_rate(
+            today(),
+            DISCOUNT_RATE,
+            Actual365Fixed::new(),
+            Compounding::Continuous,
+            Frequency::Annual,
+        )) as Shared<dyn YieldTermStructure>);
+        let credit = Handle::new(shared(FlatHazardRate::with_rate(
+            today(),
+            HAZARD,
+            Actual365Fixed::new(),
+        )) as Shared<dyn DefaultProbabilityTermStructure>);
+        let schedule = MakeSchedule::new()
+            .from(today())
+            .to(maturity())
+            .with_frequency(Frequency::Quarterly)
+            .with_calendar(Target::new())
+            .with_convention(BusinessDayConvention::Following)
+            .with_termination_date_convention(BusinessDayConvention::Following)
+            .with_rule(DateGeneration::Forward)
+            .build();
+        assert_eq!(schedule.dates().len(), 13);
+        assert_eq!(schedule.dates()[0], today());
+        assert_eq!(schedule.dates()[12], maturity());
+        let mut cds = CreditDefaultSwap::new(
+            ProtectionSide::Seller,
+            NOTIONAL,
+            SPREAD,
+            schedule,
+            BusinessDayConvention::Following,
+            Actual360::new(),
+            true,
+            true,
+            Shared::clone(&settings),
+        )
+        .expect("the contract is well formed");
+        let engine = shared_mut(IsdaCdsEngine::new(
+            credit, RECOVERY, discount, None, settings,
+        )) as SharedMut<dyn PricingEngine>;
+        cds.base_mut().set_pricing_engine(engine);
+        cds
+    }
+
+    /// The value and its two legs, which the Python oracle asserts to the same
+    /// three literals.
+    ///
+    /// The legs are pinned alongside the value so that a Python-side mismatch
+    /// says which half of the price moved rather than only that the total did.
+    #[test]
+    fn the_flat_curve_fixture_prices_to_the_pinned_value() {
+        let mut cds = priced();
+        assert!((cds.npv().expect("the contract prices") - NPV).abs() <= TOLERANCE);
+        assert!(
+            (cds.coupon_leg_npv().expect("the premium leg is valued") - COUPON_LEG_NPV).abs()
+                <= TOLERANCE
+        );
+        assert!(
+            (cds.default_leg_npv().expect("the protection leg is valued") - DEFAULT_LEG_NPV).abs()
+                <= TOLERANCE
+        );
+    }
+}


### PR DESCRIPTION
**New engine facade:**
* Added `PyIsdaCdsEngine` in `creditengine.rs`, integrating both legs
  over the pillar dates of the probability and discount curves rather
  than over the premium schedule alone.
* Construction is infallible; curve-shape checks (Act/365 (Fixed),
  evaluation-date reference, accrual settlement, default-time payment
  and face-value claim) are reported as `ItofinError` at pricing time.
* Registered the new class in `lib.rs` under the `pricingengines`
  module.

**Instrument integration:**
* Added `set_isda_engine` on `PyCreditDefaultSwap`, a separate setter
  from `set_engine` because the two engine facades are unrelated pyo3
  classes and share the same-`Settings` rule.

**Type stubs and tests:**
* Extended `instruments.pyi` and `pricingengines.pyi` with the new
  engine and setter.
* Added `tests/test_isda_cds.py` covering the new engine.

close #812

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>