### PR TITLE
feat(example): add ISDA CDS, YoY inflation and seasonality examples

### DIFF
--- a/example/python/credit_cds.py
+++ b/example/python/credit_cds.py
@@ -5,7 +5,9 @@ Two parts:
 1. Price a single CDS with `MidPointCdsEngine` off a flat hazard-rate curve.
    The engine needs a survival (hazard) curve, a recovery rate and a discount
    curve. This reproduces QuantLib's `creditdefaultswap.cpp` cached value:
-   NPV 295.0153398 and fair spread 0.007517539081.
+   NPV 295.0153398 and fair spread 0.007517539081. Both are matched to 1e-7,
+   the tolerance `test_credit_cds.py` grades them at: the fair spread's
+   difference sits in the eighth decimal place, not in all twelve printed.
 
 2. Bootstrap a `PiecewiseDefaultCurve` from `SpreadCdsHelper` quotes (the
    inverse problem: given market spreads, solve for the hazard curve), then
@@ -30,6 +32,11 @@ from itofin.pricingengines import MidPointCdsEngine
 from itofin.quotes import SimpleQuote
 from itofin.termstructures import FlatForward, FlatHazardRate, PiecewiseDefaultCurve, SpreadCdsHelper
 from itofin.time import BusinessDayConvention, Calendar, Date, DateGeneration, DayCounter, Frequency, Period, Schedule
+
+# The `creditdefaultswap.cpp` cached figures, as transcribed in
+# `crates/itofin-py/tests/test_credit_cds.py`, which grades both at 1e-7.
+CACHED_NPV = 295.0153398
+CACHED_FAIR_SPREAD = 0.007517539081
 
 
 def price_single_cds() -> None:
@@ -65,9 +72,11 @@ def price_single_cds() -> None:
     )
     cds.set_engine(MidPointCdsEngine(hazard, 0.4, discount, settings))
 
+    npv = cds.npv()
+    fair = cds.fair_spread()
     print("10Y CDS (seller, notional 10000, spread 120bp, hazard 1.234%):")
-    print(f"  NPV            = {cds.npv():.7f}")
-    print(f"  fair spread    = {cds.fair_spread():.12f}")
+    print(f"  NPV            = {npv:.7f}      cached={CACHED_NPV}   |diff|={abs(npv - CACHED_NPV):.2e}")
+    print(f"  fair spread    = {fair:.12f}   cached={CACHED_FAIR_SPREAD}   |diff|={abs(fair - CACHED_FAIR_SPREAD):.2e}")
     print(f"  coupon leg NPV = {cds.coupon_leg_npv():.7f}")
     print(f"  default leg NPV= {cds.default_leg_npv():.7f}")
 

--- a/example/python/inflation_swap.py
+++ b/example/python/inflation_swap.py
@@ -32,7 +32,12 @@ from itofin.indexes import CpiInterpolationType, ZeroInflationIndex
 from itofin.instruments import SwapType, ZeroCouponInflationSwap
 from itofin.pricingengines import DiscountingSwapEngine
 from itofin.quotes import SimpleQuote
-from itofin.termstructures import FlatForward, PiecewiseZeroInflationCurve, ZeroCouponInflationSwapHelper
+from itofin.termstructures import (
+    FlatForward,
+    MultiplicativePriceSeasonality,
+    PiecewiseZeroInflationCurve,
+    ZeroCouponInflationSwapHelper,
+)
 from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Frequency, Period
 
 TODAY = Date(13, 8, 2007)
@@ -93,6 +98,17 @@ ZC_DATA = [
     (Date(13, 8, 2047), 3.308),
     (Date(13, 8, 2057), 3.228),
 ]
+
+
+# Twelve monthly seasonal factors (`inflation.cpp:469-483`), anchored on the 31
+# January of the year the curve's base period ends in. They are stationary, so
+# the lookup wrapping modulo twelve reuses them for every later year.
+SEASONALITY_FACTORS = [
+    1.003245, 1.000000, 0.999715, 1.000495, 1.000929, 0.998687,
+    0.995949, 0.994682, 0.995949, 1.000519, 1.003705, 1.004186,
+]
+SEASONALITY_ANCHOR = Date(31, 1, 2007)
+SEASONALITY_PROBE = Date(1, 8, 2012)
 
 
 def _fixing_date(i: int) -> Date:
@@ -157,6 +173,41 @@ def build_swap(settings, index, maturity, fixed_rate):
     return swap
 
 
+def apply_seasonality(settings, index, curve) -> None:
+    """Install a seasonal correction on the solved curve and watch it move.
+
+    A price index does not grow smoothly through the year, so
+    `MultiplicativePriceSeasonality` multiplies the index level by a factor per
+    period. The factors are not applied raw: the one at the queried date is
+    normalized against the one at the curve's base date, so the correction is
+    the identity there and grows away from it.
+
+    Two things worth seeing. The correction reaches everything through the
+    index's own forecast, which is the path every helper and every swap takes;
+    and because the curve re-solves against it, the quoted swaps still reprice
+    to zero afterwards. A correction that were merely stored and never folded
+    into the published rate would also reprice to zero, so the forecast moving
+    is the part that proves it is live."""
+    raw_forecast = index.fixing(SEASONALITY_PROBE, True)
+    raw_rate = curve.zero_rate_date(SEASONALITY_PROBE)
+
+    curve.set_seasonality(MultiplicativePriceSeasonality(SEASONALITY_ANCHOR, Frequency.Monthly, SEASONALITY_FACTORS))
+
+    print(f"\nSeasonality installed (has_seasonality={curve.has_seasonality()}), probed at {SEASONALITY_PROBE}:")
+    print(f"  index forecast  {raw_forecast:.10f} -> {index.fixing(SEASONALITY_PROBE, True):.10f}")
+    print(f"  zero rate       {raw_rate * 100:.6f}% -> {curve.zero_rate_date(SEASONALITY_PROBE) * 100:.6f}%")
+
+    worst = max(abs(build_swap(settings, index, maturity, rate / 100.0).npv()) for maturity, rate in ZC_DATA)
+    print(f"  worst |NPV| after the re-bootstrap = {worst:.3e}   (the quotes still reprice to zero)")
+
+    # Clearing it puts the raw forecast back, which is how it is undone.
+    curve.set_seasonality(None)
+    print(
+        f"  cleared (has_seasonality={curve.has_seasonality()}): "
+        f"forecast back to {index.fixing(SEASONALITY_PROBE, True):.10f}"
+    )
+
+
 def main() -> None:
     # D5: one Settings threaded through index, helpers, swaps and engines.
     settings = Settings()
@@ -195,6 +246,8 @@ def main() -> None:
         worst = max(worst, abs(npv))
         print(f"  {maturity}  NPV={npv:14.6f}")
     print(f"  worst |NPV| = {worst:.3e}  (should be ~1e-8 or smaller)")
+
+    apply_seasonality(settings, index, curve)
 
 
 if __name__ == "__main__":

