### PR TITLE
feat(itofin-py): add OvernightIndex base class for overnight index families

### DIFF
--- a/crates/itofin-py/python/itofin/indexes.pyi
+++ b/crates/itofin-py/python/itofin/indexes.pyi
@@ -65,7 +65,15 @@ class Euribor(IborIndex):
     def six_months(curve: YieldTermStructure, settings: Settings) -> Euribor: ...
     def fixing(self, fixing_date: Date, forecast_todays_fixing: bool) -> float: ...
 
-class Estr:
+class OvernightIndex:
+    """The base of the overnight index families.
+
+    Abstract: it has no constructor, because the core builds an overnight index
+    only through a family factory such as Estr. It exists so OISRateHelper and
+    MakeOis name one type and accept any family. The fixing accessor stays on
+    the family facade; lifting it here is deferred."""
+
+class Estr(OvernightIndex):
     """The Euro Short-Term Rate overnight index. Pass curve=None to build it over
     an empty forwarding handle (the form the OIS bootstrap needs)."""
 

--- a/crates/itofin-py/python/itofin/instruments.pyi
+++ b/crates/itofin-py/python/itofin/instruments.pyi
@@ -1,5 +1,5 @@
 # Hand-written stubs for itofin.instruments; sync manually with src/option.rs,
-# src/swap.rs, src/swaption.rs, src/capfloor.rs, src/credit.rs and
+# src/swap.rs, src/ois.rs, src/swaption.rs, src/capfloor.rs, src/credit.rs and
 # src/inflation.rs (#517).
 
 from itofin import Settings
@@ -7,6 +7,7 @@ from itofin.cashflows import YoYInflationCoupon
 from itofin.indexes import (
     CpiInterpolationType,
     Euribor,
+    OvernightIndex,
     YoYInflationIndex,
     ZeroInflationIndex,
 )
@@ -23,7 +24,7 @@ from itofin.pricingengines import (
     YoYInflationCapFloorEngine,
 )
 from itofin.processes import BlackScholesProcess
-from itofin.termstructures import YieldTermStructure
+from itofin.termstructures import RateAveraging, YieldTermStructure
 from itofin.time import (
     BusinessDayConvention,
     Calendar,
@@ -130,6 +131,39 @@ class MakeVanillaSwap:
         fixed_leg_day_count: DayCounter | None = None,
     ) -> None: ...
     def build(self) -> VanillaSwap: ...
+
+class OvernightIndexedSwap:
+    """A fixed leg versus a compounded overnight leg.
+
+    Only MakeOis builds one, so it always arrives priced; there is no
+    set_engine and no raw constructor (both deferred with the two-schedule
+    master ctor)."""
+
+    def fair_rate(self) -> float: ...
+    def npv(self) -> float: ...
+    def nominal(self) -> float: ...
+    def fixed_rate(self) -> float: ...
+
+class MakeOis:
+    """Market-convention builder for an OvernightIndexedSwap: derives both
+    schedules and the discounting engine from a swap tenor and an overnight
+    index. ``fixed_rate=None`` builds a par swap. The built swap already carries
+    its DiscountingSwapEngine."""
+
+    def __init__(
+        self,
+        swap_tenor: Period,
+        overnight_index: OvernightIndex,
+        settings: Settings,
+        fixed_rate: float | None = None,
+        forward_start: Period | None = None,
+        effective_date: Date | None = None,
+        nominal: float | None = None,
+        payment_lag: int | None = None,
+        discounting_term_structure: YieldTermStructure | None = None,
+        averaging_method: RateAveraging | None = None,
+    ) -> None: ...
+    def build(self) -> OvernightIndexedSwap: ...
 
 class EuropeanExercise:
     """A single-date exercise schedule."""

