### PR TITLE
feat(itofin-py): expose year-on-year inflation curve bindings

### DIFF
--- a/crates/itofin-py/python/itofin/indexes.pyi
+++ b/crates/itofin-py/python/itofin/indexes.pyi
@@ -2,7 +2,11 @@
 # src/swapindex.rs and src/inflation.rs (#517).
 
 from itofin import Settings
-from itofin.termstructures import YieldTermStructure, ZeroInflationTermStructure
+from itofin.termstructures import (
+    YieldTermStructure,
+    YoYInflationTermStructure,
+    ZeroInflationTermStructure,
+)
 from itofin.time import (
     BusinessDayConvention,
     Calendar,
@@ -135,5 +139,77 @@ class ZeroInflationIndex:
         """Whether fixing_date has to be forecast rather than read from
         history, decided against the latest period that could have been
         published by the settings' evaluation date."""
+        ...
+    def __repr__(self) -> str: ...
+
+class YoYInflationIndex:
+    """An index publishing one year-on-year inflation rate per period, read
+    back as a stored figure or forecast off its year-on-year curve.
+
+    Two forms. A ratio index (from_underlying) derives its rate from two
+    ZeroInflationIndex fixings a year apart and owns no history of its own; a
+    quoted one (the constructor) is published as a rate in its own right and
+    keeps its own history through add_fixing.
+
+    Both forms link to a relinkable handle the index owns, so an index can be
+    built before the curve it forecasts off exists. The handle starts empty and
+    a forecast before any link raises ItofinError; link_to fills it.
+
+    The quoted constructor spells its region and currency out as their component
+    fields: neither core type has a Python facade, and defaulting the currency
+    metadata would put made-up values on the index."""
+
+    def __init__(
+        self,
+        family_name: str,
+        region_name: str,
+        region_code: str,
+        revised: bool,
+        frequency: Frequency,
+        availability_lag: Period,
+        currency_name: str,
+        currency_code: str,
+        currency_numeric_code: int,
+        currency_symbol: str,
+        currency_fraction_symbol: str,
+        currency_fractions_per_unit: int,
+        settings: Settings,
+    ) -> None: ...
+    @staticmethod
+    def from_underlying(underlying: ZeroInflationIndex) -> YoYInflationIndex:
+        """A ratio index over underlying, dividing that index's figure for a
+        period by its figure a year earlier. The metadata is inherited bar the
+        family name, which is prefixed YYR_, so a "UK RPI" underlying yields
+        "UK YYR_RPI"; fixings belong on the underlying."""
+        ...
+    def name(self) -> str: ...
+    def ratio(self) -> bool: ...
+    def underlying_index(self) -> ZeroInflationIndex | None:
+        """The price index a ratio index divides, None on a quoted one. This is
+        the very object from_underlying was handed, not a fresh facade around
+        the same core index."""
+        ...
+    def add_fixing(self, fixing_date: Date, value: float) -> None:
+        """Records a published year-on-year rate across the whole inflation
+        period it describes. A ratio index reads the underlying's history, so
+        filing here records a figure it will never consult."""
+        ...
+    def fixing(self, fixing_date: Date, forecast_todays_fixing: bool = False) -> float:
+        """The rate at fixing_date, stored or forecast off the linked curve.
+        forecast_todays_fixing is accepted and ignored, as in the core."""
+        ...
+    def last_fixing_date(self) -> Date:
+        """The first day of the inflation period the latest figure on record
+        describes, read off the underlying on a ratio index. Raises ItofinError
+        on an index with no history."""
+        ...
+    def link_to(self, curve: YoYInflationTermStructure) -> None:
+        """Points the index at curve, so every forecast from here on reads it.
+        It is the curve behind that facade's handle at call time that is stored,
+        not the handle itself."""
+        ...
+    def needs_forecast(self, fixing_date: Date) -> bool:
+        """Whether fixing_date has to be forecast rather than read from history,
+        a ratio index deferring the question to its underlying."""
         ...
     def __repr__(self) -> str: ...

--- a/crates/itofin-py/python/itofin/instruments.pyi
+++ b/crates/itofin-py/python/itofin/instruments.pyi
@@ -3,7 +3,12 @@
 # src/inflation.rs (#517).
 
 from itofin import Settings
-from itofin.indexes import CpiInterpolationType, Euribor, ZeroInflationIndex
+from itofin.indexes import (
+    CpiInterpolationType,
+    Euribor,
+    YoYInflationIndex,
+    ZeroInflationIndex,
+)
 from itofin.models import HestonModel, HullWhite
 from itofin.pricingengines import (
     BlackCapFloorEngine,
@@ -373,3 +378,57 @@ class ZeroCouponInflationSwap:
         """The same date as obs_date, read off the indexed flow rather than off
         the swap. Both names are kept because both exist in the core."""
         ...
+
+class YearOnYearInflationSwap:
+    """A fixed leg against a leg of year-on-year inflation coupons, both paid
+    over a schedule.
+
+    SwapType names the fixed leg, so a Payer pays fixed and receives inflation -
+    the opposite reading from ZeroCouponInflationSwap, where it names the
+    inflation leg.
+
+    The two schedules are independent inputs. The fixed leg takes its payment
+    calendar from its own schedule while the year-on-year leg pays on
+    payment_calendar; both adjust with payment_convention. spread is added to
+    every forecast rate on the year-on-year leg.
+
+    Pricing needs an engine: call set_engine first. Every priced accessor drives
+    the calculation, so all of them mutate."""
+
+    def __init__(
+        self,
+        swap_type: SwapType,
+        nominal: float,
+        fixed_schedule: Schedule,
+        fixed_rate: float,
+        fixed_day_count: DayCounter,
+        yoy_schedule: Schedule,
+        yoy_index: YoYInflationIndex,
+        observation_lag: Period,
+        interpolation: CpiInterpolationType,
+        spread: float,
+        yoy_day_count: DayCounter,
+        payment_calendar: Calendar,
+        payment_convention: BusinessDayConvention,
+        settings: Settings,
+    ) -> None:
+        """Raises ItofinError when either leg cannot be built, notably from an
+        observation lag that leaves a coupon unbuildable."""
+        ...
+    def set_engine(self, engine: DiscountingSwapEngine) -> None:
+        """The engine must resolve its dates against the same Settings object
+        this swap was built with."""
+        ...
+    def npv(self) -> float: ...
+    def fair_rate(self) -> float:
+        """The fixed rate that would price the swap at zero, recovered from the
+        NPV and the fixed leg's BPS."""
+        ...
+    def fair_spread(self) -> float:
+        """The spread over the index that would price the swap at zero,
+        recovered off the year-on-year leg."""
+        ...
+    def fixed_leg_npv(self) -> float: ...
+    def yoy_leg_npv(self) -> float: ...
+    def fixed_rate(self) -> float: ...
+    def spread(self) -> float: ...

--- a/crates/itofin-py/python/itofin/termstructures.pyi
+++ b/crates/itofin-py/python/itofin/termstructures.pyi
@@ -1085,3 +1085,66 @@ class PiecewiseZeroInflationCurve(ZeroInflationTermStructure):
     def times(self) -> list[float]: ...
     def dates(self) -> list[Date]: ...
     def nodes(self) -> list[tuple[Date, float]]: ...
+
+class YoYInflationTermStructure:
+    """Shared base for every year-on-year inflation curve: the year-on-year
+    rate in a year-fraction and a date form, the base date, the base rate, the
+    fixing frequency and the seasonality correction the curve carries.
+
+    The two rate reads are not interchangeable. yoy_rate_date snaps its date to
+    the start of the inflation period containing it and is the only one that
+    folds in any seasonality; yoy_rate takes a year-fraction already measured
+    under the curve's own day counter and quantizes nothing. Neither is the
+    year-on-year swap rate, which comes from the instrument.
+
+    base_rate is answered here where the zero base defers it: a year-on-year
+    curve carries the rate observed over the period ending on its base date."""
+
+    def yoy_rate(self, t: float, extrapolate: bool = False) -> float: ...
+    def yoy_rate_date(self, date: Date, extrapolate: bool = False) -> float: ...
+    def base_date(self) -> Date: ...
+    def base_rate(self) -> float: ...
+    def frequency(self) -> Frequency: ...
+    def set_seasonality(
+        self, seasonality: MultiplicativePriceSeasonality | None
+    ) -> None:
+        """Installs seasonality on the curve, replacing whatever it carried;
+        None clears it. Raises ItofinError from the consistency gate, leaving a
+        rejected correction installed as C++ does."""
+        ...
+    def has_seasonality(self) -> bool: ...
+
+class InterpolatedYoYInflationCurve(YoYInflationTermStructure):
+    """A year-on-year inflation curve built from (date, year-on-year rate)
+    nodes, interpolating linearly in rate space.
+
+    The first date is the base date rather than the reference date, which is
+    passed separately and normally follows it; the first rate is the base rate
+    the curve publishes, and node times are measured from the reference date, so
+    the first one is negative."""
+
+    def __init__(
+        self,
+        reference_date: Date,
+        dates: list[Date],
+        rates: list[float],
+        frequency: Frequency,
+        day_counter: DayCounter,
+    ) -> None:
+        """Raises ItofinError on fewer than two dates, a dates/rates count
+        mismatch, or a rate at or below -100 % from the second node on - the
+        base rate is left unconstrained."""
+        ...
+    def times(self) -> list[float]: ...
+    def dates(self) -> list[Date]: ...
+    def nodes(self) -> list[tuple[Date, float]]: ...
+
+class YoYInflationHelper:
+    """Shared base for every year-on-year bootstrap helper: the two dates the
+    bootstrap places a curve node by.
+
+    Concrete helpers such as YearOnYearInflationSwapHelper subclass this and
+    supply only their constructor."""
+
+    def pillar_date(self) -> Date: ...
+    def latest_date(self) -> Date: ...

--- a/crates/itofin-py/python/itofin/termstructures.pyi
+++ b/crates/itofin-py/python/itofin/termstructures.pyi
@@ -3,7 +3,14 @@
 # src/credit.rs, src/credithelpers.rs and src/inflation.rs (#517).
 
 from itofin import Settings
-from itofin.indexes import CpiInterpolationType, Estr, Euribor, SwapIndex, ZeroInflationIndex
+from itofin.indexes import (
+    CpiInterpolationType,
+    Estr,
+    Euribor,
+    SwapIndex,
+    YoYInflationIndex,
+    ZeroInflationIndex,
+)
 from itofin.quotes import SimpleQuote
 from itofin.time import (
     BusinessDayConvention,
@@ -1148,3 +1155,68 @@ class YoYInflationHelper:
 
     def pillar_date(self) -> Date: ...
     def latest_date(self) -> Date: ...
+
+class YearOnYearInflationSwapHelper(YoYInflationHelper):
+    """The bootstrap helper fitting a year-on-year inflation swap quoted as a
+    rate.
+
+    The helper prices a unit-notional, zero-strike swap of its own and reports
+    that contract's fair rate; the bootstrap drives the quoted rate less that
+    fair rate to zero. Unlike its zero-coupon twin it does need a nominal curve:
+    the year-on-year legs pay on a schedule of dates rather than one, so their
+    discount factors do not cancel.
+
+    The swap starts at the evaluation date, so that date must be set before this
+    constructor runs, not merely before the bootstrap. It prices through a copy
+    of index linked to a handle of its own, so the caller's index need not be
+    linked to any curve.
+
+    pillar is accepted for signature parity but never read: it only ever
+    discriminates on the interpolated path, which is refused."""
+
+    def __init__(
+        self,
+        quote: SimpleQuote,
+        swap_obs_lag: Period,
+        maturity: Date,
+        calendar: Calendar,
+        payment_convention: BusinessDayConvention,
+        day_counter: DayCounter,
+        index: YoYInflationIndex,
+        interpolation: CpiInterpolationType,
+        nominal_term_structure: YieldTermStructure,
+        settings: Settings,
+        pillar: Pillar = ...,
+    ) -> None:
+        """Raises ItofinError on CpiInterpolationType.Linear, which the core
+        refuses outright pending the interpolated branch (#847), and on an
+        observation lag the helper's own swap legs cannot be built under."""
+        ...
+
+class PiecewiseYoYInflationCurve(YoYInflationTermStructure):
+    """A year-on-year inflation curve bootstrapped from year-on-year helpers,
+    solving one rate node per helper fixing period.
+
+    Node zero sits on base_date at base_yoy_rate and is kept rather than solved,
+    so times()[0] is negative. Each helper's observed fixing period marks a
+    later segment boundary.
+
+    Lazy: the bootstrap runs on the first read, so the evaluation date must be
+    in place before that read as well as before the helpers were built. A helper
+    quote moving invalidates the cache."""
+
+    def __init__(
+        self,
+        reference_date: Date,
+        base_date: Date,
+        base_yoy_rate: float,
+        frequency: Frequency,
+        day_counter: DayCounter,
+        helpers: list[YoYInflationHelper],
+    ) -> None:
+        """Raises ItofinError on an empty helper list."""
+        ...
+    def calculate(self) -> None: ...
+    def times(self) -> list[float]: ...
+    def dates(self) -> list[Date]: ...
+    def nodes(self) -> list[tuple[Date, float]]: ...

--- a/crates/itofin-py/src/inflation.rs
+++ b/crates/itofin-py/src/inflation.rs
@@ -20,7 +20,7 @@ use crate::market::PySimpleQuote;
 use crate::settings::PySettings;
 use crate::swap::PySwapType;
 use crate::time::{
-    PyBusinessDayConvention, PyCalendar, PyDate, PyDayCounter, PyFrequency, PyPeriod,
+    PyBusinessDayConvention, PyCalendar, PyDate, PyDayCounter, PyFrequency, PyPeriod, PySchedule,
 };
 use libitofin::currency::Currency;
 use libitofin::handle::{Handle, RelinkableHandle};
@@ -31,7 +31,7 @@ use libitofin::indexes::inflationindex::{
 };
 use libitofin::indexes::region::Region;
 use libitofin::instrument::Instrument;
-use libitofin::instruments::ZeroCouponInflationSwap;
+use libitofin::instruments::{YearOnYearInflationSwap, ZeroCouponInflationSwap};
 use libitofin::math::interpolations::linear::Linear;
 use libitofin::pricingengine::PricingEngine;
 use libitofin::pricingengines::DiscountingSwapEngine;
@@ -1732,5 +1732,166 @@ impl PyPiecewiseYoYInflationCurve {
             .into_iter()
             .map(|(date, rate)| (PyDate::from_inner(date), rate))
             .collect())
+    }
+}
+
+/// Python `YearOnYearInflationSwap`: a fixed leg against a leg of year-on-year
+/// inflation coupons, both paid over a schedule
+/// (`instruments::yearonyearinflationswap`).
+///
+/// [`SwapType`](crate::swap::PySwapType) names the *fixed* leg, so a `Payer`
+/// pays fixed and receives inflation - the opposite reading from
+/// [`PyZeroCouponInflationSwap`], where it names the inflation leg.
+///
+/// The two schedules are independent inputs. The fixed leg takes its payment
+/// calendar from its own schedule while the year-on-year leg pays on
+/// `payment_calendar`, the inflation index carrying no calendar of its own;
+/// both legs adjust with `payment_convention`, which C++ defaults to
+/// `ModifiedFollowing` and the port takes explicitly. `spread` is added to
+/// every forecast rate on the year-on-year leg.
+///
+/// Fallible at construction: both leg builds propagate, so a coupon the
+/// observation lag leaves unbuildable fails here.
+///
+/// Pricing needs an engine: call [`set_engine`](Self::set_engine) before
+/// anything else. Every accessor below is `&mut self` where the zero-coupon
+/// swap's [`fair_rate`](PyZeroCouponInflationSwap::fair_rate) is not: this
+/// contract recovers both fair values from a priced result rather than reading
+/// a single indexed flow (`yearonyearinflationswap.rs:311,326`), so each one
+/// drives the calculation.
+///
+/// Deferred (visible): the leg and coupon accessors are not surfaced, there
+/// being no cash-flow facade to hand them back through (#848).
+#[pyclass(name = "YearOnYearInflationSwap", unsendable)]
+pub struct PyYearOnYearInflationSwap {
+    inner: SharedMut<YearOnYearInflationSwap>,
+}
+
+#[pymethods]
+impl PyYearOnYearInflationSwap {
+    #[new]
+    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (
+        swap_type,
+        nominal,
+        fixed_schedule,
+        fixed_rate,
+        fixed_day_count,
+        yoy_schedule,
+        yoy_index,
+        observation_lag,
+        interpolation,
+        spread,
+        yoy_day_count,
+        payment_calendar,
+        payment_convention,
+        settings,
+    ))]
+    fn new(
+        swap_type: &PySwapType,
+        nominal: f64,
+        fixed_schedule: &PySchedule,
+        fixed_rate: f64,
+        fixed_day_count: &PyDayCounter,
+        yoy_schedule: &PySchedule,
+        yoy_index: &PyYoYInflationIndex,
+        observation_lag: &PyPeriod,
+        interpolation: &PyCpiInterpolationType,
+        spread: f64,
+        yoy_day_count: &PyDayCounter,
+        payment_calendar: &PyCalendar,
+        payment_convention: &PyBusinessDayConvention,
+        settings: &PySettings,
+    ) -> PyResult<Self> {
+        Ok(PyYearOnYearInflationSwap {
+            inner: shared_mut(
+                YearOnYearInflationSwap::new(
+                    swap_type.inner(),
+                    nominal,
+                    fixed_schedule.inner(),
+                    fixed_rate,
+                    fixed_day_count.inner(),
+                    yoy_schedule.inner(),
+                    yoy_index.shared(),
+                    observation_lag.inner(),
+                    interpolation.inner(),
+                    spread,
+                    yoy_day_count.inner(),
+                    payment_calendar.inner(),
+                    payment_convention.inner(),
+                    settings.inner(),
+                )
+                .map_err(PyQlError::from)?,
+            ),
+        })
+    }
+
+    /// Attaches a [`PyDiscountingSwapEngine`] so the swap prices.
+    ///
+    /// The engine must resolve its dates against the same `Settings` object
+    /// this swap was built with.
+    fn set_engine(&mut self, engine: &PyDiscountingSwapEngine) {
+        self.inner
+            .borrow_mut()
+            .base_mut()
+            .set_pricing_engine(engine.engine());
+    }
+
+    /// The swap NPV under the attached engine.
+    ///
+    /// Fallible: with no engine attached the core reports `"null pricing
+    /// engine"`, and with no curve linked into the index the coupons cannot be
+    /// forecast.
+    fn npv(&mut self) -> PyResult<f64> {
+        Ok(self.inner.borrow_mut().npv().map_err(PyQlError::from)?)
+    }
+
+    /// The fixed rate that would price the swap at zero, recovered from the NPV
+    /// and the fixed leg's BPS. Prices on demand, so it needs an engine.
+    fn fair_rate(&mut self) -> PyResult<f64> {
+        Ok(self
+            .inner
+            .borrow_mut()
+            .fair_rate()
+            .map_err(PyQlError::from)?)
+    }
+
+    /// The spread over the index that would price the swap at zero, recovered
+    /// off the year-on-year leg. Fallible as [`fair_rate`](Self::fair_rate).
+    fn fair_spread(&mut self) -> PyResult<f64> {
+        Ok(self
+            .inner
+            .borrow_mut()
+            .fair_spread()
+            .map_err(PyQlError::from)?)
+    }
+
+    /// The fixed leg's NPV, priced on demand. Fallible as [`npv`](Self::npv).
+    fn fixed_leg_npv(&mut self) -> PyResult<f64> {
+        Ok(self
+            .inner
+            .borrow_mut()
+            .fixed_leg_npv()
+            .map_err(PyQlError::from)?)
+    }
+
+    /// The year-on-year leg's NPV, priced on demand. Fallible as
+    /// [`npv`](Self::npv).
+    fn yoy_leg_npv(&mut self) -> PyResult<f64> {
+        Ok(self
+            .inner
+            .borrow_mut()
+            .yoy_leg_npv()
+            .map_err(PyQlError::from)?)
+    }
+
+    /// The quoted fixed rate the swap was struck at.
+    fn fixed_rate(&self) -> f64 {
+        self.inner.borrow().fixed_rate()
+    }
+
+    /// The spread the year-on-year coupons carry over the index.
+    fn spread(&self) -> f64 {
+        self.inner.borrow().spread()
     }
 }

