### PR TITLE
test(fdblackscholesvanillaengine): add Bermudan exercise oracle tests


### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ repository's issues (the board is the source of truth, not a checked-in file).
 | **L6** | indexes | `InterestRateIndex`, Ibor family (Euribor / Eonia / €STR / SOFR), `SwapIndex` | 🚧 in progress |
 | **L7** | cashflows | fixed / floating / Ibor / overnight coupons and legs, coupon pricers, duration, capped-floored coupons | 🚧 in progress |
 | **L8** | instruments | fixed-rate bonds, vanilla / OIS swaps, swaptions, caps & floors, vanilla options | 🚧 in progress |
-| **L9** | methods | lattices, trees (trinomial + Hull-White), Monte Carlo (path generators + antithetic), finite differences (European and American Black-Scholes vanilla) | 🚧 in progress |
+| **L9** | methods | lattices, trees (trinomial + Hull-White), Monte Carlo (path generators + antithetic), finite differences (European, American and Bermudan Black-Scholes vanilla) | 🚧 in progress |
 | **L10** | models | `CalibratedModel` + `calibrate()`, short-rate (Vasicek, CIR, Hull-White), Heston, calibration helpers | 🚧 in progress |
 | **L11** | engines | analytic European & Heston (Fourier), swaption (Black / Bachelier / Jamshidian), discounting swap / bond, Black cap/floor | 🚧 in progress |
 

--- a/crates/libitofin/src/exercise.rs
+++ b/crates/libitofin/src/exercise.rs
@@ -1,9 +1,9 @@
 //! Option exercise classes.
 //!
-//! Port of the European and American subset of `ql/exercise.{hpp,cpp}`: the
-//! [`Exercise`] trait is the base exercise contract, [`EuropeanExercise`] its
-//! single-date implementation and [`AmericanExercise`] the continuous
-//! `[earliest, latest]` one.
+//! Port of `ql/exercise.{hpp,cpp}`: the [`Exercise`] trait is the base exercise
+//! contract, [`EuropeanExercise`] its single-date implementation,
+//! [`AmericanExercise`] the continuous `[earliest, latest]` one and
+//! [`BermudanExercise`] the sorted multi-date one.
 //!
 //! Divergence: C++ puts the `payoffAtExpiry` flag on an intermediate
 //! `EarlyExercise` base (`exercise.hpp:57-65`). Rust has no class hierarchy to
@@ -14,9 +14,10 @@
 //! is not attempted.
 //!
 //! Deferred, omitted visibly rather than accepted and ignored:
-//! - **`BermudanExercise`** (`exercise.cpp:52-59`): the sorted multi-date form,
-//!   with the Bermudan simulation grid it needs
-//!   (`mclongstaffschwartzengine.hpp:218-231`).
+//! - **the Bermudan simulation grid of the Monte Carlo engines**
+//!   (`mclongstaffschwartzengine.hpp:218-231`). [`BermudanExercise`] itself is
+//!   ported and prices under the finite-difference engine; only the path
+//!   generator that would exercise it along a simulated path is missing.
 //! - **the latest-date-only `AmericanExercise` constructor**
 //!   (`exercise.cpp:43-50`): it opens the window at `Date::minDate()`, a
 //!   sentinel this stack has no date for.
@@ -140,6 +141,56 @@ impl Exercise for AmericanExercise {
     }
 }
 
