### PR TITLE
test(crates): reprice ZC inflation swaps under seasonality correction


### DIFF
--- a/crates/itofin-py/python/itofin/termstructures.pyi
+++ b/crates/itofin-py/python/itofin/termstructures.pyi
@@ -924,20 +924,69 @@ class PiecewiseDefaultCurve(DefaultProbabilityTermStructure):
     def data(self) -> list[float]: ...
     def nodes(self) -> list[tuple[Date, float]]: ...
 
+class MultiplicativePriceSeasonality:
+    """The seasonal correction a price index carries, whose factors multiply
+    the index level itself.
+
+    The factors are given in whole multiples of the count the frequency
+    dictates - twelve for Frequency.Monthly - and are reused as long as needed,
+    so twelve of them are stationary and twenty-four repeat every two years.
+    They are not applied raw: the factor at the queried date is normalized
+    against the one at a reference date, which for a zero rate is the curve's
+    own base date, so the correction is the identity there.
+
+    Install it with ZeroInflationTermStructure.set_seasonality. Only the
+    date-taking rate query folds the correction in; the year-fraction one
+    cannot, a time not naming the date the factors are a function of."""
+
+    def __init__(
+        self,
+        seasonality_base_date: Date,
+        frequency: Frequency,
+        seasonality_factors: list[float],
+    ) -> None:
+        """Raises ItofinError on a frequency outside semiannual-through-daily
+        (Frequency.Annual among them), an empty factor set, or a factor count
+        that is not a whole multiple of the frequency."""
+        ...
+    def seasonality_base_date(self) -> Date: ...
+    def frequency(self) -> Frequency: ...
+    def seasonality_factors(self) -> list[float]: ...
+    def seasonality_factor(self, to: Date) -> float:
+        """The raw factor covering `to`, before any normalization against a
+        reference date - not the correction the curve applies. The offset is
+        counted in whole factor periods from the seasonality base date and
+        wraps modulo the factor count, in both directions."""
+        ...
+
 class ZeroInflationTermStructure:
     """Shared base for every zero-coupon inflation curve: the zero-coupon
-    inflation rate in a year-fraction and a date form, plus the base date and
-    the fixing frequency.
+    inflation rate in a year-fraction and a date form, the base date, the
+    fixing frequency and the seasonality correction the curve carries.
 
     The two rate reads are not interchangeable. zero_rate_date snaps its date
     to the start of the inflation period containing it, because a fixing
     applies to a whole period; zero_rate takes a year-fraction already measured
-    under the curve's own day counter and quantizes nothing."""
+    under the curve's own day counter and quantizes nothing. Only the first
+    folds in any seasonality."""
 
     def zero_rate(self, t: float, extrapolate: bool = False) -> float: ...
     def zero_rate_date(self, date: Date, extrapolate: bool = False) -> float: ...
     def base_date(self) -> Date: ...
     def frequency(self) -> Frequency: ...
+    def set_seasonality(
+        self, seasonality: MultiplicativePriceSeasonality | None
+    ) -> None:
+        """Installs seasonality on the curve, replacing whatever it carried;
+        None clears it. A bootstrapped curve is invalidated here, so the next
+        read re-solves against the new correction.
+
+        Raises ItofinError from the consistency gate, which a multi-year factor
+        set fails (a documented core deferral, #807). The store happens before
+        the gate runs, as C++'s does, so a rejected correction is left
+        installed - clear it with None before reading the curve again."""
+        ...
+    def has_seasonality(self) -> bool: ...
 
 class InterpolatedZeroInflationCurve(ZeroInflationTermStructure):
     """A zero-coupon inflation curve built from (date, zero-rate) nodes,

--- a/crates/itofin-py/src/inflation.rs
+++ b/crates/itofin-py/src/inflation.rs
@@ -2,8 +2,9 @@
 //! inflation swap prices through, the [`PyCpiInterpolationType`] observation
 //! flag, the [`PyZeroInflationIndex`] family, the
 //! [`PyZeroInflationTermStructure`] curve hierarchy, the
-//! [`PyZeroInflationHelper`] bootstrap helpers that fit its piecewise member and
-//! the [`PyZeroCouponInflationSwap`] the rest of them price together.
+//! [`PyMultiplicativePriceSeasonality`] correction any of its curves can carry,
+//! the [`PyZeroInflationHelper`] bootstrap helpers that fit its piecewise member
+//! and the [`PyZeroCouponInflationSwap`] the rest of them price together.
 //!
 //! The swap engine is generic rather than inflation-specific - it prices any
 //! swap - but is homed here because the inflation tickets are the first to need
@@ -34,6 +35,9 @@ use libitofin::termstructures::inflation::inflationhelpers::{
 use libitofin::termstructures::inflation::inflationtermstructure::ZeroInflationTermStructure;
 use libitofin::termstructures::inflation::interpolatedzeroinflationcurve::InterpolatedZeroInflationCurve;
 use libitofin::termstructures::inflation::piecewisezeroinflationcurve::PiecewiseZeroInflationCurve;
+use libitofin::termstructures::inflation::seasonality::{
+    MultiplicativePriceSeasonality, Seasonality,
+};
 use pyo3::prelude::*;
 
 /// Python `DiscountingSwapEngine`: discounts each leg of a swap over a single
@@ -251,6 +255,101 @@ impl PyZeroInflationIndex {
     }
 }
 
+/// Python `MultiplicativePriceSeasonality`: the seasonal correction a price
+/// index carries, whose factors multiply the index level itself
+/// (`termstructures::inflation::seasonality::MultiplicativePriceSeasonality`).
+///
+/// Seasonality fills an inflation curve in between the integer-year maturities
+/// the market quotes. The factors are given in whole multiples of the count the
+/// frequency dictates - twelve for [`Frequency.Monthly`](crate::time::PyFrequency)
+/// - and are reused as long as needed, so twelve of them are stationary and
+/// twenty-four repeat every two years. They are not applied raw: the factor at
+/// the queried date is normalized against the one at a reference date, which for
+/// a zero rate is the curve's own base date, so the correction is the identity
+/// there.
+///
+/// Install it with
+/// [`ZeroInflationTermStructure.set_seasonality`](PyZeroInflationTermStructure::set_seasonality).
+/// Only the date-taking rate query folds the correction in; the year-fraction
+/// one cannot, a time not naming the date the factors are a function of.
+///
+/// Fallible at construction: the core rejects a frequency outside
+/// semiannual-through-daily - `Frequency.Annual` among them - an empty factor
+/// set, and a factor count that is not a whole multiple of the frequency, each
+/// as [`struct@crate::ItofinError`].
+///
+/// Deferred (visible): the core's `set`, which replaces the whole
+/// specification in place, is not exposed - building a new object and
+/// installing it says the same thing without a second mutation path. The core's
+/// `is_consistent` is not exposed either: it is what `set_seasonality` runs as
+/// its gate, and is reported from there.
+#[pyclass(name = "MultiplicativePriceSeasonality", unsendable)]
+pub struct PyMultiplicativePriceSeasonality {
+    inner: Shared<MultiplicativePriceSeasonality>,
+}
+
+#[pymethods]
+impl PyMultiplicativePriceSeasonality {
+    /// The seasonality whose `seasonality_factors` start at
+    /// `seasonality_base_date` and step at `frequency`.
+    #[new]
+    fn new(
+        seasonality_base_date: &PyDate,
+        frequency: &PyFrequency,
+        seasonality_factors: Vec<f64>,
+    ) -> PyResult<Self> {
+        Ok(PyMultiplicativePriceSeasonality {
+            inner: shared(
+                MultiplicativePriceSeasonality::new(
+                    seasonality_base_date.inner(),
+                    frequency.inner(),
+                    seasonality_factors,
+                )
+                .map_err(PyQlError::from)?,
+            ),
+        })
+    }
+
+    /// The date the factor set is anchored on.
+    fn seasonality_base_date(&self) -> PyDate {
+        PyDate::from_inner(self.inner.seasonality_base_date())
+    }
+
+    /// The frequency the factors step at.
+    fn frequency(&self) -> PyResult<PyFrequency> {
+        PyFrequency::from_inner(self.inner.frequency())
+    }
+
+    /// The factors, in order from the seasonality base date.
+    fn seasonality_factors(&self) -> Vec<f64> {
+        self.inner.seasonality_factors().to_vec()
+    }
+
+    /// The raw factor covering `to`, before any normalization against a
+    /// reference date - not the correction the curve applies.
+    ///
+    /// The offset from the seasonality base date is counted in whole factor
+    /// periods and wrapped modulo the factor count, so a set shorter than the
+    /// span repeats and dates before the anchor wrap backwards.
+    ///
+    /// # Errors
+    ///
+    /// Reports a year-based factor period, which cannot express seasonality.
+    fn seasonality_factor(&self, to: &PyDate) -> PyResult<f64> {
+        Ok(self
+            .inner
+            .seasonality_factor(to.inner())
+            .map_err(PyQlError::from)?)
+    }
+}
+
+impl PyMultiplicativePriceSeasonality {
+    /// The upcast correction, for the curve facade that installs one.
+    pub(crate) fn shared(&self) -> Shared<dyn Seasonality> {
+        Shared::clone(&self.inner) as Shared<dyn Seasonality>
+    }
+}
+
 /// Python `ZeroInflationTermStructure`: the shared base for every zero-coupon
 /// inflation curve (`termstructures::inflation::inflationtermstructure`).
 ///
@@ -268,10 +367,21 @@ impl PyZeroInflationIndex {
 /// quantizes nothing. A mid-period date therefore reads that period's rate
 /// through the first and an interpolated one through the second.
 ///
+/// [`set_seasonality`](Self::set_seasonality) lives here rather than on either
+/// concrete curve: it is an `InflationTermStructure` method reached through the
+/// erased handle, and the handle holds the very object the subclass wraps, so
+/// the one method serves both.
+///
 /// Deferred (visible): `base_rate()` is not exposed. A zero curve carries no
 /// base rate, so the core accessor is an error on every curve reachable here
 /// (`inflationtermstructure.rs:159-166`); it follows with the year-on-year
-/// structures that do carry one.
+/// structures that do carry one. The core's `seasonality()` getter is omitted
+/// too: it hands back an erased `Shared<dyn Seasonality>`, and the trait carries
+/// no downcast surface to recover the concrete
+/// [`PyMultiplicativePriceSeasonality`] from, so the getter could only return
+/// something lossy. [`has_seasonality`](Self::has_seasonality) answers the
+/// question the fixtures ask, and the caller already holds the object it
+/// installed.
 #[pyclass(name = "ZeroInflationTermStructure", subclass, unsendable)]
 pub struct PyZeroInflationTermStructure {
     inner: Handle<dyn ZeroInflationTermStructure>,
@@ -331,6 +441,43 @@ impl PyZeroInflationTermStructure {
                 .frequency(),
         )
     }
+
+    /// Installs `seasonality` on the curve, replacing whatever it carried;
+    /// `None` clears it.
+    ///
+    /// A curve that caches anything derived from the correction - every
+    /// bootstrapped one does - is invalidated here, so the next read re-solves
+    /// against the new correction.
+    ///
+    /// # Errors
+    ///
+    /// Reports the consistency gate, which a multi-year factor set fails: the
+    /// whole-year comparison deciding those is a documented core deferral
+    /// (#807). The store happens *before* the gate runs, as C++'s does, so a
+    /// rejected correction is left installed and unannounced - clear it with
+    /// `None` before reading the curve again.
+    #[pyo3(signature = (seasonality))]
+    fn set_seasonality(
+        &self,
+        seasonality: Option<&PyMultiplicativePriceSeasonality>,
+    ) -> PyResult<()> {
+        Ok(self
+            .inner
+            .current_link()
+            .map_err(PyQlError::from)?
+            .set_seasonality(seasonality.map(PyMultiplicativePriceSeasonality::shared))
+            .map_err(PyQlError::from)?)
+    }
+
+    /// Whether the curve carries a seasonality correction. Reports one left
+    /// installed by a [`set_seasonality`](Self::set_seasonality) that raised.
+    fn has_seasonality(&self) -> PyResult<bool> {
+        Ok(self
+            .inner
+            .current_link()
+            .map_err(PyQlError::from)?
+            .has_seasonality())
+    }
 }
 
 impl PyZeroInflationTermStructure {
@@ -372,8 +519,7 @@ impl PyZeroInflationTermStructure {
 /// so no interpolation argument is offered.
 ///
 /// Deferred (visible): the core's `rates()` / `data()` inspectors are omitted,
-/// both being the rate half of [`nodes`](Self::nodes); and the curve carries no
-/// seasonality, which the core does not port either.
+/// both being the rate half of [`nodes`](Self::nodes).
 #[pyclass(
     name = "InterpolatedZeroInflationCurve",
     extends = PyZeroInflationTermStructure,
@@ -631,11 +777,15 @@ impl PyZeroCouponInflationSwapHelper {
 /// constructs (`piecewisezeroinflationcurve.rs:105-125`), so no interpolation
 /// argument is offered.
 ///
+/// A seasonality installed through
+/// [`set_seasonality`](PyZeroInflationTermStructure::set_seasonality)
+/// invalidates the bootstrap, so the next read re-solves every node against the
+/// correction and the quoted swaps still reprice to nothing.
+///
 /// Deferred (visible): the core's `data()` inspector is omitted, being the rate
 /// half of [`nodes`](Self::nodes) - the choice
 /// [`PyInterpolatedZeroInflationCurve`] already made on this side, where the
-/// credit curve exposes both. Seasonality is omitted with the core, which does
-/// not port it either.
+/// credit curve exposes both.
 #[pyclass(
     name = "PiecewiseZeroInflationCurve",
     extends = PyZeroInflationTermStructure,

--- a/crates/itofin-py/src/lib.rs
+++ b/crates/itofin-py/src/lib.rs
@@ -54,8 +54,9 @@ use heston::{PyHestonModel, PyHestonModelHelper, PyHestonProcess};
 use hullwhite::{PyEuribor, PyHullWhite, PySwaptionHelper};
 use inflation::{
     PyCpiInterpolationType, PyDiscountingSwapEngine, PyInterpolatedZeroInflationCurve,
-    PyPiecewiseZeroInflationCurve, PyZeroCouponInflationSwap, PyZeroCouponInflationSwapHelper,
-    PyZeroInflationHelper, PyZeroInflationIndex, PyZeroInflationTermStructure,
+    PyMultiplicativePriceSeasonality, PyPiecewiseZeroInflationCurve, PyZeroCouponInflationSwap,
+    PyZeroCouponInflationSwapHelper, PyZeroInflationHelper, PyZeroInflationIndex,
+    PyZeroInflationTermStructure,
 };
 use libitofin::errors::QlError;
 use market::{PyBlackScholesProcess, PySimpleQuote};
@@ -190,6 +191,7 @@ fn itofin(m: &Bound<'_, PyModule>) -> PyResult<()> {
     termstructures.add_class::<PyZeroInflationHelper>()?;
     termstructures.add_class::<PyZeroCouponInflationSwapHelper>()?;
     termstructures.add_class::<PyPiecewiseZeroInflationCurve>()?;
+    termstructures.add_class::<PyMultiplicativePriceSeasonality>()?;
 
     let processes = PyModule::new(py, "processes")?;
     processes.add_class::<PyBlackScholesProcess>()?;

--- a/crates/itofin-py/tests/test_zc_inflation_reprice.py
+++ b/crates/itofin-py/tests/test_zc_inflation_reprice.py
@@ -15,11 +15,15 @@ and every forecast compounds off its 207.3. Fourteen swap rates are quoted out
 to 2057 under a three-month observation lag, flat CPI observation, UK
 settlement calendar and Thirty360 BondBasis throughout.
 
-Omitted visibly: phase 2 (`:822`), where the index forecasting off the
+Phase 3 (#813), the seasonality rerun, follows below: the same fourteen swaps
+still reprice to nothing once a twelve-factor monthly correction is installed on
+the bootstrapped curve, and the forecast the swaps reach it through demonstrably
+moves.
+
+Omitted visibly: phase 2 (`:913`), where the index forecasting off the
 bootstrapped curve is checked against the curve's own compounded zero rate, is
 left on the Rust side. It exercises no facade this file does not already build,
-and the ticket scopes it out. Phase 3, the seasonality rerun, is a documented
-deferral of the port itself and exists on neither side.
+and the ticket scopes it out.
 
 What the guards do and do not cover. Thirty-one hand-typed floats are the
 largest silent-failure surface here, and a green milestone does not vindicate
@@ -29,13 +33,16 @@ observation reads from history, and July 2007, which the forecast compounds off
 covered by count alone.
 """
 
-from itofin import Settings
+import pytest
+
+from itofin import ItofinError, Settings
 from itofin.indexes import CpiInterpolationType, ZeroInflationIndex
 from itofin.instruments import SwapType, ZeroCouponInflationSwap
 from itofin.pricingengines import DiscountingSwapEngine
 from itofin.quotes import SimpleQuote
 from itofin.termstructures import (
     FlatForward,
+    MultiplicativePriceSeasonality,
     PiecewiseZeroInflationCurve,
     ZeroCouponInflationSwapHelper,
 )
@@ -83,6 +90,18 @@ ZC_DATA = [
 ]
 
 LOAD_BEARING_FIXINGS = [(Date(1, 5, 2007), 205.4), (CURVE_BASE, 207.3)]
+
+SEASONALITY_FACTORS = [
+    1.003245, 1.000000, 0.999715, 1.000495, 1.000929, 0.998687,
+    0.995949, 0.994682, 0.995949, 1.000519, 1.003705, 1.004186,
+]
+
+SEASONALITY_ANCHOR = Date(31, 1, 2007)
+SEASONALITY_PROBE = Date(1, 8, 2012)
+FORECAST_RAW = 239.95839754779345
+FORECAST_CORRECTED = 238.4450543710035
+FORECAST_MATCH = 1e-10
+RATE_MOVE = 1e-4
 
 
 def _fixing_date(i: int) -> Date:
@@ -188,6 +207,27 @@ def _a_swap(
     return swap
 
 
+def _a_seasonality(factors: list[float] = None) -> MultiplicativePriceSeasonality:
+    """The twelve monthly factors phase 3 installs (`inflation.cpp:469-483`).
+
+    The anchor is 31 January of the year the curve's base period ends in
+    (`:467-468`). The base date is 1 July 2007 and a monthly inflation period
+    runs to the month's end, so that year is 2007; the Rust fixture derives it
+    with `inflation_period`, which is not exposed here, and
+    test_the_transcribed_fixture_is_the_one_the_oracle_runs pins the base date
+    the derivation starts from.
+
+    The anchor is not discriminated by the numbers below: the factor lookup
+    wraps modulo the factor count, so shifting a stationary twelve-factor set by
+    a whole year picks the very same factors. It is pinned by derivation alone.
+    """
+    return MultiplicativePriceSeasonality(
+        SEASONALITY_ANCHOR,
+        Frequency.Monthly,
+        SEASONALITY_FACTORS if factors is None else factors,
+    )
+
+
 def test_the_transcribed_fixture_is_the_one_the_oracle_runs():
     """The transcription guards. The counts pin the two hand-typed tables, the
     base date pins where the last figure's period falls, and the two figures the
@@ -258,3 +298,74 @@ def test_the_bootstrapped_curve_reprices_the_quoted_swaps_to_zero():
     print(f"NPV by maturity = {npv_by_maturity}")
     assert worst_npv < EPS
     assert worst_bps < EPS
+
+
+def test_a_seasonality_moves_the_forecast_and_the_curve_reprices_the_swaps_again():
+    """Phase 3. Reprice-to-zero alone would be a false pass here: if the
+    correction were stored but never folded into the published rate, the
+    re-bootstrap would hit the very same nodes off the very same quotes and
+    every swap would still come back worth nothing.
+
+    So the discriminator comes first. The index's own forecast - the path every
+    helper and every swap reaches the curve through - is required to move, and
+    to move to the level the Rust oracle measures over this identical fixture
+    (`piecewisezeroinflationcurve.rs:878`, which prints 239.95839754779345 ->
+    238.4450543710035 at this same date). Clearing the correction has to put the
+    raw forecast back. The reprice loop then covers the other half: with the
+    correction live, only a bootstrap that re-solved against it returns to zero.
+    """
+    settings = _settings()
+    index = _index(settings)
+    curve = _bootstrapped(settings, index)
+
+    assert not curve.has_seasonality()
+    raw_forecast = index.fixing(SEASONALITY_PROBE, True)
+    raw_rate = curve.zero_rate_date(SEASONALITY_PROBE)
+    assert abs(raw_forecast - FORECAST_RAW) < FORECAST_MATCH
+
+    curve.set_seasonality(_a_seasonality())
+    assert curve.has_seasonality()
+    corrected_forecast = index.fixing(SEASONALITY_PROBE, True)
+    corrected_rate = curve.zero_rate_date(SEASONALITY_PROBE)
+    print(f"forecast at {SEASONALITY_PROBE}: {raw_forecast} -> {corrected_forecast}")
+    print(f"zero rate at {SEASONALITY_PROBE}: {raw_rate} -> {corrected_rate}")
+    assert abs(corrected_forecast - FORECAST_CORRECTED) < FORECAST_MATCH
+    assert abs(corrected_forecast - raw_forecast) > 1e-3
+    assert abs(corrected_rate - raw_rate) > RATE_MOVE
+
+    worst_npv = 0.0
+    for maturity, rate in ZC_DATA:
+        swap = _a_swap(settings, index, maturity, rate / 100.0)
+        worst_npv = max(worst_npv, abs(swap.npv()))
+    print(f"worst |NPV| under seasonality = {worst_npv:.3e}")
+    assert worst_npv < EPS
+
+    curve.set_seasonality(None)
+    assert not curve.has_seasonality()
+    assert abs(index.fixing(SEASONALITY_PROBE, True) - raw_forecast) < FORECAST_MATCH
+    assert abs(curve.zero_rate_date(SEASONALITY_PROBE) - raw_rate) < FORECAST_MATCH
+
+
+def test_a_multi_year_seasonality_is_rejected_by_the_consistency_gate():
+    """The gate reports the correction's own verdict, and a twenty-four-factor
+    set is the multi-year branch the core defers (#807).
+
+    It runs on its own fixture because the failure leaves the curve in a state
+    the reprice test must not inherit: the store happens before the gate, as
+    C++'s does, so the rejected correction stays installed - which
+    has_seasonality() reports as True below, deliberately - while the
+    notification that would invalidate the bootstrap never fires. Reading the
+    curve from here would fold a correction onto nodes that were never re-solved
+    against it, so the correction is cleared before the test ends.
+    """
+    settings = _settings()
+    index = _index(settings)
+    curve = _bootstrapped(settings, index)
+
+    with pytest.raises(ItofinError) as raised:
+        curve.set_seasonality(_a_seasonality(SEASONALITY_FACTORS * 2))
+    assert "#807" in str(raised.value)
+
+    assert curve.has_seasonality(), "the store precedes the gate, as C++'s does"
+    curve.set_seasonality(None)
+    assert not curve.has_seasonality()


### PR DESCRIPTION
This adds phase 3 coverage to the zero-coupon inflation reprice tests,
verifying that a multiplicative monthly seasonality correction folds into
the published forecast and that the bootstrapped curve reprices the swaps 
to zero once it is installed.

* Added `test_a_seasonality_moves_the_forecast_and_the_curve_reprices_the_swaps_again`, which pins the raw and corrected forecasts against the Rust oracle, requires the forecast and zero rate to move under the correction, confirms every swap reprices to zero, and checks that clearing the seasonality restores the original values.
* Added `test_a_multi_year_seasonality_is_rejected_by_the_consistency_gate`, exercising the deferred multi-year branch (#807) on its own fixture and asserting the store precedes the gate before clearing the rejected correction.
* Introduced the seasonality factors, anchor, probe date, and forecast fixtures, plus the `_a_seas
onality` helper, and imported `MultiplicativePriceSeasonality`, `ItofinError`, and `pytest`.

closes #813

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>