--- a/crates/itofin-py/src/inflation.rs
+++ b/crates/itofin-py/src/inflation.rs
@@ -37,13 +37,15 @@ use libitofin::pricingengine::PricingEngine;
 use libitofin::pricingengines::DiscountingSwapEngine;
 use libitofin::shared::{Shared, SharedMut, shared, shared_mut};
 use libitofin::termstructures::inflation::inflationhelpers::{
-    YoYInflationHelper, ZeroCouponInflationSwapHelper, ZeroInflationHelper,
+    YearOnYearInflationSwapHelper, YoYInflationHelper, ZeroCouponInflationSwapHelper,
+    ZeroInflationHelper,
 };
 use libitofin::termstructures::inflation::inflationtermstructure::{
     YoYInflationTermStructure, ZeroInflationTermStructure,
 };
 use libitofin::termstructures::inflation::interpolatedyoyinflationcurve::InterpolatedYoYInflationCurve;
 use libitofin::termstructures::inflation::interpolatedzeroinflationcurve::InterpolatedZeroInflationCurve;
+use libitofin::termstructures::inflation::piecewiseyoyinflationcurve::PiecewiseYoYInflationCurve;
 use libitofin::termstructures::inflation::piecewisezeroinflationcurve::PiecewiseZeroInflationCurve;
 use libitofin::termstructures::inflation::seasonality::{
     MultiplicativePriceSeasonality, Seasonality,
@@ -637,7 +639,6 @@ impl PyZeroInflationHelper {
 
 impl PyZeroInflationHelper {
     /// The base half of a concrete helper's [`PyClassInitializer`] chain.
-    #[allow(dead_code)]
     pub(crate) fn from_shared(inner: Shared<dyn ZeroInflationHelper>) -> Self {
         PyZeroInflationHelper { inner }
     }
@@ -1315,14 +1316,12 @@ impl PyYoYInflationHelper {
 
 impl PyYoYInflationHelper {
     /// The base half of a concrete helper's [`PyClassInitializer`] chain.
-    #[allow(dead_code)]
     pub(crate) fn from_shared(inner: Shared<dyn YoYInflationHelper>) -> Self {
         PyYoYInflationHelper { inner }
     }
 
     /// A clone of the upcast helper, for the piecewise year-on-year curve
     /// facade, which threads each helper into the bootstrap.
-    #[allow(dead_code)]
     pub(crate) fn shared(&self) -> Shared<dyn YoYInflationHelper> {
         Shared::clone(&self.inner)
     }
@@ -1537,8 +1536,201 @@ impl PyYoYInflationIndex {
 
 impl PyYoYInflationIndex {
     /// The wrapped core index, for the helper and swap facades that take one.
-    #[allow(dead_code)]
     pub(crate) fn shared(&self) -> Shared<YoYInflationIndex> {
         Shared::clone(&self.inner)
+    }
+}
+
+/// Python `YearOnYearInflationSwapHelper`: the bootstrap helper fitting a
+/// year-on-year inflation swap quoted as a rate
+/// (`termstructures::inflation::inflationhelpers::YearOnYearInflationSwapHelper`).
+///
+/// The helper prices a unit-notional, zero-strike swap of its own and reports
+/// that contract's fair rate; the bootstrap drives the quoted rate less that
+/// fair rate to zero. Unlike its zero-coupon twin it does need a nominal curve:
+/// the year-on-year legs pay on a schedule of dates rather than one, so their
+/// discount factors do not cancel.
+///
+/// The swap starts at the evaluation date held by `settings` and is rebuilt
+/// whenever that date moves, so the evaluation date must be set *before* the
+/// constructor runs, not merely before the bootstrap. The helper retains the
+/// caller's [`PySimpleQuote`], so a later `set_value` re-drives the bootstrap.
+///
+/// It prices through a *copy* of `index` linked to a handle of its own, which
+/// the bootstrap points at the curve under construction; the caller's index
+/// keeps whatever curve it had and need not be linked at all.
+///
+/// `pillar` is accepted for signature parity but never read: it only ever
+/// discriminates on the interpolated path, which is refused below.
+///
+/// Fallible: [`CpiInterpolationType.Linear`](PyCpiInterpolationType) is refused
+/// outright (`inflationhelpers.rs:701-706`), the interpolated branch of the C++
+/// constructor being deferred with the rest of `CPI::Linear` (#847); and the
+/// swap is built here, so an observation lag its legs cannot be built under
+/// fails at construction. Both raise [`struct@crate::ItofinError`].
+///
+/// Deferred (visible): the zero twin's `inflation_fixing_date` has no
+/// counterpart here - a year-on-year contract observes once per coupon rather
+/// than once at maturity, and there is no cash-flow facade to enumerate them
+/// through (#848).
+#[pyclass(
+    name = "YearOnYearInflationSwapHelper",
+    extends = PyYoYInflationHelper,
+    unsendable
+)]
+pub struct PyYearOnYearInflationSwapHelper;
+
+#[pymethods]
+impl PyYearOnYearInflationSwapHelper {
+    /// A helper fitting `quote` on a swap maturing at `maturity`, discounted on
+    /// `nominal_term_structure`.
+    #[new]
+    #[pyo3(signature = (
+        quote,
+        swap_obs_lag,
+        maturity,
+        calendar,
+        payment_convention,
+        day_counter,
+        index,
+        interpolation,
+        nominal_term_structure,
+        settings,
+        pillar = PyPillar::LastRelevantDate,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        quote: &PySimpleQuote,
+        swap_obs_lag: &PyPeriod,
+        maturity: &PyDate,
+        calendar: &PyCalendar,
+        payment_convention: &PyBusinessDayConvention,
+        day_counter: &PyDayCounter,
+        index: &PyYoYInflationIndex,
+        interpolation: &PyCpiInterpolationType,
+        nominal_term_structure: &PyYieldTermStructure,
+        settings: &PySettings,
+        pillar: PyPillar,
+    ) -> PyResult<PyClassInitializer<Self>> {
+        let concrete = YearOnYearInflationSwapHelper::new(
+            quote.handle(),
+            swap_obs_lag.inner(),
+            maturity.inner(),
+            calendar.inner(),
+            payment_convention.inner(),
+            day_counter.inner(),
+            &index.shared(),
+            interpolation.inner(),
+            nominal_term_structure.handle(),
+            pillar.inner(),
+            settings.inner(),
+        )
+        .map_err(PyQlError::from)?;
+        let erased = concrete as Shared<dyn YoYInflationHelper>;
+        Ok(
+            PyClassInitializer::from(PyYoYInflationHelper::from_shared(erased))
+                .add_subclass(PyYearOnYearInflationSwapHelper),
+        )
+    }
+}
+
+/// Python `PiecewiseYoYInflationCurve`: a year-on-year inflation curve
+/// bootstrapped from year-on-year helpers, solving one rate node per helper
+/// (`termstructures::inflation::PiecewiseYoYInflationCurve<Linear>`).
+///
+/// Extends [`PyYoYInflationTermStructure`], which carries the whole query
+/// surface. Node zero sits on `base_date` at `base_yoy_rate` and is kept rather
+/// than solved: the base date is the last date for which a fixing is known and
+/// precedes the reference date, so [`times`](Self::times)`[0]` is negative.
+/// Each helper's observed fixing period marks a later segment boundary, and its
+/// node is solved so the helper reprices its own quote off the curve.
+///
+/// Lazy, like [`PyPiecewiseZeroInflationCurve`]: the constructor only registers
+/// on the helpers, and the bootstrap runs on the first read - a query, an
+/// inspector, or an explicit [`calculate`](Self::calculate). A helper quote
+/// moving invalidates the cache.
+///
+/// Fallible: the core rejects an empty helper set, and every inspector
+/// propagates a bootstrap failure as [`struct@crate::ItofinError`]. `Linear` is
+/// pinned at the boundary, it being the only interpolator the core constructs.
+#[pyclass(
+    name = "PiecewiseYoYInflationCurve",
+    extends = PyYoYInflationTermStructure,
+    unsendable
+)]
+pub struct PyPiecewiseYoYInflationCurve {
+    concrete: Shared<PiecewiseYoYInflationCurve<Linear>>,
+}
+
+#[pymethods]
+impl PyPiecewiseYoYInflationCurve {
+    /// A curve over `helpers` with a fixed `reference_date`, a `base_date`
+    /// preceding it and the `base_yoy_rate` observed over the period ending
+    /// there. `helpers` accepts any [`YoYInflationHelper`](PyYoYInflationHelper)
+    /// subclass.
+    #[new]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        reference_date: &PyDate,
+        base_date: &PyDate,
+        base_yoy_rate: f64,
+        frequency: &PyFrequency,
+        day_counter: &PyDayCounter,
+        helpers: Vec<PyRef<PyYoYInflationHelper>>,
+    ) -> PyResult<PyClassInitializer<Self>> {
+        let instruments: Vec<Shared<dyn YoYInflationHelper>> =
+            helpers.iter().map(|helper| helper.shared()).collect();
+        let concrete = PiecewiseYoYInflationCurve::<Linear>::new(
+            reference_date.inner(),
+            base_date.inner(),
+            base_yoy_rate,
+            frequency.inner(),
+            day_counter.inner(),
+            instruments,
+            None,
+        )
+        .map_err(PyQlError::from)?;
+        let erased = Shared::clone(&concrete) as Shared<dyn YoYInflationTermStructure>;
+        Ok(
+            PyClassInitializer::from(PyYoYInflationTermStructure::from_handle(Handle::new(
+                erased,
+            )))
+            .add_subclass(PyPiecewiseYoYInflationCurve { concrete }),
+        )
+    }
+
+    /// Runs the bootstrap if the cache is stale, so a solver failure surfaces
+    /// here rather than inside a later query.
+    fn calculate(&self) -> PyResult<()> {
+        Ok(self.concrete.calculate().map_err(PyQlError::from)?)
+    }
+
+    /// The node times, measured from the reference date in the curve's own day
+    /// count; the first is negative (triggers the bootstrap).
+    fn times(&self) -> PyResult<Vec<f64>> {
+        Ok(self.concrete.times().map_err(PyQlError::from)?)
+    }
+
+    /// The node dates, the first of which is the base date (triggers the
+    /// bootstrap).
+    fn dates(&self) -> PyResult<Vec<PyDate>> {
+        Ok(self
+            .concrete
+            .dates()
+            .map_err(PyQlError::from)?
+            .into_iter()
+            .map(PyDate::from_inner)
+            .collect())
+    }
+
+    /// The solved `(date, year-on-year rate)` nodes (triggers the bootstrap).
+    fn nodes(&self) -> PyResult<Vec<(PyDate, f64)>> {
+        Ok(self
+            .concrete
+            .nodes()
+            .map_err(PyQlError::from)?
+            .into_iter()
+            .map(|(date, rate)| (PyDate::from_inner(date), rate))
+            .collect())
     }
 }