+/// Bermudan exercise: the option can be exercised on a fixed set of dates
+/// (`exercise.hpp:84-88`).
+///
+/// The dates are sorted on construction and **not** deduplicated
+/// (`exercise.cpp:56-57` calls `std::sort` and no `std::unique`), which the
+/// port keeps: a repeated date is harmless downstream, since the step-condition
+/// composite deduplicates the stopping times it merges and a repeated
+/// elementwise maximum is idempotent.
+///
+/// The dates are carried in a `Vec` rather than the fixed array the other two
+/// exercises use, so this is the one exercise that is not `Copy`.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct BermudanExercise {
+    dates: Vec<Date>,
+    payoff_at_expiry: bool,
+}
+
+impl BermudanExercise {
+    /// Builds a Bermudan exercise over `dates` (`exercise.cpp:52-58`).
+    /// `payoff_at_expiry` defers the payment of an early exercise to the expiry
+    /// date.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` when `dates` is empty (`exercise.cpp:55`).
+    pub fn new(dates: Vec<Date>, payoff_at_expiry: bool) -> QlResult<BermudanExercise> {
+        require!(!dates.is_empty(), "no exercise date given");
+        let mut dates = dates;
+        dates.sort_unstable();
+        Ok(BermudanExercise {
+            dates,
+            payoff_at_expiry,
+        })
+    }
+}
+
+impl Exercise for BermudanExercise {
+    fn exercise_type(&self) -> ExerciseType {
+        ExerciseType::Bermudan
+    }
+
+    fn dates(&self) -> &[Date] {
+        &self.dates
+    }
+
+    fn payoff_at_expiry(&self) -> bool {
+        self.payoff_at_expiry
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -195,6 +246,50 @@ mod tests {
                 .payoff_at_expiry()
         );
         assert!(!EuropeanExercise::new(latest).payoff_at_expiry());
+    }
+
+    /// `exercise.cpp:56-57`: the dates come out sorted whatever order they go
+    /// in, and `lastDate()` is the latest of them.
+    #[test]
+    fn bermudan_exercise_sorts_its_dates() {
+        let first = Date::new(17, Month::May, 1998);
+        let second = Date::new(17, Month::November, 1998);
+        let third = Date::new(17, Month::May, 1999);
+
+        let exercise = BermudanExercise::new(vec![third, first, second], false).unwrap();
+
+        assert_eq!(exercise.exercise_type(), ExerciseType::Bermudan);
+        assert_eq!(exercise.dates(), &[first, second, third]);
+        assert_eq!(exercise.last_date(), third);
+        assert!(!exercise.payoff_at_expiry(), "the C++ default is false");
+    }
+
+    /// C++ sorts and stops there (`exercise.cpp:57`), with no `std::unique`, so
+    /// a repeated date survives construction rather than being folded away.
+    #[test]
+    fn bermudan_exercise_keeps_repeated_dates() {
+        let date = Date::new(17, Month::May, 1999);
+        let exercise = BermudanExercise::new(vec![date, date], false).unwrap();
+
+        assert_eq!(exercise.dates(), &[date, date]);
+    }
+
+    #[test]
+    fn an_empty_bermudan_date_set_is_rejected() {
+        match BermudanExercise::new(Vec::new(), false) {
+            Err(e) => assert_eq!(e.message(), "no exercise date given"),
+            Ok(_) => panic!("an empty date set must be rejected"),
+        }
+    }
+
+    #[test]
+    fn a_bermudan_exercise_carries_payoff_at_expiry() {
+        let date = Date::new(17, Month::May, 1999);
+        assert!(
+            BermudanExercise::new(vec![date], true)
+                .unwrap()
+                .payoff_at_expiry()
+        );
     }
 
     #[test]

--- a/crates/libitofin/src/methods/finitedifferences/stepconditions/fdmbermudanstepcondition.rs
+++ b/crates/libitofin/src/methods/finitedifferences/stepconditions/fdmbermudanstepcondition.rs
@@ -1,0 +1,179 @@
+//! The early-exercise condition of a Bermudan option.
+//!
+//! Port of `ql/methods/finitedifferences/stepconditions/fdmbermudanstepcondition.hpp:35`
+//! and its `.cpp`.
+
+use crate::math::array::Array;
+use crate::methods::finitedifferences::StepCondition;
+use crate::methods::finitedifferences::meshers::FdmMesher;
+use crate::methods::finitedifferences::utilities::FdmInnerValueCalculator;
+use crate::shared::Shared;
+use crate::time::date::Date;
+use crate::time::daycounter::DayCounter;
+use crate::types::Time;
+
+/// Lifts the rolled-back grid to the intrinsic value, but only at the exercise
+/// times.
+///
+/// This is what separates a Bermudan from an American: the American condition
+/// fires on every step from its window opening on, this one only when the step
+/// lands on an exercise date. The composite pushes
+/// [`exercise_times`](FdmBermudanStepCondition::exercise_times) into the
+/// solver's stopping times (`fdmstepconditioncomposite.cpp:139`) so that the
+/// steps do land there.
+pub struct FdmBermudanStepCondition {
+    mesher: Shared<dyn FdmMesher>,
+    calculator: Shared<dyn FdmInnerValueCalculator>,
+    exercise_times: Vec<Time>,
+}
+
+impl FdmBermudanStepCondition {
+    /// The condition over `mesher`, reading its intrinsic values off
+    /// `calculator` and firing at each of `exercise_dates`, placed on the
+    /// solver's clock by `day_counter` from `reference_date` (`cpp:27-39`).
+    pub fn new(
+        exercise_dates: &[Date],
+        reference_date: Date,
+        day_counter: &DayCounter,
+        mesher: Shared<dyn FdmMesher>,
+        calculator: Shared<dyn FdmInnerValueCalculator>,
+    ) -> FdmBermudanStepCondition {
+        let exercise_times = exercise_dates
+            .iter()
+            .map(|date| day_counter.year_fraction(reference_date, *date))
+            .collect();
+
+        FdmBermudanStepCondition {
+            mesher,
+            calculator,
+            exercise_times,
+        }
+    }
+
+    /// The exercise dates on the solver's clock (`cpp:41-43`).
+    pub fn exercise_times(&self) -> &[Time] {
+        &self.exercise_times
+    }
+}
+
+impl StepCondition for FdmBermudanStepCondition {
+    /// `cpp:45-65`: at an exercise time, the elementwise maximum of the
+    /// rolled-back values and the intrinsic value; at any other time, nothing.
+    ///
+    /// The membership test is exact equality on `Time`, as in C++'s
+    /// `std::find` (`cpp:46-47`), and that is faithful rather than fragile
+    /// here: these very times reach the solver as stopping times, and the model
+    /// applies the condition at the stopping time itself
+    /// (`finitedifferencemodel.rs:110-119`), so the value compared is the bit
+    /// pattern this constructor produced. A time that misses is a step that was
+    /// never an exercise opportunity.
+    ///
+    /// The `locations` array of `cpp:52-58` is dropped: C++ fills it from the
+    /// mesher on every grid point and then never reads it, so it is dead there
+    /// and carrying it would only cost the port a per-node allocation.
+    ///
+    /// The shape check of `cpp:49-50` is an assertion rather than an `Err`
+    /// because the trait returns unit, and a layout that disagrees with the
+    /// array is a wiring bug in the solver rather than a market input.
+    fn apply_to(&self, a: &mut Array, t: Time) {
+        if !self.exercise_times.contains(&t) {
+            return;
+        }
+
+        let layout = self.mesher.layout();
+        assert_eq!(layout.size(), a.size(), "inconsistent array dimensions");
+
+        for iter in layout.iter() {
+            let inner_value = self.calculator.inner_value(&iter, t);
+            if inner_value > a[iter.index()] {
+                a[iter.index()] = inner_value;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::methods::finitedifferences::meshers::UniformGridMesher;
+    use crate::methods::finitedifferences::operators::{FdmLinearOpIterator, FdmLinearOpLayout};
+    use crate::shared::shared;
+    use crate::time::date::Month;
+    use crate::time::daycounters::actual360::Actual360;
+    use crate::types::Real;
+
+    /// An intrinsic value read straight out of a table indexed the way the
+    /// layout indexes its points, so a test can state the payoff it wants
+    /// without building one.
+    struct TabulatedInnerValue {
+        values: Vec<Real>,
+    }
+
+    impl FdmInnerValueCalculator for TabulatedInnerValue {
+        fn inner_value(&self, iter: &FdmLinearOpIterator, _t: Time) -> Real {
+            self.values[iter.index()]
+        }
+
+        fn avg_inner_value(&self, iter: &FdmLinearOpIterator, t: Time) -> Real {
+            self.inner_value(iter, t)
+        }
+    }
+
+    fn reference() -> Date {
+        Date::new(15, Month::June, 2026)
+    }
+
+    fn condition(values: Vec<Real>, exercise_dates: &[Date]) -> FdmBermudanStepCondition {
+        let layout = shared(FdmLinearOpLayout::new(vec![values.len()]));
+        let mesher = shared(UniformGridMesher::new(layout, &[(0.0, 1.0)]).unwrap());
+        FdmBermudanStepCondition::new(
+            exercise_dates,
+            reference(),
+            &Actual360::new(),
+            mesher as Shared<dyn FdmMesher>,
+            shared(TabulatedInnerValue { values }) as Shared<dyn FdmInnerValueCalculator>,
+        )
+    }
+
+    #[test]
+    fn the_dates_are_mapped_onto_the_day_counters_clock() {
+        let condition = condition(vec![1.0], &[reference() + 90, reference() + 180]);
+
+        assert_eq!(condition.exercise_times(), &[0.25, 0.5]);
+    }
+
+    #[test]
+    fn values_below_the_intrinsic_value_are_lifted_at_an_exercise_time() {
+        let condition = condition(vec![3.0, 1.0, 0.0], &[reference() + 180]);
+        let mut values = Array::from([2.0, 1.5, 0.0]);
+
+        condition.apply_to(&mut values, 0.5);
+
+        assert_eq!(values, Array::from([3.0, 1.5, 0.0]));
+    }
+
+    /// The whole point of the condition: away from an exercise time it is inert,
+    /// where the American one would lift here.
+    #[test]
+    fn nothing_is_lifted_between_the_exercise_times() {
+        let condition = condition(vec![3.0, 1.0, 0.0], &[reference() + 180]);
+        let mut values = Array::from([2.0, 1.5, 0.0]);
+        let before = values.clone();
+
+        condition.apply_to(&mut values, 0.4);
+
+        assert_eq!(values, before);
+    }
+
+    #[test]
+    fn every_exercise_time_fires() {
+        let condition = condition(vec![3.0], &[reference() + 90, reference() + 180]);
+
+        for time in [0.25, 0.5] {
+            let mut values = Array::from([2.0]);
+            condition.apply_to(&mut values, time);
+            assert_eq!(values, Array::from([3.0]), "at {time}");
+        }
+    }
+}

--- a/crates/libitofin/src/methods/finitedifferences/stepconditions/fdmstepconditioncomposite.rs
+++ b/crates/libitofin/src/methods/finitedifferences/stepconditions/fdmstepconditioncomposite.rs
@@ -3,7 +3,7 @@
 //! Port of `ql/methods/finitedifferences/stepconditions/fdmstepconditioncomposite.hpp:43`
 //! and its `.cpp`.
 
-use super::{FdmAmericanStepCondition, FdmSnapshotCondition};
+use super::{FdmAmericanStepCondition, FdmBermudanStepCondition, FdmSnapshotCondition};
 use crate::errors::QlResult;
 use crate::exercise::{Exercise, ExerciseType};
 use crate::math::array::Array;
@@ -77,29 +77,29 @@ impl FdmStepConditionComposite {
     /// prices it. An American exercise contributes an
     /// [`FdmAmericanStepCondition`] opening at `exercise.dates()[0]` and no
     /// stopping time, because it exercises continuously rather than on a set of
-    /// dates (`cpp:126-132`).
+    /// dates (`cpp:126-132`). A Bermudan exercise contributes an
+    /// [`FdmBermudanStepCondition`] and, unlike the American one, its exercise
+    /// times as stopping times (`cpp:133-140`): the condition only fires when a
+    /// step lands on an exercise time, so the solver has to be told to put one
+    /// there.
     ///
-    /// `ref_date` and `day_counter` place `exercise_start` on the same clock as
-    /// the times the solver steps through, which is the risk-free curve's
-    /// reference date and day counter at the only call site
-    /// (`fdblackscholesvanillaengine.cpp:190-191`).
+    /// `ref_date` and `day_counter` place `exercise_start` and the Bermudan
+    /// exercise times on the same clock as the times the solver steps through,
+    /// which is the risk-free curve's reference date and day counter at the
+    /// only call site (`fdblackscholesvanillaengine.cpp:190-191`).
     ///
-    /// Deferred, and omitted rather than accepted and ignored:
-    ///
-    /// - the cash-dividend branch (`cpp:92-120`), which needs
-    ///   `FdmDividendHandler` and a `DividendSchedule`, neither of which this
-    ///   crate has: #828. C++ takes the schedule as the first argument; there
-    ///   is no type to name here yet, so the argument is absent instead of
-    ///   present and ignored;
-    /// - the Bermudan branch (`cpp:133-140`), which needs
-    ///   `FdmBermudanStepCondition`: #827. A Bermudan exercise is an error here
-    ///   rather than an empty condition list, which would silently be a
-    ///   European price.
+    /// Deferred, and omitted rather than accepted and ignored: the
+    /// cash-dividend branch (`cpp:92-120`), which needs `FdmDividendHandler`
+    /// and a `DividendSchedule`, neither of which this crate has: #828. C++
+    /// takes the schedule as the first argument; there is no type to name here
+    /// yet, so the argument is absent instead of present and ignored.
     ///
     /// # Errors
     ///
-    /// Returns `Err` for any exercise type without a branch, where C++ accepts
-    /// all three (`cpp:122-125`).
+    /// Returns `Err` for an exercise type without a branch (`cpp:122-125`).
+    /// With all three types now branched the guard is total and cannot fire;
+    /// it is kept as the port of the C++ `QL_REQUIRE`, and the exhaustive match
+    /// below is the stronger, compile-time form of the same check.
     pub fn vanilla_composite(
         exercise: &Shared<dyn Exercise>,
         mesher: Shared<dyn FdmMesher>,
@@ -110,22 +110,40 @@ impl FdmStepConditionComposite {
         require!(
             matches!(
                 exercise.exercise_type(),
-                ExerciseType::European | ExerciseType::American
+                ExerciseType::European | ExerciseType::American | ExerciseType::Bermudan
             ),
             "exercise type is not supported"
         );
 
         let mut conditions: Vec<Shared<dyn StepCondition>> = Vec::new();
-        if exercise.exercise_type() == ExerciseType::American {
-            let exercise_start = day_counter.year_fraction(ref_date, exercise.dates()[0]);
-            conditions.push(shared(FdmAmericanStepCondition::new(
-                mesher,
-                calculator,
-                exercise_start,
-            )));
+        let mut stopping_times: Vec<Vec<Time>> = Vec::new();
+        match exercise.exercise_type() {
+            ExerciseType::American => {
+                let exercise_start = day_counter.year_fraction(ref_date, exercise.dates()[0]);
+                conditions.push(shared(FdmAmericanStepCondition::new(
+                    mesher,
+                    calculator,
+                    exercise_start,
+                )));
+            }
+            ExerciseType::Bermudan => {
+                let bermudan = shared(FdmBermudanStepCondition::new(
+                    exercise.dates(),
+                    ref_date,
+                    day_counter,
+                    mesher,
+                    calculator,
+                ));
+                stopping_times.push(bermudan.exercise_times().to_vec());
+                conditions.push(bermudan);
+            }
+            ExerciseType::European => {}
         }
 
-        Ok(shared(FdmStepConditionComposite::new(&[], conditions)))
+        Ok(shared(FdmStepConditionComposite::new(
+            &stopping_times,
+            conditions,
+        )))
     }
 }
 
@@ -144,7 +162,7 @@ mod tests {
 
     use super::*;
 
-    use crate::exercise::{AmericanExercise, EuropeanExercise};
+    use crate::exercise::{AmericanExercise, BermudanExercise, EuropeanExercise};
     use crate::methods::finitedifferences::meshers::UniformGridMesher;
     use crate::methods::finitedifferences::operators::{FdmLinearOpIterator, FdmLinearOpLayout};
     use crate::time::daycounters::actual360::Actual360;
@@ -316,28 +334,21 @@ mod tests {
         assert_eq!(after, Array::from([1.0, 1.0]));
     }
 
+    /// The discriminator between the two early-exercise branches: American
+    /// contributes no stopping time (`cpp:126-132`), Bermudan contributes one
+    /// per exercise date (`cpp:139`). Without that push the solver would step
+    /// straight past every exercise time and the condition, which only fires on
+    /// an exact match, would never lift the grid.
     #[test]
-    fn a_bermudan_exercise_is_rejected_rather_than_priced_without_its_condition() {
-        struct BermudanStub {
-            dates: [Date; 2],
-        }
-        impl Exercise for BermudanStub {
-            fn exercise_type(&self) -> ExerciseType {
-                ExerciseType::Bermudan
-            }
-            fn dates(&self) -> &[Date] {
-                &self.dates
-            }
-        }
+    fn a_bermudan_exercise_contributes_its_exercise_times_as_stopping_times() {
+        let exercise = shared(
+            BermudanExercise::new(vec![reference() + 180, reference() + 360], false).unwrap(),
+        ) as Shared<dyn Exercise>;
 
-        let exercise = shared(BermudanStub {
-            dates: [reference() + 180, reference() + 360],
-        }) as Shared<dyn Exercise>;
+        let composite = vanilla_composite(exercise).unwrap();
 
-        let Err(error) = vanilla_composite(exercise) else {
-            panic!("a Bermudan exercise must be rejected");
-        };
-        assert_eq!(error.message(), "exercise type is not supported");
+        assert_eq!(composite.conditions().len(), 1);
+        assert_eq!(composite.stopping_times(), &[0.5, 1.0]);
     }
 
     #[test]

--- a/crates/libitofin/src/methods/finitedifferences/stepconditions/mod.rs
+++ b/crates/libitofin/src/methods/finitedifferences/stepconditions/mod.rs
@@ -7,15 +7,16 @@
 //! design.
 //!
 //! [`FdmStepConditionComposite::vanilla_composite`] (`cpp:80-145`) carries the
-//! European and American branches. Its two other sites are deferred and
-//! omitted visibly: `FdmDividendHandler` (`cpp:104`) to #828 and
-//! `FdmBermudanStepCondition` (`cpp:134`) to #827, so an exercise type without
-//! a branch is an error rather than an empty condition list.
+//! European, American and Bermudan branches. Its one other site is deferred and
+//! omitted visibly: `FdmDividendHandler` (`cpp:104`) to #828, so an exercise
+//! type without a branch is an error rather than an empty condition list.
 
 mod fdmamericanstepcondition;
+mod fdmbermudanstepcondition;
 mod fdmsnapshotcondition;
 mod fdmstepconditioncomposite;
 
 pub use fdmamericanstepcondition::FdmAmericanStepCondition;
+pub use fdmbermudanstepcondition::FdmBermudanStepCondition;
 pub use fdmsnapshotcondition::FdmSnapshotCondition;
 pub use fdmstepconditioncomposite::FdmStepConditionComposite;

--- a/crates/libitofin/src/pricingengines/vanilla/fdblackscholesvanillaengine.rs
+++ b/crates/libitofin/src/pricingengines/vanilla/fdblackscholesvanillaengine.rs
@@ -9,11 +9,6 @@
 //!
 //! Deferred to #636, and omitted rather than accepted and ignored:
 //!
-//! - Bermudan exercise. C++ grows an `FdmBermudanStepCondition` inside
-//!   `FdmStepConditionComposite::vanillaComposite` (`cpp:186-191`) when the
-//!   exercise is Bermudan; it is not ported, so the composite rejects that
-//!   exercise type here rather than rolling back under an empty condition list,
-//!   which would be a silently European price (#827);
 //! - cash dividends, both the `Spot` and the `Escrowed` model (`cpp:111-152`,
 //!   `cpp:172-184`). The dividend schedule is always empty and the spot
 //!   adjustment always zero, as on the C++ default path;
@@ -54,7 +49,8 @@ const SCALE_FACTOR: f64 = 1.5;
 /// The density of the concentration around the strike (`cpp:162`).
 const C_POINT_DENSITY: f64 = 0.1;
 
-/// Finite-difference pricing engine for European and American vanilla options.
+/// Finite-difference pricing engine for European, American and Bermudan
+/// vanilla options.
 ///
 /// Everything the engine builds - mesher, calculator, conditions, solver -
 /// lives inside a single [`calculate`](PricingEngine::calculate), as in C++
@@ -214,9 +210,8 @@ mod test_fd_engines {
 
     use super::super::test_market::{market, today};
     use super::FdBlackScholesVanillaEngine;
-    use crate::exercise::{Exercise, ExerciseType};
     use crate::instrument::Instrument;
-    use crate::instruments::{EuropeanOption, OneAssetOption, PlainVanillaPayoff};
+    use crate::instruments::{EuropeanOption, PlainVanillaPayoff};
     use crate::methods::finitedifferences::solvers::FdmSchemeDesc;
     use crate::option::OptionType::{self, Call, Put};
     use crate::pricingengine::PricingEngine;
@@ -355,48 +350,6 @@ mod test_fd_engines {
         println!(
             "testFdEngines: {:?} for 108 combinations; worst relative errors {worst:?}",
             started.elapsed()
-        );
-    }
-
-    /// The visible half of the Bermudan deferral: C++ prices a Bermudan
-    /// exercise through the `FdmBermudanStepCondition` branch of
-    /// `vanillaComposite` (`fdmstepconditioncomposite.cpp:133-140`), and this
-    /// port says so rather than quietly returning the European price. American
-    /// exercise, which shares the guard until #827, prices instead of failing
-    /// and is pinned by the `test_fd_values` oracle below.
-    #[test]
-    fn a_bermudan_exercise_is_rejected_rather_than_priced_as_european() {
-        struct BermudanStub {
-            dates: [Date; 2],
-        }
-        impl Exercise for BermudanStub {
-            fn exercise_type(&self) -> ExerciseType {
-                ExerciseType::Bermudan
-            }
-            fn dates(&self) -> &[Date] {
-                &self.dates
-            }
-        }
-
-        let market = market();
-        market.set(UNDERLYING, 0.00, 0.05, 0.20);
-        let expiry = today() + 360;
-        let european = fd_option(&market, Call, 100.0, expiry);
-
-        let mut bermudan = OneAssetOption::new(
-            Shared::clone(european.payoff()),
-            shared(BermudanStub {
-                dates: [today() + 180, expiry],
-            }) as Shared<dyn Exercise>,
-            Shared::clone(&market.settings),
-        );
-        bermudan
-            .base_mut()
-            .set_pricing_engine(european.base().pricing_engine().unwrap().clone());
-
-        assert_eq!(
-            bermudan.npv().unwrap_err().message(),
-            "exercise type is not supported"
         );
     }
 }

--- a/crates/libitofin/src/pricingengines/vanilla/fdblackscholesvanillaengine.rs
+++ b/crates/libitofin/src/pricingengines/vanilla/fdblackscholesvanillaengine.rs
@@ -531,17 +531,17 @@ mod test_fd_earliest_exercise_date {
     use crate::types::{Rate, Real, Size, Volatility};
 
     /// The market of `:2186-2195`.
-    const S0: Real = 80.0;
-    const STRIKE: Real = 100.0;
+    pub(super) const S0: Real = 80.0;
+    pub(super) const STRIKE: Real = 100.0;
     const SIGMA: Volatility = 0.25;
     const R: Rate = 0.05;
     const Q: Rate = 0.0;
 
     /// The grid of `:2206`.
-    const T_GRID: Size = 200;
-    const X_GRID: Size = 200;
+    pub(super) const T_GRID: Size = 200;
+    pub(super) const X_GRID: Size = 200;
 
-    fn today() -> Date {
+    pub(super) fn today() -> Date {
         Date::new(15, Month::January, 2025)
     }
 
@@ -555,7 +555,7 @@ mod test_fd_earliest_exercise_date {
         )) as Shared<dyn YieldTermStructure>)
     }
 
-    fn process() -> Shared<GeneralizedBlackScholesProcess> {
+    pub(super) fn process() -> Shared<GeneralizedBlackScholesProcess> {
         let spot = Handle::new(shared(SimpleQuote::new(S0)) as Shared<dyn Quote>);
         let vol = Handle::new(shared(BlackConstantVol::new(
             today(),
@@ -651,6 +651,178 @@ mod test_fd_earliest_exercise_date {
         assert!(
             full >= mid - 1e-8,
             "the full window should give the highest price: full {full} 6M {mid}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod test_fd_bermudan {
+    //! A degeneracy oracle for the Bermudan branch, not a port: the C++ test
+    //! suite prices no Bermudan option through this engine, so there is no
+    //! upstream number to reproduce and inventing one would pin nothing.
+    //!
+    //! It runs on the deep in-the-money put of
+    //! `test-suite/americanoption.cpp:2186-2195`, whose early-exercise premium
+    //! is around two, and prices every arm through this same engine on the same
+    //! grid so the arms differ only in the exercise.
+
+    use super::FdBlackScholesVanillaEngine;
+    use super::test_fd_earliest_exercise_date::{S0, STRIKE, T_GRID, X_GRID, process, today};
+    use crate::exercise::{AmericanExercise, BermudanExercise, EuropeanExercise, Exercise};
+    use crate::instrument::Instrument;
+    use crate::instruments::{OneAssetOption, PlainVanillaPayoff};
+    use crate::methods::finitedifferences::solvers::FdmSchemeDesc;
+    use crate::option::OptionType::Put;
+    use crate::pricingengine::PricingEngine;
+    use crate::processes::GeneralizedBlackScholesProcess;
+    use crate::settings::Settings;
+    use crate::shared::{Shared, SharedMut, shared, shared_mut};
+    use crate::time::date::Date;
+    use crate::time::period::Period;
+    use crate::time::timeunit::TimeUnit;
+    use crate::types::Real;
+
+    fn fd_price(
+        settings: &Shared<Settings<Date>>,
+        process: &Shared<GeneralizedBlackScholesProcess>,
+        exercise: Shared<dyn Exercise>,
+    ) -> Real {
+        let mut option = OneAssetOption::new(
+            shared(PlainVanillaPayoff::new(Put, STRIKE)),
+            exercise,
+            Shared::clone(settings),
+        );
+        let engine = shared_mut(FdBlackScholesVanillaEngine::new(
+            Shared::clone(process),
+            T_GRID,
+            X_GRID,
+            0,
+            FdmSchemeDesc::douglas(),
+        ));
+        option
+            .base_mut()
+            .set_pricing_engine(engine as SharedMut<dyn PricingEngine>);
+        option.npv().unwrap()
+    }
+
+    /// The exercise dates `months` after the reference date, the last of which
+    /// is the maturity when it is `12`.
+    fn every(months: &[i32]) -> Shared<dyn Exercise> {
+        let dates = months
+            .iter()
+            .map(|m| today() + Period::new(*m, TimeUnit::Months))
+            .collect();
+        shared(BermudanExercise::new(dates, false).unwrap()) as Shared<dyn Exercise>
+    }
+
+    fn maturity() -> Date {
+        today() + Period::new(1, TimeUnit::Years)
+    }
+
+    fn fixture() -> (
+        Shared<Settings<Date>>,
+        Shared<GeneralizedBlackScholesProcess>,
+    ) {
+        let settings = shared(Settings::new());
+        settings.set_evaluation_date(today());
+        (settings, process())
+    }
+
+    /// The single-date form, whose one exercise opportunity is the expiry, is
+    /// the European option. It agrees to `3.8e-7`, not to the last bit, and the
+    /// residual is mechanism rather than noise: that lone exercise time reaches
+    /// the solver as a stopping time equal to the rollback's own starting time,
+    /// so the model applies the condition once before it steps
+    /// (`finitedifferencemodel.rs:96-100`), taking `max` against a terminal grid
+    /// that the solver seeded with `avg_inner_value` while the condition reads
+    /// `inner_value`. Where the node value exceeds the cell average the grid is
+    /// lifted, and the measured gap is the sum of those lifts. C++ does the
+    /// identical thing.
+    ///
+    /// This arm pins that the Bermudan branch does not *corrupt* a price it
+    /// should reproduce. It cannot pin that the condition fires, because a
+    /// condition that never fired would pass it just as well - that is
+    /// [`dense_exercise_dates_price_above_the_european_and_under_the_american`].
+    #[test]
+    fn a_single_exercise_date_at_expiry_degenerates_to_the_european_price() {
+        let (settings, process) = fixture();
+
+        let euro = fd_price(
+            &settings,
+            &process,
+            shared(EuropeanExercise::new(maturity())) as Shared<dyn Exercise>,
+        );
+        let bermudan = fd_price(&settings, &process, every(&[12]));
+
+        let error = (bermudan - euro).abs();
+        assert!(
+            error <= 1.0e-5,
+            "a Bermudan exercisable only at expiry should be the European option: \
+             Bermudan {bermudan} european {euro} (absolute error {error})"
+        );
+    }
+
+    /// The load-bearing arm. Twelve monthly exercise opportunities on a put
+    /// this deep in the money capture almost all of an early-exercise premium
+    /// worth about two, so the price sits far above the European one and just
+    /// under the continuously exercisable American one.
+    ///
+    /// A condition that never fired - a wrong exercise-time clock, a dropped
+    /// stopping-time push leaving the solver stepping past every exercise date,
+    /// an inverted comparison - prices the European value and misses the floor
+    /// by two hundred times its slack.
+    #[test]
+    fn dense_exercise_dates_price_above_the_european_and_under_the_american() {
+        let (settings, process) = fixture();
+
+        let euro = fd_price(
+            &settings,
+            &process,
+            shared(EuropeanExercise::new(maturity())) as Shared<dyn Exercise>,
+        );
+        let monthly = fd_price(
+            &settings,
+            &process,
+            every(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
+        );
+        let american = fd_price(
+            &settings,
+            &process,
+            shared(AmericanExercise::over(today(), maturity()).unwrap()) as Shared<dyn Exercise>,
+        );
+
+        println!("testFdBermudan: S0={S0} european {euro} monthly {monthly} american {american}");
+
+        assert!(
+            monthly > euro + 1.0,
+            "monthly exercise should capture most of the early-exercise premium: \
+             monthly {monthly} european {euro}"
+        );
+        assert!(
+            monthly <= american,
+            "a Bermudan cannot beat the American it is a subset of: \
+             monthly {monthly} american {american}"
+        );
+    }
+
+    /// Adding exercise opportunities cannot make the option worth less. The
+    /// quarterly dates are a subset of the monthly ones, so this compares two
+    /// exercise sets rather than two grids of different fineness.
+    #[test]
+    fn price_is_monotone_in_the_exercise_date_set() {
+        let (settings, process) = fixture();
+
+        let quarterly = fd_price(&settings, &process, every(&[3, 6, 9, 12]));
+        let monthly = fd_price(
+            &settings,
+            &process,
+            every(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
+        );
+
+        assert!(
+            monthly >= quarterly - 1.0e-8,
+            "more exercise dates should not lower the price: \
+             quarterly {quarterly} monthly {monthly}"
         );
     }
 }


### PR DESCRIPTION
his adds a new test module for the Bermudan branch of the finite
differences Black-Scholes vanilla engine. Since the C++ suite prices no
Bermudan option through this engine, these serve as a degeneracy oracle
rather than a port of an upstream number.

The tests run on the deep in-the-money put and check that:
* a single exercise date at expiry degenerates to the European price,
* dense monthly exercise dates price above the European and under the
  American, capturing most of the early-exercise premium, and
* the price is monotone in the exercise-date set.

Supporting fixtures (constants, `today`, and `process`) are promoted to
`pub(super)` so they can be shared across the test modules. The README
is updated to note Bermudan support in the L9 methods layer.

close #827