--- a/example/python/isda_cds.py
+++ b/example/python/isda_cds.py
@@ -1,0 +1,362 @@
+"""Price credit default swaps under the ISDA standard model.
+
+`credit_cds.py` next door prices a CDS with `MidPointCdsEngine`, which
+integrates over the premium schedule. `IsdaCdsEngine` is the market-standard
+alternative: it integrates both legs over the pillar dates of the two curves it
+is built with, and it is what Markit's published upfronts are computed on. The
+whole ISDA chain shows up here:
+
+* a generic `IborIndex` on ISDA conventions (`Calendar.weekends_only`, Act/360,
+  a named `Currency`) rather than a Euribor from the named families,
+* `DepositRateHelper.from_rate` and `SwapRateHelper` feeding a
+  `PiecewiseLogLinearDiscount` curve - log-linear on discount factors, Act/365F,
+  which is the curve shape the ISDA model is specified against,
+* `MakeCreditDefaultSwap`, the post-Big-Bang builder that derives the premium
+  schedule from a term date and takes its trade date from the evaluation date,
+* `implied_hazard_rate`, which inverts a quoted trade to the flat hazard rate
+  that prices it at zero, standing on its own engine rather than on any curve
+  passed in,
+* `fair_upfront` and the accrual-rebate accessors.
+
+Two parts.
+
+1. The Markit upfront grid: five term dates crossed with two quoted spreads and
+   two recovery rates, off a 21 May 2009 USD curve. Each case implies a hazard
+   rate off a trade quoted at `spread`, then prices a *separate* 1% conventional
+   trade of the same maturity on that rate. Pricing the quoted trade itself
+   would be a different number entirely. Mirrors
+   `crates/itofin-py/tests/test_isda_markit.py` and QuantLib's `testIsdaEngine`
+   (`test-suite/creditdefaultswap.cpp:567`).
+
+2. The EUR reconciliation pair: one record traded today, which rebates the
+   thousand of accrual it has run up, and the same record traded two years
+   earlier, which settled that rebate long before today. The value differs by
+   exactly that thousand. Mirrors `test_isda_reconcile.py` and
+   `creditdefaultswap.cpp:759-960`.
+
+The Markit literals are Markit's, not a recording of what these facades return,
+so the printed differences grade the whole chain. QuantLib compares them with
+Boost's `BOOST_CHECK_CLOSE`, whose tolerance is a *percentage*: the 1e-6 there
+is a relative 1e-8, which is why the differences below are reported relative
+rather than absolute.
+
+Run it with:
+
+    python example/python/isda_cds.py
+"""
+
+# itofin library
+from itofin import Settings
+from itofin.indexes import Currency, IborIndex
+from itofin.instruments import MakeCreditDefaultSwap, PricingModel, ProtectionSide
+from itofin.pricingengines import IsdaCdsEngine
+from itofin.quotes import SimpleQuote
+from itofin.termstructures import DepositRateHelper, FlatHazardRate, PiecewiseLogLinearDiscount, SwapRateHelper
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Frequency, Period
+
+ACT365F = DayCounter.actual365_fixed()
+WEEKENDS = Calendar.weekends_only()
+
+
+def isda_ibor(tenor: Period, currency: Currency, settings: Settings) -> IborIndex:
+    """The ISDA-convention forecasting index, spelled out because it belongs to
+    no named family. `forwarding=None` builds it over an empty handle: both
+    helpers re-point their own clone at the curve being bootstrapped, so the
+    index must not already carry one."""
+    return IborIndex(
+        "IsdaIbor",
+        tenor,
+        2,  # settlement days
+        currency,
+        WEEKENDS,
+        BusinessDayConvention.ModifiedFollowing,
+        False,  # end of month
+        DayCounter.actual360(),
+        None,  # forwarding curve
+        settings,
+    )
+
+
+def isda_curve(reference, deposits, swaps, float_tenor, fixed_frequency, currency, settings):
+    """The ISDA discount curve: deposit quotes in months, par swap quotes in
+    years, bootstrapped log-linearly on discount factors over Act/365F. One
+    index of `float_tenor` feeds every swap helper."""
+    helpers = [
+        DepositRateHelper.from_rate(quote, isda_ibor(Period(months, "Months"), currency, settings))
+        for months, quote in deposits
+    ]
+    floating = isda_ibor(float_tenor, currency, settings)
+    helpers += [
+        SwapRateHelper(
+            SimpleQuote(quote),
+            Period(years, "Years"),
+            WEEKENDS,
+            fixed_frequency,
+            BusinessDayConvention.ModifiedFollowing,
+            DayCounter.thirty360_bond_basis(),
+            floating,
+        )
+        for years, quote in swaps
+    ]
+    return PiecewiseLogLinearDiscount(reference, helpers, ACT365F)
+
+
+# --- part 1: the Markit upfront grid -----------------------------------------
+
+TRADE_DATE = Date(21, 5, 2009)
+GRID_NOTIONAL = 10_000_000.0
+CONVENTIONAL_SPREAD = 0.01
+
+# creditdefaultswap.cpp:583-588, tenors in months.
+USD_DEPOSITS = [
+    (1, 0.003081),
+    (2, 0.005525),
+    (3, 0.007163),
+    (6, 0.012413),
+    (9, 0.014),
+    (12, 0.015488),
+]
+
+# creditdefaultswap.cpp:598-611, tenors in years.
+USD_SWAPS = [
+    (2, 0.011907),
+    (3, 0.01699),
+    (4, 0.021198),
+    (5, 0.02444),
+    (6, 0.026937),
+    (7, 0.028967),
+    (8, 0.030504),
+    (9, 0.031719),
+    (10, 0.03279),
+    (12, 0.034535),
+    (15, 0.036217),
+    (20, 0.036981),
+    (25, 0.037246),
+    (30, 0.037605),
+]
+
+TERM_DATES = [
+    Date(20, 6, 2010),
+    Date(20, 6, 2011),
+    Date(20, 6, 2012),
+    Date(20, 6, 2016),
+    Date(20, 6, 2019),
+]
+SPREADS = [0.001, 0.1]
+RECOVERIES = [0.2, 0.4]
+
+# creditdefaultswap.cpp:643-664: Markit's ISDA-model upfronts on a ten-million
+# notional, in the term-date / spread / recovery order the loops visit.
+MARKIT_VALUES = [
+    -97798.29358,
+    -97776.11889,
+    914971.5977,
+    894985.6298,
+    -186921.3594,
+    -186839.8148,
+    1646623.672,
+    1579803.626,
+    -274298.9203,
+    -274122.4725,
+    2279730.93,
+    2147972.527,
+    -592420.2297,
+    -591571.2294,
+    3993550.206,
+    3545843.418,
+    -797501.1422,
+    -795915.9787,
+    4702034.688,
+    4042340.999,
+]
+
+
+def grid_cases():
+    """The 20 (term date, spread, recovery) triples, in the loop order the
+    Markit values are indexed by."""
+    return [
+        (term_date, spread, recovery) for term_date in TERM_DATES for spread in SPREADS for recovery in RECOVERIES
+    ]
+
+
+def markit_grid() -> None:
+    settings = Settings()
+    # The evaluation date goes in before any helper is built: the helpers date
+    # off it, and MakeCreditDefaultSwap derives its trade date from it.
+    settings.set_evaluation_date(TRADE_DATE)
+    discount = isda_curve(
+        TRADE_DATE,
+        USD_DEPOSITS,
+        USD_SWAPS,
+        Period(3, "Months"),
+        Frequency.Semiannual,
+        Currency.usd(),
+        settings,
+    )
+
+    def trade(term_date, running_spread):
+        return MakeCreditDefaultSwap(term_date, running_spread, settings, nominal=GRID_NOTIONAL).build()
+
+    print(f"ISDA discount curve off {TRADE_DATE}: {len(USD_DEPOSITS)} deposits + {len(USD_SWAPS)} swaps")
+    print(f"  5y discount factor = {discount.discount(5.0):.10f}")
+
+    print("\nMarkit upfront grid (spread 0.1%, recovery 40%, conventional 1% trade):")
+    worst_relative = 0.0
+    for index, (term_date, spread, recovery) in enumerate(grid_cases()):
+        # Invert the quoted trade to the flat hazard rate that prices it at
+        # zero. `day_counter` counts the flat curve the solve builds, not the
+        # contract; under PricingModel.Isda it must be Act/365F, as must the
+        # discount curve, because that is what the ISDA engine demands.
+        hazard_rate = trade(term_date, spread).implied_hazard_rate(
+            0.0,  # target NPV
+            discount,
+            ACT365F,
+            recovery,
+            1e-10,  # accuracy
+            PricingModel.Isda,
+        )
+        curve = FlatHazardRate.moving_with_rate(0, WEEKENDS, hazard_rate, ACT365F, settings)
+
+        conventional = trade(term_date, CONVENTIONAL_SPREAD)
+        conventional.set_isda_engine(IsdaCdsEngine(curve, recovery, discount, settings))
+        upfront = conventional.notional() * conventional.fair_upfront()
+
+        expected = MARKIT_VALUES[index]
+        relative = abs(upfront - expected) / abs(expected)
+        worst_relative = max(worst_relative, relative)
+
+        # One representative row per term date, at the tight spread and the
+        # higher recovery; the other 15 cases still run and still feed the worst
+        # relative error below.
+        if spread == SPREADS[0] and recovery == RECOVERIES[1]:
+            print(
+                f"  {term_date}  hazard={hazard_rate:.8f}  upfront={upfront:15.4f}  "
+                f"Markit={expected:14.4f}  rel={relative:.2e}"
+            )
+
+    print(f"\n  worst relative error over all {len(MARKIT_VALUES)} cases = {worst_relative:.2e}")
+    print("  (QuantLib's own bound is a relative 1e-8, two-sided)")
+
+
+# --- part 2: the EUR reconciliation pair --------------------------------------
+
+VALUE_DATE = Date(26, 7, 2021)
+MATURITY = Date(20, 6, 2026)
+EUR_NOMINAL = 1_000_000.0
+RECOVERY = 0.4
+EUR_CONVENTIONAL_SPREAD = 0.006713
+RUNNING_SPREAD = 0.01
+PAST_TRADE_DATE = Date(20, 7, 2019)
+
+# creditdefaultswap.cpp:770-771, tenors in months.
+EUR_DEPOSITS = [
+    (1, -0.0056),
+    (3, -0.005440),
+    (6, -0.005190),
+    (12, -0.004930),
+]
+
+# creditdefaultswap.cpp:781-793, tenors in years.
+EUR_SWAPS = [
+    (2, -0.004820),
+    (3, -0.004420),
+    (4, -0.003990),
+    (5, -0.003520),
+    (6, -0.002970),
+    (7, -0.002370),
+    (8, -0.001760),
+    (9, -0.001140),
+    (10, -0.000540),
+    (12, 0.000570),
+    (15, 0.001880),
+    (20, 0.002940),
+    (30, 0.002820),
+]
+
+# creditdefaultswap.cpp:759-960: the value of each record, and the accrual the
+# traded-today one rebates.
+MARKIT_TODAY_VALUE = -16070.7
+MARKIT_PAST_VALUE = -17070.77
+MARKIT_ACCRUAL = 1000.0
+
+
+def eur_reconciliation() -> None:
+    settings = Settings()
+    settings.set_evaluation_date(VALUE_DATE)
+    discount = isda_curve(
+        VALUE_DATE,
+        EUR_DEPOSITS,
+        EUR_SWAPS,
+        Period(6, "Months"),
+        Frequency.Annual,
+        Currency.eur(),
+        settings,
+    )
+
+    def trade(running_spread, trade_date=None):
+        # trade_date overrides the evaluation date the trade is otherwise dated
+        # off, which is how a contract traded in the past is built.
+        return MakeCreditDefaultSwap(
+            MATURITY,
+            running_spread,
+            settings,
+            nominal=EUR_NOMINAL,
+            trade_date=trade_date,
+        ).build()
+
+    hazard_rate = trade(EUR_CONVENTIONAL_SPREAD).implied_hazard_rate(
+        0.0, discount, ACT365F, RECOVERY, 1e-10, PricingModel.Isda
+    )
+    curve = FlatHazardRate.moving_with_rate(0, WEEKENDS, hazard_rate, ACT365F, settings)
+    engine = IsdaCdsEngine(curve, RECOVERY, discount, settings)
+
+    print(f"\n\nEUR reconciliation, {MATURITY} maturity valued {VALUE_DATE}")
+    print(f"  hazard rate implied off the {EUR_CONVENTIONAL_SPREAD} conventional quote = {hazard_rate:.10f}")
+
+    today_record = trade(RUNNING_SPREAD)
+    today_record.set_isda_engine(engine)
+    npv = today_record.npv()
+    # The C++ fixture's own discount to cash settlement: the ratio of the
+    # upfront to the value, which the derived accrual then divides back out. It
+    # is deliberately not an independently computed discount factor.
+    df = today_record.notional() * today_record.fair_upfront() / npv
+    derived_accrual = df * (npv - today_record.default_leg_npv() - today_record.coupon_leg_npv())
+
+    print("\n  Traded today - the accrual rebate is still in the value:")
+    print(
+        f"    NPV                    = {npv:12.4f}   Markit={MARKIT_TODAY_VALUE}   "
+        f"rel={abs(npv / MARKIT_TODAY_VALUE - 1):.2e}"
+    )
+    print(f"    accrual from the legs  = {derived_accrual:12.4f}   Markit={MARKIT_ACCRUAL}")
+    print(f"    accrual_rebate_amount  = {today_record.accrual_rebate_amount():12.4f}")
+    print(f"    accrual_rebate_date    = {today_record.accrual_rebate_date()}  (3 business days off the trade date)")
+
+    past_record = trade(RUNNING_SPREAD, trade_date=PAST_TRADE_DATE)
+    past_record.set_isda_engine(engine)
+    past_npv = past_record.npv()
+    # The contract still carries the rebate flow - the core builds one whenever
+    # the flag is set, whatever the trade date - but it settled on a past date,
+    # so it no longer reaches the value and the two legs close the arithmetic.
+    residual = past_npv - past_record.default_leg_npv() - past_record.coupon_leg_npv()
+
+    print(f"\n  Traded {PAST_TRADE_DATE} - the rebate settled long ago:")
+    print(
+        f"    NPV                    = {past_npv:12.4f}   Markit={MARKIT_PAST_VALUE}   "
+        f"rel={abs(past_npv / MARKIT_PAST_VALUE - 1):.2e}"
+    )
+    print(f"    accrual from the legs  = {residual:12.4f}   (nothing left over)")
+    print(f"    accrual_rebate_date    = {past_record.accrual_rebate_date()}  (before the value date)")
+    # The two Markit literals are rounded to 2dp and differ by 1000.07, so the
+    # rebate flow's own amount is the sharper comparison of the two.
+    print(f"\n  value difference   = {npv - past_npv:.4f}")
+    print(f"  rebate on the flow = {today_record.accrual_rebate_amount():.4f}")
+    print(f"  the Markit pair differs by {MARKIT_TODAY_VALUE - MARKIT_PAST_VALUE:.4f} at their printed precision")
+
+
+def main() -> None:
+    markit_grid()
+    eur_reconciliation()
+
+
+if __name__ == "__main__":
+    main()