--- a/crates/itofin-py/src/inflation.rs
+++ b/crates/itofin-py/src/inflation.rs
@@ -4,7 +4,10 @@
 //! [`PyZeroInflationTermStructure`] curve hierarchy, the
 //! [`PyMultiplicativePriceSeasonality`] correction any of its curves can carry,
 //! the [`PyZeroInflationHelper`] bootstrap helpers that fit its piecewise member
-//! and the [`PyZeroCouponInflationSwap`] the rest of them price together.
+//! and the [`PyZeroCouponInflationSwap`] the rest of them price together, plus
+//! the year-on-year family that mirrors it: the
+//! [`PyYoYInflationTermStructure`] curve hierarchy and the
+//! [`PyYoYInflationHelper`] helpers that fit its piecewise member.
 //!
 //! The swap engine is generic rather than inflation-specific - it prices any
 //! swap - but is homed here because the inflation tickets are the first to need
@@ -30,9 +33,12 @@ use libitofin::pricingengine::PricingEngine;
 use libitofin::pricingengines::DiscountingSwapEngine;
 use libitofin::shared::{Shared, SharedMut, shared, shared_mut};
 use libitofin::termstructures::inflation::inflationhelpers::{
-    ZeroCouponInflationSwapHelper, ZeroInflationHelper,
+    YoYInflationHelper, ZeroCouponInflationSwapHelper, ZeroInflationHelper,
 };
