### PR TITLE
feat(itofin-py): expose Currency and weekends-only calendar

### DIFF
--- a/crates/itofin-py/python/itofin/indexes.pyi
+++ b/crates/itofin-py/python/itofin/indexes.pyi
@@ -1,5 +1,5 @@
 # Hand-written stubs for itofin.indexes; sync manually with src/hullwhite.rs, src/helpers.rs,
-# src/swapindex.rs and src/inflation.rs (#517).
+# src/swapindex.rs, src/currency.rs and src/inflation.rs (#517).
 
 from itofin import Settings
 from itofin.termstructures import (
@@ -14,6 +14,22 @@ from itofin.time import (
     DayCounter,
     Period,
 )
+
+class Currency:
+    """An ISO 4217 currency specification.
+
+    Only the three named currencies the core provides are exposed; the general
+    constructor is omitted, as the core ports only the currencies its indexes
+    need and the full catalogue is deferred there."""
+
+    @staticmethod
+    def eur() -> Currency: ...
+    @staticmethod
+    def usd() -> Currency: ...
+    @staticmethod
+    def gbp() -> Currency: ...
+    def code(self) -> str: ...
+    def __repr__(self) -> str: ...
 
 class Euribor:
     """The Euribor IBOR index family."""

--- a/crates/itofin-py/python/itofin/indexes.pyi
+++ b/crates/itofin-py/python/itofin/indexes.pyi
@@ -31,7 +31,29 @@ class Currency:
     def code(self) -> str: ...
     def __repr__(self) -> str: ...
 
-class Euribor:
+class IborIndex:
+    """A general Inter-Bank-Offered-Rate index, spelling out every convention.
+
+    The form for an index outside the named families (the USD-3M IsdaIbor the
+    ISDA CDS curve bootstraps off, say). Pass forwarding=None to build it over
+    an empty handle, the form the bootstrap rate helpers need."""
+
+    def __init__(
+        self,
+        family_name: str,
+        tenor: Period,
+        settlement_days: int,
+        currency: Currency,
+        fixing_calendar: Calendar,
+        convention: BusinessDayConvention,
+        end_of_month: bool,
+        day_counter: DayCounter,
+        forwarding: YieldTermStructure | None,
+        settings: Settings,
+    ) -> None: ...
+    def fixing(self, fixing_date: Date, forecast_todays_fixing: bool) -> float: ...
+
+class Euribor(IborIndex):
     """The Euribor IBOR index family."""
 
     def __init__(

--- a/crates/itofin-py/python/itofin/termstructures.pyi
+++ b/crates/itofin-py/python/itofin/termstructures.pyi
@@ -7,6 +7,7 @@ from itofin.indexes import (
     CpiInterpolationType,
     Estr,
     Euribor,
+    IborIndex,
     SwapIndex,
     YoYInflationIndex,
     ZeroInflationIndex,
@@ -230,9 +231,9 @@ class RateHelper:
 class DepositRateHelper(RateHelper):
     """A helper fitting a deposit rate."""
 
-    def __init__(self, quote: SimpleQuote, index: Euribor) -> None: ...
+    def __init__(self, quote: SimpleQuote, index: IborIndex) -> None: ...
     @staticmethod
-    def from_rate(rate: float, index: Euribor) -> DepositRateHelper: ...
+    def from_rate(rate: float, index: IborIndex) -> DepositRateHelper: ...
 
 class SwapRateHelper(RateHelper):
     """A helper fitting a par swap rate (spot-starting, no spread)."""
@@ -245,7 +246,7 @@ class SwapRateHelper(RateHelper):
         fixed_frequency: Frequency,
         fixed_convention: BusinessDayConvention,
         fixed_day_count: DayCounter,
-        ibor_index: Euribor,
+        ibor_index: IborIndex,
     ) -> None: ...
 
 class FuturesType:

--- a/crates/itofin-py/python/itofin/time.pyi
+++ b/crates/itofin-py/python/itofin/time.pyi
@@ -39,6 +39,11 @@ class Calendar:
     @staticmethod
     def null_calendar() -> Calendar: ...
     @staticmethod
+    def weekends_only() -> Calendar:
+        """The weekends-only calendar: Saturdays and Sundays are holidays and no
+        other day is. The calendar the ISDA CDS conventions roll on."""
+        ...
+    @staticmethod
     def united_kingdom() -> Calendar:
         """The UK settlement calendar. Only the Settlement market is exposed:
         the Exchange and Metals markets share an identical business-day rule in

--- a/crates/itofin-py/src/currency.rs
+++ b/crates/itofin-py/src/currency.rs
@@ -1,0 +1,71 @@
+//! Facade for the currency specification [`PyCurrency`] (`currency::Currency`).
+//!
+//! An index carries a currency, so the general [`PyIborIndex`](crate::hullwhite::PyIborIndex)
+//! constructor cannot be called without one. Only the three named currencies the
+//! core provides are exposed as staticmethods; the general
+//! [`Currency::new`](libitofin::currency::Currency::new) form is deliberately
+//! omitted, since the core itself ports only the currencies the indexes need and
+//! the full `ql/currencies/*` catalogue is deferred there (`currency.rs:9`).
+//!
+//! It is registered under `itofin.indexes` rather than a submodule of its own:
+//! the index constructors are its only consumers today, and
+//! [`PySwapIndex`](crate::swapindex::PySwapIndex) documents that gap as the one
+//! this facade closes.
+
+use libitofin::currency::Currency;
+use pyo3::prelude::*;
+
+/// Python `Currency`: an ISO 4217 currency specification (`currency::Currency`).
+///
+/// Two currencies compare equal on their name alone, matching the core's
+/// `PartialEq` (`currency.rs:132`), and `repr` prints the ISO code, matching its
+/// `Display` (`currency.rs:126`).
+#[pyclass(name = "Currency", unsendable)]
+pub struct PyCurrency {
+    inner: Currency,
+}
+
+#[pymethods]
+impl PyCurrency {
+    /// The European Euro (ISO `EUR`).
+    #[staticmethod]
+    fn eur() -> Self {
+        PyCurrency {
+            inner: Currency::eur(),
+        }
+    }
+
+    /// The U.S. dollar (ISO `USD`).
+    #[staticmethod]
+    fn usd() -> Self {
+        PyCurrency {
+            inner: Currency::usd(),
+        }
+    }
+
+    /// The British pound sterling (ISO `GBP`).
+    #[staticmethod]
+    fn gbp() -> Self {
+        PyCurrency {
+            inner: Currency::gbp(),
+        }
+    }
+
+    /// The ISO 4217 three-letter code, e.g. `"EUR"`.
+    fn code(&self) -> &str {
+        self.inner.code()
+    }
+
+    fn __repr__(&self) -> String {
+        format!("Currency({})", self.inner.code())
+    }
+}
+
+impl PyCurrency {
+    /// A clone of the inner currency for the index facades, whose constructors
+    /// take a [`Currency`] by value.
+    #[allow(dead_code)]
+    pub(crate) fn inner(&self) -> Currency {
+        self.inner.clone()
+    }
+}

--- a/crates/itofin-py/src/currency.rs
+++ b/crates/itofin-py/src/currency.rs
@@ -64,7 +64,6 @@ impl PyCurrency {
 impl PyCurrency {
     /// A clone of the inner currency for the index facades, whose constructors
     /// take a [`Currency`] by value.
-    #[allow(dead_code)]
     pub(crate) fn inner(&self) -> Currency {
         self.inner.clone()
     }

--- a/crates/itofin-py/src/helpers.rs
+++ b/crates/itofin-py/src/helpers.rs
@@ -16,7 +16,7 @@
 
 use crate::PyQlError;
 use crate::curve::PyYieldTermStructure;
-use crate::hullwhite::PyEuribor;
+use crate::hullwhite::{PyEuribor, PyIborIndex};
 use crate::market::PySimpleQuote;
 use crate::settings::PySettings;
 use crate::time::{
@@ -120,7 +120,7 @@ impl PyDepositRateHelper {
     /// A deposit helper fitting `quote`, whose schedule comes from `index`. The
     /// caller keeps `quote`; mutating it later invalidates the bootstrap.
     #[new]
-    fn new(quote: &PySimpleQuote, index: &PyEuribor) -> PyClassInitializer<Self> {
+    fn new(quote: &PySimpleQuote, index: &PyIborIndex) -> PyClassInitializer<Self> {
         let idx = index.inner();
         let helper = DepositRateHelper::new(quote.handle(), &idx) as Shared<dyn RateHelper>;
         PyClassInitializer::from(PyRateHelper { inner: helper }).add_subclass(PyDepositRateHelper)
@@ -129,7 +129,7 @@ impl PyDepositRateHelper {
     /// A deposit helper fitting a fixed `rate`, wrapped in an internal quote the
     /// caller cannot later mutate.
     #[staticmethod]
-    fn from_rate(py: Python<'_>, rate: f64, index: &PyEuribor) -> PyResult<Py<Self>> {
+    fn from_rate(py: Python<'_>, rate: f64, index: &PyIborIndex) -> PyResult<Py<Self>> {
         let idx = index.inner();
         let helper = DepositRateHelper::from_rate(rate, &idx) as Shared<dyn RateHelper>;
         Py::new(
@@ -163,7 +163,7 @@ impl PySwapRateHelper {
         fixed_frequency: &PyFrequency,
         fixed_convention: &PyBusinessDayConvention,
         fixed_day_count: &PyDayCounter,
-        ibor_index: &PyEuribor,
+        ibor_index: &PyIborIndex,
     ) -> PyClassInitializer<Self> {
         let idx = ibor_index.inner();
         let helper = SwapRateHelper::new(

--- a/crates/itofin-py/src/hullwhite.rs
+++ b/crates/itofin-py/src/hullwhite.rs
@@ -1,12 +1,13 @@
 //! Facades for the Hull-White short-rate stack: [`PyHullWhite`] and the
-//! [`PyEuribor`] index.
+//! [`PyIborIndex`] index base with its [`PyEuribor`] subclass.
 
 use crate::PyQlError;
 use crate::calibration::{PyCalibrationErrorType, PyEndCriteria, PyLevenbergMarquardt};
+use crate::currency::PyCurrency;
 use crate::curve::PyYieldTermStructure;
 use crate::option::PyOptionType;
 use crate::settings::PySettings;
-use crate::time::{PyDate, PyDayCounter, PyPeriod};
+use crate::time::{PyBusinessDayConvention, PyCalendar, PyDate, PyDayCounter, PyPeriod};
 use libitofin::cashflows::RateAveraging;
 use libitofin::handle::Handle;
 use libitofin::indexes::{Euribor, IborIndex, Index};
@@ -18,6 +19,7 @@ use libitofin::pricingengines::JamshidianSwaptionEngine;
 use libitofin::quotes::{Quote, SimpleQuote};
 use libitofin::shared::{Shared, SharedMut, shared, shared_mut};
 use libitofin::termstructures::volatility::VolatilityType;
+use libitofin::types::Natural;
 use pyo3::prelude::*;
 
 /// Python `HullWhite`: the one-factor Hull-White short-rate model
@@ -135,6 +137,97 @@ impl PyHullWhite {
     }
 }
 
+/// Python `IborIndex`: a general Inter-Bank-Offered-Rate index
+/// (`indexes::iborindex::IborIndex`).
+///
+/// The constructor spells out every convention the core ctor takes
+/// (`iborindex.rs:58`), so an index outside the named families - the USD-3M
+/// `IsdaIbor` the ISDA CDS curve bootstraps off, say - is expressible without a
+/// dedicated facade. `forwarding` `None` builds the index over an empty handle,
+/// the form the bootstrap rate helpers need, exactly as the C++ default
+/// `Handle<YieldTermStructure> h = {}` allows.
+///
+/// It is the base of [`PyEuribor`], so the deposit and swap rate helpers take
+/// this type and accept either. Every other index consumer still takes
+/// `PyEuribor` concretely, including two in the rate-helper module itself: the
+/// four `FraRateHelper` constructors and `FuturesRateHelper::from_index`. So do
+/// the swap, swap-index, optionlet-volatility, cap/floor and swaption-helper
+/// facades. Widening them is deferred to its own follow-up; no bootstrap this
+/// ticket serves needs it.
+#[pyclass(name = "IborIndex", subclass, unsendable)]
+pub struct PyIborIndex {
+    inner: Shared<IborIndex>,
+}
+
+#[pymethods]
+impl PyIborIndex {
+    /// An index of `tenor` fixing `settlement_days` before its value date on
+    /// `fixing_calendar`, rolling to maturity under `convention`/`end_of_month`,
+    /// accruing on `day_counter` and forecasting off `forwarding` (or off an
+    /// empty handle when `None`).
+    #[new]
+    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (
+        family_name,
+        tenor,
+        settlement_days,
+        currency,
+        fixing_calendar,
+        convention,
+        end_of_month,
+        day_counter,
+        forwarding,
+        settings,
+    ))]
+    fn new(
+        family_name: String,
+        tenor: &PyPeriod,
+        settlement_days: Natural,
+        currency: &PyCurrency,
+        fixing_calendar: &PyCalendar,
+        convention: &PyBusinessDayConvention,
+        end_of_month: bool,
+        day_counter: &PyDayCounter,
+        forwarding: Option<&PyYieldTermStructure>,
+        settings: &PySettings,
+    ) -> Self {
+        PyIborIndex {
+            inner: shared(IborIndex::new(
+                family_name,
+                tenor.inner(),
+                settlement_days,
+                currency.inner(),
+                fixing_calendar.inner(),
+                convention.inner(),
+                end_of_month,
+                day_counter.inner(),
+                forwarding
+                    .map(|curve| curve.handle())
+                    .unwrap_or_else(Handle::empty),
+                settings.inner(),
+            )),
+        }
+    }
+
+    /// The index's fixing for `fixing_date`, forecast off the forwarding curve
+    /// for a future date or read from stored fixings for a past one. Fallible:
+    /// an empty forwarding handle or an unset evaluation date is an error.
+    fn fixing(&self, fixing_date: &PyDate, forecast_todays_fixing: bool) -> PyResult<f64> {
+        Ok(self
+            .inner
+            .fixing(fixing_date.inner(), forecast_todays_fixing)
+            .map_err(PyQlError::from)?)
+    }
+}
+
+impl PyIborIndex {
+    /// A clone of the inner index for the rate-helper facades, which take a
+    /// `&IborIndex` and are generic over the family.
+    pub(crate) fn inner(&self) -> Shared<IborIndex> {
+        Shared::clone(&self.inner)
+    }
+}
+
 /// Python `Euribor`: the Euribor IBOR index family (`indexes::Euribor`).
 ///
 /// The general constructor takes a tenor, an optional forwarding curve, and the
@@ -144,7 +237,12 @@ impl PyHullWhite {
 /// constructors. `Euribor::new` returns an `IborIndex` by value; it is wrapped
 /// in `shared()` so downstream ctors that take a `Shared<IborIndex>`
 /// (VanillaSwap/SwaptionHelper/rate helpers) can hold the same object.
-#[pyclass(name = "Euribor", unsendable)]
+///
+/// A subclass of [`PyIborIndex`], so a Euribor is accepted wherever the general
+/// index is. It retains its own clone of the index the base holds - the same
+/// object, not a rebuild - so the facades still typed on `PyEuribor` read
+/// exactly what the base reads.
+#[pyclass(name = "Euribor", extends = PyIborIndex, unsendable)]
 pub struct PyEuribor {
     inner: Shared<IborIndex>,
 }
@@ -160,32 +258,36 @@ impl PyEuribor {
         tenor: &PyPeriod,
         curve: Option<&PyYieldTermStructure>,
         settings: &PySettings,
-    ) -> PyResult<Self> {
+    ) -> PyResult<PyClassInitializer<Self>> {
         let forwarding = match curve {
             Some(curve) => curve.handle(),
             None => Handle::empty(),
         };
         let index =
             Euribor::new(tenor.inner(), forwarding, settings.inner()).map_err(PyQlError::from)?;
-        Ok(PyEuribor {
-            inner: shared(index),
-        })
+        Ok(init_euribor(shared(index)))
     }
 
     /// The 3-month Euribor index (`Euribor3M`) forwarding off `curve`.
     #[staticmethod]
-    fn three_months(curve: &PyYieldTermStructure, settings: &PySettings) -> Self {
-        PyEuribor {
-            inner: shared(Euribor::three_months(curve.handle(), settings.inner())),
-        }
+    fn three_months(
+        py: Python<'_>,
+        curve: &PyYieldTermStructure,
+        settings: &PySettings,
+    ) -> PyResult<Py<Self>> {
+        let index = shared(Euribor::three_months(curve.handle(), settings.inner()));
+        Py::new(py, init_euribor(index))
     }
 
     /// The 6-month Euribor index (`Euribor6M`) forwarding off `curve`.
     #[staticmethod]
-    fn six_months(curve: &PyYieldTermStructure, settings: &PySettings) -> Self {
-        PyEuribor {
-            inner: shared(Euribor::six_months(curve.handle(), settings.inner())),
-        }
+    fn six_months(
+        py: Python<'_>,
+        curve: &PyYieldTermStructure,
+        settings: &PySettings,
+    ) -> PyResult<Py<Self>> {
+        let index = shared(Euribor::six_months(curve.handle(), settings.inner()));
+        Py::new(py, init_euribor(index))
     }
 
     /// The index's fixing for `fixing_date`, forecast off the forwarding curve
@@ -204,6 +306,16 @@ impl PyEuribor {
     pub(crate) fn inner(&self) -> Shared<IborIndex> {
         Shared::clone(&self.inner)
     }
+}
+
+/// The base/subclass initializer shared by the three Euribor constructors: one
+/// index object feeds both halves, so the base [`PyIborIndex`] the rate helpers
+/// read and the [`PyEuribor`] the swap facades read are the same core index.
+fn init_euribor(index: Shared<IborIndex>) -> PyClassInitializer<PyEuribor> {
+    let base = PyIborIndex {
+        inner: Shared::clone(&index),
+    };
+    PyClassInitializer::from(base).add_subclass(PyEuribor { inner: index })
 }
 
 /// Python `SwaptionHelper`: a co-terminal swaption calibration instrument

--- a/crates/itofin-py/src/lib.rs
+++ b/crates/itofin-py/src/lib.rs
@@ -57,7 +57,7 @@ use helpers::{
     PyOISRateHelper, PyPillar, PyRateAveraging, PyRateHelper, PySwapRateHelper,
 };
 use heston::{PyHestonModel, PyHestonModelHelper, PyHestonProcess};
-use hullwhite::{PyEuribor, PyHullWhite, PySwaptionHelper};
+use hullwhite::{PyEuribor, PyHullWhite, PyIborIndex, PySwaptionHelper};
 use inflation::{
     PyConstantYoYOptionletVolatility, PyCpiInterpolationType, PyDiscountingSwapEngine,
     PyInterpolatedYoYInflationCurve, PyInterpolatedZeroInflationCurve, PyMakeYoYInflationCapFloor,
@@ -214,6 +214,7 @@ fn itofin(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     let indexes = PyModule::new(py, "indexes")?;
     indexes.add_class::<PyCurrency>()?;
+    indexes.add_class::<PyIborIndex>()?;
     indexes.add_class::<PyEuribor>()?;
     indexes.add_class::<PyEstr>()?;
     indexes.add_class::<PySwapIndex>()?;

--- a/crates/itofin-py/src/lib.rs
+++ b/crates/itofin-py/src/lib.rs
@@ -13,6 +13,7 @@ mod cashflows;
 mod credit;
 mod creditengine;
 mod credithelpers;
+mod currency;
 mod curve;
 mod helpers;
 mod heston;
@@ -45,6 +46,7 @@ use creditengine::{
     PyAccrualBias, PyForwardsInCouponPeriod, PyIsdaCdsEngine, PyMidPointCdsEngine, PyNumericalFix,
 };
 use credithelpers::{PyDefaultProbabilityHelper, PySpreadCdsHelper};
+use currency::PyCurrency;
 use curve::{
     PyDiscountCurve, PyFlatForward, PyForwardCurve, PyPiecewiseFlatForward,
     PyPiecewiseLinearForward, PyPiecewiseLinearZero, PyPiecewiseLogLinearDiscount,
@@ -211,6 +213,7 @@ fn itofin(m: &Bound<'_, PyModule>) -> PyResult<()> {
     processes.add_class::<PyHestonProcess>()?;
 
     let indexes = PyModule::new(py, "indexes")?;
+    indexes.add_class::<PyCurrency>()?;
     indexes.add_class::<PyEuribor>()?;
     indexes.add_class::<PyEstr>()?;
     indexes.add_class::<PySwapIndex>()?;

--- a/crates/itofin-py/src/swapindex.rs
+++ b/crates/itofin-py/src/swapindex.rs
@@ -5,12 +5,13 @@
 //! read the at-the-money forward off them, so this is the index the cube facades
 //! stack on rather than one the Python user prices with directly.
 //!
-//! Deferred (visible): the currency is hard-coded to EUR. There is no
-//! `PyCurrency` facade yet, and the index's currency is inert for every ported
-//! consumer - `underlying_swap` never reads it, and the cube's at-the-money
-//! forward is a fair rate, not an amount. A `PyCurrency` ticket carries the
-//! general form; until then a non-EUR index is not expressible here. The
-//! `clone` family (re-curving / re-tenoring) is deferred in the core itself.
+//! Deferred (visible): the currency is hard-coded to EUR. A
+//! [`PyCurrency`](crate::currency::PyCurrency) facade now exists (#815), so the
+//! general form is expressible; threading it through this constructor is left to
+//! the follow-up that widens the remaining `PyEuribor` consumers, since the
+//! index's currency is inert for every ported consumer - `underlying_swap` never
+//! reads it, and the cube's at-the-money forward is a fair rate, not an amount.
+//! The `clone` family (re-curving / re-tenoring) is deferred in the core itself.
 
 use crate::PyQlError;
 use crate::curve::PyYieldTermStructure;

--- a/crates/itofin-py/src/time.rs
+++ b/crates/itofin-py/src/time.rs
@@ -4,7 +4,7 @@ use crate::ItofinError;
 use libitofin::time::businessdayconvention::BusinessDayConvention;
 use libitofin::time::calendar::Calendar;
 use libitofin::time::calendars::unitedkingdom::{Market, UnitedKingdom};
-use libitofin::time::calendars::{NullCalendar, Target};
+use libitofin::time::calendars::{NullCalendar, Target, WeekendsOnly};
 use libitofin::time::date::{Date, Month};
 use libitofin::time::dategenerationrule::DateGeneration;
 use libitofin::time::daycounter::DayCounter;
@@ -280,6 +280,19 @@ impl PyCalendar {
     fn null_calendar() -> Self {
         PyCalendar {
             inner: NullCalendar::new(),
+        }
+    }
+
+    /// The weekends-only calendar: every Saturday and Sunday is a holiday and no
+    /// other day is.
+    ///
+    /// The ISDA CDS conventions roll on it, and it is not substitutable by
+    /// [`Self::null_calendar`] (which holds no holidays at all) or by a national
+    /// calendar (which adds public holidays).
+    #[staticmethod]
+    fn weekends_only() -> Self {
+        PyCalendar {
+            inner: WeekendsOnly::new(),
         }
     }
 

--- a/crates/itofin-py/tests/test_ibor_index.py
+++ b/crates/itofin-py/tests/test_ibor_index.py
@@ -1,0 +1,216 @@
+"""The generic IborIndex facade and the re-typed deposit/swap helpers (#815).
+
+The discriminating oracle is an equivalence pin: an IborIndex spelled out with
+the Euribor 3M conventions (euribor.rs:53-58 plus the tenor-dependent
+euribor_convention/euribor_eom at :126-141, whose Months arms give
+ModifiedFollowing and end-of-month) must bootstrap the same curve as the Euribor
+facade itself. Nothing is read back off the index; the two curves are compared
+against each other.
+
+A mid-month evaluation date leaves the convention and end-of-month flags inert -
+the roll never crosses a month boundary, so a wrong value for either would still
+pass. The pin therefore runs at three evaluation dates, two of them chosen so
+those flags bite, and test_wrong_conventions_do_diverge proves they bite by
+showing a deliberately mis-specified index diverging at exactly those dates.
+"""
+
+import pytest
+
+from itofin import Settings
+from itofin.indexes import Currency, Euribor, IborIndex
+from itofin.quotes import SimpleQuote
+from itofin.termstructures import (
+    DepositRateHelper,
+    PiecewiseLogLinearDiscount,
+    SwapRateHelper,
+)
+from itofin.time import (
+    BusinessDayConvention,
+    Calendar,
+    Date,
+    DayCounter,
+    Frequency,
+    Period,
+)
+
+DEPOSIT_RATE = 0.04557
+
+# A plain mid-month date, one whose value date is a month end (so end-of-month
+# bites), and one whose 3M roll crosses a month boundary (so ModifiedFollowing
+# bites, parting from Following).
+PLAIN_DATE = Date(15, 6, 2026)
+END_OF_MONTH_DATE = Date(25, 2, 2026)
+MONTH_CROSSING_DATE = Date(25, 11, 2026)
+EVALUATION_DATES = [PLAIN_DATE, END_OF_MONTH_DATE, MONTH_CROSSING_DATE]
+
+
+def _settings_on(evaluation_date, calendar):
+    today = calendar.adjust(evaluation_date, BusinessDayConvention.Following)
+    settings = Settings()
+    settings.set_evaluation_date(today)
+    return settings, today
+
+
+def _euribor_3m_conventions(settings, calendar):
+    """The Euribor 3M configuration spelled out field by field."""
+    return IborIndex(
+        "Euribor",
+        Period(3, "Months"),
+        2,
+        Currency.eur(),
+        calendar,
+        BusinessDayConvention.ModifiedFollowing,
+        True,
+        DayCounter.actual360(),
+        None,
+        settings,
+    )
+
+
+def _deposit_curve(index, settlement_date):
+    helper = DepositRateHelper(SimpleQuote(DEPOSIT_RATE), index)
+    return PiecewiseLogLinearDiscount(
+        settlement_date, [helper], DayCounter.actual365_fixed()
+    )
+
+
+def _settlement_and_probe(calendar, today):
+    settlement = calendar.advance(
+        today, 2, "Days", BusinessDayConvention.Following, False
+    )
+    probe = calendar.advance(
+        settlement, 2, "Months", BusinessDayConvention.Following, False
+    )
+    return settlement, probe
+
+
+@pytest.mark.parametrize("evaluation_date", EVALUATION_DATES)
+def test_generic_index_bootstraps_the_same_curve_as_euribor(evaluation_date):
+    calendar = Calendar.target()
+    settings, today = _settings_on(evaluation_date, calendar)
+    settlement, probe = _settlement_and_probe(calendar, today)
+
+    generic = _euribor_3m_conventions(settings, calendar)
+    euribor = Euribor(Period(3, "Months"), None, settings)
+
+    generic_df = _deposit_curve(generic, settlement).discount_date(probe)
+    euribor_df = _deposit_curve(euribor, settlement).discount_date(probe)
+
+    assert generic_df == pytest.approx(euribor_df, abs=1e-12)
+
+
+@pytest.mark.parametrize(
+    ("evaluation_date", "convention", "end_of_month"),
+    [
+        (END_OF_MONTH_DATE, BusinessDayConvention.ModifiedFollowing, False),
+        (MONTH_CROSSING_DATE, BusinessDayConvention.Following, True),
+    ],
+)
+def test_wrong_conventions_do_diverge(evaluation_date, convention, end_of_month):
+    """The equivalence pin is not vacuous: at these dates a single wrong
+    convention field moves the bootstrapped curve, so the pin above would have
+    caught it."""
+    calendar = Calendar.target()
+    settings, today = _settings_on(evaluation_date, calendar)
+    settlement, probe = _settlement_and_probe(calendar, today)
+
+    wrong = IborIndex(
+        "Euribor",
+        Period(3, "Months"),
+        2,
+        Currency.eur(),
+        calendar,
+        convention,
+        end_of_month,
+        DayCounter.actual360(),
+        None,
+        settings,
+    )
+    euribor = Euribor(Period(3, "Months"), None, settings)
+
+    wrong_df = _deposit_curve(wrong, settlement).discount_date(probe)
+    euribor_df = _deposit_curve(euribor, settlement).discount_date(probe)
+
+    assert wrong_df != pytest.approx(euribor_df, abs=1e-12)
+
+
+def test_isda_style_index_bootstraps_a_deposit_and_swap_strip():
+    """A build-check for the USD-3M weekends-only index the ISDA CDS curve needs.
+
+    The Markit cached values are #816's oracle, not this one; all that is pinned
+    here is that a non-Euribor index reaches a bootstrapped curve at all.
+    """
+    calendar = Calendar.weekends_only()
+    settings, today = _settings_on(PLAIN_DATE, calendar)
+    settlement, probe = _settlement_and_probe(calendar, today)
+
+    index = IborIndex(
+        "IsdaIbor",
+        Period(3, "Months"),
+        2,
+        Currency.usd(),
+        calendar,
+        BusinessDayConvention.ModifiedFollowing,
+        False,
+        DayCounter.actual360(),
+        None,
+        settings,
+    )
+    deposit = DepositRateHelper(SimpleQuote(DEPOSIT_RATE), index)
+    swap = SwapRateHelper(
+        SimpleQuote(0.05),
+        Period(2, "Years"),
+        calendar,
+        Frequency.Annual,
+        BusinessDayConvention.Unadjusted,
+        DayCounter.thirty360_bond_basis(),
+        index,
+    )
+    curve = PiecewiseLogLinearDiscount(
+        settlement, [deposit, swap], DayCounter.actual365_fixed()
+    )
+
+    discount = curve.discount_date(probe)
+    assert 0.0 < discount < 1.0
+
+
+def test_euribor_is_an_ibor_index():
+    calendar = Calendar.target()
+    settings, _ = _settings_on(PLAIN_DATE, calendar)
+    assert isinstance(Euribor(Period(3, "Months"), None, settings), IborIndex)
+
+
+def test_deposit_helper_still_takes_a_euribor():
+    calendar = Calendar.target()
+    settings, today = _settings_on(PLAIN_DATE, calendar)
+    settlement, probe = _settlement_and_probe(calendar, today)
+
+    euribor = Euribor(Period(3, "Months"), None, settings)
+    curve = _deposit_curve(euribor, settlement)
+    assert 0.0 < curve.discount_date(probe) < 1.0
+
+
+def test_generic_index_fixing_forecasts_off_its_curve():
+    """The forwarding-curve arm of the constructor, which every other test here
+    passes None for: an index reading the curve a deposit of DEPOSIT_RATE
+    bootstrapped forecasts that same rate back over the deposit's own window."""
+    calendar = Calendar.target()
+    settings, today = _settings_on(PLAIN_DATE, calendar)
+    settlement, _ = _settlement_and_probe(calendar, today)
+
+    bootstrapped = _deposit_curve(
+        _euribor_3m_conventions(settings, calendar), settlement
+    )
+    forecasting = IborIndex(
+        "Euribor",
+        Period(3, "Months"),
+        2,
+        Currency.eur(),
+        calendar,
+        BusinessDayConvention.ModifiedFollowing,
+        True,
+        DayCounter.actual360(),
+        bootstrapped,
+        settings,
+    )
+    assert forecasting.fixing(today, False) == pytest.approx(DEPOSIT_RATE, abs=1e-10)


### PR DESCRIPTION
- **feat(itofin-py): expose Currency and weekends-only calendar**
- **feat(itofin-py): add general IborIndex base for rate helpers**
- **test(itofin-py): add tests for IBOR index**

close #815