### PR TITLE
feat(itofin-py): expose CDS accrual rebate and trade date

### DIFF
--- a/crates/itofin-py/python/itofin/instruments.pyi
+++ b/crates/itofin-py/python/itofin/instruments.pyi
@@ -293,6 +293,17 @@ class CreditDefaultSwap:
     def notional(self) -> float:
         """The notional the premium and the protection are quoted on."""
         ...
+    def accrual_rebate_amount(self) -> float | None:
+        """The accrued coupon the protection seller rebates, or None when the
+        contract does not rebate accrual at all. A contract traded in the past
+        still carries the flow, with a real amount but a past settlement date
+        that keeps it out of the value, so None means the flag rather than a
+        stale trade."""
+        ...
+    def accrual_rebate_date(self) -> Date | None:
+        """The date the accrual rebate settles on, the same cash-settlement date
+        the upfront pays on. None on the same terms as accrual_rebate_amount."""
+        ...
     def coupon_leg_npv(self) -> float: ...
     def default_leg_npv(self) -> float: ...
     def implied_hazard_rate(
@@ -324,8 +335,9 @@ class MakeCreditDefaultSwap:
     An unset optional keeps the core default: a Buyer side, a nominal of 1, no
     upfront, a 3M coupon tenor, the pre-CDS2015 DateGeneration.CDS rule, a
     Following roll, an Act/360 day counter and three cash-settlement days. Only
-    the term-date quotation is exposed; the tenor and explicit-schedule ones,
-    the trade date and the accrual-rebate flag are not."""
+    the term-date quotation is exposed; the tenor and explicit-schedule ones and
+    the accrual-rebate flag are not, the latter being reachable through
+    CreditDefaultSwap.with_terms."""
 
     def __init__(
         self,
@@ -335,7 +347,11 @@ class MakeCreditDefaultSwap:
         nominal: float | None = None,
         upfront_rate: float | None = None,
         side: ProtectionSide | None = None,
-    ) -> None: ...
+        trade_date: Date | None = None,
+    ) -> None:
+        """trade_date overrides the evaluation date the trade is otherwise dated
+        off, which is how a contract traded in the past is built."""
+        ...
     def build(self) -> CreditDefaultSwap:
         """The built contract, which carries no engine. Raises ItofinError with
         no evaluation date set, the trade date being derived from it."""

--- a/crates/itofin-py/src/credit.rs
+++ b/crates/itofin-py/src/credit.rs
@@ -11,6 +11,8 @@ use crate::curve::PyYieldTermStructure;
 use crate::market::PySimpleQuote;
 use crate::settings::PySettings;
 use crate::time::{PyBusinessDayConvention, PyCalendar, PyDate, PyDayCounter, PySchedule};