-use libitofin::termstructures::inflation::inflationtermstructure::ZeroInflationTermStructure;
+use libitofin::termstructures::inflation::inflationtermstructure::{
+    YoYInflationTermStructure, ZeroInflationTermStructure,
+};
+use libitofin::termstructures::inflation::interpolatedyoyinflationcurve::InterpolatedYoYInflationCurve;
 use libitofin::termstructures::inflation::interpolatedzeroinflationcurve::InterpolatedZeroInflationCurve;
 use libitofin::termstructures::inflation::piecewisezeroinflationcurve::PiecewiseZeroInflationCurve;
 use libitofin::termstructures::inflation::seasonality::{
@@ -1038,5 +1044,282 @@ impl PyZeroCouponInflationSwap {
     /// exist in the core, and the oracle asserts they coincide.
     fn inflation_fixing_date(&self) -> PyDate {
         PyDate::from_inner(self.inner.borrow().inflation_cash_flow().fixing_date())
+    }
+}
+
+/// Python `YoYInflationTermStructure`: the shared base for every year-on-year
+/// inflation curve (`termstructures::inflation::inflationtermstructure`).
+///
+/// Holds the erased `Handle<dyn YoYInflationTermStructure>` and exposes the
+/// query surface every concrete curve inherits, the shape
+/// [`PyZeroInflationTermStructure`] already uses on the zero side. Concrete
+/// curves such as [`PyInterpolatedYoYInflationCurve`] subclass this and supply
+/// only their constructor and node inspectors.
+///
+/// The two rate reads are not interchangeable, exactly as on the zero side.
+/// [`yoy_rate_date`](Self::yoy_rate_date) snaps its date to the start of the
+/// inflation period containing it before the curve sees it, and is the only one
+/// that folds in a seasonality correction;
+/// [`yoy_rate`](Self::yoy_rate) takes a year-fraction already measured under the
+/// curve's own day counter and quantizes nothing.
+///
+/// [`base_rate`](Self::base_rate) is exposed here where the zero base defers it:
+/// a year-on-year curve carries the rate observed over the period ending on its
+/// base date, C++ forwarding `baseYoYRate` into the base constructor's
+/// `baseRate` slot (`inflationtermstructure.rs:198`), so every curve reachable
+/// through this facade answers rather than raising.
+///
+/// Deferred (visible): the core's `seasonality()` getter, for the reason
+/// [`PyZeroInflationTermStructure`] omits it - it hands back an erased
+/// `Shared<dyn Seasonality>` there is no downcast surface to recover the
+/// concrete correction from.
+#[pyclass(name = "YoYInflationTermStructure", subclass, unsendable)]
+pub struct PyYoYInflationTermStructure {
+    inner: Handle<dyn YoYInflationTermStructure>,
+}
+
+#[pymethods]
+impl PyYoYInflationTermStructure {
+    /// The year-on-year inflation rate at year-fraction `t`.
+    ///
+    /// `t` must be measured with the curve's own day counter, and is negative
+    /// for the base period. This is not the year-on-year swap rate, which comes
+    /// from the instrument.
+    #[pyo3(signature = (t, extrapolate = false))]
+    fn yoy_rate(&self, t: f64, extrapolate: bool) -> PyResult<f64> {
+        Ok(self
+            .inner
+            .current_link()
+            .map_err(PyQlError::from)?
+            .yoy_rate(t, extrapolate)
+            .map_err(PyQlError::from)?)
+    }
+
+    /// The year-on-year inflation rate for the inflation period containing
+    /// `date`.
+    ///
+    /// The date is quantized to that period's first day before both the range
+    /// check and the time conversion, so every day inside one period reads the
+    /// same rate. Any seasonality correction is folded in last, at the
+    /// *original* date rather than the period start, as C++ does on this path.
+    #[pyo3(signature = (date, extrapolate = false))]
+    fn yoy_rate_date(&self, date: &PyDate, extrapolate: bool) -> PyResult<f64> {
+        Ok(self
+            .inner
+            .current_link()
+            .map_err(PyQlError::from)?
+            .yoy_rate_date(date.inner(), extrapolate)
+            .map_err(PyQlError::from)?)
+    }
+
+    /// The base date: the last date for which the fixing is known. It precedes
+    /// the reference date, so its year-fraction is negative.
+    fn base_date(&self) -> PyResult<PyDate> {
+        Ok(PyDate::from_inner(
+            self.inner
+                .current_link()
+                .map_err(PyQlError::from)?
+                .base_date(),
+        ))
+    }
+
+    /// The year-on-year rate observed over the period ending on the base date,
+    /// which node zero is seeded with and keeps.
+    fn base_rate(&self) -> PyResult<f64> {
+        Ok(self
+            .inner
+            .current_link()
+            .map_err(PyQlError::from)?
+            .base_rate()
+            .map_err(PyQlError::from)?)
+    }
+
+    /// The frequency of the inflation fixings the curve is built on.
+    fn frequency(&self) -> PyResult<PyFrequency> {
+        PyFrequency::from_inner(
+            self.inner
+                .current_link()
+                .map_err(PyQlError::from)?
+                .frequency(),
+        )
+    }
+
+    /// Installs `seasonality` on the curve, replacing whatever it carried;
+    /// `None` clears it.
+    ///
+    /// # Errors
+    ///
+    /// Reports the consistency gate, and leaves a rejected correction installed
+    /// as C++ does - see [`PyZeroInflationTermStructure::set_seasonality`].
+    #[pyo3(signature = (seasonality))]
+    fn set_seasonality(
+        &self,
+        seasonality: Option<&PyMultiplicativePriceSeasonality>,
+    ) -> PyResult<()> {
+        Ok(self
+            .inner
+            .current_link()
+            .map_err(PyQlError::from)?
+            .set_seasonality(seasonality.map(PyMultiplicativePriceSeasonality::shared))
+            .map_err(PyQlError::from)?)
+    }
+
+    /// Whether the curve carries a seasonality correction.
+    fn has_seasonality(&self) -> PyResult<bool> {
+        Ok(self
+            .inner
+            .current_link()
+            .map_err(PyQlError::from)?
+            .has_seasonality())
+    }
+}
+
+impl PyYoYInflationTermStructure {
+    /// The base half of a concrete curve's [`PyClassInitializer`] chain.
+    pub(crate) fn from_handle(inner: Handle<dyn YoYInflationTermStructure>) -> Self {
+        PyYoYInflationTermStructure { inner }
+    }
+
+    /// A clone of the inner curve handle for the index facade that links one.
+    #[allow(dead_code)]
+    pub(crate) fn handle(&self) -> Handle<dyn YoYInflationTermStructure> {
+        self.inner.clone()
+    }
+}
+
+/// Python `InterpolatedYoYInflationCurve`: a year-on-year inflation curve built
+/// from (date, year-on-year-rate) nodes, interpolating linearly in rate space
+/// (`termstructures::inflation::InterpolatedYoYInflationCurve<Linear>`).
+///
+/// Extends [`PyYoYInflationTermStructure`], which carries the whole query
+/// surface. The first date is the *base* date rather than the reference date,
+/// which is passed separately and normally follows it; the first rate is the
+/// base rate the curve publishes, and node times are measured from the
+/// reference date, so the first one is negative.
+///
+/// The concrete curve is retained alongside the erased handle so the node
+/// inspectors stay reachable, as [`PyInterpolatedZeroInflationCurve`] does.
+///
+/// Fallible: the core rejects fewer than two dates, a dates/rates count
+/// mismatch and, from the second node on, a rate at or below -100 %, the base
+/// rate being left unconstrained
+/// (`interpolatedyoyinflationcurve.rs:100-117`).
+///
+/// `Linear` is pinned at the boundary: it is the interpolator C++'s
+/// `YoYInflationCurve` typedef fixes, so no interpolation argument is offered.
+#[pyclass(
+    name = "InterpolatedYoYInflationCurve",
+    extends = PyYoYInflationTermStructure,
+    unsendable
+)]
+pub struct PyInterpolatedYoYInflationCurve {
+    concrete: Shared<InterpolatedYoYInflationCurve<Linear>>,
+}
+
+#[pymethods]
+impl PyInterpolatedYoYInflationCurve {
+    /// A curve through the `rates` quoted at `dates`, with `dates[0]` as the
+    /// base date and `reference_date` given separately.
+    #[new]
+    fn new(
+        reference_date: &PyDate,
+        dates: Vec<PyRef<PyDate>>,
+        rates: Vec<f64>,
+        frequency: &PyFrequency,
+        day_counter: &PyDayCounter,
+    ) -> PyResult<PyClassInitializer<Self>> {
+        let dates: Vec<_> = dates.iter().map(|date| date.inner()).collect();
+        let concrete = shared(
+            InterpolatedYoYInflationCurve::new(
+                reference_date.inner(),
+                dates,
+                rates,
+                frequency.inner(),
+                day_counter.inner(),
+                Linear,
+                None,
+            )
+            .map_err(PyQlError::from)?,
+        );
+        let erased = Shared::clone(&concrete) as Shared<dyn YoYInflationTermStructure>;
+        Ok(
+            PyClassInitializer::from(PyYoYInflationTermStructure::from_handle(Handle::new(
+                erased,
+            )))
+            .add_subclass(PyInterpolatedYoYInflationCurve { concrete }),
+        )
+    }
+
+    /// The node times, measured from the reference date; the first is negative
+    /// whenever the base date precedes it.
+    fn times(&self) -> Vec<f64> {
+        self.concrete.times().to_vec()
+    }
+
+    /// The node dates, the first of which is the base date.
+    fn dates(&self) -> Vec<PyDate> {
+        self.concrete
+            .dates()
+            .iter()
+            .copied()
+            .map(PyDate::from_inner)
+            .collect()
+    }
+
+    /// The `(date, year-on-year rate)` nodes.
+    fn nodes(&self) -> Vec<(PyDate, f64)> {
+        self.concrete
+            .nodes()
+            .into_iter()
+            .map(|(date, rate)| (PyDate::from_inner(date), rate))
+            .collect()
+    }
+}
+
+/// Python `YoYInflationHelper`: the shared base for every year-on-year
+/// bootstrap helper
+/// (`termstructures::inflation::inflationhelpers::YoYInflationHelper`).
+///
+/// Holds the erased `Shared<dyn YoYInflationHelper>` and exposes the two dates
+/// the bootstrap places a curve node by, the shape [`PyZeroInflationHelper`]
+/// already uses. Concrete helpers such as [`PyYearOnYearInflationSwapHelper`]
+/// subclass this and supply only their constructor.
+///
+/// Deferred (visible): the core trait's `earliest_date`, `maturity_date` and
+/// `latest_relevant_date` are omitted, as on the zero side - on the one
+/// concrete helper reachable here they collapse onto the same fixing-period
+/// start (`inflationhelpers.rs:730-731`), so all three would report what
+/// [`pillar_date`](Self::pillar_date) reports.
+#[pyclass(name = "YoYInflationHelper", subclass, unsendable)]
+pub struct PyYoYInflationHelper {
+    inner: Shared<dyn YoYInflationHelper>,
+}
+
+#[pymethods]
+impl PyYoYInflationHelper {
+    /// The pillar date, at which the curve node this helper sets sits.
+    fn pillar_date(&self) -> PyDate {
+        PyDate::from_inner(self.inner.pillar_date())
+    }
+
+    /// The latest date the helper needs curve data at (equal to the pillar
+    /// date).
+    fn latest_date(&self) -> PyDate {
+        PyDate::from_inner(self.inner.latest_date())
+    }
+}
+
+impl PyYoYInflationHelper {
+    /// The base half of a concrete helper's [`PyClassInitializer`] chain.
+    #[allow(dead_code)]
+    pub(crate) fn from_shared(inner: Shared<dyn YoYInflationHelper>) -> Self {
+        PyYoYInflationHelper { inner }
+    }
+
+    /// A clone of the upcast helper, for the piecewise year-on-year curve
+    /// facade, which threads each helper into the bootstrap.
+    #[allow(dead_code)]
+    pub(crate) fn shared(&self) -> Shared<dyn YoYInflationHelper> {
+        Shared::clone(&self.inner)
     }
 }

