### PR TITLE
feat(crates): support American exercise in FD Black-Scholes engine


### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ repository's issues (the board is the source of truth, not a checked-in file).
 | **L6** | indexes | `InterestRateIndex`, Ibor family (Euribor / Eonia / €STR / SOFR), `SwapIndex` | 🚧 in progress |
 | **L7** | cashflows | fixed / floating / Ibor / overnight coupons and legs, coupon pricers, duration, capped-floored coupons | 🚧 in progress |
 | **L8** | instruments | fixed-rate bonds, vanilla / OIS swaps, swaptions, caps & floors, vanilla options | 🚧 in progress |
-| **L9** | methods | lattices, trees (trinomial + Hull-White), Monte Carlo (path generators + antithetic), finite differences (European Black-Scholes vanilla vs analytic) | 🚧 in progress |
+| **L9** | methods | lattices, trees (trinomial + Hull-White), Monte Carlo (path generators + antithetic), finite differences (European and American Black-Scholes vanilla) | 🚧 in progress |
 | **L10** | models | `CalibratedModel` + `calibrate()`, short-rate (Vasicek, CIR, Hull-White), Heston, calibration helpers | 🚧 in progress |
 | **L11** | engines | analytic European & Heston (Fourier), swaption (Black / Bachelier / Jamshidian), discounting swap / bond, Black cap/floor | 🚧 in progress |
 

