### PR TITLE
feat(itofin-py): add YoY inflation cap/floor engine bindings

### DIFF
--- a/crates/itofin-py/python/itofin/instruments.pyi
+++ b/crates/itofin-py/python/itofin/instruments.pyi
@@ -19,6 +19,7 @@ from itofin.pricingengines import (
     MCEuropeanEngine,
     MCEuropeanHestonEngine,
     MidPointCdsEngine,
+    YoYInflationCapFloorEngine,
 )
 from itofin.processes import BlackScholesProcess
 from itofin.termstructures import YieldTermStructure
@@ -432,3 +433,83 @@ class YearOnYearInflationSwap:
     def yoy_leg_npv(self) -> float: ...
     def fixed_rate(self) -> float: ...
     def spread(self) -> float: ...
+
+class MakeYoYInflationCapFloor:
+    """The standard market builder for a year-on-year inflation cap or floor.
+
+    It derives an annual year-on-year leg from a length in years, trims that leg
+    to the optionlets asked for, and strikes it either at an explicit strike or
+    at the money off atm_strike. Exactly one of the two is required: the core
+    refuses both together and neither at all, at build time rather than at the
+    setters, so both surface from build().
+
+    The core builder is a consumed-self fluent chain, which does not cross the
+    FFI boundary; this facade takes the whole configuration up front and
+    assembles the chain inside build(), as MakeVanillaSwap does. An unset
+    optional leaves the core default in place: a 1,000,000 nominal, a
+    ModifiedFollowing payment roll, a 30/360 bond-basis day counter, no fixing
+    days, every optionlet kept and no forward start.
+
+    Trimming happens before the at-the-money fill, so as_optionlet and
+    first_caplet_excluded change what an unset strike resolves to: the rate that
+    reprices whatever survives, not the whole leg's.
+
+    CapFloorType.Collar has no path here - the builder carries a single strike,
+    and a collar needs two strike vectors over a coupon leg Python cannot build
+    (#848)."""
+
+    def __init__(
+        self,
+        cap_floor_type: CapFloorType,
+        index: YoYInflationIndex,
+        length: int,
+        calendar: Calendar,
+        observation_lag: Period,
+        interpolation: CpiInterpolationType,
+        settings: Settings,
+        nominal: float | None = None,
+        effective_date: Date | None = None,
+        payment_day_counter: DayCounter | None = None,
+        payment_adjustment: BusinessDayConvention | None = None,
+        fixing_days: int | None = None,
+        engine: YoYInflationCapFloorEngine | None = None,
+        as_optionlet: bool = False,
+        forward_start: Period | None = None,
+        first_caplet_excluded: bool = False,
+        strike: float | None = None,
+        atm_strike: YieldTermStructure | None = None,
+    ) -> None: ...
+    def build(self) -> YoYInflationCapFloor:
+        """Raises ItofinError when both strike and atm_strike are given and when
+        neither is; when the start date has to be derived and no evaluation date
+        is set; and on whatever the leg construction and the at-the-money fill
+        report."""
+        ...
+
+class YoYInflationCapFloor:
+    """A cap or floor over a year-on-year inflation leg.
+
+    Built only through MakeYoYInflationCapFloor: the core's raw constructors take
+    a vector of concrete year-on-year coupons, which Python has no facade to
+    build (#848), so there is no direct constructor here.
+
+    Unlike a nominal cap/floor this instrument keeps its first optionlet, so the
+    strip spans its leg exactly and cap - floor is the year-on-year swap.
+
+    Pricing needs an engine: call set_engine before npv."""
+
+    def cap_rates(self) -> list[float]: ...
+    def floor_rates(self) -> list[float]: ...
+    def coupon_count(self) -> int: ...
+    def start_date(self) -> Date: ...
+    def maturity_date(self) -> Date: ...
+    def atm_rate(self, discount_curve: YieldTermStructure) -> float:
+        """The strike at which the leg reprices on discount_curve. Raises
+        ItofinError on an unlinked curve, a curve with no reference date and a
+        leg with no basis-point sensitivity to solve over."""
+        ...
+    def set_engine(self, engine: YoYInflationCapFloorEngine) -> None:
+        """The engine must resolve its dates against the same Settings object
+        this cap/floor was built with."""
+        ...
+    def npv(self) -> float: ...

--- a/crates/itofin-py/python/itofin/pricingengines.pyi
+++ b/crates/itofin-py/python/itofin/pricingengines.pyi
@@ -2,9 +2,11 @@
 # src/capfloorengine.rs, src/creditengine.rs, src/inflation.rs and src/mcengine.rs (#517).
 
 from itofin import Settings