--- a/crates/itofin-py/src/inflation.rs
+++ b/crates/itofin-py/src/inflation.rs
@@ -22,10 +22,14 @@ use crate::swap::PySwapType;
 use crate::time::{
     PyBusinessDayConvention, PyCalendar, PyDate, PyDayCounter, PyFrequency, PyPeriod,
 };
+use libitofin::currency::Currency;
 use libitofin::handle::{Handle, RelinkableHandle};
 use libitofin::indexes::index::Index;
 use libitofin::indexes::inflation::{EuHicp, UkHicp, UkRpi};
-use libitofin::indexes::inflationindex::{CpiInterpolationType, ZeroInflationIndex};
+use libitofin::indexes::inflationindex::{
+    CpiInterpolationType, YoYInflationIndex, ZeroInflationIndex,
+};
+use libitofin::indexes::region::Region;
 use libitofin::instrument::Instrument;
 use libitofin::instruments::ZeroCouponInflationSwap;
 use libitofin::math::interpolations::linear::Linear;
@@ -633,6 +637,7 @@ impl PyZeroInflationHelper {
 
 impl PyZeroInflationHelper {
     /// The base half of a concrete helper's [`PyClassInitializer`] chain.
+    #[allow(dead_code)]
     pub(crate) fn from_shared(inner: Shared<dyn ZeroInflationHelper>) -> Self {
         PyZeroInflationHelper { inner }
     }
@@ -1181,7 +1186,6 @@ impl PyYoYInflationTermStructure {
     }
 
     /// A clone of the inner curve handle for the index facade that links one.
-    #[allow(dead_code)]
     pub(crate) fn handle(&self) -> Handle<dyn YoYInflationTermStructure> {
         self.inner.clone()
     }
@@ -1320,6 +1324,221 @@ impl PyYoYInflationHelper {
     /// facade, which threads each helper into the bootstrap.
     #[allow(dead_code)]
     pub(crate) fn shared(&self) -> Shared<dyn YoYInflationHelper> {
+        Shared::clone(&self.inner)
+    }
+}
+
+/// Python `YoYInflationIndex`: an index publishing one year-on-year inflation
+/// rate per period, read back as a stored figure or forecast off its
+/// year-on-year curve (core `indexes::inflationindex::YoYInflationIndex`).
+///
+/// Two forms, as in the core. A **ratio** index
+/// ([`from_underlying`](Self::from_underlying)) derives its rate from two
+/// [`PyZeroInflationIndex`] fixings a year apart and owns no history of its
+/// own; a **quoted** one (the constructor) is published as a rate in its own
+/// right and keeps its own history through [`add_fixing`](Self::add_fixing).
+///
+/// The curve is reached through a [`RelinkableHandle`] the facade owns and both
+/// forms link at construction, for the reason [`PyZeroInflationIndex`]
+/// documents: the core's `with_term_structure` takes a plain
+/// [`Handle`](libitofin::handle::Handle), so an index that did not take this
+/// facade's relinkable handle up front could never be pointed at a curve later
+/// and [`link_to`](Self::link_to) would silently do nothing. The handle starts
+/// empty, so a forecast before any link raises the empty-handle error.
+///
+/// The quoted constructor spells its region and currency out as their component
+/// fields: neither core type has a Python facade, and inventing a name lookup
+/// or defaulting the currency metadata would put made-up values on the index.
+#[pyclass(name = "YoYInflationIndex", unsendable)]
+pub struct PyYoYInflationIndex {
+    inner: Shared<YoYInflationIndex>,
+    curve: RelinkableHandle<dyn YoYInflationTermStructure>,
+    underlying: Option<Py<PyZeroInflationIndex>>,
+}
+
+impl PyYoYInflationIndex {
+    /// Wraps `build` over a fresh empty relinkable handle the index observes.
+    ///
+    /// Both constructors route through here: the core's `from_underlying` and
+    /// `new` alike leave the curve handle empty
+    /// (`inflationindex.rs:661,684`), and it is
+    /// [`with_term_structure`](YoYInflationIndex::with_term_structure) that
+    /// registers the index on a handle it will keep seeing.
+    fn with_curve_handle(
+        underlying: Option<Py<PyZeroInflationIndex>>,
+        build: impl FnOnce(&RelinkableHandle<dyn YoYInflationTermStructure>) -> YoYInflationIndex,
+    ) -> Self {
+        let curve = RelinkableHandle::<dyn YoYInflationTermStructure>::empty();
+        let inner = shared(build(&curve));
+        PyYoYInflationIndex {
+            inner,
+            curve,
+            underlying,
+        }
+    }
+}
+
+#[pymethods]
+impl PyYoYInflationIndex {
+    /// A quoted year-on-year index, published as a rate in its own right and
+    /// keeping its own fixing history.
+    #[new]
+    #[pyo3(signature = (
+        family_name,
+        region_name,
+        region_code,
+        revised,
+        frequency,
+        availability_lag,
+        currency_name,
+        currency_code,
+        currency_numeric_code,
+        currency_symbol,
+        currency_fraction_symbol,
+        currency_fractions_per_unit,
+        settings,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        family_name: String,
+        region_name: String,
+        region_code: String,
+        revised: bool,
+        frequency: &PyFrequency,
+        availability_lag: &PyPeriod,
+        currency_name: String,
+        currency_code: String,
+        currency_numeric_code: i32,
+        currency_symbol: String,
+        currency_fraction_symbol: String,
+        currency_fractions_per_unit: i32,
+        settings: &PySettings,
+    ) -> Self {
+        PyYoYInflationIndex::with_curve_handle(None, |curve| {
+            YoYInflationIndex::new(
+                family_name,
+                Region::new(region_name, region_code),
+                revised,
+                frequency.inner(),
+                availability_lag.inner(),
+                Currency::new(
+                    currency_name,
+                    currency_code,
+                    currency_numeric_code,
+                    currency_symbol,
+                    currency_fraction_symbol,
+                    currency_fractions_per_unit,
+                ),
+                settings.inner(),
+            )
+            .with_term_structure(curve.handle())
+        })
+    }
+
+    /// A ratio year-on-year index over `underlying`, dividing that index's
+    /// figure for a period by its figure a year earlier.
+    ///
+    /// The metadata is inherited wholesale bar the family name, which is
+    /// prefixed `YYR_`, so a `"UK RPI"` underlying yields `"UK YYR_RPI"`. The
+    /// index files no fixings of its own and reads the underlying's history
+    /// instead, so [`add_fixing`](Self::add_fixing) belongs on the underlying.
+    #[staticmethod]
+    fn from_underlying(underlying: &Bound<'_, PyZeroInflationIndex>) -> Self {
+        let zero = underlying.borrow().shared();
+        let handle = underlying.clone().unbind();
+        PyYoYInflationIndex::with_curve_handle(Some(handle), |curve| {
+            YoYInflationIndex::from_underlying(zero).with_term_structure(curve.handle())
+        })
+    }
+
+    /// The index name, e.g. `"UK YYR_RPI"`, under which fixings are stored.
+    fn name(&self) -> String {
+        self.inner.name()
+    }
+
+    /// Whether this index is the ratio of two price-index fixings rather than a
+    /// quoted rate.
+    fn ratio(&self) -> bool {
+        self.inner.ratio()
+    }
+
+    /// The price index a ratio index divides, `None` on a quoted one.
+    ///
+    /// This is the very object [`from_underlying`](Self::from_underlying) was
+    /// handed, not a fresh facade around the same core index: a rebuilt one
+    /// would carry a relinkable handle this index never sees, so linking it
+    /// would silently forecast off nothing.
+    fn underlying_index(&self, py: Python<'_>) -> Option<Py<PyZeroInflationIndex>> {
+        self.underlying
+            .as_ref()
+            .map(|underlying| underlying.clone_ref(py))
+    }
+
+    /// Records a published year-on-year rate across the whole inflation period
+    /// it describes. A ratio index reads the underlying's history, so filing
+    /// here records a figure it will never consult.
+    fn add_fixing(&self, fixing_date: &PyDate, value: f64) -> PyResult<()> {
+        Ok(self
+            .inner
+            .add_fixing(fixing_date.inner(), value)
+            .map_err(PyQlError::from)?)
+    }
+
+    /// The rate at `fixing_date`, stored or forecast off the linked curve.
+    ///
+    /// `forecast_todays_fixing` is accepted and ignored, as in the core:
+    /// [`needs_forecast`](Self::needs_forecast) alone decides. A forecast with
+    /// no curve linked raises the empty-handle error.
+    #[pyo3(signature = (fixing_date, forecast_todays_fixing = false))]
+    fn fixing(&self, fixing_date: &PyDate, forecast_todays_fixing: bool) -> PyResult<f64> {
+        Ok(self
+            .inner
+            .fixing(fixing_date.inner(), forecast_todays_fixing)
+            .map_err(PyQlError::from)?)
+    }
+
+    /// The first day of the inflation period the latest figure on record
+    /// describes, read off the underlying on a ratio index. An index with no
+    /// history is an error.
+    fn last_fixing_date(&self) -> PyResult<PyDate> {
+        Ok(PyDate::from_inner(
+            self.inner.last_fixing_date().map_err(PyQlError::from)?,
+        ))
+    }
+
+    /// Points the index at `curve`, so every forecast from here on reads it.
+    ///
+    /// Takes the [`PyYoYInflationTermStructure`] base, so any subclass links.
+    /// It is the curve *behind* `curve`'s handle at call time that is stored,
+    /// not the handle itself.
+    ///
+    /// # Errors
+    ///
+    /// Reports the empty-handle error if `curve` somehow carries no link.
+    fn link_to(&self, curve: &PyYoYInflationTermStructure) -> PyResult<()> {
+        self.curve
+            .link_to(curve.handle().current_link().map_err(PyQlError::from)?);
+        Ok(())
+    }
+
+    /// Whether `fixing_date` has to be forecast rather than read from history,
+    /// a ratio index deferring the question to its underlying.
+    fn needs_forecast(&self, fixing_date: &PyDate) -> PyResult<bool> {
+        Ok(self
+            .inner
+            .needs_forecast(fixing_date.inner())
+            .map_err(PyQlError::from)?)
+    }
+
+    fn __repr__(&self) -> String {
+        format!("YoYInflationIndex({})", self.inner.name())
+    }
+}
+
+impl PyYoYInflationIndex {
+    /// The wrapped core index, for the helper and swap facades that take one.
+    #[allow(dead_code)]
+    pub(crate) fn shared(&self) -> Shared<YoYInflationIndex> {
         Shared::clone(&self.inner)
     }
 }

--- a/crates/itofin-py/src/lib.rs
+++ b/crates/itofin-py/src/lib.rs
@@ -57,10 +57,10 @@ use hullwhite::{PyEuribor, PyHullWhite, PySwaptionHelper};
 use inflation::{
     PyCpiInterpolationType, PyDiscountingSwapEngine, PyInterpolatedYoYInflationCurve,
     PyInterpolatedZeroInflationCurve, PyMultiplicativePriceSeasonality,
-    PyPiecewiseYoYInflationCurve, PyPiecewiseZeroInflationCurve, PyYearOnYearInflationSwapHelper,
-    PyYoYInflationHelper, PyYoYInflationIndex, PyYoYInflationTermStructure,
-    PyZeroCouponInflationSwap, PyZeroCouponInflationSwapHelper, PyZeroInflationHelper,
-    PyZeroInflationIndex, PyZeroInflationTermStructure,
+    PyPiecewiseYoYInflationCurve, PyPiecewiseZeroInflationCurve, PyYearOnYearInflationSwap,
+    PyYearOnYearInflationSwapHelper, PyYoYInflationHelper, PyYoYInflationIndex,
+    PyYoYInflationTermStructure, PyZeroCouponInflationSwap, PyZeroCouponInflationSwapHelper,
+    PyZeroInflationHelper, PyZeroInflationIndex, PyZeroInflationTermStructure,
 };
 use libitofin::errors::QlError;
 use market::{PyBlackScholesProcess, PySimpleQuote};
@@ -230,6 +230,7 @@ fn itofin(m: &Bound<'_, PyModule>) -> PyResult<()> {
     instruments.add_class::<PyPricingModel>()?;
     instruments.add_class::<PyCreditDefaultSwap>()?;
     instruments.add_class::<PyZeroCouponInflationSwap>()?;
+    instruments.add_class::<PyYearOnYearInflationSwap>()?;
 
     let models = PyModule::new(py, "models")?;
     models.add_class::<PyHestonModel>()?;

--- a/crates/itofin-py/src/lib.rs
+++ b/crates/itofin-py/src/lib.rs
@@ -55,10 +55,11 @@ use helpers::{
 use heston::{PyHestonModel, PyHestonModelHelper, PyHestonProcess};
 use hullwhite::{PyEuribor, PyHullWhite, PySwaptionHelper};
 use inflation::{
-    PyCpiInterpolationType, PyDiscountingSwapEngine, PyInterpolatedZeroInflationCurve,
-    PyMultiplicativePriceSeasonality, PyPiecewiseZeroInflationCurve, PyZeroCouponInflationSwap,
-    PyZeroCouponInflationSwapHelper, PyZeroInflationHelper, PyZeroInflationIndex,
-    PyZeroInflationTermStructure,
+    PyCpiInterpolationType, PyDiscountingSwapEngine, PyInterpolatedYoYInflationCurve,
+    PyInterpolatedZeroInflationCurve, PyMultiplicativePriceSeasonality,
+    PyPiecewiseZeroInflationCurve, PyYoYInflationHelper, PyYoYInflationTermStructure,
+    PyZeroCouponInflationSwap, PyZeroCouponInflationSwapHelper, PyZeroInflationHelper,
+    PyZeroInflationIndex, PyZeroInflationTermStructure,
 };
 use libitofin::errors::QlError;
 use market::{PyBlackScholesProcess, PySimpleQuote};
@@ -194,6 +195,9 @@ fn itofin(m: &Bound<'_, PyModule>) -> PyResult<()> {
     termstructures.add_class::<PyZeroCouponInflationSwapHelper>()?;
     termstructures.add_class::<PyPiecewiseZeroInflationCurve>()?;
     termstructures.add_class::<PyMultiplicativePriceSeasonality>()?;
+    termstructures.add_class::<PyYoYInflationTermStructure>()?;
+    termstructures.add_class::<PyInterpolatedYoYInflationCurve>()?;
+    termstructures.add_class::<PyYoYInflationHelper>()?;
 
     let processes = PyModule::new(py, "processes")?;
     processes.add_class::<PyBlackScholesProcess>()?;

--- a/crates/itofin-py/src/lib.rs
+++ b/crates/itofin-py/src/lib.rs
@@ -57,9 +57,9 @@ use hullwhite::{PyEuribor, PyHullWhite, PySwaptionHelper};
 use inflation::{
     PyCpiInterpolationType, PyDiscountingSwapEngine, PyInterpolatedYoYInflationCurve,
     PyInterpolatedZeroInflationCurve, PyMultiplicativePriceSeasonality,
-    PyPiecewiseZeroInflationCurve, PyYoYInflationHelper, PyYoYInflationTermStructure,
-    PyZeroCouponInflationSwap, PyZeroCouponInflationSwapHelper, PyZeroInflationHelper,
-    PyZeroInflationIndex, PyZeroInflationTermStructure,
+    PyPiecewiseZeroInflationCurve, PyYoYInflationHelper, PyYoYInflationIndex,
+    PyYoYInflationTermStructure, PyZeroCouponInflationSwap, PyZeroCouponInflationSwapHelper,
+    PyZeroInflationHelper, PyZeroInflationIndex, PyZeroInflationTermStructure,
 };
 use libitofin::errors::QlError;
 use market::{PyBlackScholesProcess, PySimpleQuote};
@@ -209,6 +209,7 @@ fn itofin(m: &Bound<'_, PyModule>) -> PyResult<()> {
     indexes.add_class::<PySwapIndex>()?;
     indexes.add_class::<PyCpiInterpolationType>()?;
     indexes.add_class::<PyZeroInflationIndex>()?;
+    indexes.add_class::<PyYoYInflationIndex>()?;
 
     let instruments = PyModule::new(py, "instruments")?;
     instruments.add_class::<PyOptionType>()?;

--- a/crates/itofin-py/src/lib.rs
+++ b/crates/itofin-py/src/lib.rs
@@ -57,9 +57,10 @@ use hullwhite::{PyEuribor, PyHullWhite, PySwaptionHelper};
 use inflation::{
     PyCpiInterpolationType, PyDiscountingSwapEngine, PyInterpolatedYoYInflationCurve,
     PyInterpolatedZeroInflationCurve, PyMultiplicativePriceSeasonality,
-    PyPiecewiseZeroInflationCurve, PyYoYInflationHelper, PyYoYInflationIndex,
-    PyYoYInflationTermStructure, PyZeroCouponInflationSwap, PyZeroCouponInflationSwapHelper,
-    PyZeroInflationHelper, PyZeroInflationIndex, PyZeroInflationTermStructure,
+    PyPiecewiseYoYInflationCurve, PyPiecewiseZeroInflationCurve, PyYearOnYearInflationSwapHelper,
+    PyYoYInflationHelper, PyYoYInflationIndex, PyYoYInflationTermStructure,
+    PyZeroCouponInflationSwap, PyZeroCouponInflationSwapHelper, PyZeroInflationHelper,
+    PyZeroInflationIndex, PyZeroInflationTermStructure,
 };
 use libitofin::errors::QlError;
 use market::{PyBlackScholesProcess, PySimpleQuote};
@@ -198,6 +199,8 @@ fn itofin(m: &Bound<'_, PyModule>) -> PyResult<()> {
     termstructures.add_class::<PyYoYInflationTermStructure>()?;
     termstructures.add_class::<PyInterpolatedYoYInflationCurve>()?;
     termstructures.add_class::<PyYoYInflationHelper>()?;
+    termstructures.add_class::<PyYearOnYearInflationSwapHelper>()?;
+    termstructures.add_class::<PyPiecewiseYoYInflationCurve>()?;
 
     let processes = PyModule::new(py, "processes")?;
     processes.add_class::<PyBlackScholesProcess>()?;

--- a/crates/itofin-py/tests/test_yoy_inflation_reprice.py
+++ b/crates/itofin-py/tests/test_yoy_inflation_reprice.py
@@ -1,0 +1,276 @@
+"""The year-on-year inflation milestone (#849): fifteen quoted year-on-year
+inflation swaps bootstrap a curve, and the fourteen past the base pillar are
+then repriced to nothing off it.
+
+This mirrors the Rust oracle `piecewiseyoyinflationcurve.rs:807-858` (itself
+`test-suite/inflation.cpp` `testYYTermStructure` `:1198-1224`). The swaps
+repriced here are rebuilt standalone on the real 5 % nominal curve rather than
+read off the helpers, so nothing the bootstrap cached can carry the result: only
+the curve does. It discriminates the bootstrap's convergence, the base-date node
+placement, the fixing-period quantization and the year-on-year forecast at once.
+
+Fixture. It is 13 August 2007. UK RPI carries the thirty-one monthly figures
+published from January 2005, so the curve's base date is the July 2007 period.
+The year-on-year index is the *ratio* form over that RPI, which owns no history
+of its own and divides two RPI figures a year apart. Fifteen swap rates are
+quoted out to 2037 under a two-month observation lag, flat CPI observation, UK
+settlement calendar and Thirty360 BondBasis throughout.
+
+Two frequencies live in this fixture and must not be conflated. The *curve* is
+Monthly, because UK RPI publishes monthly and the curve's frequency is what
+quantizes its nodes and its base date. The *swap schedules* are Annual, because
+year-on-year coupons pay yearly. Passing either one where the other belongs
+moves every number.
+
+Omitted visibly: seasonality on a year-on-year curve, which the zero side covers
+(test_zc_inflation_reprice.py) through the same base-class setter this curve
+inherits.
+"""
+
+import pytest
+
+from itofin import ItofinError, Settings
+from itofin.indexes import CpiInterpolationType, YoYInflationIndex, ZeroInflationIndex
+from itofin.instruments import SwapType, YearOnYearInflationSwap
+from itofin.pricingengines import DiscountingSwapEngine
+from itofin.quotes import SimpleQuote
+from itofin.termstructures import (
+    FlatForward,
+    PiecewiseYoYInflationCurve,
+    YearOnYearInflationSwapHelper,
+)
+from itofin.time import (
+    BusinessDayConvention,
+    Calendar,
+    Date,
+    DateGeneration,
+    DayCounter,
+    Frequency,
+    Period,
+    Schedule,
+)
+
+TODAY = Calendar.united_kingdom().adjust(
+    Date(13, 8, 2007), BusinessDayConvention.Following
+)
+CURVE_BASE = Date(1, 7, 2007)
+LAG = Period(2, "Months")
+NOMINAL = 1_000_000.0
+NOMINAL_RATE = 0.05
+EPS = 1e-6
+
+FIX_DATA = [
+    189.9, 189.9, 189.6, 190.5, 191.6, 192.0, 192.2, 192.2, 192.6, 193.1,
+    193.3, 193.6, 194.1, 193.4, 194.2, 195.0, 196.5, 197.7, 198.5, 198.5,
+    199.2, 200.1, 200.4, 201.1, 202.7, 201.6, 203.1, 204.4, 205.4, 206.2,
+    207.3,
+]
+
+YY_DATA = [
+    (Date(13, 8, 2008), 2.95),
+    (Date(13, 8, 2009), 2.95),
+    (Date(13, 8, 2010), 2.93),
+    (Date(15, 8, 2011), 2.955),
+    (Date(13, 8, 2012), 2.945),
+    (Date(13, 8, 2013), 2.985),
+    (Date(13, 8, 2014), 3.01),
+    (Date(13, 8, 2015), 3.035),
+    (Date(13, 8, 2016), 3.055),
+    (Date(13, 8, 2017), 3.075),
+    (Date(13, 8, 2019), 3.105),
+    (Date(15, 8, 2022), 3.135),
+    (Date(13, 8, 2027), 3.155),
+    (Date(13, 8, 2032), 3.145),
+    (Date(13, 8, 2037), 3.145),
+]
+
+
+def _fixing_date(i: int) -> Date:
+    """The i-th monthly fixing date, walked from 1 January 2005.
+
+    A monthly index is filed under the first of its month and the schedule is
+    never adjusted, so the walk is plain month arithmetic.
+    """
+    return Date(1, i % 12 + 1, 2005 + i // 12)
+
+
+def _settings() -> Settings:
+    """One Settings object serves the index, every helper, every swap and every
+    engine: a swap and its engine resolving their dates against different
+    evaluation dates would price silently wrong rather than raise."""
+    settings = Settings()
+    settings.set_evaluation_date(TODAY)
+    return settings
+
+
+def _rpi(settings: Settings) -> ZeroInflationIndex:
+    """The published UK RPI. The fixings go on the *zero* index: the ratio
+    year-on-year index files none of its own and reads this history."""
+    rpi = ZeroInflationIndex.uk_rpi(settings)
+    for i, fixing in enumerate(FIX_DATA):
+        rpi.add_fixing(_fixing_date(i), fixing)
+    return rpi
+
+
+def _nominal_curve() -> FlatForward:
+    """The 5 % discount curve the helpers and the standalone swaps both run on.
+    The three-argument facade is Continuous compounding at Annual frequency,
+    which is what the Rust fixture passes explicitly."""
+    return FlatForward(Date(13, 8, 2007), NOMINAL_RATE, DayCounter.actual360())
+
+
+def _helpers(
+    settings: Settings,
+    index: YoYInflationIndex,
+    nominal: FlatForward,
+    interpolation: CpiInterpolationType = CpiInterpolationType.Flat,
+) -> list[YearOnYearInflationSwapHelper]:
+    return [
+        YearOnYearInflationSwapHelper(
+            SimpleQuote(rate / 100.0),
+            LAG,
+            maturity,
+            Calendar.united_kingdom(),
+            BusinessDayConvention.ModifiedFollowing,
+            DayCounter.thirty360_bond_basis(),
+            index,
+            interpolation,
+            nominal,
+            settings,
+        )
+        for maturity, rate in YY_DATA
+    ]
+
+
+def _bootstrapped(
+    settings: Settings, index: YoYInflationIndex, nominal: FlatForward
+) -> PiecewiseYoYInflationCurve:
+    """The curve, with the caller's index relinked onto it.
+
+    The curve frequency is Monthly, matching the RPI the ratio index reads; the
+    swap schedules below are Annual, which is a different thing entirely. Node
+    zero is seeded with the first quote and kept rather than solved, which is
+    why the reprice loop skips that pillar.
+    """
+    curve = PiecewiseYoYInflationCurve(
+        TODAY,
+        CURVE_BASE,
+        YY_DATA[0][1] / 100.0,
+        Frequency.Monthly,
+        DayCounter.thirty360_bond_basis(),
+        _helpers(settings, index, nominal),
+    )
+    index.link_to(curve)
+    return curve
+
+
+def _a_swap(
+    settings: Settings,
+    index: YoYInflationIndex,
+    nominal: FlatForward,
+    maturity: Date,
+    fixed_rate: float,
+) -> YearOnYearInflationSwap:
+    """A quoted swap rebuilt standalone on the real nominal curve, running from
+    that curve's reference date. One schedule serves both legs, as the Rust
+    oracle's does. Each swap gets its own engine: an engine carries the
+    arguments and results of the contract it last priced."""
+    schedule = Schedule(
+        nominal.reference_date(),
+        maturity,
+        Frequency.Annual,
+        Calendar.united_kingdom(),
+        BusinessDayConvention.Unadjusted,
+        DateGeneration.Backward,
+    )
+    day_counter = DayCounter.thirty360_bond_basis()
+    swap = YearOnYearInflationSwap(
+        SwapType.Payer,
+        NOMINAL,
+        schedule,
+        fixed_rate,
+        day_counter,
+        schedule,
+        index,
+        LAG,
+        CpiInterpolationType.Flat,
+        0.0,
+        day_counter,
+        Calendar.united_kingdom(),
+        BusinessDayConvention.ModifiedFollowing,
+        settings,
+    )
+    swap.set_engine(DiscountingSwapEngine(nominal, settings))
+    return swap
+
+
+def test_the_transcribed_fixture_is_the_one_the_oracle_runs():
+    """The transcription guards. The counts pin the two hand-typed tables, and
+    the base date pins where the last RPI figure's period falls - it is the
+    curve's node zero, so a month-walk landing in the wrong period would move
+    every rate the swaps forecast."""
+    assert len(FIX_DATA) == 31
+    assert len(YY_DATA) == 15
+
+    settings = _settings()
+    rpi = _rpi(settings)
+    assert rpi.last_fixing_date() == CURVE_BASE
+
+    index = YoYInflationIndex.from_underlying(rpi)
+    assert index.ratio()
+    assert index.name() == "UK YYR_RPI"
+    assert index.underlying_index() is rpi, "the ratio index hands back the very object it was built over, not a fresh facade whose relinkable handle the core index would never see"
+
+
+def test_the_first_node_is_the_base_date():
+    """Node zero sits on the base date rather than on the reference date, so the
+    first time is negative. Both reads go through dates() and times(), which
+    propagate a bootstrap failure rather than hiding it."""
+    settings = _settings()
+    nominal = _nominal_curve()
+    index = YoYInflationIndex.from_underlying(_rpi(settings))
+    curve = _bootstrapped(settings, index, nominal)
+
+    assert curve.dates()[0] == curve.base_date()
+    assert curve.dates()[0] == CURVE_BASE
+    assert curve.times()[0] < 0.0
+
+
+def test_an_interpolated_helper_is_refused():
+    """CpiInterpolationType.Linear is refused outright by the core helper: the
+    interpolated branch of the C++ constructor is deferred with the rest of
+    CPI::Linear (#847), and refusing is how that stays visible rather than
+    silently pricing as a flat one."""
+    settings = _settings()
+    index = YoYInflationIndex.from_underlying(_rpi(settings))
+
+    with pytest.raises(ItofinError) as raised:
+        _helpers(settings, index, _nominal_curve(), CpiInterpolationType.Linear)
+    assert "not ported yet" in str(raised.value)
+
+
+def test_the_bootstrapped_curve_reprices_the_quoted_swaps_to_zero():
+    """The milestone. Every quoted swap past the base pillar, rebuilt standalone
+    and discounted on the 5 % nominal curve, comes back worth nothing off the
+    bootstrapped year-on-year curve.
+
+    Row 0 is skipped: its rate seeds node zero rather than being solved for, so
+    the curve was never fitted to a swap at that maturity. The margin is printed
+    rather than only asserted - the distance from 1e-6 is the report.
+    """
+    settings = _settings()
+    nominal = _nominal_curve()
+    index = YoYInflationIndex.from_underlying(_rpi(settings))
+    _bootstrapped(settings, index, nominal)
+
+    npv_by_maturity = {}
+    worst_npv = 0.0
+    for row in range(1, len(YY_DATA)):
+        maturity, rate = YY_DATA[row]
+        npv = _a_swap(settings, index, nominal, maturity, rate / 100.0).npv()
+        npv_by_maturity[str(maturity)] = npv
+        worst_npv = max(worst_npv, abs(npv))
+
+    print(f"worst |NPV| = {worst_npv:.3e}")
+    print(f"NPV by maturity = {npv_by_maturity}")
+    assert worst_npv < EPS

--- a/crates/itofin-py/tests/test_yoy_inflation_swap.py
+++ b/crates/itofin-py/tests/test_yoy_inflation_swap.py
@@ -1,0 +1,167 @@
+"""The year-on-year inflation swap facade (#849), struck at the rate its own
+curve publishes.
+
+A flat year-on-year curve at R forecasts R for every coupon, so a swap struck at
+R pays the same amount on both legs on the same dates and is worth nothing. That
+makes the fixture a discriminator rather than a tautology: it is the *forecast*
+path - the quoted index reading the linked curve at each coupon's fixing date -
+that has to land on R for the two legs to cancel, and a mis-wired schedule, lag
+or day counter shows up as a non-zero NPV.
+
+The index here is the quoted form, which is also what exercises the constructor
+spelling region and currency out as their component fields. The ratio form and
+a bootstrapped curve are the reprice oracle's job
+(test_yoy_inflation_reprice.py).
+"""
+
+from itofin import Settings
+from itofin.indexes import CpiInterpolationType, YoYInflationIndex
+from itofin.instruments import SwapType, YearOnYearInflationSwap
+from itofin.pricingengines import DiscountingSwapEngine
+from itofin.termstructures import FlatForward, InterpolatedYoYInflationCurve
+from itofin.time import (
+    BusinessDayConvention,
+    Calendar,
+    Date,
+    DateGeneration,
+    DayCounter,
+    Frequency,
+    Period,
+    Schedule,
+)
+
+TODAY = Date(13, 8, 2007)
+CURVE_BASE = Date(1, 7, 2007)
+CURVE_END = Date(1, 1, 2040)
+MATURITY = Date(13, 8, 2012)
+FLAT_YOY = 0.03
+LAG = Period(2, "Months")
+NOMINAL = 1_000_000.0
+EPS = 1e-6
+RATE_EPS = 1e-12
+
+
+def _settings() -> Settings:
+    settings = Settings()
+    settings.set_evaluation_date(TODAY)
+    return settings
+
+
+def _index(settings: Settings) -> YoYInflationIndex:
+    """A quoted year-on-year index carrying UK RPI's own metadata, so its
+    monthly frequency and one-month availability lag match the curve below."""
+    return YoYInflationIndex(
+        "YY_RPI",
+        "UK",
+        "GB",
+        False,
+        Frequency.Monthly,
+        Period(1, "Months"),
+        "British pound sterling",
+        "GBP",
+        826,
+        "£",
+        "p",
+        100,
+        settings,
+    )
+
+
+def _flat_curve() -> InterpolatedYoYInflationCurve:
+    """Two nodes at the same rate: linear interpolation between them is that
+    rate everywhere, and the base date precedes the reference date as every
+    inflation curve's does."""
+    return InterpolatedYoYInflationCurve(
+        TODAY,
+        [CURVE_BASE, CURVE_END],
+        [FLAT_YOY, FLAT_YOY],
+        Frequency.Monthly,
+        DayCounter.thirty360_bond_basis(),
+    )
+
+
+def _a_swap(settings: Settings, fixed_rate: float) -> YearOnYearInflationSwap:
+    """One schedule serves both legs, as the Rust oracle's does: unadjusted
+    annual accrual dates, with the payment convention applied afterwards."""
+    schedule = Schedule(
+        TODAY,
+        MATURITY,
+        Frequency.Annual,
+        Calendar.united_kingdom(),
+        BusinessDayConvention.Unadjusted,
+        DateGeneration.Backward,
+    )
+    day_counter = DayCounter.thirty360_bond_basis()
+    index = _index(settings)
+    index.link_to(_flat_curve())
+    swap = YearOnYearInflationSwap(
+        SwapType.Payer,
+        NOMINAL,
+        schedule,
+        fixed_rate,
+        day_counter,
+        schedule,
+        index,
+        LAG,
+        CpiInterpolationType.Flat,
+        0.0,
+        day_counter,
+        Calendar.united_kingdom(),
+        BusinessDayConvention.ModifiedFollowing,
+        settings,
+    )
+    swap.set_engine(
+        DiscountingSwapEngine(
+            FlatForward(TODAY, 0.05, DayCounter.actual360()), settings
+        )
+    )
+    return swap
+
+
+def test_the_quoted_index_carries_the_metadata_it_was_given():
+    """The quoted constructor's region and currency fields reach the core: the
+    name is the region name and the family name joined, and the index is not a
+    ratio one, so it has no underlying to defer to."""
+    index = _index(_settings())
+
+    assert index.name() == "UK YY_RPI"
+    assert not index.ratio()
+    assert index.underlying_index() is None
+
+
+def test_the_curve_publishes_the_base_rate_it_was_seeded_with():
+    """base_rate is the year-on-year divergence from the zero base, which defers
+    it; the first node's rate is what the curve keeps."""
+    curve = _flat_curve()
+
+    assert abs(curve.base_rate() - FLAT_YOY) < RATE_EPS
+    assert curve.base_date() == CURVE_BASE
+
+
+def test_a_swap_struck_at_the_flat_curve_rate_is_worth_nothing():
+    """Both legs pay the same amount on the same dates, so the NPV vanishes and
+    the fair rate comes back to the rate the curve publishes. The leg NPVs are
+    signed, so they add up to the swap NPV."""
+    settings = _settings()
+    swap = _a_swap(settings, FLAT_YOY)
+
+    npv = swap.npv()
+    print(f"|NPV| = {abs(npv):.3e}, fair rate = {swap.fair_rate()}")
+    assert abs(npv) < EPS
+    assert abs(swap.fair_rate() - FLAT_YOY) < EPS
+    assert abs(swap.fixed_leg_npv() + swap.yoy_leg_npv() - npv) < EPS
+
+
+def test_an_off_market_swap_prices_away_from_zero_and_reports_a_fair_spread():
+    """The guard on the test above: a swap struck fifty basis points off the
+    curve is emphatically not worth nothing, and its fair rate is still the
+    curve's own - the fair values are recovered from the priced result rather
+    than read off the strike."""
+    settings = _settings()
+    swap = _a_swap(settings, FLAT_YOY + 0.005)
+
+    assert abs(swap.npv()) > 1.0
+    assert abs(swap.fair_rate() - FLAT_YOY) < EPS
+    assert abs(swap.fair_spread() - 0.005) < EPS
+    assert swap.fixed_rate() == FLAT_YOY + 0.005
+    assert swap.spread() == 0.0


### PR DESCRIPTION
- **feat(itofin-py): expose year-on-year inflation curve bindings**
- **feat(itofin-py): expose YoYInflationIndex to Python**
- **feat(itofin-py): expose year-on-year inflation bootstrap bindings**
- **feat(itofin-py): add YearOnYearInflationSwap bindings**
- **test(itofin-py): add YoY inflation reprice test**

close #849