--- a/example/python/yoy_inflation_capfloor.py
+++ b/example/python/yoy_inflation_capfloor.py
@@ -1,0 +1,270 @@
+"""Price a year-on-year inflation cap and floor under three distributions.
+
+A `YoYInflationCapFloor` is a strip of optionlets on the year-on-year rate a
+`YoYInflationIndex` publishes, one per coupon of an annual inflation leg. It is
+built through `MakeYoYInflationCapFloor`, the standard market builder: the core
+builder is a consumed-self fluent chain that does not cross the FFI boundary, so
+the Python facade takes the whole configuration up front and assembles the chain
+inside `build()`.
+
+Three things this shows that no other example does.
+
+* The distribution is chosen by the *constructor*, mirroring C++'s three engine
+  classes rather than being passed as an argument: `YoYInflationCapFloorEngine`
+  has `black` (lognormal), `unit_displaced` (lognormal in 1 + rate) and
+  `bachelier` (normal). On this fixture the last two sit two orders of magnitude
+  above Black, so a constructor wired to the wrong distribution cannot hide.
+* An engine carries the arguments and results of whatever it last priced, so a
+  cap and a floor priced together want one engine each.
+* `strike` and `atm_strike` are mutually exclusive and exactly one is required.
+  The refusal lands in `build()`, not at the setters, because a fluent setter
+  returning `Self` has nowhere to raise from.
+
+The numbers reproduce QuantLib's `inflationcapfloorengines.cpp:452-522`
+(`testCachedValue`), as transcribed in
+`crates/itofin-py/tests/test_yoy_inflation_capfloor.py`. QuantLib's own
+tolerance is 0.02 on a notional of a million, which these only reach if the
+curve, the base date, the zero observation lag and the distribution are all
+right at once.
+
+Fixture warning. `yoy_inflation_swap.py` next door runs a *different* UK RPI
+fixture, and the two must not be crossed. This one files thirty-one published
+figures followed by TWO -999.0 sentinels on a BACKWARD-generated schedule, which
+carries the index's last fixing date - and with it the curve's base date - out
+to 1 August 2007. The leg, the volatility surface and the builder observe ZERO
+days of lag while only the fifteen bootstrap helpers observe two months (in C++
+this comes of a `CommonVars` member being shadowed by a local in the constructor
+body); pricing the leg at two months instead misses every cached value by about
+47. The nominal curve is Act/Act (ISDA), not Act/360.
+
+Run it with:
+
+    python example/python/yoy_inflation_capfloor.py
+"""
+
+# itofin library
+from itofin import ItofinError, Settings
+from itofin.indexes import CpiInterpolationType, YoYInflationIndex, ZeroInflationIndex
+from itofin.instruments import CapFloorType, MakeYoYInflationCapFloor
+from itofin.pricingengines import YoYInflationCapFloorEngine
+from itofin.quotes import SimpleQuote
+from itofin.termstructures import (
+    ConstantYoYOptionletVolatility,
+    FlatForward,
+    PiecewiseYoYInflationCurve,
+    YearOnYearInflationSwapHelper,
+)
+from itofin.time import BusinessDayConvention, Calendar, Date, DateGeneration, DayCounter, Frequency, Period, Schedule
+
+UK = Calendar.united_kingdom()
+TODAY = UK.adjust(Date(13, 8, 2007), BusinessDayConvention.Following)
+NO_LAG = Period(0, "Days")
+HELPER_LAG = Period(2, "Months")
+NOMINAL = 1_000_000.0
+NOMINAL_RATE = 0.05
+STRIKE = 0.0295
+VOLATILITY = 0.01
+DAY_COUNTER = DayCounter.thirty360_bond_basis()
+
+# Thirty-one published UK RPI figures from January 2005, then two -999.0
+# sentinels. Neither sentinel is ever read as a rate - every fixing date here is
+# 2008 or later, so the ratio index forecasts off the curve - but they carry the
+# curve's base date from June to 1 August 2007, the origin every number below is
+# measured from. Dropping them silently moves every optionlet.
+FIX_DATA = [
+    189.9, 189.9, 189.6, 190.5, 191.6, 192.0, 192.2, 192.2, 192.6, 193.1,
+    193.3, 193.6, 194.1, 193.4, 194.2, 195.0, 196.5, 197.7, 198.5, 198.5,
+    199.2, 200.1, 200.4, 201.1, 202.7, 201.6, 203.1, 204.4, 205.4, 206.2,
+    207.3, -999.0, -999.0,
+]
+
+# (maturity, quoted year-on-year swap rate in percent).
+YY_DATA = [
+    (Date(13, 8, 2008), 2.95),
+    (Date(13, 8, 2009), 2.95),
+    (Date(13, 8, 2010), 2.93),
+    (Date(15, 8, 2011), 2.955),
+    (Date(13, 8, 2012), 2.945),
+    (Date(13, 8, 2013), 2.985),
+    (Date(13, 8, 2014), 3.01),
+    (Date(13, 8, 2015), 3.035),
+    (Date(13, 8, 2016), 3.055),
+    (Date(13, 8, 2017), 3.075),
+    (Date(13, 8, 2019), 3.105),
+    (Date(15, 8, 2022), 3.135),
+    (Date(13, 8, 2027), 3.155),
+    (Date(13, 8, 2032), 3.145),
+    (Date(13, 8, 2037), 3.145),
+]
+
+# inflationcapfloorengines.cpp:452-522, by distribution: (cap, floor, tolerance).
+CACHED = {
+    "black": (219.452, 314.641, 0.02),
+    "unit_displaced": (9114.61, 9209.8, 0.22),
+    "bachelier": (8852.4, 8947.59, 0.22),
+}
+
+
+def rpi_schedule() -> Schedule:
+    """The dates the RPI figures are filed on: monthly from 1 January 2005 to
+    13 August 2007, generated BACKWARD so the schedule walks back from the 13th
+    and carries a short front stub. The Python `Schedule` facade defaults to
+    Forward, so the rule is passed explicitly; generating forward instead would
+    shift every figure by a month."""
+    return Schedule(
+        Date(1, 1, 2005),
+        Date(13, 8, 2007),
+        Frequency.Monthly,
+        UK,
+        BusinessDayConvention.ModifiedFollowing,
+        DateGeneration.Backward,
+    )
+
+
+def build_market():
+    """One Settings, a ratio year-on-year index over a UK RPI carrying the
+    sentinel history, and the 5% nominal curve. The index is returned linked to
+    the bootstrapped year-on-year curve."""
+    settings = Settings()
+    settings.set_evaluation_date(TODAY)
+
+    rpi = ZeroInflationIndex.uk_rpi(settings)
+    for date, figure in zip(rpi_schedule().dates(), FIX_DATA):
+        rpi.add_fixing(date, figure)
+
+    # A ratio index derives its year-on-year rate from two RPI fixings a year
+    # apart; it owns no history of its own, so the fixings go on the underlying.
+    index = YoYInflationIndex.from_underlying(rpi)
+    nominal = FlatForward(TODAY, NOMINAL_RATE, DayCounter.actual_actual_isda())
+
+    helpers = [
+        YearOnYearInflationSwapHelper(
+            SimpleQuote(rate / 100.0),
+            HELPER_LAG,  # only the helpers observe two months
+            maturity,
+            UK,
+            BusinessDayConvention.ModifiedFollowing,
+            DAY_COUNTER,
+            index,
+            CpiInterpolationType.Flat,
+            nominal,
+            settings,
+        )
+        for maturity, rate in YY_DATA
+    ]
+    curve = PiecewiseYoYInflationCurve(
+        TODAY,
+        rpi.last_fixing_date(),  # the base date the sentinels carried to August
+        YY_DATA[0][1] / 100.0,  # the base year-on-year rate at node zero
+        Frequency.Monthly,  # what UK RPI publishes, not the annual leg's
+        DAY_COUNTER,
+        helpers,
+    )
+    index.link_to(curve)
+    return settings, index, nominal
+
+
+def surface(settings: Settings) -> ConstantYoYOptionletVolatility:
+    """The flat 1% surface the cached values were produced on. Its observation
+    lag is zero, like the leg's and unlike the helpers'."""
+    return ConstantYoYOptionletVolatility(
+        VOLATILITY,
+        0,  # settlement days
+        UK,
+        BusinessDayConvention.ModifiedFollowing,
+        DAY_COUNTER,
+        NO_LAG,
+        Frequency.Annual,
+        False,  # index is interpolated
+        -1.0,  # min strike
+        100.0,  # max strike
+        settings,
+    )
+
+
+def cap_floor(settings, index, cap_floor_type, **kwargs):
+    """A two-year factory-built cap or floor. The builder's own defaults - an
+    annual schedule, a ModifiedFollowing payment roll, 30/360 bond basis, no
+    fixing days, every optionlet kept - are exactly the cached fixture's, so
+    nothing beyond the strike and the nominal has to be said."""
+    return MakeYoYInflationCapFloor(
+        cap_floor_type,
+        index,
+        2,  # length in years
+        UK,
+        NO_LAG,
+        CpiInterpolationType.Flat,
+        settings,
+        nominal=NOMINAL,
+        **kwargs,
+    ).build()
+
+
+def priced(settings, index, nominal, cap_floor_type, distribution) -> float:
+    """One instrument, one engine: an engine carries the results of whatever it
+    last priced, so a cap and a floor never share one."""
+    instrument = cap_floor(settings, index, cap_floor_type, strike=STRIKE)
+    engine = getattr(YoYInflationCapFloorEngine, distribution)(index, surface(settings), nominal)
+    instrument.set_engine(engine)
+    return instrument.npv()
+
+
+def price_under_each_distribution(settings, index, nominal) -> None:
+    print(f"Two-year year-on-year cap and floor struck at {STRIKE:.2%}, notional {NOMINAL:,.0f}, vol {VOLATILITY:.0%}")
+    for distribution, (cached_cap, cached_floor, tolerance) in CACHED.items():
+        cap = priced(settings, index, nominal, CapFloorType.Cap, distribution)
+        floor = priced(settings, index, nominal, CapFloorType.Floor, distribution)
+        print(f"\n  {distribution}:")
+        print(
+            f"    cap   = {cap:10.4f}   cached={cached_cap:>9}   "
+            f"|diff|={abs(cap - cached_cap):.4f}  (tol {tolerance})"
+        )
+        print(
+            f"    floor = {floor:10.4f}   cached={cached_floor:>9}   "
+            f"|diff|={abs(floor - cached_floor):.4f}  (tol {tolerance})"
+        )
+
+
+def fill_the_strike_at_the_money(settings, index, nominal) -> None:
+    """With no strike given, `atm_strike` resolves one off the nominal curve.
+    The rate that lands on the leg is the rate the instrument itself would
+    reprice at, which `atm_rate` reads back independently.
+
+    Trimming happens before the at-the-money fill, so `as_optionlet` and
+    `first_caplet_excluded` would change what an unset strike resolves to: the
+    rate repricing whatever survives, not the whole leg's."""
+    cap = cap_floor(settings, index, CapFloorType.Cap, atm_strike=nominal)
+    struck = cap.cap_rates()[0]
+
+    print("\n\nAt-the-money fill (no strike given, resolved off the nominal curve):")
+    print(f"  strike on the leg = {struck:.10f}")
+    print(f"  atm_rate()        = {cap.atm_rate(nominal):.10f}   |diff|={abs(struck - cap.atm_rate(nominal)):.2e}")
+    print(f"  optionlets        = {cap.coupon_count()}   floor rates on a cap = {cap.floor_rates()}")
+    print(f"  runs {cap.start_date()} -> {cap.maturity_date()}")
+
+
+def strike_and_atm_are_exclusive(settings, index, nominal) -> None:
+    """Both together and neither at all are refused, and both refusals surface
+    from `build()`."""
+    print("\n\nThe strike is required, and exactly one way of giving it:")
+    for label, kwargs in [
+        ("both a strike and an ATM curve", {"strike": STRIKE, "atm_strike": nominal}),
+        ("neither", {}),
+    ]:
+        try:
+            cap_floor(settings, index, CapFloorType.Cap, **kwargs)
+        except ItofinError as error:
+            print(f"  {label:32} -> {type(error).__name__}: {error}")
+
+
+def main() -> None:
+    settings, index, nominal = build_market()
+    print(f"UK RPI last fixing date (the curve's base) = {index.underlying_index().last_fixing_date()}\n")
+
+    price_under_each_distribution(settings, index, nominal)
+    fill_the_strike_at_the_money(settings, index, nominal)
+    strike_and_atm_are_exclusive(settings, index, nominal)
+
+
+if __name__ == "__main__":
+    main()