+from itofin.indexes import YoYInflationIndex
 from itofin.processes import BlackScholesProcess, HestonProcess
 from itofin.quotes import SimpleQuote
 from itofin.termstructures import (
+    ConstantYoYOptionletVolatility,
     DefaultProbabilityTermStructure,
     OptionletVolatilityStructure,
     SwaptionVolatilityStructure,
@@ -252,4 +254,42 @@ class MCAmericanEngine:
         """Raises ItofinError when neither or both of steps / steps_per_year are
         given, and when both samples and absolute_tolerance are given. The
         polynomial order defaults to 2 and the calibration samples to 2048."""
+        ...
+
+class YoYInflationCapFloorEngine:
+    """Prices a year-on-year inflation cap or floor optionlet by optionlet.
+
+    The distribution is chosen by the constructor rather than passed as an
+    argument, mirroring C++'s three engine classes: black is lognormal,
+    unit_displaced lognormal in 1 + rate and bachelier normal. The core
+    YoYOptionletDistribution enum is not bound, so distribution() reads back as
+    a string.
+
+    The settings behind the volatility surface and behind the cap/floor this
+    engine prices must be the same object, or the two resolve their dates
+    against different evaluation dates and the NPV is silently wrong.
+
+    An engine carries the arguments and results of the contract it last priced,
+    so a cap and a floor priced together want one engine each."""
+
+    @staticmethod
+    def black(
+        index: YoYInflationIndex,
+        volatility: ConstantYoYOptionletVolatility,
+        nominal_ts: YieldTermStructure,
+    ) -> YoYInflationCapFloorEngine: ...
+    @staticmethod
+    def unit_displaced(
+        index: YoYInflationIndex,
+        volatility: ConstantYoYOptionletVolatility,
+        nominal_ts: YieldTermStructure,
+    ) -> YoYInflationCapFloorEngine: ...
+    @staticmethod
+    def bachelier(
+        index: YoYInflationIndex,
+        volatility: ConstantYoYOptionletVolatility,
+        nominal_ts: YieldTermStructure,
+    ) -> YoYInflationCapFloorEngine: ...
+    def distribution(self) -> str:
+        """"black", "unit_displaced" or "bachelier"."""
         ...

--- a/crates/itofin-py/python/itofin/termstructures.pyi
+++ b/crates/itofin-py/python/itofin/termstructures.pyi
@@ -1220,3 +1220,50 @@ class PiecewiseYoYInflationCurve(YoYInflationTermStructure):
     def times(self) -> list[float]: ...
     def dates(self) -> list[Date]: ...
     def nodes(self) -> list[tuple[Date, float]]: ...
+
+class ConstantYoYOptionletVolatility:
+    """One year-on-year optionlet volatility for every strike and every date.
+
+    The reference date moves with the evaluation date carried by settings,
+    settlement_days business days on from it, so that date must be set before
+    anything is priced off the surface.
+
+    min_strike and max_strike bound the strike domain a query is answered over;
+    C++ defaults them to -1.0 and 100.0 and the port carries no default
+    arguments, so both are passed here too.
+
+    Only the flat surface is bound: the live-quote constructor and the whole
+    stripped/interpolated hierarchy are deferred."""
+
+    def __init__(
+        self,
+        volatility: float,
+        settlement_days: int,
+        calendar: Calendar,
+        business_day_convention: BusinessDayConvention,
+        day_counter: DayCounter,
+        observation_lag: Period,
+        frequency: Frequency,
+        index_is_interpolated: bool,
+        min_strike: float,
+        max_strike: float,
+        settings: Settings,
+    ) -> None: ...
+    def observation_lag(self) -> Period: ...
+    def frequency(self) -> Frequency: ...
+    def index_is_interpolated(self) -> bool: ...
+    def base_date(self) -> Date:
+        """The date the surface measures its variance from. Raises ItofinError
+        on an unset evaluation date, and on a frequency admitting no publication
+        period."""
+        ...
+    def volatility(self, date: Date, strike: float, obs_lag: Period) -> float:
+        """The lag is explicit rather than defaulted: pass observation_lag() for
+        the surface's own. Raises ItofinError when the observed date falls before
+        base_date(), or strike lies outside the strike domain."""
+        ...
+    def total_variance(self, date: Date, strike: float, obs_lag: Period) -> float:
+        """The total integrated variance, the figure that scales time out of the
+        optionlet formulae without committing to a distribution. Raises as
+        volatility()."""
+        ...

--- a/crates/itofin-py/src/capfloor.rs
+++ b/crates/itofin-py/src/capfloor.rs
@@ -42,7 +42,7 @@ pub enum PyCapFloorType {
 
 impl PyCapFloorType {
     /// The core [`CapFloorType`] this variant stands for.
-    fn inner(&self) -> CapFloorType {
+    pub(crate) fn inner(&self) -> CapFloorType {
         match self {
             PyCapFloorType::Cap => CapFloorType::Cap,
             PyCapFloorType::Floor => CapFloorType::Floor,

--- a/crates/itofin-py/src/inflation.rs
+++ b/crates/itofin-py/src/inflation.rs
@@ -9,14 +9,17 @@
 //! [`PyYoYInflationTermStructure`] curve hierarchy and the
 //! [`PyYoYInflationHelper`] helpers that fit its piecewise member, and the
 //! optionlet stack written over that curve: the flat
-//! [`PyConstantYoYOptionletVolatility`] surface and the
-//! [`PyYoYInflationCapFloorEngine`] pricing against it.
+//! [`PyConstantYoYOptionletVolatility`] surface, the
+//! [`PyYoYInflationCapFloorEngine`] pricing against it and the
+//! [`PyYoYInflationCapFloor`] it prices, which
+//! [`PyMakeYoYInflationCapFloor`] is the only way to build.
 //!
 //! The swap engine is generic rather than inflation-specific - it prices any
 //! swap - but is homed here because the inflation tickets are the first to need
 //! it and are its only consumers today.
 
 use crate::PyQlError;
+use crate::capfloor::PyCapFloorType;
 use crate::curve::PyYieldTermStructure;
 use crate::helpers::PyPillar;
 use crate::market::PySimpleQuote;
@@ -35,10 +38,14 @@ use libitofin::indexes::inflationindex::{
 };
 use libitofin::indexes::region::Region;
 use libitofin::instrument::Instrument;
-use libitofin::instruments::{YearOnYearInflationSwap, ZeroCouponInflationSwap};
+use libitofin::instruments::{
+    MakeYoYInflationCapFloor, YearOnYearInflationSwap, YoYInflationCapFloor,
+    ZeroCouponInflationSwap,
+};
 use libitofin::math::interpolations::linear::Linear;
 use libitofin::pricingengine::PricingEngine;
 use libitofin::pricingengines::{DiscountingSwapEngine, YoYInflationCapFloorEngine};
+use libitofin::settings::Settings;
 use libitofin::shared::{Shared, SharedMut, shared, shared_mut};
 use libitofin::termstructures::inflation::inflationhelpers::{
     YearOnYearInflationSwapHelper, YoYInflationHelper, ZeroCouponInflationSwapHelper,
@@ -57,6 +64,12 @@ use libitofin::termstructures::inflation::seasonality::{
 use libitofin::termstructures::volatility::{
     ConstantYoYOptionletVolatility, YoYOptionletVolatilitySurface,
 };
+use libitofin::termstructures::yieldtermstructure::YieldTermStructure;
+use libitofin::time::businessdayconvention::BusinessDayConvention;
+use libitofin::time::calendar::Calendar;
+use libitofin::time::date::Date;
+use libitofin::time::daycounter::DayCounter;
+use libitofin::time::period::Period;
 use pyo3::prelude::*;
 
 /// Python `DiscountingSwapEngine`: discounts each leg of a swap over a single
@@ -2117,5 +2130,294 @@ impl PyYoYInflationCapFloorEngine {
             YoYOptionletDistribution::Bachelier => "bachelier",
         }
         .to_string()
+    }
+}
+
+impl PyYoYInflationCapFloorEngine {
+    /// The erased engine the cap/floor facade installs via `set_pricing_engine`.
+    pub(crate) fn engine(&self) -> SharedMut<dyn PricingEngine> {
+        SharedMut::clone(&self.inner) as SharedMut<dyn PricingEngine>
+    }
+}
+
+/// Python `MakeYoYInflationCapFloor`: the standard market builder for a
+/// year-on-year inflation cap or floor
+/// (`instruments::makeyoyinflationcapfloor`).
+///
+/// It derives an annual year-on-year leg from a length in years, trims that leg
+/// to the optionlets asked for, and strikes it either at an explicit `strike` or
+/// at the money off `atm_strike`. Exactly one of the two is required: the core
+/// refuses both together and neither at all, at build time rather than at the
+/// setters, so both surface from [`build`](Self::build).
+///
+/// The core builder is a consumed-self fluent chain, which does not cross the
+/// FFI boundary; this facade takes the whole configuration up front and
+/// assembles the chain inside [`build`](Self::build), as
+/// [`MakeVanillaSwap`](crate::swap::PyMakeVanillaSwap) does. An unset optional
+/// leaves the core default in place: a 1,000,000 nominal, a `ModifiedFollowing`
+/// payment roll, a 30/360 bond-basis day counter, no fixing days, every
+/// optionlet kept and no forward start.
+///
+/// Trimming happens *before* the at-the-money fill, so `as_optionlet` and
+/// `first_caplet_excluded` change what an unset strike resolves to: the rate
+/// that reprices whatever survives, not the whole leg's.
+///
+/// Deferred (visible): `CapFloorType.Collar` has no path here either - the
+/// builder carries a single strike, and a collar needs two strike vectors over a
+/// coupon leg Python cannot build (#848).
+#[pyclass(name = "MakeYoYInflationCapFloor", unsendable)]
+pub struct PyMakeYoYInflationCapFloor {
+    cap_floor_type: PyCapFloorType,
+    index: Shared<YoYInflationIndex>,
+    length: u64,
+    calendar: Calendar,
+    observation_lag: Period,
+    interpolation: CpiInterpolationType,
+    settings: Shared<Settings<Date>>,
+    nominal: Option<f64>,
+    effective_date: Option<Date>,
+    payment_day_counter: Option<DayCounter>,
+    payment_adjustment: Option<BusinessDayConvention>,
+    fixing_days: Option<u32>,
+    engine: Option<SharedMut<dyn PricingEngine>>,
+    as_optionlet: bool,
+    forward_start: Option<Period>,
+    first_caplet_excluded: bool,
+    strike: Option<f64>,
+    atm_strike: Option<Handle<dyn YieldTermStructure>>,
+}
+
+#[pymethods]
+impl PyMakeYoYInflationCapFloor {
+    /// A builder for a `cap_floor_type` cap/floor of `length` years on `index`,
+    /// observed `observation_lag` back under `interpolation` and paying on
+    /// `calendar`.
+    #[new]
+    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (
+        cap_floor_type,
+        index,
+        length,
+        calendar,
+        observation_lag,
+        interpolation,
+        settings,
+        nominal = None,
+        effective_date = None,
+        payment_day_counter = None,
+        payment_adjustment = None,
+        fixing_days = None,
+        engine = None,
+        as_optionlet = false,
+        forward_start = None,
+        first_caplet_excluded = false,
+        strike = None,
+        atm_strike = None,
+    ))]
+    fn new(
+        cap_floor_type: PyCapFloorType,
+        index: &PyYoYInflationIndex,
+        length: u64,
+        calendar: &PyCalendar,
+        observation_lag: &PyPeriod,
+        interpolation: PyCpiInterpolationType,
+        settings: &PySettings,
+        nominal: Option<f64>,
+        effective_date: Option<&PyDate>,
+        payment_day_counter: Option<&PyDayCounter>,
+        payment_adjustment: Option<&PyBusinessDayConvention>,
+        fixing_days: Option<u32>,
+        engine: Option<&PyYoYInflationCapFloorEngine>,
+        as_optionlet: bool,
+        forward_start: Option<&PyPeriod>,
+        first_caplet_excluded: bool,
+        strike: Option<f64>,
+        atm_strike: Option<&PyYieldTermStructure>,
+    ) -> Self {
+        PyMakeYoYInflationCapFloor {
+            cap_floor_type,
+            index: index.shared(),
+            length,
+            calendar: calendar.inner(),
+            observation_lag: observation_lag.inner(),
+            interpolation: interpolation.inner(),
+            settings: settings.inner(),
+            nominal,
+            effective_date: effective_date.map(PyDate::inner),
+            payment_day_counter: payment_day_counter.map(PyDayCounter::inner),
+            payment_adjustment: payment_adjustment.map(PyBusinessDayConvention::inner),
+            fixing_days,
+            engine: engine.map(PyYoYInflationCapFloorEngine::engine),
+            as_optionlet,
+            forward_start: forward_start.map(PyPeriod::inner),
+            first_caplet_excluded,
+            strike,
+            atm_strike: atm_strike.map(PyYieldTermStructure::handle),
+        }
+    }
+
+    /// Builds the cap/floor, which already carries its engine when one was
+    /// given.
+    ///
+    /// # Errors
+    ///
+    /// Reports both an explicit `strike` and an `atm_strike` given together and
+    /// neither given at all; an unset evaluation date when the start date has to
+    /// be derived; and whatever the leg construction and the at-the-money fill
+    /// report.
+    fn build(&self) -> PyResult<PyYoYInflationCapFloor> {
+        let mut maker = MakeYoYInflationCapFloor::new(
+            self.cap_floor_type.inner(),
+            Shared::clone(&self.index),
+            self.length as usize,
+            self.calendar.clone(),
+            self.observation_lag,
+            self.interpolation,
+            Shared::clone(&self.settings),
+        );
+        if let Some(nominal) = self.nominal {
+            maker = maker.with_nominal(nominal);
+        }
+        if let Some(effective_date) = self.effective_date {
+            maker = maker.with_effective_date(effective_date);
+        }
+        if let Some(day_counter) = &self.payment_day_counter {
+            maker = maker.with_payment_day_counter(day_counter.clone());
+        }
+        if let Some(convention) = self.payment_adjustment {
+            maker = maker.with_payment_adjustment(convention);
+        }
+        if let Some(fixing_days) = self.fixing_days {
+            maker = maker.with_fixing_days(fixing_days);
+        }
+        if let Some(engine) = &self.engine {
+            maker = maker.with_pricing_engine(SharedMut::clone(engine));
+        }
+        if self.as_optionlet {
+            maker = maker.as_optionlet(true);
+        }
+        if let Some(forward_start) = self.forward_start {
+            maker = maker.with_forward_start(forward_start);
+        }
+        if self.first_caplet_excluded {
+            maker = maker.with_first_caplet_excluded();
+        }
+        if let Some(strike) = self.strike {
+            maker = maker.with_strike(strike);
+        }
+        if let Some(atm_strike) = &self.atm_strike {
+            maker = maker.with_atm_strike(atm_strike.clone());
+        }
+        Ok(PyYoYInflationCapFloor::from_inner(shared_mut(
+            maker.build().map_err(PyQlError::from)?,
+        )))
+    }
+}
+
+/// Python `YoYInflationCapFloor`: a cap or floor over a year-on-year inflation
+/// leg (`instruments::inflationcapfloor::YoYInflationCapFloor`).
+///
+/// Built only through [`MakeYoYInflationCapFloor`](PyMakeYoYInflationCapFloor):
+/// the core's raw constructors take a vector of concrete year-on-year coupons,
+/// which Python has no facade to build (#848), so there is no direct
+/// constructor here.
+///
+/// Unlike a nominal cap/floor this instrument keeps its first optionlet, so the
+/// strip spans its leg exactly and cap - floor is the year-on-year swap.
+///
+/// Pricing needs an engine: call [`set_engine`](Self::set_engine) before
+/// [`npv`](Self::npv).
+#[pyclass(name = "YoYInflationCapFloor", unsendable)]
+pub struct PyYoYInflationCapFloor {
+    inner: SharedMut<YoYInflationCapFloor>,
+}
+
+#[pymethods]
+impl PyYoYInflationCapFloor {
+    /// The cap strikes, one per coupon; empty on a floor.
+    fn cap_rates(&self) -> Vec<f64> {
+        self.inner.borrow().cap_rates().to_vec()
+    }
+
+    /// The floor strikes, one per coupon; empty on a cap.
+    fn floor_rates(&self) -> Vec<f64> {
+        self.inner.borrow().floor_rates().to_vec()
+    }
+
+    /// The number of optionlets, one per year-on-year coupon.
+    fn coupon_count(&self) -> usize {
+        self.inner.borrow().yoy_leg().len()
+    }
+
+    /// The leg's earliest accrual start.
+    ///
+    /// # Errors
+    ///
+    /// Reports an empty leg, which the constructors already refuse.
+    fn start_date(&self) -> PyResult<PyDate> {
+        Ok(PyDate::from_inner(
+            self.inner.borrow().start_date().map_err(PyQlError::from)?,
+        ))
+    }
+
+    /// The leg's latest accrual end. Fallible as
+    /// [`start_date`](Self::start_date).
+    fn maturity_date(&self) -> PyResult<PyDate> {
+        Ok(PyDate::from_inner(
+            self.inner
+                .borrow()
+                .maturity_date()
+                .map_err(PyQlError::from)?,
+        ))
+    }
+
+    /// The at-the-money rate: the strike at which the leg reprices on
+    /// `discount_curve`.
+    ///
+    /// The core takes the curve itself rather than a handle, so the link is
+    /// resolved here and held for the call.
+    ///
+    /// # Errors
+    ///
+    /// Reports an unlinked `discount_curve`, a curve with no reference date and
+    /// a leg with no basis-point sensitivity to solve over.
+    fn atm_rate(&self, discount_curve: &PyYieldTermStructure) -> PyResult<f64> {
+        let handle = discount_curve.handle();
+        let link = handle.current_link().map_err(PyQlError::from)?;
+        Ok(self
+            .inner
+            .borrow()
+            .atm_rate(link.as_ref())
+            .map_err(PyQlError::from)?)
+    }
+
+    /// Attaches a [`PyYoYInflationCapFloorEngine`], replacing whatever engine
+    /// the factory installed.
+    ///
+    /// The engine must resolve its dates against the same `Settings` object this
+    /// cap/floor was built with: two different ones would price the leg and the
+    /// optionlets on different dates with no error raised.
+    fn set_engine(&mut self, engine: &PyYoYInflationCapFloorEngine) {
+        self.inner
+            .borrow_mut()
+            .base_mut()
+            .set_pricing_engine(engine.engine());
+    }
+
+    /// The cap/floor NPV under the attached engine.
+    ///
+    /// # Errors
+    ///
+    /// Reports `"null pricing engine"` with no engine attached, and whatever the
+    /// engine reports.
+    fn npv(&mut self) -> PyResult<f64> {
+        Ok(self.inner.borrow_mut().npv().map_err(PyQlError::from)?)
+    }
+}
+
+impl PyYoYInflationCapFloor {
+    /// Wraps the instrument the factory built.
+    pub(crate) fn from_inner(inner: SharedMut<YoYInflationCapFloor>) -> Self {
+        PyYoYInflationCapFloor { inner }
     }
 }

--- a/crates/itofin-py/src/inflation.rs
+++ b/crates/itofin-py/src/inflation.rs
@@ -7,7 +7,10 @@
 //! and the [`PyZeroCouponInflationSwap`] the rest of them price together, plus
 //! the year-on-year family that mirrors it: the
 //! [`PyYoYInflationTermStructure`] curve hierarchy and the
-//! [`PyYoYInflationHelper`] helpers that fit its piecewise member.
+//! [`PyYoYInflationHelper`] helpers that fit its piecewise member, and the
+//! optionlet stack written over that curve: the flat
+//! [`PyConstantYoYOptionletVolatility`] surface and the
+//! [`PyYoYInflationCapFloorEngine`] pricing against it.
 //!
 //! The swap engine is generic rather than inflation-specific - it prices any
 //! swap - but is homed here because the inflation tickets are the first to need
@@ -22,6 +25,7 @@ use crate::swap::PySwapType;
 use crate::time::{
     PyBusinessDayConvention, PyCalendar, PyDate, PyDayCounter, PyFrequency, PyPeriod, PySchedule,
 };
+use libitofin::cashflows::YoYOptionletDistribution;
 use libitofin::currency::Currency;
 use libitofin::handle::{Handle, RelinkableHandle};
 use libitofin::indexes::index::Index;
@@ -34,7 +38,7 @@ use libitofin::instrument::Instrument;
 use libitofin::instruments::{YearOnYearInflationSwap, ZeroCouponInflationSwap};
 use libitofin::math::interpolations::linear::Linear;
 use libitofin::pricingengine::PricingEngine;
-use libitofin::pricingengines::DiscountingSwapEngine;
+use libitofin::pricingengines::{DiscountingSwapEngine, YoYInflationCapFloorEngine};
 use libitofin::shared::{Shared, SharedMut, shared, shared_mut};
 use libitofin::termstructures::inflation::inflationhelpers::{
     YearOnYearInflationSwapHelper, YoYInflationHelper, ZeroCouponInflationSwapHelper,
@@ -49,6 +53,9 @@ use libitofin::termstructures::inflation::piecewiseyoyinflationcurve::PiecewiseY
 use libitofin::termstructures::inflation::piecewisezeroinflationcurve::PiecewiseZeroInflationCurve;
 use libitofin::termstructures::inflation::seasonality::{
     MultiplicativePriceSeasonality, Seasonality,
+};
+use libitofin::termstructures::volatility::{
+    ConstantYoYOptionletVolatility, YoYOptionletVolatilitySurface,
 };
 use pyo3::prelude::*;
 
@@ -1893,5 +1900,222 @@ impl PyYearOnYearInflationSwap {
     /// The spread the year-on-year coupons carry over the index.
     fn spread(&self) -> f64 {
         self.inner.borrow().spread()
+    }
+}
+
+/// Python `ConstantYoYOptionletVolatility`: one volatility for every strike and
+/// every date (`termstructures::volatility::ConstantYoYOptionletVolatility`).
+///
+/// The reference date moves with the evaluation date carried by `settings`,
+/// `settlement_days` business days on from it, so that date must be set before
+/// anything is priced off the surface.
+///
+/// `min_strike` and `max_strike` bound the strike domain a query is answered
+/// over; C++ defaults them to `-1.0` and `100.0` and the port carries no default
+/// arguments, so both are passed here too.
+///
+/// Deferred (visible): the live-quote constructor
+/// (`constantyoyoptionletvol.rs:122`), whose quote changes notify the surface's
+/// observers, and the whole stripped/interpolated surface hierarchy, which has
+/// no port at all. A flat surface is what the cap/floor engine oracle needs.
+#[pyclass(name = "ConstantYoYOptionletVolatility", unsendable)]
+pub struct PyConstantYoYOptionletVolatility {
+    inner: Shared<ConstantYoYOptionletVolatility>,
+}
+
+#[pymethods]
+impl PyConstantYoYOptionletVolatility {
+    /// A flat surface at `volatility`, observing inflation `observation_lag`
+    /// back on an index publishing at `frequency`.
+    ///
+    /// Infallible, unlike most curve constructors: nothing is resolved here.
+    /// The reference date, the base date and the strike range are all read at
+    /// query time, so an unset evaluation date surfaces then.
+    #[new]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        volatility: f64,
+        settlement_days: u32,
+        calendar: &PyCalendar,
+        business_day_convention: &PyBusinessDayConvention,
+        day_counter: &PyDayCounter,
+        observation_lag: &PyPeriod,
+        frequency: &PyFrequency,
+        index_is_interpolated: bool,
+        min_strike: f64,
+        max_strike: f64,
+        settings: &PySettings,
+    ) -> Self {
+        PyConstantYoYOptionletVolatility {
+            inner: shared(ConstantYoYOptionletVolatility::new(
+                volatility,
+                settlement_days,
+                calendar.inner(),
+                business_day_convention.inner(),
+                day_counter.inner(),
+                observation_lag.inner(),
+                frequency.inner(),
+                index_is_interpolated,
+                min_strike,
+                max_strike,
+                settings.inner(),
+            )),
+        }
+    }
+
+    /// The lag the surface itself observes inflation with.
+    fn observation_lag(&self) -> PyPeriod {
+        PyPeriod::from_inner(self.inner.observation_lag())
+    }
+
+    /// How often the observed index publishes.
+    fn frequency(&self) -> PyResult<PyFrequency> {
+        PyFrequency::from_inner(self.inner.frequency())
+    }
+
+    /// Whether the observed index interpolates between publications.
+    fn index_is_interpolated(&self) -> bool {
+        self.inner.index_is_interpolated()
+    }
+
+    /// The date the surface measures its variance from: the reference date
+    /// pulled back by the surface's own observation lag, snapped to the start of
+    /// the publication period unless the index is interpolated.
+    ///
+    /// # Errors
+    ///
+    /// Reports an unset evaluation date, and a frequency admitting no
+    /// publication period.
+    fn base_date(&self) -> PyResult<PyDate> {
+        Ok(PyDate::from_inner(
+            self.inner.base_date().map_err(PyQlError::from)?,
+        ))
+    }
+
+    /// The volatility for an exercise on `date` struck at `strike`, observing
+    /// inflation `obs_lag` back.
+    ///
+    /// The lag is explicit rather than defaulted: C++ substitutes the surface's
+    /// own for a sentinel period, and the port has no sentinel to carry, so a
+    /// caller wanting it passes [`observation_lag`](Self::observation_lag).
+    ///
+    /// # Errors
+    ///
+    /// Reports an observed date before [`base_date`](Self::base_date), and a
+    /// `strike` outside the surface's strike domain.
+    fn volatility(&self, date: &PyDate, strike: f64, obs_lag: &PyPeriod) -> PyResult<f64> {
+        Ok(self
+            .inner
+            .volatility(date.inner(), strike, obs_lag.inner())
+            .map_err(PyQlError::from)?)
+    }
+
+    /// The total integrated variance for an exercise on `date` struck at
+    /// `strike`: the figure that scales time out of the optionlet formulae
+    /// without committing to the distribution reading it.
+    ///
+    /// # Errors
+    ///
+    /// As [`volatility`](Self::volatility).
+    fn total_variance(&self, date: &PyDate, strike: f64, obs_lag: &PyPeriod) -> PyResult<f64> {
+        Ok(self
+            .inner
+            .total_variance(date.inner(), strike, obs_lag.inner())
+            .map_err(PyQlError::from)?)
+    }
+}
+
+impl PyConstantYoYOptionletVolatility {
+    /// The erased surface handle the cap/floor engine constructors take.
+    pub(crate) fn handle(&self) -> Handle<dyn YoYOptionletVolatilitySurface> {
+        Handle::new(Shared::clone(&self.inner) as Shared<dyn YoYOptionletVolatilitySurface>)
+    }
+}
+
+/// Python `YoYInflationCapFloorEngine`: prices a year-on-year cap or floor
+/// optionlet by optionlet (`pricingengines::YoYInflationCapFloorEngine`).
+///
+/// The distribution is chosen by the constructor rather than passed as an
+/// argument, mirroring the core's three constructors and C++'s three engine
+/// classes: [`black`](Self::black) is lognormal, `unit_displaced` lognormal in
+/// `1 + rate` and `bachelier` normal. The core
+/// `YoYOptionletDistribution` enum is not bound - nothing takes one by value -
+/// so [`distribution`](Self::distribution) reads back as a string.
+///
+/// The `settings` behind the volatility surface and behind the cap/floor this
+/// engine prices must be the same object, or the two resolve their dates
+/// against different evaluation dates and the NPV is silently wrong.
+///
+/// An engine carries the arguments and results of the contract it last priced,
+/// so a cap and a floor priced together want one engine each.
+#[pyclass(name = "YoYInflationCapFloorEngine", unsendable)]
+pub struct PyYoYInflationCapFloorEngine {
+    inner: SharedMut<YoYInflationCapFloorEngine>,
+}
+
+#[pymethods]
+impl PyYoYInflationCapFloorEngine {
+    /// Optionlets under the lognormal model (C++
+    /// `YoYInflationBlackCapFloorEngine`), forwards read off `index`,
+    /// volatilities off `volatility` and discounting on `nominal_ts`.
+    #[staticmethod]
+    fn black(
+        index: &PyYoYInflationIndex,
+        volatility: &PyConstantYoYOptionletVolatility,
+        nominal_ts: &PyYieldTermStructure,
+    ) -> Self {
+        PyYoYInflationCapFloorEngine {
+            inner: shared_mut(YoYInflationCapFloorEngine::black(
+                index.shared(),
+                volatility.handle(),
+                nominal_ts.handle(),
+            )),
+        }
+    }
+
+    /// Optionlets under the unit-displaced lognormal model (C++
+    /// `YoYInflationUnitDisplacedBlackCapFloorEngine`), the usual quoting
+    /// convention for a rate that may be negative. See [`black`](Self::black).
+    #[staticmethod]
+    fn unit_displaced(
+        index: &PyYoYInflationIndex,
+        volatility: &PyConstantYoYOptionletVolatility,
+        nominal_ts: &PyYieldTermStructure,
+    ) -> Self {
+        PyYoYInflationCapFloorEngine {
+            inner: shared_mut(YoYInflationCapFloorEngine::unit_displaced(
+                index.shared(),
+                volatility.handle(),
+                nominal_ts.handle(),
+            )),
+        }
+    }
+
+    /// Optionlets under the normal model (C++
+    /// `YoYInflationBachelierCapFloorEngine`). See [`black`](Self::black).
+    #[staticmethod]
+    fn bachelier(
+        index: &PyYoYInflationIndex,
+        volatility: &PyConstantYoYOptionletVolatility,
+        nominal_ts: &PyYieldTermStructure,
+    ) -> Self {
+        PyYoYInflationCapFloorEngine {
+            inner: shared_mut(YoYInflationCapFloorEngine::bachelier(
+                index.shared(),
+                volatility.handle(),
+                nominal_ts.handle(),
+            )),
+        }
+    }
+
+    /// The distribution optionlets are valued under, as `"black"`,
+    /// `"unit_displaced"` or `"bachelier"`.
+    fn distribution(&self) -> String {
+        match self.inner.borrow().distribution() {
+            YoYOptionletDistribution::Black => "black",
+            YoYOptionletDistribution::UnitDisplaced => "unit_displaced",
+            YoYOptionletDistribution::Bachelier => "bachelier",
+        }
+        .to_string()
     }
 }

--- a/crates/itofin-py/src/lib.rs
+++ b/crates/itofin-py/src/lib.rs
@@ -56,12 +56,12 @@ use heston::{PyHestonModel, PyHestonModelHelper, PyHestonProcess};
 use hullwhite::{PyEuribor, PyHullWhite, PySwaptionHelper};
 use inflation::{
     PyConstantYoYOptionletVolatility, PyCpiInterpolationType, PyDiscountingSwapEngine,
-    PyInterpolatedYoYInflationCurve, PyInterpolatedZeroInflationCurve,
+    PyInterpolatedYoYInflationCurve, PyInterpolatedZeroInflationCurve, PyMakeYoYInflationCapFloor,
     PyMultiplicativePriceSeasonality, PyPiecewiseYoYInflationCurve, PyPiecewiseZeroInflationCurve,
-    PyYearOnYearInflationSwap, PyYearOnYearInflationSwapHelper, PyYoYInflationCapFloorEngine,
-    PyYoYInflationHelper, PyYoYInflationIndex, PyYoYInflationTermStructure,
-    PyZeroCouponInflationSwap, PyZeroCouponInflationSwapHelper, PyZeroInflationHelper,
-    PyZeroInflationIndex, PyZeroInflationTermStructure,
+    PyYearOnYearInflationSwap, PyYearOnYearInflationSwapHelper, PyYoYInflationCapFloor,
+    PyYoYInflationCapFloorEngine, PyYoYInflationHelper, PyYoYInflationIndex,
+    PyYoYInflationTermStructure, PyZeroCouponInflationSwap, PyZeroCouponInflationSwapHelper,
+    PyZeroInflationHelper, PyZeroInflationIndex, PyZeroInflationTermStructure,
 };
 use libitofin::errors::QlError;
 use market::{PyBlackScholesProcess, PySimpleQuote};
@@ -233,6 +233,8 @@ fn itofin(m: &Bound<'_, PyModule>) -> PyResult<()> {
     instruments.add_class::<PyCreditDefaultSwap>()?;
     instruments.add_class::<PyZeroCouponInflationSwap>()?;
     instruments.add_class::<PyYearOnYearInflationSwap>()?;
+    instruments.add_class::<PyMakeYoYInflationCapFloor>()?;
+    instruments.add_class::<PyYoYInflationCapFloor>()?;
 
     let models = PyModule::new(py, "models")?;
     models.add_class::<PyHestonModel>()?;

--- a/crates/itofin-py/src/lib.rs
+++ b/crates/itofin-py/src/lib.rs
@@ -55,12 +55,13 @@ use helpers::{
 use heston::{PyHestonModel, PyHestonModelHelper, PyHestonProcess};
 use hullwhite::{PyEuribor, PyHullWhite, PySwaptionHelper};
 use inflation::{
-    PyCpiInterpolationType, PyDiscountingSwapEngine, PyInterpolatedYoYInflationCurve,
-    PyInterpolatedZeroInflationCurve, PyMultiplicativePriceSeasonality,
-    PyPiecewiseYoYInflationCurve, PyPiecewiseZeroInflationCurve, PyYearOnYearInflationSwap,
-    PyYearOnYearInflationSwapHelper, PyYoYInflationHelper, PyYoYInflationIndex,
-    PyYoYInflationTermStructure, PyZeroCouponInflationSwap, PyZeroCouponInflationSwapHelper,
-    PyZeroInflationHelper, PyZeroInflationIndex, PyZeroInflationTermStructure,
+    PyConstantYoYOptionletVolatility, PyCpiInterpolationType, PyDiscountingSwapEngine,
+    PyInterpolatedYoYInflationCurve, PyInterpolatedZeroInflationCurve,
+    PyMultiplicativePriceSeasonality, PyPiecewiseYoYInflationCurve, PyPiecewiseZeroInflationCurve,
+    PyYearOnYearInflationSwap, PyYearOnYearInflationSwapHelper, PyYoYInflationCapFloorEngine,
+    PyYoYInflationHelper, PyYoYInflationIndex, PyYoYInflationTermStructure,
+    PyZeroCouponInflationSwap, PyZeroCouponInflationSwapHelper, PyZeroInflationHelper,
+    PyZeroInflationIndex, PyZeroInflationTermStructure,
 };
 use libitofin::errors::QlError;
 use market::{PyBlackScholesProcess, PySimpleQuote};
@@ -201,6 +202,7 @@ fn itofin(m: &Bound<'_, PyModule>) -> PyResult<()> {
     termstructures.add_class::<PyYoYInflationHelper>()?;
     termstructures.add_class::<PyYearOnYearInflationSwapHelper>()?;
     termstructures.add_class::<PyPiecewiseYoYInflationCurve>()?;
+    termstructures.add_class::<PyConstantYoYOptionletVolatility>()?;
 
     let processes = PyModule::new(py, "processes")?;
     processes.add_class::<PyBlackScholesProcess>()?;
@@ -249,6 +251,7 @@ fn itofin(m: &Bound<'_, PyModule>) -> PyResult<()> {
     pricingengines.add_class::<PyAccrualBias>()?;
     pricingengines.add_class::<PyForwardsInCouponPeriod>()?;
     pricingengines.add_class::<PyDiscountingSwapEngine>()?;
+    pricingengines.add_class::<PyYoYInflationCapFloorEngine>()?;
     pricingengines.add_class::<PyMCEuropeanEngine>()?;
     pricingengines.add_class::<PyMCEuropeanHestonEngine>()?;
     pricingengines.add_class::<PyMCAmericanEngine>()?;

--- a/crates/itofin-py/tests/test_yoy_inflation_capfloor.py
+++ b/crates/itofin-py/tests/test_yoy_inflation_capfloor.py
@@ -1,0 +1,332 @@
+"""The year-on-year inflation cap/floor binding (#858): a two-year cap and floor
+struck at 2.95 %, priced through the Python surface against the values QuantLib
+caches.
+
+This reproduces the Rust engine oracle
+`inflationcapfloorengines.rs:818` (`testCachedValue`, `.cpp:452-522`), not the
+year-on-year reprice milestone next door: the two fixtures differ in exactly the
+spots that move these numbers. The six cached values are the only assertions in
+that suite that would notice the fixture being subtly wrong - parity and
+optionlet-sum consistency are internal identities that hold whatever the curve
+says - so they are what a binding has to reproduce to have proved anything.
+
+Fixture, and the four things about it that are load-bearing.
+
+1. The RPI history is thirty-one published figures followed by TWO -999.0
+   sentinels. Neither sentinel is ever read as a rate (every fixing date here is
+   2008 or later, so the ratio index forecasts off the curve), but they move the
+   index's last fixing date, and with it the curve's base date, to 1 August 2007
+   - the origin every number below is measured from.
+2. The schedule those figures are filed on runs monthly from 1 January 2005 to
+   13 August 2007 under the default BACKWARD generation, so it walks back from
+   the 13th and carries a short front stub: dates()[0] is 4 January 2005 and
+   dates()[1] 13 January 2005, both in the January period. Filing quantizes to
+   the publication period, so the store is thirty-one months from January 2005
+   with the sentinels in July and August 2007. Generating forward instead would
+   shift every figure by a month.
+3. The observation lag splits two ways. The leg, the volatility surface and the
+   builder all observe ZERO days; only the fifteen bootstrap helpers observe two
+   months. In C++ this comes of a `CommonVars` member being shadowed by a local
+   in the constructor body; pricing the leg at two months instead misses every
+   cached value by about 47.
+4. The nominal curve is Actual/Actual (ISDA), not Actual/360, and the curve
+   frequency is Monthly (what UK RPI publishes, and what quantizes the curve's
+   nodes) while the cap/floor schedule is Annual. Conflating the two frequencies
+   moves every rate.
+
+The volatility is 1 %, which is what the cached-value case passes; the 15 % in
+the Rust module's `VOLS` array belongs to the parity sweep.
+"""
+
+import pytest
+
+from itofin import ItofinError, Settings
+from itofin.indexes import CpiInterpolationType, YoYInflationIndex, ZeroInflationIndex
+from itofin.instruments import (
+    CapFloorType,
+    MakeYoYInflationCapFloor,
+    YoYInflationCapFloor,
+)
+from itofin.pricingengines import YoYInflationCapFloorEngine
+from itofin.quotes import SimpleQuote
+from itofin.termstructures import (
+    ConstantYoYOptionletVolatility,
+    FlatForward,
+    PiecewiseYoYInflationCurve,
+    YearOnYearInflationSwapHelper,
+)
+from itofin.time import (
+    BusinessDayConvention,
+    Calendar,
+    Date,
+    DateGeneration,
+    DayCounter,
+    Frequency,
+    Period,
+    Schedule,
+)
+
+UK = Calendar.united_kingdom()
+TODAY = UK.adjust(Date(13, 8, 2007), BusinessDayConvention.Following)
+CURVE_BASE = Date(1, 8, 2007)
+NO_LAG = Period(0, "Days")
+HELPER_LAG = Period(2, "Months")
+NOMINAL = 1_000_000.0
+NOMINAL_RATE = 0.05
+STRIKE = 0.0295
+VOLATILITY = 0.01
+
+FIX_DATA = [
+    189.9, 189.9, 189.6, 190.5, 191.6, 192.0, 192.2, 192.2, 192.6, 193.1,
+    193.3, 193.6, 194.1, 193.4, 194.2, 195.0, 196.5, 197.7, 198.5, 198.5,
+    199.2, 200.1, 200.4, 201.1, 202.7, 201.6, 203.1, 204.4, 205.4, 206.2,
+    207.3, -999.0, -999.0,
+]
+
+YY_DATA = [
+    (Date(13, 8, 2008), 2.95),
+    (Date(13, 8, 2009), 2.95),
+    (Date(13, 8, 2010), 2.93),
+    (Date(15, 8, 2011), 2.955),
+    (Date(13, 8, 2012), 2.945),
+    (Date(13, 8, 2013), 2.985),
+    (Date(13, 8, 2014), 3.01),
+    (Date(13, 8, 2015), 3.035),
+    (Date(13, 8, 2016), 3.055),
+    (Date(13, 8, 2017), 3.075),
+    (Date(13, 8, 2019), 3.105),
+    (Date(15, 8, 2022), 3.135),
+    (Date(13, 8, 2027), 3.155),
+    (Date(13, 8, 2032), 3.145),
+    (Date(13, 8, 2037), 3.145),
+]
+
+
+def _day_counter() -> DayCounter:
+    return DayCounter.thirty360_bond_basis()
+
+
+def _rpi_schedule() -> Schedule:
+    """The dates the RPI figures are filed on: monthly from 1 January 2005 to
+    13 August 2007, generated BACKWARD, which is the core MakeSchedule default
+    the Rust fixture leaves in place. The Python facade defaults to Forward, so
+    the rule is passed explicitly."""
+    return Schedule(
+        Date(1, 1, 2005),
+        Date(13, 8, 2007),
+        Frequency.Monthly,
+        UK,
+        BusinessDayConvention.ModifiedFollowing,
+        DateGeneration.Backward,
+    )
+
+
+def _market() -> tuple[Settings, YoYInflationIndex, FlatForward]:
+    """The bootstrapped market: one Settings, the ratio year-on-year index over a
+    UK RPI carrying the sentinel history, and the 5 % nominal curve. The index is
+    left linked to the bootstrapped curve."""
+    settings = Settings()
+    settings.set_evaluation_date(TODAY)
+
+    rpi = ZeroInflationIndex.uk_rpi(settings)
+    for date, figure in zip(_rpi_schedule().dates(), FIX_DATA):
+        rpi.add_fixing(date, figure)
+
+    index = YoYInflationIndex.from_underlying(rpi)
+    nominal = FlatForward(TODAY, NOMINAL_RATE, DayCounter.actual_actual_isda())
+
+    helpers = [
+        YearOnYearInflationSwapHelper(
+            SimpleQuote(rate / 100.0),
+            HELPER_LAG,
+            maturity,
+            UK,
+            BusinessDayConvention.ModifiedFollowing,
+            _day_counter(),
+            index,
+            CpiInterpolationType.Flat,
+            nominal,
+            settings,
+        )
+        for maturity, rate in YY_DATA
+    ]
+    curve = PiecewiseYoYInflationCurve(
+        TODAY,
+        rpi.last_fixing_date(),
+        YY_DATA[0][1] / 100.0,
+        Frequency.Monthly,
+        _day_counter(),
+        helpers,
+    )
+    index.link_to(curve)
+    return settings, index, nominal
+
+
+def _surface(settings: Settings) -> ConstantYoYOptionletVolatility:
+    """The flat 1 % surface the cached values were produced on. Its observation
+    lag is zero, like the leg's and unlike the helpers'."""
+    return ConstantYoYOptionletVolatility(
+        VOLATILITY,
+        0,
+        UK,
+        BusinessDayConvention.ModifiedFollowing,
+        _day_counter(),
+        NO_LAG,
+        Frequency.Annual,
+        False,
+        -1.0,
+        100.0,
+        settings,
+    )
+
+
+def _cap_floor(
+    settings: Settings,
+    index: YoYInflationIndex,
+    cap_floor_type: CapFloorType,
+    **kwargs,
+) -> YoYInflationCapFloor:
+    """A two-year factory-built cap or floor. The builder's own defaults - annual
+    schedule, ModifiedFollowing payment roll, Thirty360 bond basis, no fixing
+    days - are exactly what the Rust fixture's hand-built leg uses, so nothing
+    beyond the strike and the nominal has to be said."""
+    return MakeYoYInflationCapFloor(
+        cap_floor_type,
+        index,
+        2,
+        UK,
+        NO_LAG,
+        CpiInterpolationType.Flat,
+        settings,
+        nominal=NOMINAL,
+        **kwargs,
+    ).build()
+
+
+def _priced(
+    settings: Settings,
+    index: YoYInflationIndex,
+    nominal: FlatForward,
+    cap_floor_type: CapFloorType,
+    distribution: str,
+) -> float:
+    """One instrument, one engine. An engine carries the arguments and results of
+    the contract it last priced, so a cap and a floor never share one."""
+    instrument = _cap_floor(settings, index, cap_floor_type, strike=STRIKE)
+    engine = getattr(YoYInflationCapFloorEngine, distribution)(
+        index, _surface(settings), nominal
+    )
+    assert engine.distribution() == distribution
+    instrument.set_engine(engine)
+    return instrument.npv()
+
+
+def test_the_transcribed_fixture_is_the_one_the_oracle_runs():
+    """The transcription guards, and the sharpest one is the base date: it is the
+    curve's node zero, so a fixing schedule generated the wrong way round - or
+    the sentinels dropped - would move every rate the optionlets are struck
+    against, silently."""
+    assert len(FIX_DATA) == 33
+    assert FIX_DATA[-2:] == [-999.0, -999.0]
+    assert len(YY_DATA) == 15
+
+    schedule = _rpi_schedule()
+    assert schedule.size() == 33
+    assert schedule.dates()[0] == Date(4, 1, 2005)
+    assert schedule.dates()[1] == Date(13, 1, 2005)
+    assert schedule.dates()[-1] == Date(13, 8, 2007)
+
+    _, index, _ = _market()
+    assert index.underlying_index().last_fixing_date() == CURVE_BASE
+
+    fresh = Settings()
+    fresh.set_evaluation_date(TODAY)
+    without_sentinels = ZeroInflationIndex.uk_rpi(fresh)
+    for date, figure in zip(_rpi_schedule().dates(), FIX_DATA[:-2]):
+        without_sentinels.add_fixing(date, figure)
+    assert without_sentinels.last_fixing_date() == Date(1, 6, 2007), (
+        "the two sentinels are what carry the base date from June to August; "
+        "dropping them moves the curve's origin and every optionlet with it"
+    )
+
+
+def test_a_two_year_cap_and_floor_match_the_cached_black_values():
+    """The load-bearing binding oracle. QuantLib's own tolerance is 0.02 on a
+    notional of 1e6, which these values only reach if the curve, the base date,
+    the zero observation lag and the Black distribution are all right at once."""
+    settings, index, nominal = _market()
+
+    cap = _priced(settings, index, nominal, CapFloorType.Cap, "black")
+    floor = _priced(settings, index, nominal, CapFloorType.Floor, "black")
+
+    print(f"black cap = {cap:.4f} (cached 219.452), floor = {floor:.4f} (cached 314.641)")
+    assert abs(cap - 219.452) < 0.02
+    assert abs(floor - 314.641) < 0.02
+
+
+def test_the_displaced_and_normal_constructors_are_distinct_from_black():
+    """The unit-displaced and Bachelier values sit two orders of magnitude above
+    the Black ones on the same fixture, so a constructor wired to the wrong
+    distribution cannot alias another. This is what pins the choice being made by
+    the constructor rather than defaulted somewhere."""
+    settings, index, nominal = _market()
+
+    for distribution, cached_cap, cached_floor in [
+        ("unit_displaced", 9114.61, 9209.8),
+        ("bachelier", 8852.4, 8947.59),
+    ]:
+        cap = _priced(settings, index, nominal, CapFloorType.Cap, distribution)
+        floor = _priced(settings, index, nominal, CapFloorType.Floor, distribution)
+
+        print(f"{distribution} cap = {cap:.4f}, floor = {floor:.4f}")
+        assert abs(cap - cached_cap) < 0.22
+        assert abs(floor - cached_floor) < 0.22
+
+
+def test_an_unset_strike_is_filled_at_the_money():
+    """An unset strike is resolved off the nominal curve, and the rate that lands
+    on the leg is the rate the instrument itself would reprice it at.
+
+    The instrument's atm_rate bridges a handle to the bare curve reference the
+    core takes, so this also pins that bridge: a broken one raises rather than
+    returning a number."""
+    settings, index, nominal = _market()
+    cap = _cap_floor(settings, index, CapFloorType.Cap, atm_strike=nominal)
+
+    print(f"atm strike = {cap.cap_rates()[0]:.10f}, 2y quote = {YY_DATA[1][1] / 100.0}")
+    assert abs(cap.cap_rates()[0] - cap.atm_rate(nominal)) < 1e-12
+    assert cap.coupon_count() == 2
+    assert cap.floor_rates() == []
+
+
+def test_the_derived_start_date_is_spot_at_zero_fixing_days():
+    """The factory derives the start date rather than taking one: the evaluation
+    date advanced by the fixing days under Following, plus the forward start.
+    Both default to zero here, so the leg starts on the evaluation date itself
+    and runs the two years out to an unadjusted anniversary. A non-zero default
+    creeping into either would move every accrual and every fixing."""
+    settings, index, _ = _market()
+    cap = _cap_floor(settings, index, CapFloorType.Cap, strike=STRIKE)
+
+    assert cap.start_date() == TODAY
+    assert cap.maturity_date() == UK.advance(
+        TODAY, 2, "Years", BusinessDayConvention.Unadjusted, False
+    )
+
+
+def test_a_strike_and_an_atm_curve_are_mutually_exclusive():
+    """The core refuses both together and neither at all, at build time rather
+    than at the setters: a consumed-self fluent setter returning Self cannot
+    raise, so the refusal lands in build() and travels the binding as an
+    ItofinError."""
+    settings, index, nominal = _market()
+
+    with pytest.raises(ItofinError) as both:
+        _cap_floor(
+            settings, index, CapFloorType.Cap, strike=STRIKE, atm_strike=nominal
+        )
+    assert "both given" in str(both.value)
+
+    with pytest.raises(ItofinError) as neither:
+        _cap_floor(settings, index, CapFloorType.Cap)
+    assert "no strike and no ATM curve given" in str(neither.value)


### PR DESCRIPTION
- **feat(itofin-py): add YoY inflation cap/floor engine bindings**
- **feat(itofin-py): expose year-on-year inflation cap/floor bindings**
- **test(itofin-py): add tests for YoY inflation cap/floor**

close #858