### PR TITLE
feat(itofin-py): add __eq__ and __hash__ to Period and DayCounter

### DIFF
--- a/crates/itofin-py/python/itofin/time.pyi
+++ b/crates/itofin-py/python/itofin/time.pyi
@@ -29,6 +29,15 @@ class Period:
     """A signed length in one calendar unit (unit: Days, Weeks, Months, Years)."""
 
     def __init__(self, n: int, unit: str) -> None: ...
+    def __eq__(self, other: object) -> bool:
+        """Semantic equality: 7 Days equals 1 Week and 12 Months equals 1 Year,
+        while an undecidable pair such as 30 Days against 1 Month is not equal."""
+        ...
+
+    def __hash__(self) -> int:
+        """Hashes the canonical form, so equal periods hash equal."""
+        ...
+
     def __repr__(self) -> str: ...
 
 class Calendar:
@@ -71,6 +80,15 @@ class DayCounter:
     def actual_actual_isda() -> DayCounter: ...
     @staticmethod
     def thirty360_bond_basis() -> DayCounter: ...
+    def __eq__(self, other: object) -> bool:
+        """Equality by convention name, so two independently built Actual360s
+        are equal."""
+        ...
+
+    def __hash__(self) -> int:
+        """Hashes the convention name, the field equality compares."""
+        ...
+
     def __repr__(self) -> str: ...
 
 class Frequency:

--- a/crates/itofin-py/src/time.rs
+++ b/crates/itofin-py/src/time.rs
@@ -19,9 +19,21 @@ use libitofin::time::schedule::{MakeSchedule, Schedule};
 use libitofin::time::timeunit::TimeUnit;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 
 const MIN_SERIAL: i64 = 367;
 const MAX_SERIAL: i64 = 109_574;
+
+/// The hash of `value`, for the `__hash__` facades.
+///
+/// Each caller feeds this exactly what its `__eq__` compares, so equal objects
+/// hash equal: `DayCounter` its name, `Period` its canonical (normalized) form.
+fn hash_of<T: Hash>(value: &T) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    value.hash(&mut hasher);
+    hasher.finish()
+}
 
 /// Days in `month` (1-based) for `year`, using the Gregorian leap rule.
 ///
@@ -178,6 +190,19 @@ impl PyDayCounter {
         }
     }
 
+    /// Equality by convention name, delegating to the core `PartialEq`: two
+    /// independently built `Actual360`s are equal, an `Actual360` and an
+    /// `Actual365Fixed` are not.
+    fn __eq__(&self, other: &PyDayCounter) -> bool {
+        self.inner == other.inner
+    }
+
+    /// Hashes the name, the one field [`__eq__`](Self::__eq__) compares, so a
+    /// day counter can key a dict or join a set.
+    fn __hash__(&self) -> u64 {
+        hash_of(&self.inner.name())
+    }
+
     fn __repr__(&self) -> String {
         format!("DayCounter({})", self.inner.name())
     }