--- a/crates/itofin-py/python/itofin/termstructures.pyi
+++ b/crates/itofin-py/python/itofin/termstructures.pyi
@@ -5,9 +5,9 @@
 from itofin import Settings
 from itofin.indexes import (
     CpiInterpolationType,
-    Estr,
     Euribor,
     IborIndex,
+    OvernightIndex,
     SwapIndex,
     YoYInflationIndex,
     ZeroInflationIndex,
@@ -374,7 +374,7 @@ class OISRateHelper(RateHelper):
         settlement_days: int,
         tenor: Period,
         quote: SimpleQuote,
-        overnight_index: Estr,
+        overnight_index: OvernightIndex,
         payment_lag: int,
         payment_convention: BusinessDayConvention,
         payment_frequency: Frequency,

--- a/crates/itofin-py/src/helpers.rs
+++ b/crates/itofin-py/src/helpers.rs
@@ -529,6 +529,30 @@ impl PyFraRateHelper {
     }
 }
 
+/// Python `OvernightIndex`: the base of the overnight index families
+/// (`indexes::iborindex::OvernightIndex`).
+///
+/// Abstract from Python: it has no constructor, because the core builds an
+/// overnight index only through a family factory such as [`PyEstr`], which is
+/// what supplies the conventions. It exists so the facades consuming an
+/// overnight index - [`PyOISRateHelper`] and the OIS-swap builder - name one
+/// type and accept any family, mirroring [`PyIborIndex`] under
+/// [`PyEuribor`]. The `fixing` accessor stays on the family facade rather than
+/// being lifted here; nothing reads a fixing off the base yet, so widening it
+/// is deferred.
+#[pyclass(name = "OvernightIndex", subclass, unsendable)]
+pub struct PyOvernightIndex {
+    inner: Shared<OvernightIndex>,
+}
+
+impl PyOvernightIndex {
+    /// A clone of the inner index for the facades that take an overnight index
+    /// and are generic over the family.
+    pub(crate) fn inner(&self) -> Shared<OvernightIndex> {
+        Shared::clone(&self.inner)
+    }
+}
+
 /// Python `Estr`: the Euro Short-Term Rate overnight index (`indexes::Estr`).
 ///
 /// `Estr::new` returns an `OvernightIndex` by value (it adds no behaviour over