+use libitofin::cashflow::CashFlow;
+use libitofin::event::Event;
 use libitofin::handle::Handle;
 use libitofin::instrument::Instrument;
 use libitofin::instruments::{
@@ -692,6 +694,37 @@ impl PyCreditDefaultSwap {
         self.inner.borrow().notional()
     }
 
+    /// The accrued coupon the protection seller rebates, or `None` when the
+    /// contract does not rebate accrual at all (`rebates_accrual` false).
+    ///
+    /// A contract traded in the past still carries the flow: the core builds it
+    /// whenever the flag is set, regardless of the trade date
+    /// (`creditdefaultswap.rs:515-544`), so `None` here means the flag, never a
+    /// stale trade. Such a flow carries a real accrued amount but settled on a
+    /// past date, so it no longer reaches the value.
+    ///
+    /// The amount is returned bare rather than behind a cash-flow facade, there
+    /// being none. Fallible in principle, the core's amount being a `Result`.
+    fn accrual_rebate_amount(&self) -> PyResult<Option<f64>> {
+        Ok(self
+            .inner
+            .borrow()
+            .accrual_rebate()
+            .map(|rebate| rebate.amount())
+            .transpose()
+            .map_err(PyQlError::from)?)
+    }
+
+    /// The date the accrual rebate settles on, which is the cash-settlement
+    /// date the upfront also pays on, or `None` on the same terms as
+    /// [`accrual_rebate_amount`](Self::accrual_rebate_amount).
+    fn accrual_rebate_date(&self) -> Option<PyDate> {
+        self.inner
+            .borrow()
+            .accrual_rebate()
+            .map(|rebate| PyDate::from_inner(Event::date(rebate.as_ref())))
+    }
+
     /// The premium leg's NPV. Fallible as [`fair_spread`](Self::fair_spread).
     fn coupon_leg_npv(&mut self) -> PyResult<f64> {
         Ok(self
@@ -775,8 +808,9 @@ impl PyCreditDefaultSwap {
 /// one builder object cannot carry a setting into a later contract. An unset
 /// optional leaves the core default in place (`makecds.rs:150-171`).
 ///
-/// Deferred (visible): three of the core's setters are exposed.
-/// `with_trade_date` and the accrual-rebate flag are #870's; the rest keep
+/// Deferred (visible): four of the core's setters are exposed. The
+/// accrual-rebate flag (`makecds.rs:257`) stays unbound, the `with_terms`
+/// constructor on [`PyCreditDefaultSwap`] already reaching it; the rest keep
 /// their defaults, notably the 3M coupon tenor, the pre-CDS2015
 /// `DateGeneration::CDS` rule, the `Following` roll, the Act/360 day counter
 /// and the three cash-settlement days.
@@ -788,12 +822,17 @@ pub struct PyMakeCreditDefaultSwap {
     nominal: Option<f64>,
     upfront_rate: Option<f64>,
     side: Option<PyProtectionSide>,
+    trade_date: Option<Date>,
 }
 
 #[pymethods]
 impl PyMakeCreditDefaultSwap {
     /// A builder for a contract maturing on `term_date` and paying
     /// `running_spread`.
+    ///
+    /// `trade_date` overrides the evaluation date the trade would otherwise be
+    /// dated off (`makecds.rs:263`), which is how a contract traded in the past
+    /// is built.
     #[new]
     #[pyo3(signature = (
         term_date,
@@ -802,6 +841,7 @@ impl PyMakeCreditDefaultSwap {
         nominal = None,
         upfront_rate = None,
         side = None,
+        trade_date = None,
     ))]
     fn new(
         term_date: &PyDate,
@@ -810,6 +850,7 @@ impl PyMakeCreditDefaultSwap {
         nominal: Option<f64>,
         upfront_rate: Option<f64>,
         side: Option<PyProtectionSide>,
+        trade_date: Option<&PyDate>,
     ) -> Self {
         PyMakeCreditDefaultSwap {
             term_date: term_date.inner(),
@@ -818,6 +859,7 @@ impl PyMakeCreditDefaultSwap {
             nominal,
             upfront_rate,
             side,
+            trade_date: trade_date.map(PyDate::inner),
         }
     }
 
@@ -843,6 +885,9 @@ impl PyMakeCreditDefaultSwap {
         }
         if let Some(side) = self.side {
             maker = maker.with_side(side.inner());
+        }
+        if let Some(trade_date) = self.trade_date {
+            maker = maker.with_trade_date(trade_date);
         }
         let cds = maker.build().map_err(PyQlError::from)?;
         Ok(PyCreditDefaultSwap::from_inner(shared_mut(cds)))

--- a/crates/itofin-py/tests/test_isda_reconcile.py
+++ b/crates/itofin-py/tests/test_isda_reconcile.py
@@ -1,0 +1,316 @@
+"""The two EUR Markit reconciliation records, through the Python facades (#870).
+
+The oracle is QuantLib's `testIsdaEngine` reconciliation half
+(test-suite/creditdefaultswap.cpp:759-960), which the Rust core reproduces in
+`a_traded_today_record_reconciles_with_its_accrual_rebate` and
+`a_record_traded_in_the_past_reconciles_without_its_accrual_rebate`
+(crates/libitofin/src/pricingengines/credit/isdacdsengine.rs:2085 and :2147).
+Both fixtures are rebuilt here: the same 26 July 2021 value date, the same four
+deposit and thirteen swap EUR quotes bootstrapped log-linearly on discount
+factors over Act/365F, and the same flat hazard rate implied off a trade quoted
+at the conventional 0.006713 spread.
+
+One record is traded today and rebates the thousand of accrual it has run up;
+the same record traded two years earlier settled that rebate long before today,
+so the value drops by exactly that thousand and the two legs then account for
+all of what is left. The MARKIT_VALUE literals are Markit's, so they grade the
+whole chain rather than restating it.
+
+The helpers below are the USD ones of test_isda_markit.py parameterized on what
+the EUR curve changes - the quotes, the 6M float tenor, the Annual fixed
+frequency and the currency. They are duplicated rather than imported because no
+test module in this suite imports another and there is no conftest to share
+them through.
+
+The tolerance is Boost's `BOOST_CHECK_CLOSE`, a *percentage*, so the bound is a
+relative 1e-5 and it is two-sided against both operands.
+"""
+
+from itofin import Settings
+from itofin.indexes import Currency, IborIndex
+from itofin.instruments import (
+    CreditDefaultSwap,
+    MakeCreditDefaultSwap,
+    PricingModel,
+    ProtectionSide,
+)
+from itofin.pricingengines import IsdaCdsEngine
+from itofin.quotes import SimpleQuote
+from itofin.termstructures import (
+    DepositRateHelper,
+    FlatHazardRate,
+    PiecewiseLogLinearDiscount,
+    SwapRateHelper,
+)
+from itofin.time import (
+    BusinessDayConvention,
+    Calendar,
+    Date,
+    DayCounter,
+    Frequency,
+    Period,
+    Schedule,
+)
+
+# creditdefaultswap.cpp:765 and :869: today, on both records.
+VALUE_DATE = Date(26, 7, 2021)
+MATURITY = Date(20, 6, 2026)
+
+# creditdefaultswap.cpp:770-771 and :875-876, in months.
+EUR_DEPOSITS = [
+    (1, -0.0056),
+    (3, -0.005440),
+    (6, -0.005190),
+    (12, -0.004930),
+]
+
+# creditdefaultswap.cpp:781-793 and :886-898, in years.
+EUR_SWAPS = [
+    (2, -0.004820),
+    (3, -0.004420),
+    (4, -0.003990),
+    (5, -0.003520),
+    (6, -0.002970),
+    (7, -0.002370),
+    (8, -0.001760),
+    (9, -0.001140),
+    (10, -0.000540),
+    (12, 0.000570),
+    (15, 0.001880),
+    (20, 0.002940),
+    (30, 0.002820),
+]
+
+NOMINAL = 1000000.0
+RECOVERY = 0.4
+CONVENTIONAL_SPREAD = 0.006713
+RUNNING_SPREAD = 0.01
+CASH_SETTLEMENT_DAYS = 3
+
+TOLERANCE = 1e-3
+RELATIVE = TOLERANCE / 100.0
+
+
+def assert_close(actual, expected, what):
+    """Boost's BOOST_CHECK_CLOSE: a percentage tolerance, cleared against both
+    operands. With a zero expected the bound collapses to bit-exact equality,
+    which is the intended reading; only the diagnostic guards the division."""
+    difference = abs(actual - expected)
+    relative = difference / abs(expected) if expected else "undefined against 0"
+    assert difference <= RELATIVE * abs(actual) and difference <= RELATIVE * abs(
+        expected
+    ), (
+        f"{what}: {actual} is not within {TOLERANCE}% of {expected} "
+        f"(relative {relative})"
+    )
+
+
+def ymd(date):
+    """A date as a comparable triple: Date carries __eq__ but no ordering."""
+    return (date.year, date.month, date.day)
+
+
+def isda_ibor(tenor, currency, settings):
+    """The ISDA-convention forecasting index (isdacdsengine.rs:1741-1758), over
+    an empty forwarding handle because both helpers re-point their own clone at
+    the curve being bootstrapped. Only the tenor and the currency vary."""
+    return IborIndex(
+        "IsdaIbor",
+        tenor,
+        2,
+        currency,
+        Calendar.weekends_only(),
+        BusinessDayConvention.ModifiedFollowing,
+        False,
+        DayCounter.actual360(),
+        None,
+        settings,
+    )
+
+
+def isda_curve(
+    reference, deposits, swaps, float_tenor, fixed_frequency, currency, settings
+):
+    """The ISDA discount curve (isdacdsengine.rs:1768-1806): deposits in months,
+    swaps in years, bootstrapped log-linearly on discount factors over Act/365F.
+    One index of `float_tenor` feeds every swap helper."""
+    helpers = [
+        DepositRateHelper.from_rate(
+            quote, isda_ibor(Period(months, "Months"), currency, settings)
+        )
+        for months, quote in deposits
+    ]
+    floating = isda_ibor(float_tenor, currency, settings)
+    helpers += [
+        SwapRateHelper(
+            SimpleQuote(quote),
+            Period(years, "Years"),
+            Calendar.weekends_only(),
+            fixed_frequency,
+            BusinessDayConvention.ModifiedFollowing,
+            DayCounter.thirty360_bond_basis(),
+            floating,
+        )
+        for years, quote in swaps
+    ]
+    return PiecewiseLogLinearDiscount(reference, helpers, DayCounter.actual365_fixed())
+
+
+def cash_settlement(trade_date):
+    """The date the upfront and the rebate settle on: three business days off
+    the trade date, rolled Following on WeekendsOnly (makecds.rs:295-303)."""
+    return Calendar.weekends_only().advance(
+        trade_date,
+        CASH_SETTLEMENT_DAYS,
+        "Days",
+        BusinessDayConvention.Following,
+        False,
+    )
+
+
+class Market:
+    """The EUR curve of both records and the engine over the flat hazard rate
+    implied off a trade quoted at the conventional spread
+    (isdacdsengine.rs:2042-2076).
+
+    The evaluation date is set before any helper is built: the helpers date off
+    it and MakeCreditDefaultSwap derives its trade date from it.
+    """
+
+    def __init__(self):
+        self.settings = Settings()
+        self.settings.set_evaluation_date(VALUE_DATE)
+        self.discount = isda_curve(
+            VALUE_DATE,
+            EUR_DEPOSITS,
+            EUR_SWAPS,
+            Period(6, "Months"),
+            Frequency.Annual,
+            Currency.eur(),
+            self.settings,
+        )
+
+    def trade(self, running_spread, trade_date=None):
+        return MakeCreditDefaultSwap(
+            MATURITY,
+            running_spread,
+            self.settings,
+            nominal=NOMINAL,
+            trade_date=trade_date,
+        ).build()
+
+    def engine(self):
+        hazard_rate = self.trade(CONVENTIONAL_SPREAD).implied_hazard_rate(
+            0.0,
+            self.discount,
+            DayCounter.actual365_fixed(),
+            RECOVERY,
+            1e-10,
+            PricingModel.Isda,
+        )
+        curve = FlatHazardRate.moving_with_rate(
+            0,
+            Calendar.weekends_only(),
+            hazard_rate,
+            DayCounter.actual365_fixed(),
+            self.settings,
+        )
+        return IsdaCdsEngine(curve, RECOVERY, self.discount, self.settings)
+
+
+def test_a_traded_today_record_reconciles_with_its_accrual_rebate():
+    """creditdefaultswap.cpp:759-861: the record's value, its upfront and the
+    thousand of accrual it rebates, read both off the legs and off the rebate
+    flow itself.
+
+    `df` is the C++ fixture's own: the ratio of the upfront to the value, which
+    carries the discount to cash settlement and which the second and third
+    assertions then divide back out. It is deliberately not an independently
+    derived discount factor.
+    """
+    market = Market()
+    conventional = market.trade(RUNNING_SPREAD)
+    conventional.set_isda_engine(market.engine())
+
+    npv = conventional.npv()
+    calculated_upfront = conventional.notional() * conventional.fair_upfront()
+    df = calculated_upfront / npv
+    derived_accrual = df * (
+        npv - conventional.default_leg_npv() - conventional.coupon_leg_npv()
+    )
+
+    assert_close(npv, -16070.7, "the value")
+    assert_close(calculated_upfront, df * -16070.7, "the upfront")
+    assert_close(derived_accrual, 1000.0, "the accrual derived from the legs")
+    assert_close(
+        conventional.accrual_rebate_amount(), 1000.0, "the accrual on the rebate flow"
+    )
+    assert conventional.accrual_rebate_date() == cash_settlement(VALUE_DATE)
+
+
+def test_a_record_traded_in_the_past_reconciles_without_its_accrual_rebate():
+    """creditdefaultswap.cpp:863-960: the same record traded two years ago
+    settled its rebate long before today, so the value drops by exactly the
+    thousand the rebate carried and the legs account for all of what is left.
+
+    The contract still carries the rebate flow - the core builds one whenever
+    the flag is set, whatever the trade date (creditdefaultswap.rs:515-544) -
+    but it settled on a past date, which is why it no longer reaches the value
+    and why the legs alone close the arithmetic to zero.
+    """
+    past_trade_date = Date(20, 7, 2019)
+    market = Market()
+    conventional = market.trade(RUNNING_SPREAD, trade_date=past_trade_date)
+    conventional.set_isda_engine(market.engine())
+
+    npv = conventional.npv()
+    calculated_accrual = (
+        npv - conventional.default_leg_npv() - conventional.coupon_leg_npv()
+    )
+
+    assert_close(npv, -17070.77, "the value")
+    assert_close(calculated_accrual, 0.0, "the accrual derived from the legs")
+
+    assert conventional.accrual_rebate_amount() is not None
+    assert conventional.accrual_rebate_date() == cash_settlement(past_trade_date)
+    assert ymd(conventional.accrual_rebate_date()) < ymd(VALUE_DATE)
+
+
+def test_a_contract_that_does_not_rebate_accrual_carries_no_rebate_flow():
+    """The only None arm the accessors have (creditdefaultswap.rs:1349): the
+    flag, not a stale trade date. MakeCreditDefaultSwap does not expose it, so
+    the pin goes through the with_terms constructor that does.
+
+    Both arms are built on the one constructor, so a with_terms that never
+    reached the rebate at all would fail the rebating half rather than pass
+    both.
+    """
+    settings = Settings()
+    settings.set_evaluation_date(VALUE_DATE)
+    schedule = Schedule(
+        VALUE_DATE,
+        MATURITY,
+        Frequency.Quarterly,
+        Calendar.weekends_only(),
+        BusinessDayConvention.Following,
+    )
+
+    def contract(**terms):
+        return CreditDefaultSwap.with_terms(
+            ProtectionSide.Buyer,
+            NOMINAL,
+            RUNNING_SPREAD,
+            schedule,
+            BusinessDayConvention.Following,
+            DayCounter.actual360(),
+            settings,
+            **terms,
+        )
+
+    bare = contract(rebates_accrual=False)
+    assert bare.accrual_rebate_amount() is None
+    assert bare.accrual_rebate_date() is None
+
+    rebating = contract()
+    assert rebating.accrual_rebate_amount() is not None
+    assert rebating.accrual_rebate_date() is not None


### PR DESCRIPTION
- **feat(itofin-py): expose CDS accrual rebate and trade date**
- **test(itofin-py): add ISDA reconciliation test**

close #870