@@ -192,8 +217,8 @@ impl PyDayCounter {
 
     /// Wraps a core [`DayCounter`] a facade read back off an object it built.
     ///
-    /// The result carries no factory identity, so it compares only through its
-    /// `repr`.
+    /// The result carries no factory identity, but equality is by convention
+    /// name, so it compares equal to the factory call that built it.
     pub(crate) fn from_inner(inner: DayCounter) -> Self {
         PyDayCounter { inner }
     }
@@ -227,6 +252,21 @@ impl PyPeriod {
         Ok(PyPeriod {
             inner: Period::new(n, units),
         })
+    }
+
+    /// Semantic equality, delegating to the core `PartialEq`: `7 Days` equals
+    /// `1 Week` and `12 Months` equals `1 Year`, while a pair no calendar can
+    /// decide (`30 Days` against `1 Month`) is not equal.
+    fn __eq__(&self, other: &PyPeriod) -> bool {
+        self.inner == other.inner
+    }
+
+    /// Hashes the canonical form, so every decidably equal pair hashes equal:
+    /// normalizing collapses `7 Days` onto `1 Week`, `12 Months` onto `1 Year`
+    /// and every zero length onto `0 Days` before the hash is taken.
+    fn __hash__(&self) -> u64 {
+        let normalized = self.inner.normalized();
+        hash_of(&(normalized.length(), normalized.units()))
     }
 
     fn __repr__(&self) -> String {

--- a/crates/itofin-py/tests/test_time_eq_hash.py
+++ b/crates/itofin-py/tests/test_time_eq_hash.py
@@ -1,0 +1,97 @@
+"""Value equality and hashing for Period and DayCounter (#864).
+
+Both facades wrap a core type that defines equality, but neither exposed it, so
+Python compared them by identity and neither could key a dict or join a set.
+
+The oracle is the core semantics, not a field comparison. Period equality is
+decidable-ordering equality (period.rs:315-320): `partial_cmp` returns None for
+a pair no calendar can resolve, which equality reads as not equal. So 7 Days
+equals 1 Week and 12 Months equals 1 Year, while 30 Days against 1 Month is not
+equal. DayCounter equality is by convention name (daycounter.rs:131-141).
+
+The discriminating cases are the cross-unit ones. A naive hash of the raw
+(length, unit) pair satisfies every equality assertion here and still breaks the
+hash contract: it would separate 7 Days from 1 Week in a set although they
+compare equal. Each cross-unit equality below is therefore paired with a hash
+assertion, and the set and dict cases turn that contract into observable
+behaviour.
+
+Omitted visibly: the arm reading a DayCounter back off an object that built one
+(the from_inner path). The only such getter is the year-on-year coupon's
+`day_counter()`, which needs a bootstrapped inflation curve to reach; equality
+delegates to the same core PartialEq either way, so the fixture is not worth its
+cost here.
+"""
+
+from itofin.time import DayCounter, Period
+
+
+def test_days_and_weeks_compare_and_hash_across_units():
+    assert Period(7, "Days") == Period(1, "Weeks")
+    assert hash(Period(7, "Days")) == hash(Period(1, "Weeks"))
+
+
+def test_a_multi_week_length_normalizes_too():
+    assert Period(14, "Days") == Period(2, "Weeks")
+    assert hash(Period(14, "Days")) == hash(Period(2, "Weeks"))
+
+
+def test_months_and_years_compare_and_hash_across_units():
+    assert Period(12, "Months") == Period(1, "Years")
+    assert hash(Period(12, "Months")) == hash(Period(1, "Years"))
+
+
+def test_every_zero_length_is_the_same_period():
+    assert Period(0, "Days") == Period(0, "Months")
+    assert Period(0, "Days") == Period(0, "Years")
+    assert Period(0, "Days") == Period(0, "Weeks")
+    assert hash(Period(0, "Days")) == hash(Period(0, "Months"))
+    assert hash(Period(0, "Days")) == hash(Period(0, "Years"))
+    assert hash(Period(0, "Days")) == hash(Period(0, "Weeks"))
+
+
+def test_an_undecidable_pair_is_not_equal():
+    """A month is 28 to 31 days, so 30 Days and 1 Month overlap without
+    resolving; the core returns None and equality reads that as not equal."""
+    assert Period(30, "Days") != Period(1, "Months")
+
+
+def test_an_exactly_convertible_pair_that_differs_is_not_equal():
+    assert Period(2, "Weeks") != Period(15, "Days")
+
+
+def test_equal_periods_collapse_in_a_set():
+    assert len({Period(7, "Days"), Period(1, "Weeks")}) == 1
+    assert len({Period(7, "Days"), Period(1, "Months")}) == 2
+
+
+def test_a_period_keys_a_dict_by_value():
+    tenors = {Period(12, "Months"): "annual"}
+    assert tenors[Period(1, "Years")] == "annual"
+
+
+def test_a_period_is_not_equal_to_a_non_period():
+    """pyo3 returns False for an argument it cannot extract rather than raising,
+    matching Date.__eq__ (time.rs:100)."""
+    assert Period(1, "Days") != 1
+    assert Period(1, "Days") != "1D"
+
+
+def test_independently_built_day_counters_compare_and_hash_equal():
+    assert DayCounter.actual360() == DayCounter.actual360()
+    assert hash(DayCounter.actual360()) == hash(DayCounter.actual360())
+
+
+def test_different_conventions_are_not_equal():
+    assert DayCounter.actual360() != DayCounter.actual365_fixed()
+    assert DayCounter.actual_actual_isda() != DayCounter.thirty360_bond_basis()
+
+
+def test_a_day_counter_keys_a_dict_by_value():
+    curves = {DayCounter.actual365_fixed(): "discount"}
+    assert curves[DayCounter.actual365_fixed()] == "discount"
+    assert DayCounter.actual360() not in curves
+
+
+def test_a_day_counter_is_not_equal_to_a_non_day_counter():
+    assert DayCounter.actual360() != "Actual/360"


### PR DESCRIPTION
Enable `Period` and `DayCounter` facades to be compared and used as dict
keys or set members from Python.

**Equality and hashing:**
* Added a shared `hash_of` helper so equal objects hash equal, feeding it
  exactly what each type's `__eq__` compares.
* `DayCounter` now compares by convention name, so two independently built
  `Actual360`s are equal, and hashes that same name.
* `Period` now uses semantic equality delegating to the core `PartialEq`
  (`7 Days` equals `1 Week`, `12 Months` equals `1 Year`), and hashes the
  canonical normalized form so decidably equal periods hash equal.

**Docs and tests:**
* Updated `from_inner` docs and the `time.pyi` stubs to describe the new
  equality-by-name behavior for both types.
* Added `test_time_eq_hash.py` covering equality and hashing.

close #864
