### PR TITLE
feat(crates): port interpolated year-on-year swap helper branch

### DIFF
--- a/crates/itofin-py/tests/test_yoy_inflation_reprice.py
+++ b/crates/itofin-py/tests/test_yoy_inflation_reprice.py
@@ -37,6 +37,7 @@ from itofin.quotes import SimpleQuote
 from itofin.termstructures import (
     FlatForward,
     PiecewiseYoYInflationCurve,
+    Pillar,
     YearOnYearInflationSwapHelper,
 )
 from itofin.time import (
@@ -142,6 +143,32 @@ def _helpers(
     ]
 
 
+def _one_helper(
+    settings: Settings,
+    index: YoYInflationIndex,
+    nominal: FlatForward,
+    interpolation: CpiInterpolationType,
+    pillar: Pillar,
+    obs_lag: Period = LAG,
+) -> YearOnYearInflationSwapHelper:
+    """A single helper on the front quote, for the construction-level pins that
+    need a pillar or an observation lag the bootstrap fixture does not vary."""
+    maturity, rate = YY_DATA[0]
+    return YearOnYearInflationSwapHelper(
+        SimpleQuote(rate / 100.0),
+        obs_lag,
+        maturity,
+        Calendar.united_kingdom(),
+        BusinessDayConvention.ModifiedFollowing,
+        DayCounter.thirty360_bond_basis(),
+        index,
+        interpolation,
+        nominal,
+        settings,
+        pillar,
+    )
+
+
 def _bootstrapped(
     settings: Settings, index: YoYInflationIndex, nominal: FlatForward
 ) -> PiecewiseYoYInflationCurve:
@@ -236,17 +263,62 @@ def test_the_first_node_is_the_base_date():
     assert curve.times()[0] < 0.0
 
 
-def test_an_interpolated_helper_is_refused():
-    """CpiInterpolationType.Linear is refused outright by the core helper: the
-    interpolated branch of the C++ constructor is deferred with the rest of
-    CPI::Linear (#847), and refusing is how that stays visible rather than
-    silently pricing as a flat one."""
+def test_an_interpolated_helper_widens_the_window_and_weighs_its_pillar():
+    """CpiInterpolationType.Linear now constructs (#847). The interpolated swap
+    reads the fixings bracketing its observation date, so the helper's window
+    closes a month past the flat collapse, and the pillar goes to whichever end
+    carries the dominant interpolation weight: 13 August sits 12/31 of the way
+    through its month, so the near end wins under Pillar.LastRelevantDate,
+    while Pillar.MaturityDate pins the far end regardless."""
     settings = _settings()
     index = YoYInflationIndex.from_underlying(_rpi(settings))
+    nominal = _nominal_curve()
+
+    flat = _one_helper(
+        settings, index, nominal, CpiInterpolationType.Flat, Pillar.LastRelevantDate
+    )
+    weighted = _one_helper(
+        settings, index, nominal, CpiInterpolationType.Linear, Pillar.LastRelevantDate
+    )
+    far = _one_helper(
+        settings, index, nominal, CpiInterpolationType.Linear, Pillar.MaturityDate
+    )
+
+    assert flat.latest_date() == Date(1, 6, 2008)
+    assert weighted.latest_date() == Date(1, 7, 2008)
+    assert weighted.pillar_date() == Date(1, 6, 2008)
+    assert far.pillar_date() == Date(1, 7, 2008)
+
+
+def test_an_interpolated_lag_short_of_an_index_period_is_rejected():
+    """The interpolated path needs a whole index period of observation lag on
+    top of the index's availability lag: it reads the fixing of the month after
+    the one the lag lands in, and UK RPI publishes a month in arrears. The flat
+    path builds on the same one-month lag - the check is Linear-gated."""
+    settings = _settings()
+    index = YoYInflationIndex.from_underlying(_rpi(settings))
+    nominal = _nominal_curve()
+    short_lag = Period(1, "Months")
 
     with pytest.raises(ItofinError) as raised:
-        _helpers(settings, index, _nominal_curve(), CpiInterpolationType.Linear)
-    assert "not ported yet" in str(raised.value)
+        _one_helper(
+            settings,
+            index,
+            nominal,
+            CpiInterpolationType.Linear,
+            Pillar.LastRelevantDate,
+            short_lag,
+        )
+    assert "need (obsLag-index period) >= availLag" in str(raised.value)
+
+    _one_helper(
+        settings,
+        index,
+        nominal,
+        CpiInterpolationType.Flat,
+        Pillar.LastRelevantDate,
+        short_lag,
+    )
 
 
 def test_the_bootstrapped_curve_reprices_the_quoted_swaps_to_zero():

--- a/crates/libitofin/src/termstructures/inflation/inflationhelpers.rs
+++ b/crates/libitofin/src/termstructures/inflation/inflationhelpers.rs
@@ -27,12 +27,9 @@
 //! - The **start/end-date constructor** (`cpp:52-69`, #806), so every helper here
 //!   rebuilds its schedule off the evaluation date, and the deprecated
 //!   nominal-curve constructor (`cpp:71-86`).
-//! - The `Pillar::CustomDate` choice (`cpp:140-150`, #808), which needs an
-//!   explicit pillar date threaded through construction plus its bounds check.
-//! - The interpolated branch of [`YearOnYearInflationSwapHelper`]
-//!   (`cpp:253-306`), which widens the date window, picks a pillar and checks
-//!   the observation lag against the index period. It is refused rather than
-//!   ignored, and comes with the rest of `CPI::Linear` (#730 follow-up).
+//! - The `Pillar::CustomDate` choice, on both helpers (`cpp:140-150` and
+//!   `cpp:271-281`, #808), which needs an explicit pillar date threaded through
+//!   construction plus its bounds check.
 
 use std::cell::{Ref, RefCell, RefMut};
 use std::rc::Weak;
@@ -671,19 +668,27 @@ impl YearOnYearInflationSwapHelper {
     /// nominal curve (`cpp:304-305`); it does **not** observe the curve it is
     /// bootstrapped against.
     ///
-    /// `pillar` is accepted for signature parity but never read: it only ever
-    /// discriminates on the interpolated path (`cpp:294-303`), which is
-    /// deferred below.
+    /// `pillar` picks which of the two nodes the interpolated swap straddles the
+    /// helper fits (`cpp:257-270`); the flat swap reads one fixing, so its
+    /// single node is the pillar whatever the choice (`cpp:286-291`). C++
+    /// defaults the argument to [`Pillar::LastRelevantDate`] (`hpp:130`).
+    ///
+    /// On the interpolated path C++ weights that choice by the swap's *start*
+    /// date where it has one, falling back to the maturity (`cpp:263`), so that
+    /// helpers sharing a start date all pick the same side. This constructor is
+    /// the relative-date one, whose start date is the moving evaluation date and
+    /// not a schedule input, so it is always the maturity arm - the fixed-date
+    /// constructor that would supply the other is #806.
     ///
     /// # Errors
     ///
-    /// [`Linear`](CpiInterpolationType::Linear) is refused: the interpolated
-    /// branch of the C++ constructor - its wider date window, its pillar choice
-    /// and its observation-lag consistency check (`cpp:253-306`) - is deferred
-    /// with the rest of `CPI::Linear`, and refusing is how that stays visible.
-    /// The swap the helper prices is also built here, so a `swap_obs_lag` its
-    /// legs cannot be built under fails at construction, as the C++
-    /// `initializeDates` throws.
+    /// The interpolated path needs a further whole index period of lag on top of
+    /// the index's availability lag (`cpp:296-302`), reading as it does the
+    /// fixing of the month *after* the one the lag lands in; a pair of lags
+    /// [`Period`]'s partial ordering cannot decide fails there too, where C++
+    /// throws out of the comparison itself. The swap the helper prices is also
+    /// built here, so a `swap_obs_lag` its legs cannot be built under fails at
+    /// construction, as the C++ `initializeDates` throws.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         quote: Handle<dyn Quote>,
@@ -695,16 +700,25 @@ impl YearOnYearInflationSwapHelper {
         yii: &Shared<YoYInflationIndex>,
         interpolation: CpiInterpolationType,
         nominal_term_structure: Handle<dyn YieldTermStructure>,
-        _pillar: Pillar,
+        pillar: Pillar,
         settings: Shared<Settings<Date>>,
     ) -> QlResult<Shared<YearOnYearInflationSwapHelper>> {
-        require!(
-            interpolation == CpiInterpolationType::Flat,
-            "interpolated year-on-year swap helpers are not ported yet: the pillar \
-             choice and the observation-lag consistency check the interpolated \
-             branch carries (inflationhelpers.cpp:253-306) come with CPI::Linear"
-        );
         let fixing_period = inflation_period(maturity - swap_obs_lag, yii.frequency())?;
+        let (earliest_date, latest_date, pillar_date) =
+            Self::dates(fixing_period, maturity, yii, interpolation, pillar)?;
+        if interpolation == CpiInterpolationType::Linear {
+            let period_shift = Period::try_from(yii.frequency())?;
+            let availability_lag = yii.availability_lag();
+            let excess = swap_obs_lag - period_shift;
+            require!(
+                excess
+                    .partial_cmp(&availability_lag)
+                    .is_some_and(std::cmp::Ordering::is_ge),
+                "inconsistency between swap observation lag {swap_obs_lag}, index period \
+                 {period_shift} and index availability {availability_lag}: need (obsLag-index \
+                 period) >= availLag"
+            );
+        }
 
         let helper = Shared::new_cyclic(|weak: &Weak<YearOnYearInflationSwapHelper>| {
             let weak = weak.clone();
@@ -727,8 +741,11 @@ impl YearOnYearInflationSwapHelper {
             yii.observable().register_observer(&base.observer());
             nominal_term_structure.register_observer(&base.observer());
 
-            base.set_earliest_date(fixing_period.0);
-            base.set_latest_date(fixing_period.0);
+            base.set_earliest_date(earliest_date);
+            base.set_latest_date(latest_date);
+            if let Some(pillar_date) = pillar_date {
+                base.set_pillar_date(pillar_date);
+            }
 
             let helper = YearOnYearInflationSwapHelper {
                 base,
@@ -755,6 +772,49 @@ impl YearOnYearInflationSwapHelper {
             return Err(error.clone());
         }
         Ok(helper)
+    }
+
+    /// The helper's earliest and latest dates and its pillar, if it pins one
+    /// (`cpp:253-291`).
+    ///
+    /// The flat swap reads a single fixing, so all three collapse onto the first
+    /// day of the observed fixing period (`cpp:286-291`). The interpolated swap
+    /// reads the fixings bracketing its observation date, so its window opens on
+    /// that day and closes the day after the period ends (`cpp:254-255`), and
+    /// the pillar goes to whichever end carries the dominant interpolation
+    /// weight (`cpp:257-270`).
+    ///
+    /// `None` is the C++ `pillarDate_ == Date()` the `dt/dp > 0.5` arm leaves
+    /// behind (`cpp:267-268`): the pillar is not the fixing period's start
+    /// there, it is unset, and
+    /// [`BootstrapHelperBase::pillar_date`](crate::termstructures::bootstraphelper::BootstrapHelperBase::pillar_date)
+    /// answers with the latest date exactly as `bootstraphelper.hpp:193-197`
+    /// does.
+    fn dates(
+        fixing_period: (Date, Date),
+        maturity: Date,
+        yii: &Shared<YoYInflationIndex>,
+        interpolation: CpiInterpolationType,
+        pillar: Pillar,
+    ) -> QlResult<(Date, Date, Option<Date>)> {
+        match interpolation {
+            CpiInterpolationType::Flat => {
+                Ok((fixing_period.0, fixing_period.0, Some(fixing_period.0)))
+            }
+            CpiInterpolationType::Linear => {
+                let latest_date = fixing_period.1 + 1;
+                let pillar_date = match pillar {
+                    Pillar::MaturityDate => Some(latest_date),
+                    Pillar::LastRelevantDate => {
+                        let weight_period = inflation_period(maturity, yii.frequency())?;
+                        let dp = Real::from(weight_period.1 + 1 - weight_period.0);
+                        let dt = Real::from(maturity - weight_period.0);
+                        (dt / dp <= 0.5).then_some(fixing_period.0)
+                    }
+                };
+                Ok((fixing_period.0, latest_date, pillar_date))
+            }
+        }
     }
 
     /// The cached swap, or the error that stopped it being built (`swap()`,
@@ -1470,7 +1530,7 @@ mod yoy_swap_helper_tests {
     use crate::quotes::SimpleQuote;
     use crate::termstructures::inflation::interpolatedyoyinflationcurve::YoYInflationCurve;
     use crate::time::calendars::unitedkingdom::{self, UnitedKingdom};
-    use crate::time::date::Month::{August, July};
+    use crate::time::date::Month::{August, July, June};
     use crate::time::daycounters::actual360::Actual360;
     use crate::time::daycounters::thirty360::{Convention, Thirty360};
 
@@ -1537,17 +1597,33 @@ mod yoy_swap_helper_tests {
         settings: &Shared<Settings<Date>>,
         interpolation: CpiInterpolationType,
     ) -> QlResult<Shared<YearOnYearInflationSwapHelper>> {
+        a_helper_with(
+            settings,
+            interpolation,
+            Pillar::LastRelevantDate,
+            maturity(),
+            lag(),
+        )
+    }
+
+    fn a_helper_with(
+        settings: &Shared<Settings<Date>>,
+        interpolation: CpiInterpolationType,
+        pillar: Pillar,
+        maturity: Date,
+        obs_lag: Period,
+    ) -> QlResult<Shared<YearOnYearInflationSwapHelper>> {
         YearOnYearInflationSwapHelper::new(
             Handle::new(shared(SimpleQuote::new(Some(CURVE_RATE)))),
-            lag(),
-            maturity(),
+            obs_lag,
+            maturity,
             UnitedKingdom::new(unitedkingdom::Market::Settlement),
             BusinessDayConvention::ModifiedFollowing,
             Thirty360::with_convention(Convention::BondBasis),
             &an_index(settings),
             interpolation,
             a_nominal_curve(),
-            Pillar::LastRelevantDate,
+            pillar,
             Shared::clone(settings),
         )
     }
@@ -1609,18 +1685,115 @@ mod yoy_swap_helper_tests {
         );
     }
 
-    /// The interpolated branch is refused rather than silently taking the flat
-    /// path (`cpp:253-306` is deferred).
+    /// The interpolated window straddles the observed fixing period
+    /// (`cpp:254-255`). The observation falls in June 2012, whose monthly period
+    /// is 1 to 30 June, and the swap reads the fixings bracketing it: the June
+    /// figure, dated 1 June, and the July one, dated the day after June's period
+    /// ends - 1 July 2012. The flat helper collapses both onto 1 June.
     #[test]
-    fn the_interpolated_branch_is_refused() {
+    fn the_interpolated_window_reaches_a_month_past_the_flat_one() {
         let settings = settings_today();
-        let error = a_helper(&settings, CpiInterpolationType::Linear)
-            .map(|_| ())
-            .expect_err("the interpolated branch is deferred");
+        let interpolated = a_helper(&settings, CpiInterpolationType::Linear)
+            .expect("a two-month lag leaves a month over the index's availability");
+        let flat = a_helper(&settings, CpiInterpolationType::Flat).expect("a well-formed helper");
+
+        assert_eq!(interpolated.earliest_date(), Date::new(1, June, 2012));
+        assert_eq!(interpolated.latest_date(), Date::new(1, July, 2012));
+        assert!(interpolated.latest_date() > flat.latest_date());
+    }
+
+    /// [`Pillar::MaturityDate`] pins the node at the window's far end
+    /// (`cpp:258-260`), the July figure's date - not the near end the weighted
+    /// choice picks for this same maturity below.
+    #[test]
+    fn the_maturity_date_pillar_is_the_windows_far_end() {
+        let helper = a_helper_with(
+            &settings_today(),
+            CpiInterpolationType::Linear,
+            Pillar::MaturityDate,
+            maturity(),
+            lag(),
+        )
+        .expect("a well-formed helper");
+
+        assert_eq!(helper.pillar_date(), helper.latest_date());
+        assert_eq!(helper.pillar_date(), Date::new(1, July, 2012));
+    }
+
+    /// [`Pillar::LastRelevantDate`] pins the node at whichever end carries the
+    /// dominant interpolation weight (`cpp:261-278`), weighed on the maturity
+    /// because this relative-date helper has no schedule start date
+    /// (`cpp:263`). 13 August 2012 falls 12 days into a 31-day month, so `dt/dp`
+    /// is 12/31 = 0.387 and the near end wins: the pillar is the window's start,
+    /// a full month before its far end.
+    #[test]
+    fn the_weighted_pillar_takes_the_windows_start_early_in_the_month() {
+        let helper = a_helper(&settings_today(), CpiInterpolationType::Linear)
+            .expect("a well-formed helper");
+
+        assert_eq!(helper.pillar_date(), Date::new(1, June, 2012));
+    }
+
+    /// The far side of the same threshold: 25 August 2012 falls 24 days into
+    /// that 31-day month, `dt/dp` is 24/31 = 0.774, and the far end wins. C++
+    /// leaves the pillar unset there rather than assigning one (`cpp:267-268`)
+    /// and the base answers with the latest date
+    /// (`bootstraphelper.hpp:193-197`); this port does the same. The window
+    /// itself does not move - 25 June 2012 sits in the same June period - so the
+    /// weight is the only thing the later maturity changes.
+    #[test]
+    fn the_weighted_pillar_takes_the_windows_far_end_late_in_the_month() {
+        let helper = a_helper_with(
+            &settings_today(),
+            CpiInterpolationType::Linear,
+            Pillar::LastRelevantDate,
+            Date::new(25, August, 2012),
+            lag(),
+        )
+        .expect("a well-formed helper");
+
+        assert_eq!(helper.earliest_date(), Date::new(1, June, 2012));
+        assert_eq!(helper.pillar_date(), Date::new(1, July, 2012));
+    }
+
+    /// The interpolated path needs a whole index period of observation lag on
+    /// top of the index's availability lag (`cpp:296-302`), since it reads the
+    /// month *after* the one the lag lands in. The index publishes a month in
+    /// arrears, so a one-month lag leaves nothing for that second figure.
+    ///
+    /// The message names all three quantities, which is what tells this apart
+    /// from any failure the contract itself would raise - the flat path builds
+    /// on the same one-month lag.
+    #[test]
+    fn an_interpolated_lag_short_of_an_index_period_is_rejected() {
+        let settings = settings_today();
+        let short_lag = Period::new(1, TimeUnit::Months);
+        let error = a_helper_with(
+            &settings,
+            CpiInterpolationType::Linear,
+            Pillar::LastRelevantDate,
+            maturity(),
+            short_lag,
+        )
+        .err()
+        .expect("one month of lag cannot cover the interpolation");
 
         assert!(
-            error.message().contains("not ported yet"),
+            error
+                .message()
+                .contains("need (obsLag-index period) >= availLag"),
             "err was: {error}"
+        );
+        assert!(
+            a_helper_with(
+                &settings,
+                CpiInterpolationType::Flat,
+                Pillar::LastRelevantDate,
+                maturity(),
+                short_lag,
+            )
+            .is_ok(),
+            "the flat path has no such requirement"
         );
     }
 }


### PR DESCRIPTION
The interpolated path of YearOnYearInflationSwapHelper was previously
refused rather than ported. It now widens the date window a month past
the flat one, picks a pillar from the interpolation weight or the
maturity, and enforces a whole index period of observation lag on top
of the index's availability lag.

The Flat arm now sets its pillar date explicitly where it previously
set none, but pillar_date() returns fixing_period.0 either way, so
there is no observable change and the_flat_helper_pins_one_date passes
unchanged. This mirrors the zero side's documented choice.

Closes #847