@@ -538,7 +562,12 @@ impl PyFraRateHelper {
 /// curve builds the index over an empty forwarding handle, the form the OIS
 /// bootstrap needs. Infallible (unlike `Euribor::new`, which rejects daily
 /// tenors): the overnight tenor is fixed to `1*Days` by the base.
-#[pyclass(name = "Estr", unsendable)]
+///
+/// A subclass of [`PyOvernightIndex`], so an ESTR index is accepted wherever
+/// the general overnight index is. It retains its own clone of the index the
+/// base holds - the same object, not a rebuild - so a facade typed on either
+/// half reads exactly the same core index.
+#[pyclass(name = "Estr", extends = PyOvernightIndex, unsendable)]
 pub struct PyEstr {
     inner: Shared<OvernightIndex>,
 }
@@ -549,14 +578,15 @@ impl PyEstr {
     /// is `None`.
     #[new]
     #[pyo3(signature = (curve, settings))]
-    fn new(curve: Option<&PyYieldTermStructure>, settings: &PySettings) -> Self {
+    fn new(
+        curve: Option<&PyYieldTermStructure>,
+        settings: &PySettings,
+    ) -> PyClassInitializer<Self> {
         let forwarding = match curve {
             Some(curve) => curve.handle(),
             None => Handle::empty(),
         };
-        PyEstr {
-            inner: shared(Estr::new(forwarding, settings.inner())),
-        }
+        init_overnight(shared(Estr::new(forwarding, settings.inner())))
     }
 
     /// The index's fixing for `fixing_date`, forecast off the forwarding curve
@@ -570,12 +600,14 @@ impl PyEstr {
     }
 }
 
-impl PyEstr {
-    /// A clone of the inner overnight index for the OIS helper facade, which
-    /// takes a `&OvernightIndex`.
-    pub(crate) fn inner(&self) -> Shared<OvernightIndex> {
-        Shared::clone(&self.inner)
-    }
+/// The base/subclass initializer the ESTR constructor builds: one index object
+/// feeds both halves, so the base [`PyOvernightIndex`] the OIS facades read and
+/// the [`PyEstr`] its own `fixing` reads are the same core index.
+fn init_overnight(index: Shared<OvernightIndex>) -> PyClassInitializer<PyEstr> {
+    let base = PyOvernightIndex {
+        inner: Shared::clone(&index),
+    };
+    PyClassInitializer::from(base).add_subclass(PyEstr { inner: index })
 }
 
 /// Python `RateAveraging`: how an overnight coupon combines its daily fixings
@@ -642,7 +674,7 @@ impl PyOISRateHelper {
         settlement_days: Natural,
         tenor: &PyPeriod,
         quote: &PySimpleQuote,
-        overnight_index: &PyEstr,
+        overnight_index: &PyOvernightIndex,
         payment_lag: Integer,
         payment_convention: &PyBusinessDayConvention,
         payment_frequency: &PyFrequency,

--- a/crates/itofin-py/src/lib.rs
+++ b/crates/itofin-py/src/lib.rs
@@ -21,6 +21,7 @@ mod hullwhite;
 mod inflation;
 mod market;
 mod mcengine;
+mod ois;
 mod option;
 mod optionletvol;
 mod settings;
@@ -74,6 +75,7 @@ use inflation::{
 use libitofin::errors::QlError;
 use market::{PyBlackScholesProcess, PySimpleQuote};
 use mcengine::{PyMCAmericanEngine, PyMCEuropeanEngine, PyMCEuropeanHestonEngine};
+use ois::{PyMakeOis, PyOvernightIndexedSwap};
 use option::{PyOptionType, PyVanillaOption};
 use optionletvol::{
     PyConstantOptionletVolatility, PyOptionletStripper1, PyOptionletVolatilityStructure,
@@ -239,6 +241,8 @@ fn itofin(m: &Bound<'_, PyModule>) -> PyResult<()> {
     instruments.add_class::<PySwapType>()?;
     instruments.add_class::<PyVanillaSwap>()?;
     instruments.add_class::<PyMakeVanillaSwap>()?;
+    instruments.add_class::<PyOvernightIndexedSwap>()?;
+    instruments.add_class::<PyMakeOis>()?;
     instruments.add_class::<PyEuropeanExercise>()?;
     instruments.add_class::<PySettlementType>()?;
     instruments.add_class::<PySettlementMethod>()?;

--- a/crates/itofin-py/src/lib.rs
+++ b/crates/itofin-py/src/lib.rs
@@ -58,7 +58,7 @@ use curve::{
 };
 use helpers::{
     PyDepositRateHelper, PyEstr, PyFraRateHelper, PyFuturesRateHelper, PyFuturesType,
-    PyOISRateHelper, PyPillar, PyRateAveraging, PyRateHelper, PySwapRateHelper,
+    PyOISRateHelper, PyOvernightIndex, PyPillar, PyRateAveraging, PyRateHelper, PySwapRateHelper,
 };
 use heston::{PyHestonModel, PyHestonModelHelper, PyHestonProcess};
 use hullwhite::{PyEuribor, PyHullWhite, PyIborIndex, PySwaptionHelper};
@@ -220,6 +220,7 @@ fn itofin(m: &Bound<'_, PyModule>) -> PyResult<()> {
     indexes.add_class::<PyCurrency>()?;
     indexes.add_class::<PyIborIndex>()?;
     indexes.add_class::<PyEuribor>()?;
+    indexes.add_class::<PyOvernightIndex>()?;
     indexes.add_class::<PyEstr>()?;
     indexes.add_class::<PySwapIndex>()?;
     indexes.add_class::<PyCpiInterpolationType>()?;

--- a/crates/itofin-py/src/ois.rs
+++ b/crates/itofin-py/src/ois.rs
@@ -1,0 +1,207 @@
+//! Facades for the overnight-indexed-swap stack: [`PyOvernightIndexedSwap`]
+//! and the [`PyMakeOis`] builder.
+//!
+//! The OIS analogue of [`crate::swap`]: the builder derives both schedules and
+//! the discounting engine from a swap tenor and an overnight index, and
+//! [`PyMakeOis::build`] returns a swap that already carries its
+//! [`DiscountingSwapEngine`] (`makeois.rs:508-516`), so it prices straight
+//! away.
+
+use crate::PyQlError;
+use crate::curve::PyYieldTermStructure;
+use crate::helpers::{PyOvernightIndex, PyRateAveraging};
+use crate::settings::PySettings;
+use crate::time::{PyDate, PyPeriod};
+use libitofin::cashflows::RateAveraging;
+use libitofin::handle::Handle;
+use libitofin::indexes::OvernightIndex;
+use libitofin::instrument::Instrument;
+use libitofin::instruments::{MakeOis, OvernightIndexedSwap};
+use libitofin::settings::Settings;
+use libitofin::shared::{Shared, SharedMut, shared_mut};
+use libitofin::termstructures::yieldtermstructure::YieldTermStructure;
+use libitofin::time::date::Date;
+use libitofin::time::period::Period;
+use libitofin::time::timeunit::TimeUnit;
+use libitofin::types::{Integer, Real};
+use pyo3::prelude::*;
+
+/// Python `OvernightIndexedSwap`: a fixed leg versus a compounded overnight leg
+/// (`instruments::overnightindexedswap::OvernightIndexedSwap`).
+///
+/// Held as the OIS type rather than lowered to its [`FixedVsFloatingSwap`] base
+/// (unlike [`crate::swap::PyVanillaSwap`], which a swaption underlying needs in
+/// the base shape): nothing here consumes the base, and keeping the OIS type
+/// leaves the overnight accessors reachable for a later widening. The base's
+/// rate and nominal are read through `fixed_vs_floating`
+/// (`overnightindexedswap.rs:235-241`).
+///
+/// Only [`PyMakeOis`] builds one, so the swap always arrives priced; there is
+/// no `set_engine` and no raw constructor. Both are deferred with the
+/// two-schedule master ctor (`overnightindexedswap.rs:169`), which needs a
+/// [`crate::time::PySchedule`] pair the OIS oracle does not build.
+///
+/// [`FixedVsFloatingSwap`]: libitofin::instruments::FixedVsFloatingSwap
+#[pyclass(name = "OvernightIndexedSwap", unsendable)]
+pub struct PyOvernightIndexedSwap {
+    inner: SharedMut<OvernightIndexedSwap>,
+}
+
+#[pymethods]
+impl PyOvernightIndexedSwap {
+    /// The fair fixed rate that zeroes the swap NPV (`fairRate()`), read
+    /// through the base (`overnightindexedswap.rs:241`).
+    ///
+    /// Fallible: the swap must be non-expired and its engine must price.
+    fn fair_rate(&mut self) -> PyResult<f64> {
+        Ok(self
+            .inner
+            .borrow_mut()
+            .fixed_vs_floating_mut()
+            .fair_rate()
+            .map_err(PyQlError::from)?)
+    }
+
+    /// The swap NPV under the engine [`PyMakeOis::build`] attached.
+    fn npv(&mut self) -> PyResult<f64> {
+        Ok(self.inner.borrow_mut().npv().map_err(PyQlError::from)?)
+    }
+
+    /// The swap nominal, read through the base (`nominal()`).
+    ///
+    /// Fallible: the base errors on a swap whose legs carry per-coupon
+    /// nominals, which has no single one to report.
+    fn nominal(&self) -> PyResult<f64> {
+        Ok(self
+            .inner
+            .borrow()
+            .fixed_vs_floating()
+            .nominal()
+            .map_err(PyQlError::from)?)
+    }
+
+    /// The fixed-leg rate: the rate given to the builder, or the fair rate it
+    /// filled in for a `fixed_rate=None` par swap.
+    fn fixed_rate(&self) -> f64 {
+        self.inner.borrow().fixed_vs_floating().fixed_rate()
+    }
+}
+
+impl PyOvernightIndexedSwap {
+    /// Wraps the swap [`PyMakeOis::build`] hands back.
+    fn from_inner(inner: SharedMut<OvernightIndexedSwap>) -> PyOvernightIndexedSwap {
+        PyOvernightIndexedSwap { inner }
+    }
+}
+
+/// Python `MakeOis`: the market-convention builder for a
+/// [`PyOvernightIndexedSwap`] (`instruments::makeois::MakeOis`).
+///
+/// Derives the start and end dates, both schedules and the discounting engine
+/// from a swap tenor and an overnight index, so the caller states conventions
+/// instead of hand-building two schedules. `fixed_rate=None` builds a par swap:
+/// the fair rate is computed off a temporary swap and written into the fixed
+/// leg (`makeois.rs:461-469`), so the result prices to a zero NPV.
+///
+/// The core's `with_*` chain consumes the builder by value, which a
+/// `#[pyclass]` cannot hand out, so the overrides are constructor keywords
+/// instead and the chain is assembled inside [`build`](Self::build). Only the
+/// five the OIS reprice oracle needs are exposed - `effective_date`,
+/// `nominal`, `payment_lag`, `discounting_term_structure` and
+/// `averaging_method`. Every other core override (the swap type, the overnight
+/// spread, the fixed-leg day count, the settlement days, the termination date,
+/// the payment frequency and calendar, the schedule conventions and rule, the
+/// end-of-month flag) is deferred and keeps its core default; the four the core
+/// rejects outright (telescopic value dates, lookback, lockout, observation
+/// shift, `makeois.rs:364-387`) are unreachable from here by construction.
+#[pyclass(name = "MakeOis", unsendable)]
+pub struct PyMakeOis {
+    swap_tenor: Period,
+    overnight_index: Shared<OvernightIndex>,
+    fixed_rate: Option<Real>,
+    forward_start: Period,
+    settings: Shared<Settings<Date>>,
+    effective_date: Option<Date>,
+    nominal: Option<Real>,
+    payment_lag: Option<Integer>,
+    discounting_term_structure: Option<Handle<dyn YieldTermStructure>>,
+    averaging_method: Option<RateAveraging>,
+}
+
+#[pymethods]
+impl PyMakeOis {
+    #[new]
+    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (
+        swap_tenor,
+        overnight_index,
+        settings,
+        fixed_rate = None,
+        forward_start = None,
+        effective_date = None,
+        nominal = None,
+        payment_lag = None,
+        discounting_term_structure = None,
+        averaging_method = None,
+    ))]
+    fn new(
+        swap_tenor: &PyPeriod,
+        overnight_index: &PyOvernightIndex,
+        settings: &PySettings,
+        fixed_rate: Option<f64>,
+        forward_start: Option<&PyPeriod>,
+        effective_date: Option<&PyDate>,
+        nominal: Option<f64>,
+        payment_lag: Option<Integer>,
+        discounting_term_structure: Option<&PyYieldTermStructure>,
+        averaging_method: Option<PyRateAveraging>,
+    ) -> Self {
+        PyMakeOis {
+            swap_tenor: swap_tenor.inner(),
+            overnight_index: overnight_index.inner(),
+            fixed_rate,
+            forward_start: forward_start
+                .map(PyPeriod::inner)
+                .unwrap_or_else(|| Period::new(0, TimeUnit::Days)),
+            settings: settings.inner(),
+            effective_date: effective_date.map(PyDate::inner),
+            nominal,
+            payment_lag,
+            discounting_term_structure: discounting_term_structure.map(|curve| curve.handle()),
+            averaging_method: averaging_method.map(|method| method.inner()),
+        }
+    }
+
+    /// Builds the priced swap.
+    ///
+    /// Fallible: without an `effective_date` the start date is derived from the
+    /// evaluation date, so an unset one is an error (D10); the schedule and the
+    /// overnight leg can be degenerate; and the par-rate fill propagates a
+    /// pricing failure.
+    fn build(&self) -> PyResult<PyOvernightIndexedSwap> {
+        let mut maker = MakeOis::new(
+            self.swap_tenor,
+            Shared::clone(&self.overnight_index),
+            self.fixed_rate,
+            self.forward_start,
+            Shared::clone(&self.settings),
+        );
+        if let Some(effective_date) = self.effective_date {
+            maker = maker.with_effective_date(effective_date);
+        }
+        if let Some(nominal) = self.nominal {
+            maker = maker.with_nominal(nominal);
+        }
+        if let Some(payment_lag) = self.payment_lag {
+            maker = maker.with_payment_lag(payment_lag);
+        }
+        if let Some(curve) = &self.discounting_term_structure {
+            maker = maker.with_discounting_term_structure(curve.clone());
+        }
+        if let Some(averaging_method) = self.averaging_method {
+            maker = maker.with_averaging_method(averaging_method);
+        }
+        let swap = maker.build().map_err(PyQlError::from)?;
+        Ok(PyOvernightIndexedSwap::from_inner(shared_mut(swap)))
+    }
+}

--- a/crates/itofin-py/tests/test_ois_rate_helper.py
+++ b/crates/itofin-py/tests/test_ois_rate_helper.py
@@ -188,10 +188,16 @@ def test_make_ois_without_a_fixed_rate_prices_at_par():
     temporary swap at zero and writes its fair rate into the fixed leg
     (makeois.rs:461-469), so the built swap prices to a zero NPV by construction.
     Complements the reprice arm, which fixes the rate at 0.0 and reads the fair
-    rate back."""
+    rate back.
+
+    The filled rate is also read back through fixed_rate() and pinned to the
+    bootstrapped quote: a par swap on a curve built from these quotes must have
+    been filled at the quote itself, which ties the None branch to the fill
+    rather than to any rate that happens to zero a mis-built swap."""
     _, curve, settings, settlement = _curve()
 
     for n, unit in [(5, "Years"), (10, "Years")]:
+        quote = next(r for m, u, r in ESTR_SWAP_DATA if (m, u) == (n, unit)) / 100.0
         swap = MakeOis(
             P(n, unit),
             Estr(curve, settings),
@@ -204,6 +210,9 @@ def test_make_ois_without_a_fixed_rate_prices_at_par():
             averaging_method=RateAveraging.Compound,
         ).build()
         assert abs(swap.npv()) < 1.0e-6, f"{n} {unit} par OIS NPV {swap.npv()}"
+        assert abs(swap.fixed_rate() - quote) < 1.0e-8, (
+            f"{n} {unit} par fill {swap.fixed_rate()} vs quote {quote}"
+        )
 
 
 def test_estr_forecasts_a_fixing_off_its_forwarding_curve():

--- a/crates/itofin-py/tests/test_ois_rate_helper.py
+++ b/crates/itofin-py/tests/test_ois_rate_helper.py
@@ -1,25 +1,25 @@
-"""OIS rate-helper bootstrap - facing the overnight strip (#551).
+"""OIS rate-helper bootstrap - facing the overnight strip (#551, #554).
 
 Mirrors the merged core oracle `ois_bootstrap_reprices_the_quotes`
 (crates/libitofin/src/termstructures/yields/ratehelpers.rs:1677-1753): an ESTR
 discounting curve bootstrapped purely from OISRateHelpers reprices every OIS
 quote it was built from.
 
-HONEST LIMITATION - convergence/wiring gate, not a discriminating oracle. The
-core test's discriminating arm reprices with MakeOis + fair_rate()
-(ratehelpers.rs:1731-1746); neither MakeOis nor an OvernightIndexedSwap is faced
-in itofin-py yet, so the Python acceptance is the helper-level reprice:
-abs(implied_quote - quote_value) is the bootstrap's OWN root
-(bootstraphelper.rs:317) driven to ~1e-12, so it re-asserts the solver residual
-and would still pass a mis-wired quote. The structural arms (node count, strictly
-decreasing discount factors) carry what discrimination there is. A discriminating
-OIS oracle needs a MakeOis/OvernightIndexedSwap facade - a recommended follow-up.
+The reprice arm is the core loop (ratehelpers.rs:1729-1752) ported verbatim:
+each quote is repriced by an independently built OvernightIndexedSwap
+(MakeOis + fair_rate()) floating off a FRESH Estr forwarding on the
+BOOTSTRAPPED curve, not off the empty-handle index the helpers were built with.
+That is a real instrument valuation, unlike the helper-level
+abs(implied_quote - quote_value) it replaces (#554), which was the bootstrap's
+OWN root (bootstraphelper.rs:317) and so re-asserted the solver residual rather
+than discriminating a mis-wire.
 """
 
 import pytest
 
 from itofin import Settings
 from itofin.indexes import Estr
+from itofin.instruments import MakeOis
 from itofin.quotes import SimpleQuote
 from itofin.termstructures import (
     FlatForward,
@@ -81,11 +81,16 @@ def _curve():
     today = 5-Feb-2009, TARGET, an Estr forwarding off an empty handle, one
     OISRateHelper per quote, and a PiecewiseLogLinearDiscount whose reference is
     TODAY (not settlement, :1719-1720) on Actual/365 Fixed. Returns the ordered
-    helper list and the curve."""
+    helper list, the curve, the settings the reprice arm must share (D5: a fresh
+    Settings has no evaluation date, so the engine MakeOis attaches would fail on
+    it) and the settlement date the repriced swaps start on (:1689-1695)."""
     today = Date(5, 2, 2009)
     settings = Settings()
     settings.set_evaluation_date(today)
-    _ = Calendar.target()
+    calendar = Calendar.target()
+    settlement = calendar.advance(
+        today, 2, "Days", BusinessDayConvention.Following, False
+    )
 
     estr = Estr(None, settings)
     helpers = []
@@ -110,7 +115,7 @@ def _curve():
         )
 
     curve = PiecewiseLogLinearDiscount(today, helpers, DayCounter.actual365_fixed())
-    return helpers, curve
+    return helpers, curve, settings, settlement
 
 
 def test_ois_bootstrap_reprices_the_quotes():
@@ -119,14 +124,24 @@ def test_ois_bootstrap_reprices_the_quotes():
     1. STRUCTURAL PIN: one curve node per helper plus the reference node.
        `dates()` also forces the lazy bootstrap, so the reprice arm below reads a
        solved curve. This arm cannot be faked by the solver.
-    2. WIRING/CONVERGENCE GATE (not a discriminating oracle, see module docstring):
-       abs(implied_quote - quote_value) IS the bootstrap's own root, solved to
-       ~1e-12, so it re-asserts the solver residual within 1e-8.
+    2. REPRICE (ratehelpers.rs:1729-1752): every quote is recovered as the fair
+       rate of an independently built OIS floating off a fresh Estr on the
+       bootstrapped curve. It discriminates the wiring the bootstrap root cannot:
+       the payment lag, the averaging method and the fresh-index-on-the-solved-
+       curve forwarding each move the fair rate off the quote when mis-set. The
+       nominal is asserted separately - fair_rate() is nominal-invariant, so the
+       reprice alone would not catch a dropped with_nominal (the core default is
+       1.0). Two of the knobs passed here are degenerate under this fixture and
+       are NOT pinned, though the core loop passes them too: effective_date,
+       because MakeOis derives the same 9-Feb-2009 start from its own two-day
+       family default (makeois.rs:526-534 - the ESTR family, not the index's own
+       zero settlement days), and discounting_term_structure, because the curve
+       passed is already the index's forwarding curve.
     3. SHAPE: discount factors strictly positive and strictly decreasing across
        the (increasing) helper maturity dates - a structural property the solver
        cannot fake.
     """
-    helpers, curve = _curve()
+    helpers, curve, settings, settlement = _curve()
 
     # Arm 1 - structural pin (forces the bootstrap).
     nodes = curve.dates()
@@ -134,17 +149,31 @@ def test_ois_bootstrap_reprices_the_quotes():
         "one curve node per helper plus the reference"
     )
 
-    # Arm 2 - wiring/convergence gate (re-asserts the solver root, see docstring).
+    # Arm 2 - reprice each quote with an independently built OIS.
     worst = 0.0
-    for helper in helpers:
-        implied = helper.implied_quote()
-        quote = helper.quote_value()
-        error = abs(implied - quote)
+    for n, unit, rate in ESTR_SWAP_DATA:
+        priced_estr = Estr(curve, settings)
+        swap = MakeOis(
+            P(n, unit),
+            priced_estr,
+            settings,
+            fixed_rate=0.0,
+            forward_start=P(0, "Days"),
+            effective_date=settlement,
+            nominal=100.0,
+            payment_lag=PAYMENT_LAG,
+            discounting_term_structure=curve,
+            averaging_method=RateAveraging.Compound,
+        ).build()
+        assert swap.nominal() == 100.0, "the builder nominal reached the swap"
+        calculated = swap.fair_rate()
+        expected = rate / 100.0
+        error = abs(calculated - expected)
         worst = max(worst, error)
-        assert error <= TOLERANCE, (
-            f"OIS reprice: implied {implied} vs quote {quote} (err {error})"
+        assert error < TOLERANCE, (
+            f"{n} {unit} OIS: calculated {calculated} vs expected {expected}"
         )
-    assert worst <= TOLERANCE, f"worst OIS reprice error {worst}"
+    assert worst < TOLERANCE, f"worst OIS reprice error {worst}"
 
     # Arm 3 - shape: strictly positive, strictly decreasing discount factors.
     previous = 1.0
@@ -152,6 +181,29 @@ def test_ois_bootstrap_reprices_the_quotes():
         df = curve.discount_date(helper.maturity_date())
         assert 0.0 < df < previous, f"non-decreasing/negative df {df} after {previous}"
         previous = df
+
+
+def test_make_ois_without_a_fixed_rate_prices_at_par():
+    """`fixed_rate=None` is the C++ `Null<Rate>()` default: MakeOis assembles a
+    temporary swap at zero and writes its fair rate into the fixed leg
+    (makeois.rs:461-469), so the built swap prices to a zero NPV by construction.
+    Complements the reprice arm, which fixes the rate at 0.0 and reads the fair
+    rate back."""
+    _, curve, settings, settlement = _curve()
+
+    for n, unit in [(5, "Years"), (10, "Years")]:
+        swap = MakeOis(
+            P(n, unit),
+            Estr(curve, settings),
+            settings,
+            forward_start=P(0, "Days"),
+            effective_date=settlement,
+            nominal=100.0,
+            payment_lag=PAYMENT_LAG,
+            discounting_term_structure=curve,
+            averaging_method=RateAveraging.Compound,
+        ).build()
+        assert abs(swap.npv()) < 1.0e-6, f"{n} {unit} par OIS NPV {swap.npv()}"
 
 
 def test_estr_forecasts_a_fixing_off_its_forwarding_curve():


### PR DESCRIPTION
- **feat(itofin-py): add OvernightIndex base class for overnight index families**
- **feat(itofin-py): add Python bindings for overnight indexed swaps**
- **test(crates): reprice OIS quotes with independent instruments**
- **test(crates): assert par OIS fill matches bootstrapped quote**

close #554