--- a/crates/libitofin/src/methods/finitedifferences/stepconditions/fdmamericanstepcondition.rs
+++ b/crates/libitofin/src/methods/finitedifferences/stepconditions/fdmamericanstepcondition.rs
@@ -1,0 +1,137 @@
+//! The early-exercise condition of an American option.
+//!
+//! Port of `ql/methods/finitedifferences/stepconditions/fdmamericanstepcondition.hpp:37`
+//! and its `.cpp`.
+
+use crate::math::array::Array;
+use crate::methods::finitedifferences::StepCondition;
+use crate::methods::finitedifferences::meshers::FdmMesher;
+use crate::methods::finitedifferences::utilities::FdmInnerValueCalculator;
+use crate::shared::Shared;
+use crate::types::Time;
+
+/// Lifts the rolled-back grid to the intrinsic value wherever holding is worth
+/// less than exercising.
+///
+/// The condition is inert before `exercise_start`, which is what makes an
+/// American window opening after the reference date price below one opening at
+/// it (`cpp:37-38`).
+pub struct FdmAmericanStepCondition {
+    mesher: Shared<dyn FdmMesher>,
+    calculator: Shared<dyn FdmInnerValueCalculator>,
+    exercise_start: Time,
+}
+
+impl FdmAmericanStepCondition {
+    /// The condition over `mesher`, reading its intrinsic values off
+    /// `calculator` and applying from `exercise_start` on (`cpp:28-34`).
+    pub fn new(
+        mesher: Shared<dyn FdmMesher>,
+        calculator: Shared<dyn FdmInnerValueCalculator>,
+        exercise_start: Time,
+    ) -> FdmAmericanStepCondition {
+        FdmAmericanStepCondition {
+            mesher,
+            calculator,
+            exercise_start,
+        }
+    }
+}
+
+impl StepCondition for FdmAmericanStepCondition {
+    /// `cpp:36-49`: the elementwise maximum of the rolled-back values and the
+    /// intrinsic value, taken at every grid point.
+    ///
+    /// The intrinsic value comes from
+    /// [`inner_value`](FdmInnerValueCalculator::inner_value) rather than
+    /// [`avg_inner_value`](FdmInnerValueCalculator::avg_inner_value)
+    /// (`cpp:44`): the cell average seeds the terminal grid, the point value
+    /// bounds it from below at every step.
+    ///
+    /// The shape check of `cpp:40-41` is an assertion rather than an `Err`
+    /// because the trait returns unit, and a layout that disagrees with the
+    /// array is a wiring bug in the solver rather than a market input.
+    fn apply_to(&self, a: &mut Array, t: Time) {
+        if t < self.exercise_start {
+            return;
+        }
+
+        let layout = self.mesher.layout();
+        assert_eq!(layout.size(), a.size(), "inconsistent array dimensions");
+
+        for iter in layout.iter() {
+            let inner_value = self.calculator.inner_value(&iter, t);
+            if inner_value > a[iter.index()] {
+                a[iter.index()] = inner_value;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::methods::finitedifferences::meshers::UniformGridMesher;
+    use crate::methods::finitedifferences::operators::{FdmLinearOpIterator, FdmLinearOpLayout};
+    use crate::shared::shared;
+    use crate::types::Real;
+
+    /// An intrinsic value read straight out of a table indexed the way the
+    /// layout indexes its points, so a test can state the payoff it wants
+    /// without building one.
+    struct TabulatedInnerValue {
+        values: Vec<Real>,
+    }
+
+    impl FdmInnerValueCalculator for TabulatedInnerValue {
+        fn inner_value(&self, iter: &FdmLinearOpIterator, _t: Time) -> Real {
+            self.values[iter.index()]
+        }
+
+        fn avg_inner_value(&self, iter: &FdmLinearOpIterator, t: Time) -> Real {
+            self.inner_value(iter, t)
+        }
+    }
+
+    fn condition(values: Vec<Real>, exercise_start: Time) -> FdmAmericanStepCondition {
+        let layout = shared(FdmLinearOpLayout::new(vec![values.len()]));
+        let mesher = shared(UniformGridMesher::new(layout, &[(0.0, 1.0)]).unwrap());
+        FdmAmericanStepCondition::new(
+            mesher as Shared<dyn FdmMesher>,
+            shared(TabulatedInnerValue { values }) as Shared<dyn FdmInnerValueCalculator>,
+            exercise_start,
+        )
+    }
+
+    #[test]
+    fn values_below_the_intrinsic_value_are_lifted_and_the_rest_are_left_alone() {
+        let condition = condition(vec![3.0, 1.0, 0.0], 0.0);
+        let mut values = Array::from([2.0, 1.5, 0.0]);
+
+        condition.apply_to(&mut values, 0.5);
+
+        assert_eq!(values, Array::from([3.0, 1.5, 0.0]));
+    }
+
+    #[test]
+    fn nothing_is_lifted_before_the_exercise_window_opens() {
+        let condition = condition(vec![3.0, 1.0, 0.0], 0.25);
+        let mut values = Array::from([2.0, 1.5, 0.0]);
+        let before = values.clone();
+
+        condition.apply_to(&mut values, 0.2);
+
+        assert_eq!(values, before);
+    }
+
+    #[test]
+    fn the_window_is_open_at_its_own_start() {
+        let condition = condition(vec![3.0, 1.0, 0.0], 0.25);
+        let mut values = Array::from([2.0, 1.5, 0.0]);
+
+        condition.apply_to(&mut values, 0.25);
+
+        assert_eq!(values, Array::from([3.0, 1.5, 0.0]));
+    }
+}

--- a/crates/libitofin/src/methods/finitedifferences/stepconditions/fdmstepconditioncomposite.rs
+++ b/crates/libitofin/src/methods/finitedifferences/stepconditions/fdmstepconditioncomposite.rs
@@ -3,10 +3,17 @@
 //! Port of `ql/methods/finitedifferences/stepconditions/fdmstepconditioncomposite.hpp:43`
 //! and its `.cpp`.
 
-use super::FdmSnapshotCondition;
+use super::{FdmAmericanStepCondition, FdmSnapshotCondition};
+use crate::errors::QlResult;
+use crate::exercise::{Exercise, ExerciseType};
 use crate::math::array::Array;
 use crate::methods::finitedifferences::StepCondition;
+use crate::methods::finitedifferences::meshers::FdmMesher;
+use crate::methods::finitedifferences::utilities::FdmInnerValueCalculator;
+use crate::require;
 use crate::shared::{Shared, shared};
+use crate::time::date::Date;
+use crate::time::daycounter::DayCounter;
 use crate::types::{Real, Time};
 
 /// The step conditions of one solver, applied in order at every step.
@@ -63,6 +70,63 @@ impl FdmStepConditionComposite {
             vec![composite, snapshot],
         ))
     }
+
+    /// The conditions a vanilla option is rolled back under (`cpp:80-145`).
+    ///
+    /// A European exercise contributes nothing: the terminal payoff alone
+    /// prices it. An American exercise contributes an
+    /// [`FdmAmericanStepCondition`] opening at `exercise.dates()[0]` and no
+    /// stopping time, because it exercises continuously rather than on a set of
+    /// dates (`cpp:126-132`).
+    ///
+    /// `ref_date` and `day_counter` place `exercise_start` on the same clock as
+    /// the times the solver steps through, which is the risk-free curve's
+    /// reference date and day counter at the only call site
+    /// (`fdblackscholesvanillaengine.cpp:190-191`).
+    ///
+    /// Deferred, and omitted rather than accepted and ignored:
+    ///
+    /// - the cash-dividend branch (`cpp:92-120`), which needs
+    ///   `FdmDividendHandler` and a `DividendSchedule`, neither of which this
+    ///   crate has: #828. C++ takes the schedule as the first argument; there
+    ///   is no type to name here yet, so the argument is absent instead of
+    ///   present and ignored;
+    /// - the Bermudan branch (`cpp:133-140`), which needs
+    ///   `FdmBermudanStepCondition`: #827. A Bermudan exercise is an error here
+    ///   rather than an empty condition list, which would silently be a
+    ///   European price.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` for any exercise type without a branch, where C++ accepts
+    /// all three (`cpp:122-125`).
+    pub fn vanilla_composite(
+        exercise: &Shared<dyn Exercise>,
+        mesher: Shared<dyn FdmMesher>,
+        calculator: Shared<dyn FdmInnerValueCalculator>,
+        ref_date: Date,
+        day_counter: &DayCounter,
+    ) -> QlResult<Shared<FdmStepConditionComposite>> {
+        require!(
+            matches!(
+                exercise.exercise_type(),
+                ExerciseType::European | ExerciseType::American
+            ),
+            "exercise type is not supported"
+        );
+
+        let mut conditions: Vec<Shared<dyn StepCondition>> = Vec::new();
+        if exercise.exercise_type() == ExerciseType::American {
+            let exercise_start = day_counter.year_fraction(ref_date, exercise.dates()[0]);
+            conditions.push(shared(FdmAmericanStepCondition::new(
+                mesher,
+                calculator,
+                exercise_start,
+            )));
+        }
+
+        Ok(shared(FdmStepConditionComposite::new(&[], conditions)))
+    }
 }
 
 impl StepCondition for FdmStepConditionComposite {
@@ -79,6 +143,11 @@ mod tests {
     use std::cell::RefCell;
 
     use super::*;
+
+    use crate::exercise::{AmericanExercise, EuropeanExercise};
+    use crate::methods::finitedifferences::meshers::UniformGridMesher;
+    use crate::methods::finitedifferences::operators::{FdmLinearOpIterator, FdmLinearOpLayout};
+    use crate::time::daycounters::actual360::Actual360;
 
     struct Recorder {
         tag: &'static str,
@@ -174,6 +243,101 @@ mod tests {
 
         assert_eq!(*log.borrow(), vec!["inner:1".to_string()]);
         assert_eq!(snapshot.values(), Array::from([3.0]));
+    }
+
+    /// A payoff of one everywhere, so a lifted grid point is visible without
+    /// building a payoff and a log-grid calculator around it.
+    struct UnitInnerValue;
+
+    impl FdmInnerValueCalculator for UnitInnerValue {
+        fn inner_value(&self, _iter: &FdmLinearOpIterator, _t: Time) -> Real {
+            1.0
+        }
+
+        fn avg_inner_value(&self, iter: &FdmLinearOpIterator, t: Time) -> Real {
+            self.inner_value(iter, t)
+        }
+    }
+
+    fn vanilla_composite(
+        exercise: Shared<dyn Exercise>,
+    ) -> QlResult<Shared<FdmStepConditionComposite>> {
+        let layout = shared(FdmLinearOpLayout::new(vec![2]));
+        let mesher = shared(UniformGridMesher::new(layout, &[(0.0, 1.0)]).unwrap());
+        FdmStepConditionComposite::vanilla_composite(
+            &exercise,
+            mesher as Shared<dyn FdmMesher>,
+            shared(UnitInnerValue) as Shared<dyn FdmInnerValueCalculator>,
+            reference(),
+            &Actual360::new(),
+        )
+    }
+
+    fn reference() -> Date {
+        Date::new(15, crate::time::date::Month::June, 2026)
+    }
+
+    #[test]
+    fn a_european_exercise_contributes_no_condition_and_no_stopping_time() {
+        let exercise = shared(EuropeanExercise::new(reference() + 360)) as Shared<dyn Exercise>;
+
+        let composite = vanilla_composite(exercise).unwrap();
+
+        assert!(composite.conditions().is_empty());
+        assert!(composite.stopping_times().is_empty());
+    }
+
+    #[test]
+    fn an_american_exercise_contributes_one_condition_and_no_stopping_time() {
+        let exercise = shared(AmericanExercise::over(reference(), reference() + 360).unwrap())
+            as Shared<dyn Exercise>;
+
+        let composite = vanilla_composite(exercise).unwrap();
+
+        assert_eq!(composite.conditions().len(), 1);
+        assert!(composite.stopping_times().is_empty());
+    }
+
+    /// The window opens at the first exercise date, not the last: reading
+    /// `last_date()` here would put `exercise_start` at 1.0 and leave the grid
+    /// untouched at 0.3.
+    #[test]
+    fn the_american_window_opens_at_the_first_exercise_date() {
+        let exercise = shared(AmericanExercise::over(reference() + 90, reference() + 360).unwrap())
+            as Shared<dyn Exercise>;
+        let composite = vanilla_composite(exercise).unwrap();
+
+        let mut before = Array::from([0.0, 0.0]);
+        composite.apply_to(&mut before, 0.2);
+        let mut after = Array::from([0.0, 0.0]);
+        composite.apply_to(&mut after, 0.3);
+
+        assert_eq!(before, Array::from([0.0, 0.0]));
+        assert_eq!(after, Array::from([1.0, 1.0]));
+    }
+
+    #[test]
+    fn a_bermudan_exercise_is_rejected_rather_than_priced_without_its_condition() {
+        struct BermudanStub {
+            dates: [Date; 2],
+        }
+        impl Exercise for BermudanStub {
+            fn exercise_type(&self) -> ExerciseType {
+                ExerciseType::Bermudan
+            }
+            fn dates(&self) -> &[Date] {
+                &self.dates
+            }
+        }
+
+        let exercise = shared(BermudanStub {
+            dates: [reference() + 180, reference() + 360],
+        }) as Shared<dyn Exercise>;
+
+        let Err(error) = vanilla_composite(exercise) else {
+            panic!("a Bermudan exercise must be rejected");
+        };
+        assert_eq!(error.message(), "exercise type is not supported");
     }
 
     #[test]

--- a/crates/libitofin/src/methods/finitedifferences/stepconditions/mod.rs
+++ b/crates/libitofin/src/methods/finitedifferences/stepconditions/mod.rs
@@ -6,13 +6,16 @@
 //! [`stepcondition`](super::StepCondition) and this directory coexist by
 //! design.
 //!
-//! `FdmStepConditionComposite::vanillaComposite` (`cpp:80-145`) is deferred to
-//! #636: it is the only site of `FdmDividendHandler` (`cpp:104`),
-//! `FdmAmericanStepCondition` (`cpp:130`) and `FdmBermudanStepCondition`
-//! (`cpp:134`), none of which are ported yet.
+//! [`FdmStepConditionComposite::vanilla_composite`] (`cpp:80-145`) carries the
+//! European and American branches. Its two other sites are deferred and
+//! omitted visibly: `FdmDividendHandler` (`cpp:104`) to #828 and
+//! `FdmBermudanStepCondition` (`cpp:134`) to #827, so an exercise type without
+//! a branch is an error rather than an empty condition list.
 
+mod fdmamericanstepcondition;
 mod fdmsnapshotcondition;
 mod fdmstepconditioncomposite;
 
+pub use fdmamericanstepcondition::FdmAmericanStepCondition;
 pub use fdmsnapshotcondition::FdmSnapshotCondition;
 pub use fdmstepconditioncomposite::FdmStepConditionComposite;

--- a/crates/libitofin/src/pricingengines/vanilla/fdblackscholesvanillaengine.rs
+++ b/crates/libitofin/src/pricingengines/vanilla/fdblackscholesvanillaengine.rs
@@ -3,16 +3,17 @@
 //! Port of `ql/pricingengines/vanilla/fdblackscholesvanillaengine.{hpp,cpp}`,
 //! minus everything the FDM sub-umbrella has not reached yet. The engine lays
 //! a `ln(S)` grid over the process, seeds it with the payoff, rolls it back
-//! through [`FdmBlackScholesSolver`] and reads value, delta, gamma and theta
-//! off the rolled grid at the spot (`cpp:109-215`).
+//! through [`FdmBlackScholesSolver`] under the step conditions of
+//! [`FdmStepConditionComposite::vanilla_composite`] and reads value, delta,
+//! gamma and theta off the rolled grid at the spot (`cpp:109-215`).
 //!
 //! Deferred to #636, and omitted rather than accepted and ignored:
 //!
-//! - early exercise. C++ builds its step conditions through
-//!   `FdmStepConditionComposite::vanillaComposite` (`cpp:186-191`), which grows
-//!   an `FdmAmericanStepCondition` or an `FdmBermudanStepCondition` when the
-//!   exercise is not European; neither is ported, so a non-European exercise is
-//!   an explicit error here rather than a silently European price;
+//! - Bermudan exercise. C++ grows an `FdmBermudanStepCondition` inside
+//!   `FdmStepConditionComposite::vanillaComposite` (`cpp:186-191`) when the
+//!   exercise is Bermudan; it is not ported, so the composite rejects that
+//!   exercise type here rather than rolling back under an empty condition list,
+//!   which would be a silently European price (#827);
 //! - cash dividends, both the `Spot` and the `Escrowed` model (`cpp:111-152`,
 //!   `cpp:172-184`). The dividend schedule is always empty and the spot
 //!   adjustment always zero, as on the C++ default path;
@@ -23,7 +24,6 @@
 //!   constructors (`hpp:62-95`).
 
 use crate::errors::QlResult;
-use crate::exercise::ExerciseType;
 use crate::fail;
 use crate::instruments::{Greeks, OneAssetOptionEngine, OneAssetOptionResults, OptionArguments};
 use crate::methods::finitedifferences::meshers::{
@@ -54,7 +54,7 @@ const SCALE_FACTOR: f64 = 1.5;
 /// The density of the concentration around the strike (`cpp:162`).
 const C_POINT_DENSITY: f64 = 0.1;
 
-/// Finite-difference pricing engine for European vanilla options.
+/// Finite-difference pricing engine for European and American vanilla options.
 ///
 /// Everything the engine builds - mesher, calculator, conditions, solver -
 /// lives inside a single [`calculate`](PricingEngine::calculate), as in C++
@@ -126,9 +126,7 @@ impl PricingEngine for FdBlackScholesVanillaEngine {
         let Some(exercise) = &arguments.exercise else {
             fail!("no exercise given");
         };
-        if exercise.exercise_type() != ExerciseType::European {
-            fail!("early exercise is not supported by the finite-difference engine yet");
-        }
+        let exercise = Shared::clone(exercise);
         let Some(payoff) = &arguments.payoff else {
             fail!("no payoff given");
         };
@@ -159,10 +157,22 @@ impl PricingEngine for FdBlackScholesVanillaEngine {
             DIRECTION,
         )) as Shared<dyn FdmInnerValueCalculator>;
 
+        let risk_free = self.process.risk_free_rate().current_link()?;
+        let Some(day_counter) = risk_free.day_counter() else {
+            fail!("no day counter provided for the risk-free curve");
+        };
+        let condition = FdmStepConditionComposite::vanilla_composite(
+            &exercise,
+            Shared::clone(&mesher),
+            Shared::clone(&calculator),
+            risk_free.reference_date()?,
+            &day_counter,
+        )?;
+
         let solver_desc = FdmSolverDesc {
             mesher,
             bc_set: Vec::new(),
-            condition: shared(FdmStepConditionComposite::new(&[], Vec::new())),
+            condition,
             calculator,
             maturity,
             time_steps: self.t_grid,
@@ -348,17 +358,20 @@ mod test_fd_engines {
         );
     }
 
-    /// The visible half of the early-exercise deferral: C++ prices an American
-    /// exercise through `vanillaComposite` (`cpp:186-191`), and this port says
-    /// so rather than quietly returning the European price.
+    /// The visible half of the Bermudan deferral: C++ prices a Bermudan
+    /// exercise through the `FdmBermudanStepCondition` branch of
+    /// `vanillaComposite` (`fdmstepconditioncomposite.cpp:133-140`), and this
+    /// port says so rather than quietly returning the European price. American
+    /// exercise, which shares the guard until #827, prices instead of failing
+    /// and is pinned by the `test_fd_values` oracle below.
     #[test]
-    fn early_exercise_is_rejected_rather_than_priced_as_european() {
-        struct AmericanStub {
-            dates: [Date; 1],
+    fn a_bermudan_exercise_is_rejected_rather_than_priced_as_european() {
+        struct BermudanStub {
+            dates: [Date; 2],
         }
-        impl Exercise for AmericanStub {
+        impl Exercise for BermudanStub {
             fn exercise_type(&self) -> ExerciseType {
-                ExerciseType::American
+                ExerciseType::Bermudan
             }
             fn dates(&self) -> &[Date] {
                 &self.dates
@@ -370,18 +383,321 @@ mod test_fd_engines {
         let expiry = today() + 360;
         let european = fd_option(&market, Call, 100.0, expiry);
 
-        let mut american = OneAssetOption::new(
+        let mut bermudan = OneAssetOption::new(
             Shared::clone(european.payoff()),
-            shared(AmericanStub { dates: [expiry] }) as Shared<dyn Exercise>,
+            shared(BermudanStub {
+                dates: [today() + 180, expiry],
+            }) as Shared<dyn Exercise>,
             Shared::clone(&market.settings),
         );
-        american
+        bermudan
             .base_mut()
             .set_pricing_engine(european.base().pricing_engine().unwrap().clone());
 
         assert_eq!(
-            american.npv().unwrap_err().message(),
-            "early exercise is not supported by the finite-difference engine yet"
+            bermudan.npv().unwrap_err().message(),
+            "exercise type is not supported"
+        );
+    }
+}
+
+#[cfg(test)]
+mod test_fd_values {
+    //! The first half of the `testFdValues` oracle of
+    //! `test-suite/americanoption.cpp:375-427`: American options priced on a
+    //! 100 by 400 grid against the Ju-1998 table (`:256-322`) within 8e-2
+    //! (`:389`). The second assertion of the C++ case (`:428-443`) compares
+    //! the same values against the QR+ boundary-approximation engine, which is
+    //! a different engine and out of scope here.
+    //!
+    //! The long-dated dividend-paying calls are what make this oracle
+    //! discriminate: their early-exercise premium is around one, so an engine
+    //! that rolled back under an empty condition list and returned the
+    //! European price would miss by more than ten tolerances. The short-dated
+    //! puts alone would not separate the two.
+
+    use super::super::test_market::{Market, market, time_to_days, today};
+    use super::FdBlackScholesVanillaEngine;
+    use crate::exercise::{AmericanExercise, Exercise};
+    use crate::instrument::Instrument;
+    use crate::instruments::{OneAssetOption, PlainVanillaPayoff};
+    use crate::methods::finitedifferences::solvers::FdmSchemeDesc;
+    use crate::option::OptionType::{self, Call, Put};
+    use crate::pricingengine::PricingEngine;
+    use crate::shared::{Shared, SharedMut, shared, shared_mut};
+    use crate::types::{Rate, Real, Size, Time, Volatility};
+
+    /// The grid of the `pdeEngine` of `:399`.
+    const T_GRID: Size = 100;
+    const X_GRID: Size = 400;
+
+    /// `tolerance` of `:389`.
+    const TOLERANCE: Real = 8.0e-2;
+
+    /// One row of the Ju table (`:256-322`).
+    struct JuValue {
+        option_type: OptionType,
+        strike: Real,
+        spot: Real,
+        q: Rate,
+        r: Rate,
+        t: Time,
+        vol: Volatility,
+        expected: Real,
+    }
+
+    /// The maturity of `:407`: the year fraction rounded to whole days on the
+    /// 360-day year the market's Actual/360 curves count on, not the year
+    /// fraction itself (`test-suite/utilities.hpp:141-143`).
+    fn price(market: &Market, ju: &JuValue) -> Real {
+        market.set(ju.spot, ju.q, ju.r, ju.vol);
+
+        let exercise = AmericanExercise::over(today(), today() + time_to_days(ju.t)).unwrap();
+        let mut option = OneAssetOption::new(
+            shared(PlainVanillaPayoff::new(ju.option_type, ju.strike)),
+            shared(exercise) as Shared<dyn Exercise>,
+            Shared::clone(&market.settings),
+        );
+        let engine = shared_mut(FdBlackScholesVanillaEngine::new(
+            Shared::clone(&market.process),
+            T_GRID,
+            X_GRID,
+            0,
+            FdmSchemeDesc::douglas(),
+        ));
+        option
+            .base_mut()
+            .set_pricing_engine(engine as SharedMut<dyn PricingEngine>);
+        option.npv().unwrap()
+    }
+
+    #[test]
+    fn american_options_reproduce_the_ju_values() {
+        let market = market();
+        let rows = [
+            JuValue {
+                option_type: Put,
+                strike: 40.0,
+                spot: 40.0,
+                q: 0.0,
+                r: 0.0488,
+                t: 0.3333,
+                vol: 0.2,
+                expected: 1.576,
+            },
+            JuValue {
+                option_type: Put,
+                strike: 45.0,
+                spot: 40.0,
+                q: 0.0,
+                r: 0.0488,
+                t: 0.5833,
+                vol: 0.2,
+                expected: 5.260,
+            },
+            JuValue {
+                option_type: Call,
+                strike: 100.0,
+                spot: 100.0,
+                q: 0.07,
+                r: 0.03,
+                t: 3.0,
+                vol: 0.2,
+                expected: 9.065,
+            },
+            JuValue {
+                option_type: Call,
+                strike: 100.0,
+                spot: 120.0,
+                q: 0.07,
+                r: 0.03,
+                t: 3.0,
+                vol: 0.2,
+                expected: 21.398,
+            },
+        ];
+
+        for ju in &rows {
+            let calculated = price(&market, ju);
+            let error = (calculated - ju.expected).abs();
+            println!(
+                "testFdValues: {:?} K={} S={} t={}: Ju {} finite difference {calculated}",
+                ju.option_type, ju.strike, ju.spot, ju.t, ju.expected
+            );
+            assert!(
+                error <= TOLERANCE,
+                "{:?} K={} S={} q={} r={} t={} v={}: Ju {} vs finite difference {calculated} \
+                 (absolute error {error} over {TOLERANCE})",
+                ju.option_type,
+                ju.strike,
+                ju.spot,
+                ju.q,
+                ju.r,
+                ju.t,
+                ju.vol,
+                ju.expected
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod test_fd_earliest_exercise_date {
+    //! The `testFdEarliestExerciseDate` oracle of
+    //! `test-suite/americanoption.cpp:2173-2255`: a deep in-the-money put whose
+    //! exercise window is narrowed from the front.
+    //!
+    //! This is the only oracle that drives a non-zero `exercise_start`.
+    //! `testFdValues` opens every window at the reference date, so the
+    //! early-return of `FdmAmericanStepCondition::apply_to`
+    //! (`fdmamericanstepcondition.cpp:37-38`) never fires there and an engine
+    //! ignoring the earliest exercise date would pass it.
+
+    use super::super::AnalyticEuropeanEngine;
+    use super::FdBlackScholesVanillaEngine;
+    use crate::exercise::{AmericanExercise, EuropeanExercise, Exercise};
+    use crate::handle::Handle;
+    use crate::instrument::Instrument;
+    use crate::instruments::{OneAssetOption, PlainVanillaPayoff};
+    use crate::interestrate::Compounding;
+    use crate::methods::finitedifferences::solvers::FdmSchemeDesc;
+    use crate::option::OptionType::Put;
+    use crate::pricingengine::PricingEngine;
+    use crate::processes::{BlackScholesMertonProcess, GeneralizedBlackScholesProcess};
+    use crate::quotes::{Quote, SimpleQuote};
+    use crate::settings::Settings;
+    use crate::shared::{Shared, SharedMut, shared, shared_mut};
+    use crate::termstructures::volatility::{BlackConstantVol, BlackVolTermStructure};
+    use crate::termstructures::yields::FlatForward;
+    use crate::termstructures::yieldtermstructure::YieldTermStructure;
+    use crate::time::date::{Date, Month};
+    use crate::time::daycounters::actual365fixed::Actual365Fixed;
+    use crate::time::frequency::Frequency;
+    use crate::time::period::Period;
+    use crate::time::timeunit::TimeUnit;
+    use crate::types::{Rate, Real, Size, Volatility};
+
+    /// The market of `:2186-2195`.
+    const S0: Real = 80.0;
+    const STRIKE: Real = 100.0;
+    const SIGMA: Volatility = 0.25;
+    const R: Rate = 0.05;
+    const Q: Rate = 0.0;
+
+    /// The grid of `:2206`.
+    const T_GRID: Size = 200;
+    const X_GRID: Size = 200;
+
+    fn today() -> Date {
+        Date::new(15, Month::January, 2025)
+    }
+
+    fn flat_rate(rate: Rate) -> Handle<dyn YieldTermStructure> {
+        Handle::new(shared(FlatForward::with_rate(
+            today(),
+            rate,
+            Actual365Fixed::new(),
+            Compounding::Continuous,
+            Frequency::Annual,
+        )) as Shared<dyn YieldTermStructure>)
+    }
+
+    fn process() -> Shared<GeneralizedBlackScholesProcess> {
+        let spot = Handle::new(shared(SimpleQuote::new(S0)) as Shared<dyn Quote>);
+        let vol = Handle::new(shared(BlackConstantVol::new(
+            today(),
+            None,
+            SIGMA,
+            Actual365Fixed::new(),
+        )) as Shared<dyn BlackVolTermStructure>);
+        shared(BlackScholesMertonProcess::new(
+            spot,
+            flat_rate(Q),
+            flat_rate(R),
+            vol,
+        ))
+    }
+
+    /// The American put over `[earliest, maturity]`, priced by the
+    /// finite-difference engine (`:2203-2208`).
+    fn american_price(
+        settings: &Shared<Settings<Date>>,
+        process: &Shared<GeneralizedBlackScholesProcess>,
+        earliest: Date,
+        maturity: Date,
+    ) -> Real {
+        let exercise = AmericanExercise::over(earliest, maturity).unwrap();
+        let mut option = OneAssetOption::new(
+            shared(PlainVanillaPayoff::new(Put, STRIKE)),
+            shared(exercise) as Shared<dyn Exercise>,
+            Shared::clone(settings),
+        );
+        let engine = shared_mut(FdBlackScholesVanillaEngine::new(
+            Shared::clone(process),
+            T_GRID,
+            X_GRID,
+            0,
+            FdmSchemeDesc::douglas(),
+        ));
+        option
+            .base_mut()
+            .set_pricing_engine(engine as SharedMut<dyn PricingEngine>);
+        option.npv().unwrap()
+    }
+
+    #[test]
+    fn narrowing_the_exercise_window_lowers_the_price_toward_the_european_one() {
+        let settings = shared(Settings::new());
+        settings.set_evaluation_date(today());
+        let process = process();
+        let maturity = today() + Period::new(1, TimeUnit::Years);
+
+        let full = american_price(&settings, &process, today(), maturity);
+        let mid = american_price(
+            &settings,
+            &process,
+            maturity - Period::new(6, TimeUnit::Months),
+            maturity,
+        );
+        let late = american_price(
+            &settings,
+            &process,
+            maturity - Period::new(3, TimeUnit::Months),
+            maturity,
+        );
+
+        let mut european = OneAssetOption::new(
+            shared(PlainVanillaPayoff::new(Put, STRIKE)),
+            shared(EuropeanExercise::new(maturity)) as Shared<dyn Exercise>,
+            Shared::clone(&settings),
+        );
+        let analytic = shared_mut(AnalyticEuropeanEngine::new(Shared::clone(&process)));
+        european
+            .base_mut()
+            .set_pricing_engine(analytic as SharedMut<dyn PricingEngine>);
+        let euro = european.npv().unwrap();
+
+        println!("testFdEarliestExerciseDate: full {full} 6M {mid} 3M {late} european {euro}");
+
+        assert!(
+            full - euro > 1.0,
+            "the early-exercise premium should be significant: full {full} european {euro}"
+        );
+        assert!(
+            full - late > 0.01,
+            "restricting the exercise window should reduce the price: full {full} late {late}"
+        );
+        assert!(
+            late > euro + 0.01,
+            "the restricted American should exceed the European: late {late} european {euro}"
+        );
+        assert!(
+            mid >= late - 1e-8,
+            "a wider window should give a higher price: 6M {mid} 3M {late}"
+        );
+        assert!(
+            full >= mid - 1e-8,
+            "the full window should give the highest price: full {full} 6M {mid}"
         );
     }
 }


### PR DESCRIPTION
The finite-difference vanilla engine now prices American options by
building its step conditions through
`FdmStepConditionComposite::vanilla_composite`, replacing the previous
guard that rejected all early exercise. Bermudan exercise remains
deferred to #827 and is still rejected rather than silently priced as
European.

**Engine changes:**
* Roll the grid back under the vanilla composite step conditions, using
  the risk-free curve's reference date and day counter.
* Drop the engine's blanket early-exercise error and let the vanilla
  composite reject the exercise types it has no branch for, as in C++.
* Record American finite differences in the L9 row of the README table.

**Testing improvements:**
* Add the `testFdValues` oracle pinning American prices against the
  Ju-1998 table on a 100x400 grid within 8e-2.
* Add the `testFdEarliestExerciseDate` oracle, the only case driving a
  non-zero exercise start, checking that narrowing the exercise window
  lowers the price toward the European one.
* Retarget the deferral test to Bermudan exercise.

Closes #826