--- a/example/python/yoy_inflation_swap.py
+++ b/example/python/yoy_inflation_swap.py
@@ -1,0 +1,260 @@
+"""Price a year-on-year inflation swap and inspect its coupons one by one.
+
+`inflation_swap.py` next door prices a `ZeroCouponInflationSwap`: one fixed flow
+against one indexed flow, both exchanged at maturity. A
+`YearOnYearInflationSwap` instead pays a *stream* of coupons, each rating the
+year-on-year inflation observed over its own accrual period. That makes the
+coupon the interesting object, so this example builds the leg twice: once inside
+the swap, and once directly through the `YoYInflationLeg` facade, which hands
+back `YoYInflationCoupon` objects you can interrogate.
+
+Two readings that trip people up.
+
+* `SwapType` names the *fixed* leg here, so a Payer pays fixed and receives
+  inflation. That is the opposite reading from `ZeroCouponInflationSwap`, where
+  it names the inflation leg.
+* A year-on-year coupon overrides the base rule that reads the index at the
+  fixing date: it lags off the *accrual end* instead, and the lag is subtracted
+  before the period is snapped to the index's Monthly publication. With no
+  fixing days the two dates coincide and the distinction is invisible, so the
+  last section pushes them into different months to make it show.
+
+The leg built standalone, discounted coupon by coupon, is the swap's own
+year-on-year leg - which is what pins the two construction paths to each other.
+Mirrors `crates/itofin-py/tests/test_yoy_inflation_leg.py`.
+
+Fixture warning. `yoy_inflation_capfloor.py` next door runs a *different* UK RPI
+fixture, and the two must not be crossed. This one files thirty-one published
+figures with no sentinels, on the plain `Date(1, month, year)` walk, giving a
+curve base date of 1 July 2007; the lag is two months everywhere, and the
+nominal curve is Act/360. The cap/floor fixture adds two -999.0 sentinels, moves
+the base to 1 August, observes zero lag on everything but its helpers and
+discounts on Act/Act (ISDA).
+
+Run it with:
+
+    python example/python/yoy_inflation_swap.py
+"""
+
+# itofin library
+from itofin import Settings
+from itofin.cashflows import YoYInflationLeg
+from itofin.indexes import CpiInterpolationType, YoYInflationIndex, ZeroInflationIndex
+from itofin.instruments import SwapType, YearOnYearInflationSwap
+from itofin.pricingengines import DiscountingSwapEngine
+from itofin.quotes import SimpleQuote
+from itofin.termstructures import FlatForward, PiecewiseYoYInflationCurve, YearOnYearInflationSwapHelper
+from itofin.time import BusinessDayConvention, Calendar, Date, DateGeneration, DayCounter, Frequency, Period, Schedule
+
+TODAY = Calendar.united_kingdom().adjust(Date(13, 8, 2007), BusinessDayConvention.Following)
+CURVE_BASE = Date(1, 7, 2007)
+LAG = Period(2, "Months")
+MATURITY = Date(13, 8, 2010)
+NOMINAL_RATE = 0.05
+NOTIONAL = 1_000_000.0
+FIXED_RATE = 0.03
+
+# Thirty-one monthly UK RPI figures published from January 2005. No sentinels
+# here: the last real figure, 207.3, is the July 2007 period, which is what
+# makes 1 July 2007 the curve's base date.
+FIX_DATA = [
+    189.9, 189.9, 189.6, 190.5, 191.6, 192.0, 192.2, 192.2, 192.6, 193.1,
+    193.3, 193.6, 194.1, 193.4, 194.2, 195.0, 196.5, 197.7, 198.5, 198.5,
+    199.2, 200.1, 200.4, 201.1, 202.7, 201.6, 203.1, 204.4, 205.4, 206.2,
+    207.3,
+]
+
+# (maturity, quoted year-on-year swap rate in percent).
+YY_DATA = [
+    (Date(13, 8, 2008), 2.95),
+    (Date(13, 8, 2009), 2.95),
+    (Date(13, 8, 2010), 2.93),
+    (Date(15, 8, 2011), 2.955),
+    (Date(13, 8, 2012), 2.945),
+    (Date(13, 8, 2013), 2.985),
+    (Date(13, 8, 2014), 3.01),
+    (Date(13, 8, 2015), 3.035),
+    (Date(13, 8, 2016), 3.055),
+    (Date(13, 8, 2017), 3.075),
+    (Date(13, 8, 2019), 3.105),
+    (Date(15, 8, 2022), 3.135),
+    (Date(13, 8, 2027), 3.155),
+    (Date(13, 8, 2032), 3.145),
+    (Date(13, 8, 2037), 3.145),
+]
+
+
+class Market:
+    """The bootstrapped year-on-year curve with its index, plus the day count,
+    calendar and annual schedule every leg and swap below shares."""
+
+    def __init__(self):
+        self.settings = Settings()
+        self.settings.set_evaluation_date(TODAY)
+        self.calendar = Calendar.united_kingdom()
+        self.day_counter = DayCounter.thirty360_bond_basis()
+
+        rpi = ZeroInflationIndex.uk_rpi(self.settings)
+        for i, fixing in enumerate(FIX_DATA):
+            # A monthly index files each figure under the first of its month.
+            rpi.add_fixing(Date(1, i % 12 + 1, 2005 + i // 12), fixing)
+        # A ratio index derives its year-on-year rate from two RPI fixings a
+        # year apart, so the history belongs on the underlying, not here.
+        self.index = YoYInflationIndex.from_underlying(rpi)
+
+        self.nominal = FlatForward(TODAY, NOMINAL_RATE, DayCounter.actual360())
+        self.curve = PiecewiseYoYInflationCurve(
+            TODAY,
+            CURVE_BASE,
+            YY_DATA[0][1] / 100.0,  # the base year-on-year rate at node zero
+            Frequency.Monthly,  # what UK RPI publishes, not the annual leg's
+            self.day_counter,
+            self._helpers(),
+        )
+        # Until this link is made every forecast raises "empty Handle".
+        self.index.link_to(self.curve)
+
+        self.schedule = Schedule(
+            self.nominal.reference_date(),
+            MATURITY,
+            Frequency.Annual,
+            self.calendar,
+            BusinessDayConvention.Unadjusted,
+            DateGeneration.Backward,
+        )
+
+    def _helpers(self):
+        return [
+            YearOnYearInflationSwapHelper(
+                SimpleQuote(rate / 100.0),
+                LAG,
+                maturity,
+                self.calendar,
+                BusinessDayConvention.ModifiedFollowing,
+                self.day_counter,
+                self.index,
+                CpiInterpolationType.Flat,
+                self.nominal,
+                self.settings,
+            )
+            for maturity, rate in YY_DATA
+        ]
+
+    def leg(self, **overrides) -> YoYInflationLeg:
+        """A year-on-year leg on the fixture schedule. The keywords go straight
+        through: notional / notionals, gearing(s), spread(s), fixing_days and
+        the payment adjustment."""
+        return YoYInflationLeg(
+            self.schedule,
+            self.calendar,
+            self.index,
+            LAG,
+            CpiInterpolationType.Flat,
+            self.day_counter,
+            **overrides,
+        )
+
+    def swap(self, spread: float = 0.0) -> YearOnYearInflationSwap:
+        """A payer swap: SwapType names the FIXED leg, so a Payer pays the 3%
+        fixed and receives inflation. Both legs run the same annual schedule
+        here, but they are independent inputs."""
+        swap = YearOnYearInflationSwap(
+            SwapType.Payer,
+            NOTIONAL,
+            self.schedule,  # fixed schedule
+            FIXED_RATE,
+            self.day_counter,
+            self.schedule,  # year-on-year schedule
+            self.index,
+            LAG,
+            CpiInterpolationType.Flat,
+            spread,
+            self.day_counter,
+            self.calendar,  # the year-on-year leg's payment calendar
+            BusinessDayConvention.ModifiedFollowing,
+            self.settings,
+        )
+        swap.set_engine(DiscountingSwapEngine(self.nominal, self.settings))
+        return swap
+
+
+def price_the_swap(market: Market) -> None:
+    swap = market.swap()
+    print(f"3Y year-on-year inflation swap, payer of {FIXED_RATE:.2%} on {NOTIONAL:,.0f}, to {MATURITY}:")
+    print(f"  NPV                  = {swap.npv():14.4f}")
+    print(f"  fixed leg NPV        = {swap.fixed_leg_npv():14.4f}")
+    print(f"  year-on-year leg NPV = {swap.yoy_leg_npv():14.4f}")
+    print(f"  fair fixed rate      = {swap.fair_rate() * 100:10.6f}%   (prices the swap at zero)")
+    print(f"  fair spread          = {swap.fair_spread() * 100:10.6f}%   (over the index instead)")
+    # A free self-check: the swap runs to the third quoted pillar, so its fair
+    # rate must come back as that pillar's own quote. If it drifts, the curve
+    # was bootstrapped off a fixture that does not match the schedule.
+    print(f"  quoted {MATURITY} rate = {YY_DATA[2][1]:10.6f}%   (the fair rate must reproduce it)")
+
+
+def inspect_the_coupons(market: Market) -> None:
+    """The leg built standalone hands back coupons, and each one reports where
+    its rate came from. The coupons are bound once: the leg rebuilds them on
+    every `coupons()` call, so reading through two calls compares different
+    objects."""
+    gearing, spread = 1.5, 0.002
+    coupons = market.leg(notional=NOTIONAL, gearing=gearing, spread=spread).coupons()
+
+    print(f"\n\nStandalone leg, geared {gearing} with a {spread:.2%} spread ({len(coupons)} coupons):")
+    for coupon in coupons:
+        print(
+            f"  {coupon.accrual_start_date()} -> {coupon.accrual_end_date()}  "
+            f"pays {coupon.date()}  fixing={coupon.index_fixing():.8f}"
+        )
+        print(
+            f"      rate = {gearing} * fixing + {spread} = {coupon.rate():.8f}   "
+            f"amount = rate * {coupon.accrual_period():.4f} * {coupon.nominal():,.0f} = {coupon.amount():.4f}"
+        )
+
+
+def the_leg_is_the_swaps_leg(market: Market) -> None:
+    """A plain leg, discounted coupon by coupon on the nominal curve, is the
+    year-on-year leg of the swap built over the same schedule and index. The
+    swap reaches its leg through the core builder this facade wraps, so the two
+    agreeing pins the wiring: the notional broadcast, the payment roll and the
+    discounting all have to line up.
+
+    Discounting to the curve reference date is exact here because the engine's
+    NPV date defaults to it, leaving nothing to divide out."""
+    coupons = market.leg(notional=NOTIONAL).coupons()
+    discounted = sum(coupon.amount() * market.nominal.discount_date(coupon.date(), True) for coupon in coupons)
+    from_swap = market.swap().yoy_leg_npv()
+
+    print("\n\nThe standalone leg is the swap's own leg:")
+    print(f"  discounted coupons = {discounted:.8f}")
+    print(f"  swap.yoy_leg_npv() = {from_swap:.8f}")
+    print(f"  |diff|             = {abs(discounted - from_swap):.2e}")
+
+
+def the_rate_lags_off_the_accrual_end(market: Market) -> None:
+    """With no fixing days a coupon's fixing date and its lagged accrual end are
+    the same day, so the two possible rules agree by accident. Fifteen fixing
+    days roll the fixing date back into the previous month, where the curve
+    carries a different rate - and the coupon stays on the accrual-end figure."""
+    coupon = market.leg(notional=NOTIONAL, fixing_days=15).coupons()[2]
+    accrual_end_month = Date(1, 6, 2010)
+    fixing_date_month = Date(1, 5, 2010)
+
+    print("\n\nThe rate lags off the accrual end, not off the fixing date:")
+    print(f"  accrual ends       {coupon.accrual_end_date()}, less the {LAG} lag, snapped -> {accrual_end_month}")
+    print(f"  fixing date        {coupon.fixing_date()} (15 days back), which snaps -> {fixing_date_month}")
+    print(f"  index at {accrual_end_month} = {market.index.fixing(accrual_end_month):.8f}  <- what the coupon reads")
+    print(f"  index at {fixing_date_month} = {market.index.fixing(fixing_date_month):.8f}  <- the other month")
+    print(f"  coupon.index_fixing()      = {coupon.index_fixing():.8f}")
+
+
+def main() -> None:
+    market = Market()
+    price_the_swap(market)
+    inspect_the_coupons(market)
+    the_leg_is_the_swaps_leg(market)
+    the_rate_lags_off_the_accrual_end(market)
+
+
+if __name__ == "__main__":
+    main()

--- a/example/rust/american_option_fd.rs
+++ b/example/rust/american_option_fd.rs
@@ -1,0 +1,250 @@
+//! American options priced by finite differences with
+//! `FdBlackScholesVanillaEngine`.
+//!
+//! Reproduces the first half of the `testFdValues` oracle of
+//! `test-suite/americanoption.cpp` (`:375-427`): four rows of the Ju-1998
+//! reference table (`:256-322`) priced on a 100 by 400 grid under the Douglas
+//! scheme, which QuantLib checks to within 8e-2.
+//!
+//! The same rows are also priced as European options with the closed-form
+//! `AnalyticEuropeanEngine`, so the early-exercise premium the free-boundary
+//! rollback recovers is visible next to each value. The long-dated
+//! dividend-paying calls are what make this oracle discriminate: their premium
+//! runs from roughly 1.7 to 5.3, so an engine that rolled back with no exercise
+//! condition and returned the European price would miss by tens of tolerances.
+//!
+//! The wiring is copied from the `test_fd_values` module in
+//! `crates/libitofin/src/pricingengines/vanilla/fdblackscholesvanillaengine.rs`
+//! and the flat `test_market` it prices on. See `monte_carlo.rs` for the same
+//! problem under Longstaff-Schwartz Monte Carlo.
+
+use libitofin::exercise::{AmericanExercise, EuropeanExercise, Exercise};
+use libitofin::handle::Handle;
+use libitofin::instrument::Instrument;
+use libitofin::instruments::{OneAssetOption, PlainVanillaPayoff};
+use libitofin::interestrate::Compounding;
+use libitofin::methods::finitedifferences::solvers::FdmSchemeDesc;
+use libitofin::option::OptionType::{self, Call, Put};
+use libitofin::pricingengine::PricingEngine;
+use libitofin::pricingengines::AnalyticEuropeanEngine;
+use libitofin::pricingengines::vanilla::FdBlackScholesVanillaEngine;
+use libitofin::processes::{BlackScholesMertonProcess, GeneralizedBlackScholesProcess};
+use libitofin::quotes::{Quote, SimpleQuote};
+use libitofin::settings::Settings;
+use libitofin::shared::{Shared, SharedMut, shared, shared_mut};
+use libitofin::termstructures::volatility::{BlackConstantVol, BlackVolTermStructure};
+use libitofin::termstructures::yields::FlatForward;
+use libitofin::termstructures::yieldtermstructure::YieldTermStructure;
+use libitofin::time::date::{Date, Month};
+use libitofin::time::daycounters::actual360::Actual360;
+use libitofin::time::frequency::Frequency;
+use libitofin::types::{Rate, Real, Size, Time, Volatility};
+
+/// The grid of the `pdeEngine` of `americanoption.cpp:399`.
+const T_GRID: Size = 100;
+const X_GRID: Size = 400;
+
+/// `tolerance` of `americanoption.cpp:389`.
+const TOLERANCE: Real = 8.0e-2;
+
+fn today() -> Date {
+    Date::new(15, Month::June, 2026)
+}
+
+/// `timeToDays` from `test-suite/utilities.hpp`: the year fraction rounded to
+/// whole days on the 360-day year the market's Actual/360 curves count on.
+fn time_to_days(t: Time) -> i32 {
+    (t * 360.0).round() as i32
+}
+
+/// One row of the Ju table (`americanoption.cpp:256-322`).
+struct JuValue {
+    option_type: OptionType,
+    strike: Real,
+    spot: Real,
+    q: Rate,
+    r: Rate,
+    t: Time,
+    vol: Volatility,
+    expected: Real,
+}
+
+/// The flat market of `test-suite/europeanoption.cpp`: quote-backed flat curves
+/// on Actual/360, so a single process can be re-pointed at each Ju row.
+struct Market {
+    settings: Shared<Settings<Date>>,
+    spot: Shared<SimpleQuote>,
+    q_rate: Shared<SimpleQuote>,
+    r_rate: Shared<SimpleQuote>,
+    vol: Shared<SimpleQuote>,
+    process: Shared<GeneralizedBlackScholesProcess>,
+}
+
+impl Market {
+    /// Moving a quote notifies the process, which notifies the engine, which
+    /// invalidates the instrument's cached price (D1).
+    fn set(&self, spot: Real, q: Rate, r: Rate, vol: Volatility) {
+        self.spot.set_value(spot);
+        self.q_rate.set_value(q);
+        self.r_rate.set_value(r);
+        self.vol.set_value(vol);
+    }
+}
+
+fn quote_handle(quote: &Shared<SimpleQuote>) -> Handle<dyn Quote> {
+    Handle::new(Shared::clone(quote) as Shared<dyn Quote>)
+}
+
+fn flat_rate(reference: Date, quote: &Shared<SimpleQuote>) -> Shared<dyn YieldTermStructure> {
+    shared(FlatForward::new(
+        reference,
+        quote_handle(quote),
+        Actual360::new(),
+        Compounding::Continuous,
+        Frequency::Annual,
+    )) as Shared<dyn YieldTermStructure>
+}
+
+fn flat_vol(reference: Date, quote: &Shared<SimpleQuote>) -> Shared<dyn BlackVolTermStructure> {
+    shared(BlackConstantVol::with_quote(
+        reference,
+        None, // no calendar override
+        quote_handle(quote),
+        Actual360::new(),
+    )) as Shared<dyn BlackVolTermStructure>
+}
+
+fn market() -> Market {
+    // D5: the evaluation date is set explicitly on an owned Settings.
+    let settings = shared(Settings::new());
+    settings.set_evaluation_date(today());
+    let spot = shared(SimpleQuote::new(0.0));
+    let q_rate = shared(SimpleQuote::new(0.0));
+    let r_rate = shared(SimpleQuote::new(0.0));
+    let vol = shared(SimpleQuote::new(0.0));
+    let process = shared(BlackScholesMertonProcess::new(
+        quote_handle(&spot),
+        Handle::new(flat_rate(today(), &q_rate)),
+        Handle::new(flat_rate(today(), &r_rate)),
+        Handle::new(flat_vol(today(), &vol)),
+    ));
+    Market {
+        settings,
+        spot,
+        q_rate,
+        r_rate,
+        vol,
+        process,
+    }
+}
+
+/// The Ju row priced under the free-boundary rollback.
+fn american_price(market: &Market, ju: &JuValue) -> Real {
+    market.set(ju.spot, ju.q, ju.r, ju.vol);
+
+    let exercise = AmericanExercise::over(today(), today() + time_to_days(ju.t))
+        .expect("the window opens before it closes");
+    let mut option = OneAssetOption::new(
+        shared(PlainVanillaPayoff::new(ju.option_type, ju.strike)),
+        shared(exercise) as Shared<dyn Exercise>,
+        Shared::clone(&market.settings),
+    );
+    let engine = shared_mut(FdBlackScholesVanillaEngine::new(
+        Shared::clone(&market.process),
+        T_GRID,
+        X_GRID,
+        0, // damping steps
+        FdmSchemeDesc::douglas(),
+    ));
+    option
+        .base_mut()
+        .set_pricing_engine(engine as SharedMut<dyn PricingEngine>);
+    option.npv().expect("the grid prices it")
+}
+
+/// The same row without the early-exercise right, in closed form.
+fn european_price(market: &Market, ju: &JuValue) -> Real {
+    market.set(ju.spot, ju.q, ju.r, ju.vol);
+
+    let mut option = OneAssetOption::new(
+        shared(PlainVanillaPayoff::new(ju.option_type, ju.strike)),
+        shared(EuropeanExercise::new(today() + time_to_days(ju.t))) as Shared<dyn Exercise>,
+        Shared::clone(&market.settings),
+    );
+    let engine = shared_mut(AnalyticEuropeanEngine::new(Shared::clone(&market.process)));
+    option
+        .base_mut()
+        .set_pricing_engine(engine as SharedMut<dyn PricingEngine>);
+    option.npv().expect("the closed form prices it")
+}
+
+fn main() {
+    let market = market();
+    let rows = [
+        JuValue {
+            option_type: Put,
+            strike: 40.0,
+            spot: 40.0,
+            q: 0.0,
+            r: 0.0488,
+            t: 0.3333,
+            vol: 0.2,
+            expected: 1.576,
+        },
+        JuValue {
+            option_type: Put,
+            strike: 45.0,
+            spot: 40.0,
+            q: 0.0,
+            r: 0.0488,
+            t: 0.5833,
+            vol: 0.2,
+            expected: 5.260,
+        },
+        JuValue {
+            option_type: Call,
+            strike: 100.0,
+            spot: 100.0,
+            q: 0.07,
+            r: 0.03,
+            t: 3.0,
+            vol: 0.2,
+            expected: 9.065,
+        },
+        JuValue {
+            option_type: Call,
+            strike: 100.0,
+            spot: 120.0,
+            q: 0.07,
+            r: 0.03,
+            t: 3.0,
+            vol: 0.2,
+            expected: 21.398,
+        },
+    ];
+
+    println!(
+        "American options on a {T_GRID}x{X_GRID} Douglas grid, against the Ju-1998 table \
+         (tolerance {TOLERANCE})"
+    );
+    println!(
+        "  type   K      S      q     r       T       finite diff       Ju   European  premium"
+    );
+    for ju in &rows {
+        let american = american_price(&market, ju);
+        let european = european_price(&market, ju);
+        println!(
+            "  {:<5} {:>6} {:>6} {:>5} {:>7} {:>7} {american:>11.6} {:>8} {european:>10.5} \
+             {:>8.5}",
+            format!("{:?}", ju.option_type),
+            ju.strike,
+            ju.spot,
+            ju.q,
+            ju.r,
+            ju.t,
+            ju.expected,
+            american - european
+        );
+        assert!((american - ju.expected).abs() <= TOLERANCE);
+    }
+}

--- a/example/rust/credit_cds.rs
+++ b/example/rust/credit_cds.rs
@@ -8,15 +8,26 @@
 //! probabilities at each pillar, and the fair spreads a contract rebuilt off
 //! the curve reproduces (each returns its input quote to ~1e-6).
 //!
+//! Part C settles the protection leg against a `FaceValueAccrualClaim` on a
+//! reference bond instead of the default `FaceValueClaim`: the accrual the
+//! protection buyer no longer collects is surrendered out of the claim, so the
+//! protection leg pays less.
+//!
 //! Every signature below is taken verbatim from the crate's own tests:
-//! `midpointcdsengine.rs` (mod `oracle`) and `piecewisedefaultcurve.rs`
-//! (mod `tests`). Notes on D5 (explicit `Settings`, no global singleton) and
-//! D2 (`Handle`) inline.
+//! `midpointcdsengine.rs` (mod `oracle`), `piecewisedefaultcurve.rs`
+//! (mod `tests`) and `claim.rs` (mod `tests`). Notes on D5 (explicit `Settings`,
+//! no global singleton) and D2 (`Handle`) inline. See `isda_cds.rs` for the ISDA
+//! standard-model engine and the Markit reconciliation flow.
 
+use libitofin::cashflow::{CashFlow, Leg};
+use libitofin::cashflows::FixedRateCoupon;
 use libitofin::errors::QlResult;
 use libitofin::handle::Handle;
 use libitofin::instrument::Instrument; // brings npv(), base_mut(), recalculate()
-use libitofin::instruments::{CdsTerms, CreditDefaultSwap, ProtectionSide};
+use libitofin::instruments::{
+    Bond, CdsTerms, Claim, CreditDefaultSwap, FaceValueAccrualClaim, FaceValueClaim,
+    MakeCreditDefaultSwap, ProtectionSide,
+};
 use libitofin::interestrate::Compounding;
 use libitofin::math::interpolations::flat::BackwardFlat;
 use libitofin::pricingengine::PricingEngine; // needed for the `as SharedMut<dyn PricingEngine>` cast
@@ -55,6 +66,8 @@ fn main() -> QlResult<()> {
     part_a_price_a_cds(today)?;
     println!();
     part_b_bootstrap_a_default_curve(today)?;
+    println!();
+    part_c_settle_against_a_reference_bond(today)?;
     Ok(())
 }
 
@@ -126,7 +139,7 @@ fn part_a_price_a_cds(today: Date) -> QlResult<()> {
 
     let npv = cds.npv()?;
     let fair_spread = cds.fair_spread()?;
-    println!("  maturity              : {:?}", cds.maturity());
+    println!("  maturity              : {}", cds.maturity());
     println!("  NPV (buyer)           : {npv:.4}");
     println!("  fair spread           : {fair_spread:.10}");
 
@@ -204,7 +217,7 @@ fn part_b_bootstrap_a_default_curve(today: Date) -> QlResult<()> {
     // Bootstrapped (date, hazard-rate) nodes. nodes() triggers the bootstrap.
     println!("  bootstrapped hazard-rate nodes:");
     for (date, hazard) in curve.nodes()? {
-        println!("    {date:?}  h = {hazard:.10}");
+        println!("    {date}  h = {hazard:.10}");
     }
 
     // Survival probability at each pillar (the helper's latest/pillar date).
@@ -212,7 +225,7 @@ fn part_b_bootstrap_a_default_curve(today: Date) -> QlResult<()> {
     for (helper, n) in helpers.iter().zip(tenors) {
         let pillar = helper.latest_date();
         let survival = curve.survival_probability_date(pillar, false)?;
-        println!("    {n}Y  pillar {pillar:?}  S = {survival:.10}");
+        println!("    {n}Y  pillar {pillar}  S = {survival:.10}");
     }
 
     // Round trip: rebuild each pillar's CDS and reprice it off the bootstrapped
@@ -248,6 +261,112 @@ fn part_b_bootstrap_a_default_curve(today: Date) -> QlResult<()> {
 
         let fair = cds.fair_spread()?;
         println!("    {n}Y  input {quote:.6}  ->  fair {fair:.10}");
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Part C: settle the protection leg against a FaceValueAccrualClaim.
+// ---------------------------------------------------------------------------
+fn part_c_settle_against_a_reference_bond(today: Date) -> QlResult<()> {
+    println!("== Part C: FaceValueClaim against FaceValueAccrualClaim ==");
+
+    let settings = shared(Settings::<Date>::new());
+    settings.set_evaluation_date(today);
+
+    // The reference security: two annual 5% coupons on a notional of 100,
+    // running `today` to `today` + 2Y (the `claim.rs` par-bond fixture).
+    let first_period_end = today + Period::new(1, TimeUnit::Years);
+    let redemption = today + Period::new(2, TimeUnit::Years);
+    let coupons: Leg = vec![
+        shared(FixedRateCoupon::from_rate(
+            first_period_end,
+            100.0,
+            0.05,
+            Actual360::new(),
+            today,
+            first_period_end,
+            None,
+            None,
+            None,
+        )) as Shared<dyn CashFlow>,
+        shared(FixedRateCoupon::from_rate(
+            redemption,
+            100.0,
+            0.05,
+            Actual360::new(),
+            first_period_end,
+            redemption,
+            None,
+            None,
+            None,
+        )) as Shared<dyn CashFlow>,
+    ];
+    let reference_security = shared(Bond::from_coupons(
+        2,
+        Target::new(),
+        Some(today),
+        coupons,
+        Shared::clone(&settings),
+    )?);
+
+    // The two claims side by side at a default half way through the first
+    // coupon period: the 5% Actual/360 coupon accrued there, normalised by the
+    // reference notional, is what the accrual claim surrenders.
+    let mid_first_period = today + Period::new(6, TimeUnit::Months);
+    let accrual_claim = FaceValueAccrualClaim::new(Shared::clone(&reference_security));
+    println!(
+        "  face value         claim on 100 at R=0.4 : {:.10}",
+        FaceValueClaim.amount(&mid_first_period, 100.0, RECOVERY)?
+    );
+    println!(
+        "  face value accrual claim on 100 at R=0.4 : {:.10}",
+        accrual_claim.amount(&mid_first_period, 100.0, RECOVERY)?
+    );
+
+    // The same contract priced with each claim. `with_claim` overrides the
+    // default FaceValueClaim the builder fills in.
+    let discount: Handle<dyn YieldTermStructure> = Handle::new(shared(FlatForward::with_rate(
+        today,
+        0.03,
+        Actual360::new(),
+        Compounding::Continuous,
+        Frequency::Annual,
+    ))
+        as Shared<dyn YieldTermStructure>);
+    let hazard: Handle<dyn DefaultProbabilityTermStructure> = Handle::new(shared(
+        FlatHazardRate::with_rate(today, 0.02, Actual360::new()),
+    )
+        as Shared<dyn DefaultProbabilityTermStructure>);
+    let term_date = today + Period::new(18, TimeUnit::Months);
+
+    for (label, claim) in [
+        ("face value        ", None),
+        (
+            "face value accrual",
+            Some(shared(accrual_claim) as Shared<dyn Claim>),
+        ),
+    ] {
+        let mut builder =
+            MakeCreditDefaultSwap::from_term_date(term_date, 0.01, Shared::clone(&settings))
+                .with_nominal(10_000_000.0);
+        if let Some(claim) = claim {
+            builder = builder.with_claim(claim);
+        }
+        let mut cds = builder.build()?;
+        cds.base_mut()
+            .set_pricing_engine(shared_mut(MidPointCdsEngine::new(
+                hazard.clone(),
+                RECOVERY,
+                discount.clone(),
+                None,
+                Shared::clone(&settings),
+            )) as SharedMut<dyn PricingEngine>);
+        println!(
+            "  {label} : protection leg {:>14.4}   NPV {:>12.4}",
+            cds.default_leg_npv()?,
+            cds.npv()?
+        );
     }
     Ok(())
 }

--- a/example/rust/inflation_swap.rs
+++ b/example/rust/inflation_swap.rs
@@ -30,7 +30,7 @@ use libitofin::termstructures::inflation::inflationhelpers::{
 };
 use libitofin::termstructures::inflation::inflationtermstructure::ZeroInflationTermStructure;
 use libitofin::termstructures::inflation::piecewisezeroinflationcurve::PiecewiseZeroInflationCurve;
-use libitofin::termstructures::yields::FlatForward;
+use libitofin::termstructures::yields::{FlatForward, Pillar};
 use libitofin::termstructures::yieldtermstructure::YieldTermStructure;
 use libitofin::time::businessdayconvention::BusinessDayConvention;
 use libitofin::time::calendar::Calendar;
@@ -117,6 +117,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 day_counter.clone(),
                 &index, // note: &Shared<ZeroInflationIndex>
                 CpiInterpolationType::Flat,
+                Pillar::LastRelevantDate,
                 Shared::clone(&settings),
             )
             .expect("a three-month lag covers UK RPI's availability")
@@ -135,6 +136,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Frequency::Monthly,
         day_counter.clone(),
         helpers,
+        None, // no seasonality correction
     )?;
 
     // Link the index's forecast handle to the freshly bootstrapped curve.

--- a/example/rust/isda_cds.rs
+++ b/example/rust/isda_cds.rs
@@ -1,0 +1,472 @@
+//! Credit-default swaps under the ISDA standard model, and the Markit
+//! reconciliation flow.
+//!
+//! Part A reproduces the twenty-case ISDA/Markit upfront grid of
+//! `test-suite/creditdefaultswap.cpp` `testIsdaEngine` (`:567-722`): a USD
+//! ISDA-convention discount curve, a flat hazard rate implied off a quoted trade
+//! through `implied_hazard_rate`, and a 1 % conventional trade of the same
+//! maturity repriced on it. Each case also checks that both sides are worth
+//! nothing once the fair upfront is paid.
+//!
+//! Part B reproduces the two single-record reconciliations (`:759-861` and
+//! `:863-960`): the same Markit record traded today, whose value carries an
+//! unsettled accrual rebate of a thousand, and traded two years ago, whose
+//! rebate settled long before today so the value drops by exactly that thousand.
+//!
+//! Part C converts a trade quoted with an upfront into a running spread with
+//! `conventional_spread`.
+//!
+//! Every construction step is copied from the port's `markit_oracle` module in
+//! `crates/libitofin/src/pricingengines/credit/isdacdsengine.rs`. See
+//! `credit_cds.rs` for the mid-point engine and default-curve bootstrapping.
+
+use libitofin::cashflow::CashFlow; // brings amount() on the rebate flow into scope
+use libitofin::currency::Currency;
+use libitofin::errors::QlResult;
+use libitofin::event::Event;
+use libitofin::handle::Handle;
+use libitofin::indexes::IborIndex;
+use libitofin::instrument::Instrument;
+use libitofin::instruments::{MakeCreditDefaultSwap, PricingModel, ProtectionSide};
+use libitofin::math::interpolations::loglinear::LogLinear;
+use libitofin::pricingengine::PricingEngine;
+use libitofin::pricingengines::credit::{
+    AccrualBias, ForwardsInCouponPeriod, IsdaCdsEngine, NumericalFix,
+};
+use libitofin::settings::Settings;
+use libitofin::shared::{Shared, SharedMut, shared, shared_mut};
+use libitofin::termstructures::bootstraphelper::RateHelper;
+use libitofin::termstructures::bootstraptraits::Discount;
+use libitofin::termstructures::credit::defaulttermstructure::DefaultProbabilityTermStructure;
+use libitofin::termstructures::credit::flathazardrate::FlatHazardRate;
+use libitofin::termstructures::yields::{DepositRateHelper, PiecewiseYieldCurve, SwapRateHelper};
+use libitofin::termstructures::yieldtermstructure::YieldTermStructure;
+use libitofin::time::businessdayconvention::BusinessDayConvention;
+use libitofin::time::calendars::weekendsonly::WeekendsOnly;
+use libitofin::time::date::{Date, Month};
+use libitofin::time::daycounters::actual360::Actual360;
+use libitofin::time::daycounters::actual365fixed::Actual365Fixed;
+use libitofin::time::daycounters::thirty360::{Convention, Thirty360};
+use libitofin::time::frequency::Frequency;
+use libitofin::time::period::Period;
+use libitofin::time::timeunit::TimeUnit;
+use libitofin::types::{Integer, Rate, Real};
+
+/// `creditdefaultswap.cpp:583-588`: the Markit deposit quotes, in months.
+const USD_DEPOSITS: [(Integer, Real); 6] = [
+    (1, 0.003081),
+    (2, 0.005525),
+    (3, 0.007163),
+    (6, 0.012413),
+    (9, 0.014),
+    (12, 0.015488),
+];
+
+/// `creditdefaultswap.cpp:598-611`: the Markit swap quotes, in years.
+const USD_SWAPS: [(Integer, Real); 14] = [
+    (2, 0.011907),
+    (3, 0.01699),
+    (4, 0.021198),
+    (5, 0.02444),
+    (6, 0.026937),
+    (7, 0.028967),
+    (8, 0.030504),
+    (9, 0.031719),
+    (10, 0.03279),
+    (12, 0.034535),
+    (15, 0.036217),
+    (20, 0.036981),
+    (25, 0.037246),
+    (30, 0.037605),
+];
+
+/// `creditdefaultswap.cpp:643-664`: the ISDA-model upfronts on a ten-million
+/// notional, in the term-date / spread / recovery order the loop below visits.
+const MARKIT_VALUES: [Real; 20] = [
+    -97798.29358,
+    -97776.11889,
+    914971.5977,
+    894985.6298,
+    -186921.3594,
+    -186839.8148,
+    1646623.672,
+    1579803.626,
+    -274298.9203,
+    -274122.4725,
+    2279730.93,
+    2147972.527,
+    -592420.2297,
+    -591571.2294,
+    3993550.206,
+    3545843.418,
+    -797501.1422,
+    -795915.9787,
+    4702034.688,
+    4042340.999,
+];
+
+/// `creditdefaultswap.cpp:770-771` and `:875-876`: the EUR deposit quotes, in
+/// months. Both reconciliation records build the same curve.
+const EUR_DEPOSITS: [(Integer, Real); 4] = [
+    (1, -0.0056),
+    (3, -0.005440),
+    (6, -0.005190),
+    (12, -0.004930),
+];
+
+/// `creditdefaultswap.cpp:781-793` and `:886-898`: the EUR swap quotes, in years.
+const EUR_SWAPS: [(Integer, Real); 13] = [
+    (2, -0.004820),
+    (3, -0.004420),
+    (4, -0.003990),
+    (5, -0.003520),
+    (6, -0.002970),
+    (7, -0.002370),
+    (8, -0.001760),
+    (9, -0.001140),
+    (10, -0.000540),
+    (12, 0.000570),
+    (15, 0.001880),
+    (20, 0.002940),
+    (30, 0.002820),
+];
+
+const NOTIONAL: Real = 10_000_000.0;
+const RECONCILE_NOMINAL: Real = 1.0e6;
+const RECONCILE_RECOVERY: Real = 0.4;
+/// The spread the reconciliation records are quoted at (`:764-826`).
+const CONVENTIONAL_SPREAD: Rate = 0.006713;
+
+/// The ISDA-convention forecasting index the C++ fixture builds inline
+/// (`creditdefaultswap.cpp:616-618` and `:796-798`).
+///
+/// The forwarding handle is left empty: both helper families re-point their own
+/// clone of the index at the curve being bootstrapped.
+fn isda_ibor(tenor: Period, currency: Currency, settings: &Shared<Settings<Date>>) -> IborIndex {
+    IborIndex::new(
+        "IsdaIbor".to_string(),
+        tenor,
+        2, // settlement days
+        currency,
+        WeekendsOnly::new(),
+        BusinessDayConvention::ModifiedFollowing,
+        false, // end of month
+        Actual360::new(),
+        Handle::empty(),
+        Shared::clone(settings),
+    )
+}
+
+/// The ISDA-compliant discount curve: deposits in months, swaps in years,
+/// bootstrapped log-linearly on discount factors over Act/365F
+/// (`creditdefaultswap.cpp:628-632`).
+fn isda_curve(
+    reference: Date,
+    deposits: &[(Integer, Real)],
+    swaps: &[(Integer, Real)],
+    float_tenor: Period,
+    fixed_frequency: Frequency,
+    currency: Currency,
+    settings: &Shared<Settings<Date>>,
+) -> QlResult<Handle<dyn YieldTermStructure>> {
+    let mut helpers: Vec<Shared<dyn RateHelper>> = Vec::new();
+    for (months, quote) in deposits {
+        let index = isda_ibor(
+            Period::new(*months, TimeUnit::Months),
+            currency.clone(),
+            settings,
+        );
+        helpers.push(DepositRateHelper::from_rate(*quote, &index) as Shared<dyn RateHelper>);
+    }
+    let float_index = isda_ibor(float_tenor, currency, settings);
+    for (years, quote) in swaps {
+        helpers.push(SwapRateHelper::from_rate(
+            *quote,
+            Period::new(*years, TimeUnit::Years),
+            WeekendsOnly::new(),
+            fixed_frequency,
+            BusinessDayConvention::ModifiedFollowing,
+            Thirty360::with_convention(Convention::BondBasis),
+            &float_index,
+        ) as Shared<dyn RateHelper>);
+    }
+    let curve = PiecewiseYieldCurve::<Discount, LogLinear>::new(
+        reference,
+        helpers,
+        Actual365Fixed::new(),
+        LogLinear,
+    )?;
+    Ok(Handle::new(curve as Shared<dyn YieldTermStructure>))
+}
+
+/// The engine over a flat hazard rate and the three fidelity flags C++ spells
+/// out (`creditdefaultswap.cpp:686-688`). They select which of the standard
+/// model's known approximations the engine reproduces, so it can be graded
+/// against the model's own C code rather than against the theory.
+fn isda_engine(
+    hazard_rate: Rate,
+    recovery: Real,
+    discount: &Handle<dyn YieldTermStructure>,
+    settings: &Shared<Settings<Date>>,
+) -> SharedMut<dyn PricingEngine> {
+    let probability = Handle::new(shared(FlatHazardRate::moving_with_rate(
+        0, // settlement days
+        WeekendsOnly::new(),
+        hazard_rate,
+        Actual365Fixed::new(),
+        Shared::clone(settings),
+    )) as Shared<dyn DefaultProbabilityTermStructure>);
+    shared_mut(
+        IsdaCdsEngine::new(
+            probability,
+            recovery,
+            discount.clone(),
+            None, // include_settlement_date_flows override
+            Shared::clone(settings),
+        )
+        .with_fidelity(
+            NumericalFix::Taylor,
+            AccrualBias::HalfDayBias,
+            ForwardsInCouponPeriod::Piecewise,
+        ),
+    ) as SharedMut<dyn PricingEngine>
+}
+
+fn main() -> QlResult<()> {
+    part_a_the_markit_grid()?;
+    println!();
+    part_b_reconcile_a_single_record()?;
+    println!();
+    part_c_convert_an_upfront_to_a_running_spread()?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Part A: the twenty-case ISDA/Markit upfront grid.
+// ---------------------------------------------------------------------------
+fn part_a_the_markit_grid() -> QlResult<()> {
+    println!("== Part A: the ISDA/Markit upfront grid (notional 10mm) ==");
+
+    let settings = shared(Settings::<Date>::new());
+    let trade_date = Date::new(21, Month::May, 2009);
+    settings.set_evaluation_date(trade_date);
+    let discount = isda_curve(
+        trade_date,
+        &USD_DEPOSITS,
+        &USD_SWAPS,
+        Period::new(3, TimeUnit::Months),
+        Frequency::Semiannual,
+        Currency::usd(),
+        &settings,
+    )?;
+
+    let term_dates = [
+        Date::new(20, Month::June, 2010),
+        Date::new(20, Month::June, 2011),
+        Date::new(20, Month::June, 2012),
+        Date::new(20, Month::June, 2016),
+        Date::new(20, Month::June, 2019),
+    ];
+    println!("  term date   spread  recov  upfront            Markit             rel. error");
+    let mut case = 0;
+    for term_date in term_dates {
+        for spread in [0.001, 0.1] {
+            for recovery in [0.2, 0.4] {
+                let trade = |running: Rate| {
+                    MakeCreditDefaultSwap::from_term_date(
+                        term_date,
+                        running,
+                        Shared::clone(&settings),
+                    )
+                    .with_nominal(NOTIONAL)
+                };
+
+                // The quoted trade fixes the credit: invert it for the flat
+                // hazard rate that prices it to zero on the ISDA engine.
+                let hazard_rate = trade(spread).build()?.implied_hazard_rate(
+                    0.0, // target NPV
+                    &discount,
+                    Actual365Fixed::new(),
+                    recovery,
+                    1.0e-10, // accuracy
+                    PricingModel::Isda,
+                )?;
+                let engine = isda_engine(hazard_rate, recovery, &discount, &settings);
+
+                // The conventional 1 % trade of the same maturity, priced on it.
+                let mut conventional = trade(0.01).build()?;
+                conventional
+                    .base_mut()
+                    .set_pricing_engine(SharedMut::clone(&engine));
+                let fair_upfront = conventional.fair_upfront()?;
+                let upfront = conventional.notional() * fair_upfront;
+                let expected = MARKIT_VALUES[case];
+                println!(
+                    "  {term_date}  {spread:>5}  {recovery:>4}  {upfront:>17.5}  {expected:>17.5}  \
+                     {:.2e}",
+                    (upfront - expected).abs() / expected.abs()
+                );
+
+                // Both sides of the same trade are worth nothing once that
+                // upfront is paid.
+                for side in [ProtectionSide::Buyer, ProtectionSide::Seller] {
+                    let mut at_fair = trade(0.01)
+                        .with_upfront_rate(fair_upfront)
+                        .with_side(side)
+                        .build()?;
+                    at_fair
+                        .base_mut()
+                        .set_pricing_engine(SharedMut::clone(&engine));
+                    assert!(at_fair.npv()?.abs() <= 1.0e-6);
+                }
+                case += 1;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// The EUR curve both reconciliation records share, and the engine over the flat
+/// hazard rate implied off a trade quoted at the conventional spread
+/// (`creditdefaultswap.cpp:764-826`). Returns the engine and the term date.
+///
+/// The evaluation date is set before the helpers are built, since they date
+/// themselves off it (D5).
+fn reconcile_engine(
+    settings: &Shared<Settings<Date>>,
+) -> QlResult<(SharedMut<dyn PricingEngine>, Date)> {
+    let value_date = Date::new(26, Month::July, 2021);
+    settings.set_evaluation_date(value_date);
+    let discount = isda_curve(
+        value_date,
+        &EUR_DEPOSITS,
+        &EUR_SWAPS,
+        Period::new(6, TimeUnit::Months),
+        Frequency::Annual,
+        Currency::eur(),
+        settings,
+    )?;
+    let maturity = Date::new(20, Month::June, 2026);
+    let hazard_rate = MakeCreditDefaultSwap::from_term_date(
+        maturity,
+        CONVENTIONAL_SPREAD,
+        Shared::clone(settings),
+    )
+    .with_nominal(RECONCILE_NOMINAL)
+    .build()?
+    .implied_hazard_rate(
+        0.0,
+        &discount,
+        Actual365Fixed::new(),
+        RECONCILE_RECOVERY,
+        1.0e-10,
+        PricingModel::Isda,
+    )?;
+    Ok((
+        isda_engine(hazard_rate, RECONCILE_RECOVERY, &discount, settings),
+        maturity,
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Part B: the two single-record Markit reconciliations.
+// ---------------------------------------------------------------------------
+fn part_b_reconcile_a_single_record() -> QlResult<()> {
+    println!("== Part B: one Markit record, traded today and traded in the past ==");
+
+    // Traded today: the rebate is still unsettled at the value date, so it is
+    // part of what the trade is worth.
+    let settings = shared(Settings::<Date>::new());
+    let (engine, maturity) = reconcile_engine(&settings)?;
+    let mut today_trade =
+        MakeCreditDefaultSwap::from_term_date(maturity, 0.01, Shared::clone(&settings))
+            .with_nominal(RECONCILE_NOMINAL)
+            .build()?;
+    today_trade.base_mut().set_pricing_engine(engine);
+
+    let npv = today_trade.npv()?;
+    let upfront = today_trade.notional() * today_trade.fair_upfront()?;
+    // C++'s own discount to cash settlement: the ratio of the upfront to the
+    // value, which the derived accrual then divides back out.
+    let df = upfront / npv;
+    let derived_accrual =
+        df * (npv - today_trade.default_leg_npv()? - today_trade.coupon_leg_npv()?);
+    let rebate = today_trade
+        .accrual_rebate()
+        .expect("a rebating trade carries the flow");
+
+    println!("  traded today     value    = {npv:.4}   (Markit -16070.7)");
+    println!("  traded today     upfront  = {upfront:.4}");
+    println!("  accrual off the legs      = {derived_accrual:.6}   (expected 1000)");
+    println!("  accrual on the rebate     = {:.6}", rebate.amount()?);
+    println!(
+        "  rebate settles           : {}",
+        Event::date(rebate.as_ref())
+    );
+
+    // The same record traded two years ago: its rebate settled long before
+    // today, so the value drops by exactly the thousand the rebate carried.
+    let settings = shared(Settings::<Date>::new());
+    let (engine, maturity) = reconcile_engine(&settings)?;
+    let mut past_trade =
+        MakeCreditDefaultSwap::from_term_date(maturity, 0.01, Shared::clone(&settings))
+            .with_nominal(RECONCILE_NOMINAL)
+            .with_trade_date(Date::new(20, Month::July, 2019))
+            .build()?;
+    past_trade.base_mut().set_pricing_engine(engine);
+
+    let npv = past_trade.npv()?;
+    let residual = npv - past_trade.default_leg_npv()? - past_trade.coupon_leg_npv()?;
+    println!("  traded 2019-07-20 value   = {npv:.4}   (Markit -17070.77)");
+    println!("  accrual off the legs      = {residual:.6}   (expected 0)");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Part C: an upfront quotation converted into a running spread.
+// ---------------------------------------------------------------------------
+fn part_c_convert_an_upfront_to_a_running_spread() -> QlResult<()> {
+    println!("== Part C: conventional_spread on an upfront-quoted trade ==");
+
+    let settings = shared(Settings::<Date>::new());
+    let trade_date = Date::new(21, Month::May, 2009);
+    settings.set_evaluation_date(trade_date);
+    let discount = isda_curve(
+        trade_date,
+        &USD_DEPOSITS,
+        &USD_SWAPS,
+        Period::new(3, TimeUnit::Months),
+        Frequency::Semiannual,
+        Currency::usd(),
+        &settings,
+    )?;
+    let term_date = Date::new(20, Month::June, 2016);
+
+    // A five-year trade paying 1 % running plus a 5 % upfront, still unsettled
+    // at the evaluation date - which is what stops the conversion collapsing
+    // back onto the running spread.
+    let quoted = MakeCreditDefaultSwap::from_term_date(term_date, 0.01, Shared::clone(&settings))
+        .with_nominal(NOTIONAL)
+        .with_upfront_rate(0.05)
+        .build()?;
+
+    let hazard_rate = quoted.implied_hazard_rate(
+        0.0,
+        &discount,
+        Actual365Fixed::new(),
+        RECONCILE_RECOVERY,
+        1.0e-9,
+        PricingModel::Isda,
+    )?;
+    let conventional = quoted.conventional_spread(
+        RECONCILE_RECOVERY,
+        &discount,
+        Actual365Fixed::new(),
+        PricingModel::Isda,
+    )?;
+
+    println!("  quoted            : 1 % running + 5 % upfront to {term_date}");
+    println!("  implied hazard    : {hazard_rate:.10}");
+    println!("  conventional spread: {:.10}", conventional);
+    Ok(())
+}

--- a/example/rust/yoy_inflation_capfloor.rs
+++ b/example/rust/yoy_inflation_capfloor.rs
@@ -1,0 +1,501 @@
+//! Year-on-year inflation caps and floors priced off a bootstrapped YoY curve.
+//!
+//! Part A reproduces the six cached values of `test-suite/inflationcapfloor.cpp`
+//! `testCachedValue` (`:452-522`): a two-year cap and floor struck at 2.95 % on
+//! 1 % volatility, valued under all three optionlet distributions (Black,
+//! unit-displaced Black, Bachelier).
+//!
+//! Part B is `testParity` (`:388-450`): cap - floor reprices the plain
+//! `YearOnYearInflationSwap` over the same leg, model-independently.
+//!
+//! Part C builds a cap through `MakeYoYInflationCapFloor` struck at the money
+//! off the nominal curve, and shows the trim-before-fill order: read as a single
+//! optionlet, the strike is the surviving coupon's rate rather than the whole
+//! leg's.
+//!
+//! The market is the port's `instrument_oracle` fixture in
+//! `crates/libitofin/src/pricingengines/inflation/inflationcapfloorengines.rs`,
+//! copied step for step; the builder calls are those of the `tests` module in
+//! `crates/libitofin/src/instruments/makeyoyinflationcapfloor.rs`.
+//!
+//! Two fixture quirks are deliberate, and are what reproduce the cached values:
+//! the RPI history overruns by two `-999.0` sentinels, which move the curve's
+//! base date from 1 July to 1 August 2007, and the leg observes a ZERO lag while
+//! only the bootstrap helpers observe two months.
+
+use libitofin::cashflow::{CashFlow, Leg};
+use libitofin::cashflows::{
+    CashFlows, YoYInflationCoupon, YoYInflationLeg, YoYOptionletDistribution,
+};
+use libitofin::errors::QlResult;
+use libitofin::handle::{Handle, RelinkableHandle};
+use libitofin::indexes::Index; // brings add_fixing / last_fixing_date into scope
+use libitofin::indexes::inflation::UkRpi;
+use libitofin::indexes::inflationindex::{CpiInterpolationType, InflationIndex, YoYInflationIndex};
+use libitofin::instrument::Instrument;
+use libitofin::instruments::{
+    CapFloorType, MakeYoYInflationCapFloor, SwapType, YearOnYearInflationSwap, YoYInflationCapFloor,
+};
+use libitofin::interestrate::Compounding;
+use libitofin::math::interpolations::linear::Linear;
+use libitofin::pricingengine::PricingEngine;
+use libitofin::pricingengines::{DiscountingSwapEngine, YoYInflationCapFloorEngine};
+use libitofin::quotes::SimpleQuote;
+use libitofin::settings::Settings;
+use libitofin::shared::{Shared, SharedMut, shared, shared_mut};
+use libitofin::termstructures::inflation::inflationhelpers::{
+    YearOnYearInflationSwapHelper, YoYInflationHelper,
+};
+use libitofin::termstructures::inflation::inflationtermstructure::YoYInflationTermStructure;
+use libitofin::termstructures::inflation::piecewiseyoyinflationcurve::PiecewiseYoYInflationCurve;
+use libitofin::termstructures::volatility::{
+    ConstantYoYOptionletVolatility, YoYOptionletVolatilitySurface,
+};
+use libitofin::termstructures::yields::{FlatForward, Pillar};
+use libitofin::termstructures::yieldtermstructure::YieldTermStructure;
+use libitofin::time::businessdayconvention::BusinessDayConvention;
+use libitofin::time::calendar::Calendar;
+use libitofin::time::calendars::unitedkingdom::{Market, UnitedKingdom};
+use libitofin::time::date::Month::{August, January};
+use libitofin::time::date::{Date, Day, Month, Year};
+use libitofin::time::dategenerationrule::DateGeneration;
+use libitofin::time::daycounter::DayCounter;
+use libitofin::time::daycounters::actualactual::{
+    ActualActual, Convention as ActualActualConvention,
+};
+use libitofin::time::daycounters::thirty360::{Convention, Thirty360};
+use libitofin::time::frequency::Frequency;
+use libitofin::time::period::Period;
+use libitofin::time::schedule::MakeSchedule;
+use libitofin::time::timeunit::TimeUnit;
+use libitofin::types::{Rate, Real, Volatility};
+
+/// UK RPI, thirty-one real figures then the two `-999.0` sentinels
+/// (`inflationcapfloor.cpp:132-137`). See the module docs.
+const FIX_DATA: [Real; 33] = [
+    189.9, 189.9, 189.6, 190.5, 191.6, 192.0, 192.2, 192.2, 192.6, 193.1, 193.3, 193.6, 194.1,
+    193.4, 194.2, 195.0, 196.5, 197.7, 198.5, 198.5, 199.2, 200.1, 200.4, 201.1, 202.7, 201.6,
+    203.1, 204.4, 205.4, 206.2, 207.3, -999.0, -999.0,
+];
+
+/// The fifteen quoted year-on-year swap rates, in per cent
+/// (`inflationcapfloor.cpp:152-168`).
+const YY_DATA: [(Day, Month, Year, Real); 15] = [
+    (13, August, 2008, 2.95),
+    (13, August, 2009, 2.95),
+    (13, August, 2010, 2.93),
+    (15, August, 2011, 2.955),
+    (13, August, 2012, 2.945),
+    (13, August, 2013, 2.985),
+    (13, August, 2014, 3.01),
+    (13, August, 2015, 3.035),
+    (13, August, 2016, 3.055),
+    (13, August, 2017, 3.075),
+    (13, August, 2019, 3.105),
+    (15, August, 2022, 3.135),
+    (13, August, 2027, 3.155),
+    (13, August, 2032, 3.145),
+    (13, August, 2037, 3.145),
+];
+
+const NOTIONAL: Real = 1_000_000.0;
+
+fn uk() -> Calendar {
+    UnitedKingdom::new(Market::Settlement)
+}
+
+fn day_counter() -> DayCounter {
+    Thirty360::with_convention(Convention::BondBasis)
+}
+
+/// The lag the leg, the volatility surface and the parity swap observe: zero.
+/// Only the bootstrap helpers observe two months.
+fn observation_lag() -> Period {
+    Period::new(0, TimeUnit::Days)
+}
+
+struct Fixture {
+    settings: Shared<Settings<Date>>,
+    index: Shared<YoYInflationIndex>,
+    nominal: Handle<dyn YieldTermStructure>,
+    evaluation_date: Date,
+    base_date: Date,
+    _curve: Shared<PiecewiseYoYInflationCurve<Linear>>,
+    _handle: RelinkableHandle<dyn YoYInflationTermStructure>,
+}
+
+/// `CommonVars` (`inflationcapfloor.cpp:109-187`): UK RPI with monthly history,
+/// a flat 5 % nominal curve, and a year-on-year curve bootstrapped from the
+/// fifteen quotes above.
+fn a_bootstrapped_market() -> QlResult<Fixture> {
+    let settings = shared(Settings::<Date>::new());
+    let evaluation_date = uk().adjust(
+        Date::new(13, August, 2007),
+        BusinessDayConvention::Following,
+    );
+    settings.set_evaluation_date(evaluation_date);
+
+    // D11: fixings live on the index, not on a global IndexManager.
+    let rpi_schedule = MakeSchedule::new()
+        .from(Date::new(1, January, 2005))
+        .to(Date::new(13, August, 2007))
+        .with_tenor(Period::new(1, TimeUnit::Months))
+        .with_calendar(uk())
+        .with_convention(BusinessDayConvention::ModifiedFollowing)
+        .build();
+    let rpi = shared(UkRpi::new(Shared::clone(&settings)));
+    for (date, &figure) in rpi_schedule.dates().iter().zip(FIX_DATA.iter()) {
+        rpi.add_fixing(*date, figure)?;
+    }
+
+    // The YoY index forecasts through an empty relinkable handle, relinked to
+    // the curve once it is bootstrapped (D2).
+    let handle = RelinkableHandle::<dyn YoYInflationTermStructure>::empty();
+    let index = shared(
+        YoYInflationIndex::from_underlying(Shared::clone(&rpi))
+            .with_term_structure(handle.handle()),
+    );
+    let nominal = Handle::new(shared(FlatForward::with_rate(
+        evaluation_date,
+        0.05,
+        ActualActual::with_convention(ActualActualConvention::ISDA),
+        Compounding::Continuous,
+        Frequency::Annual,
+    )) as Shared<dyn YieldTermStructure>);
+
+    // Only the helpers see two months (`inflationcapfloor.cpp:150`, `:174`).
+    let helper_lag = Period::new(2, TimeUnit::Months);
+    let helpers: Vec<Shared<dyn YoYInflationHelper>> = YY_DATA
+        .iter()
+        .map(|&(day, month, year, rate)| {
+            YearOnYearInflationSwapHelper::new(
+                Handle::new(shared(SimpleQuote::new(Some(rate / 100.0)))),
+                helper_lag,
+                Date::new(day, month, year),
+                uk(),
+                BusinessDayConvention::ModifiedFollowing,
+                day_counter(),
+                &index,
+                CpiInterpolationType::Flat,
+                nominal.clone(),
+                Pillar::LastRelevantDate,
+                Shared::clone(&settings),
+            )
+            .expect("a well-formed helper") as Shared<dyn YoYInflationHelper>
+        })
+        .collect();
+
+    // Bootstrap is lazy: the first read off the curve solves it.
+    let base_date = rpi.last_fixing_date()?;
+    let curve = PiecewiseYoYInflationCurve::<Linear>::new(
+        evaluation_date,
+        base_date,
+        YY_DATA[0].3 / 100.0, // base YoY rate
+        index.frequency(),
+        day_counter(),
+        helpers,
+        None, // no seasonality correction
+    )?;
+    handle.link_to(Shared::clone(&curve) as Shared<dyn YoYInflationTermStructure>);
+
+    Ok(Fixture {
+        settings,
+        index,
+        nominal,
+        evaluation_date,
+        base_date,
+        _curve: curve,
+        _handle: handle,
+    })
+}
+
+/// `makeYoYLeg` (`inflationcapfloor.cpp:190-201`), a plain annual leg.
+fn a_yoy_leg(fixture: &Fixture, length: i32) -> QlResult<Vec<Shared<YoYInflationCoupon>>> {
+    let start = fixture.evaluation_date;
+    let end = uk().advance_by_period(
+        start,
+        Period::new(length, TimeUnit::Years),
+        BusinessDayConvention::Unadjusted,
+        false,
+    );
+    let schedule = MakeSchedule::new()
+        .from(start)
+        .to(end)
+        .with_frequency(Frequency::Annual)
+        .with_calendar(uk())
+        .with_convention(BusinessDayConvention::Unadjusted)
+        .with_termination_date_convention(BusinessDayConvention::Unadjusted)
+        .with_rule(DateGeneration::Forward)
+        .build();
+    YoYInflationLeg::new(
+        schedule,
+        uk(),
+        Shared::clone(&fixture.index),
+        observation_lag(),
+        CpiInterpolationType::Flat,
+    )
+    .with_notional(NOTIONAL)
+    .with_payment_day_counter(day_counter())
+    .with_payment_adjustment(BusinessDayConvention::ModifiedFollowing)
+    .coupons()
+}
+
+/// `makeEngine` (`inflationcapfloor.cpp:204-241`): a flat optionlet surface
+/// under one of the three distributions.
+fn an_engine(
+    fixture: &Fixture,
+    volatility: Volatility,
+    distribution: YoYOptionletDistribution,
+) -> SharedMut<dyn PricingEngine> {
+    let surface = Handle::new(shared(ConstantYoYOptionletVolatility::new(
+        volatility,
+        0, // settlement days
+        uk(),
+        BusinessDayConvention::ModifiedFollowing,
+        day_counter(),
+        observation_lag(),
+        Frequency::Annual,
+        false, // index is not interpolated
+        -1.0,  // minimum strike
+        100.0, // maximum strike
+        Shared::clone(&fixture.settings),
+    )) as Shared<dyn YoYOptionletVolatilitySurface>);
+    let index = Shared::clone(&fixture.index);
+    let nominal = fixture.nominal.clone();
+    let engine = match distribution {
+        YoYOptionletDistribution::Black => {
+            YoYInflationCapFloorEngine::black(index, surface, nominal)
+        }
+        YoYOptionletDistribution::UnitDisplaced => {
+            YoYInflationCapFloorEngine::unit_displaced(index, surface, nominal)
+        }
+        YoYOptionletDistribution::Bachelier => {
+            YoYInflationCapFloorEngine::bachelier(index, surface, nominal)
+        }
+    };
+    shared_mut(engine) as SharedMut<dyn PricingEngine>
+}
+
+/// `makeYoYCapFloor` (`inflationcapfloor.cpp:244-264`): the instrument with its
+/// engine already attached.
+fn a_cap_floor(
+    fixture: &Fixture,
+    cap_floor_type: CapFloorType,
+    coupons: Vec<Shared<YoYInflationCoupon>>,
+    strike: Rate,
+    volatility: Volatility,
+    distribution: YoYOptionletDistribution,
+) -> QlResult<YoYInflationCapFloor> {
+    let mut instrument = match cap_floor_type {
+        CapFloorType::Floor => {
+            YoYInflationCapFloor::floor(coupons, vec![strike], Shared::clone(&fixture.settings))
+        }
+        _ => YoYInflationCapFloor::cap(coupons, vec![strike], Shared::clone(&fixture.settings)),
+    }?;
+    instrument
+        .base_mut()
+        .set_pricing_engine(an_engine(fixture, volatility, distribution));
+    Ok(instrument)
+}
+
+fn main() -> QlResult<()> {
+    let fixture = a_bootstrapped_market()?;
+    println!("evaluation date        : {}", fixture.evaluation_date);
+    println!("curve base date        : {}", fixture.base_date);
+    println!();
+
+    part_a_cached_values(&fixture)?;
+    println!();
+    part_b_parity(&fixture)?;
+    println!();
+    part_c_at_the_money_builder(&fixture)?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Part A: the six values QuantLib caches for a 2Y cap and floor.
+// ---------------------------------------------------------------------------
+fn part_a_cached_values(fixture: &Fixture) -> QlResult<()> {
+    println!("== Part A: 2Y cap/floor struck at 2.95 % on 1 % vol vs the cached values ==");
+    let strike = 0.0295;
+    let coupons = a_yoy_leg(fixture, 2)?;
+
+    // (distribution, cached cap, cached floor) from inflationcapfloor.cpp:474,
+    // :493 and :512. QuantLib's own tolerances are 0.02 / 0.22 / 0.22.
+    for (distribution, cached_cap, cached_floor) in [
+        (YoYOptionletDistribution::Black, 219.452, 314.641),
+        (YoYOptionletDistribution::UnitDisplaced, 9114.61, 9209.8),
+        (YoYOptionletDistribution::Bachelier, 8852.4, 8947.59),
+    ] {
+        let mut cap = a_cap_floor(
+            fixture,
+            CapFloorType::Cap,
+            coupons.clone(),
+            strike,
+            0.01,
+            distribution,
+        )?;
+        let mut floor = a_cap_floor(
+            fixture,
+            CapFloorType::Floor,
+            coupons.clone(),
+            strike,
+            0.01,
+            distribution,
+        )?;
+
+        println!(
+            "  {distribution:<13?} cap   = {:>10.4}  (cached {cached_cap})",
+            cap.npv()?
+        );
+        println!(
+            "  {distribution:<13?} floor = {:>10.4}  (cached {cached_floor})",
+            floor.npv()?
+        );
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Part B: cap - floor is the year-on-year swap, whatever the distribution.
+// ---------------------------------------------------------------------------
+fn part_b_parity(fixture: &Fixture) -> QlResult<()> {
+    println!("== Part B: cap - floor == YoY swap (5Y, strike 3 %, vol 15 %) ==");
+    let strike = 0.03;
+    let volatility = 0.15;
+    let length = 5;
+    let coupons = a_yoy_leg(fixture, length)?;
+    let from = fixture
+        .nominal
+        .current_link()?
+        .reference_date()
+        .expect("a fixed-reference curve has one");
+
+    // The swap's own annual schedule over the same span, generated backwards.
+    let schedule = MakeSchedule::new()
+        .from(from)
+        .to(from + Period::new(length, TimeUnit::Years))
+        .with_tenor(Period::new(1, TimeUnit::Years))
+        .with_calendar(uk())
+        .with_convention(BusinessDayConvention::Unadjusted)
+        .backwards()
+        .build();
+    let mut swap = YearOnYearInflationSwap::new(
+        SwapType::Payer,
+        NOTIONAL,
+        schedule.clone(), // fixed schedule
+        strike,           // fixed rate
+        day_counter(),    // fixed day counter
+        schedule,         // yoy schedule
+        Shared::clone(&fixture.index),
+        observation_lag(),
+        CpiInterpolationType::Flat,
+        0.0,           // spread
+        day_counter(), // yoy day counter
+        uk(),
+        BusinessDayConvention::ModifiedFollowing,
+        Shared::clone(&fixture.settings),
+    )?;
+    swap.base_mut()
+        .set_pricing_engine(shared_mut(DiscountingSwapEngine::new(
+            fixture.nominal.clone(),
+            None,
+            None,
+            None,
+            Shared::clone(&fixture.settings),
+        )) as SharedMut<dyn PricingEngine>);
+    let swap_npv = swap.npv()?;
+
+    for distribution in [
+        YoYOptionletDistribution::Black,
+        YoYOptionletDistribution::UnitDisplaced,
+        YoYOptionletDistribution::Bachelier,
+    ] {
+        let mut cap = a_cap_floor(
+            fixture,
+            CapFloorType::Cap,
+            coupons.clone(),
+            strike,
+            volatility,
+            distribution,
+        )?;
+        let mut floor = a_cap_floor(
+            fixture,
+            CapFloorType::Floor,
+            coupons.clone(),
+            strike,
+            volatility,
+            distribution,
+        )?;
+        let parity = (cap.npv()? - floor.npv()?) - swap_npv;
+        println!("  {distribution:<13?} cap - floor - swap = {parity:.3e}");
+    }
+    println!("  swap NPV = {swap_npv:.6}");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Part C: MakeYoYInflationCapFloor, at-the-money strikes, and atm_rate.
+// ---------------------------------------------------------------------------
+fn part_c_at_the_money_builder(fixture: &Fixture) -> QlResult<()> {
+    println!("== Part C: MakeYoYInflationCapFloor at the money ==");
+    let curve = fixture.nominal.current_link()?;
+
+    let builder = || {
+        MakeYoYInflationCapFloor::new(
+            CapFloorType::Cap,
+            Shared::clone(&fixture.index),
+            5, // length in years
+            uk(),
+            observation_lag(),
+            CpiInterpolationType::Flat,
+            Shared::clone(&fixture.settings),
+        )
+        .with_nominal(NOTIONAL)
+    };
+
+    // A strike left unset is filled at the money off the nominal curve: the rate
+    // that reprices the leg the builder just laid down.
+    let whole_leg = builder().with_atm_strike(fixture.nominal.clone()).build()?;
+    println!(
+        "  5Y cap, atm strike       = {:.10}",
+        whole_leg.cap_rates()[0]
+    );
+    println!(
+        "  5Y cap, atm_rate()       = {:.10}",
+        whole_leg.atm_rate(curve.as_ref())?
+    );
+
+    // atm_rate is CashFlows::atm_rate over the instrument's own leg, off the
+    // curve's reference date.
+    let leg: Leg = whole_leg
+        .yoy_leg()
+        .iter()
+        .map(|coupon| Shared::clone(coupon) as Shared<dyn CashFlow>)
+        .collect();
+    let by_hand = CashFlows::atm_rate(
+        &leg,
+        curve.as_ref(),
+        &fixture.settings,
+        Some(false), // include settlement date flows
+        Some(curve.reference_date().expect("a reference date")),
+        None, // npv date
+        None, // target npv
+    )?;
+    println!("  the same by hand         = {by_hand:.10}");
+
+    // as_optionlet keeps only the last coupon, and the trim happens BEFORE the
+    // at-the-money fill: the strike is that coupon's rate, not the whole leg's.
+    // This market is near flat, so the two sit under ten basis points apart; on
+    // a curve with real slope the gap runs to a couple of hundred.
+    let optionlet = builder()
+        .as_optionlet(true)
+        .with_atm_strike(fixture.nominal.clone())
+        .build()?;
+    println!(
+        "  last-coupon optionlet    = {:.10}  ({} coupon)",
+        optionlet.cap_rates()[0],
+        optionlet.yoy_leg().len()
+    );
+    Ok(())
+}


### PR DESCRIPTION
This adds several new examples and extends existing ones with functional
demonstrations across the credit and inflation domains.

**New examples:**
* Added `isda_cds.py` and `isda_cds.rs` demonstrating the ISDA standard-model
  engine and the Markit reconciliation flow.
* Added `yoy_inflation_swap.py`, `yoy_inflation_capfloor.py` and
  `yoy_inflation_capfloor.rs` for year-on-year inflation instruments.
* Added `american_option_fd.rs` for finite-difference American option pricing.

**Credit CDS enhancements:**
* Extended `credit_cds.rs` with Part C, settling the protection leg against a
  `FaceValueAccrualClaim` on a reference bond via `MakeCreditDefaultSwap` and
  `with_claim`, showing the reduced protection-leg payout.

**Inflation seasonality:**
* Extended `inflation_swap.py` with `apply_seasonality`, installing a
  `MultiplicativePriceSeasonality` correction on the bootstrapped curve and
  verifying the quotes still reprice to zero after re-solving.
* Updated `inflation_swap.rs` to thread `Pillar::LastRelevantDate` and the new
  seasonality argument through the helper and curve construction.

**Documentation:**
* Clarified the cached NPV and fair-spread tolerance notes in `credit_cds.py`
  and printed the diffs against the cached QuantLib figures.
