### PR TITLE
feat(itofin-py): widen index consumers to accept general IborIndex

### DIFF
--- a/crates/itofin-py/python/itofin/indexes.pyi
+++ b/crates/itofin-py/python/itofin/indexes.pyi
@@ -90,22 +90,23 @@ class Estr(OvernightIndex):
 
 class SwapIndex:
     """The index whose fixing is the fair rate of an on-the-fly vanilla swap,
-    assembled from the index tenor, the forecasting Euribor index and the
-    fixed-leg conventions.
+    assembled from the index tenor, the forecasting Ibor index and the fixed-leg
+    conventions.
 
-    The currency is hard-coded to EUR: there is no Currency facade yet, and the
-    currency is inert for every ported consumer."""
+    The currency is inert for every ported consumer, so currency() reading it
+    back off the core index is the only place it shows."""
 
     def __init__(
         self,
         family_name: str,
         tenor: Period,
         settlement_days: int,
+        currency: Currency,
         calendar: Calendar,
         fixed_leg_tenor: Period,
         fixed_leg_convention: BusinessDayConvention,
         fixed_leg_day_counter: DayCounter,
-        ibor_index: Euribor,
+        ibor_index: IborIndex,
         settings: Settings,
     ) -> None:
         """Forecasts and discounts off the ibor index's forwarding curve."""
@@ -115,11 +116,12 @@ class SwapIndex:
         family_name: str,
         tenor: Period,
         settlement_days: int,
+        currency: Currency,
         calendar: Calendar,
         fixed_leg_tenor: Period,
         fixed_leg_convention: BusinessDayConvention,
         fixed_leg_day_counter: DayCounter,
-        ibor_index: Euribor,
+        ibor_index: IborIndex,
         discount: YieldTermStructure,
         settings: Settings,
     ) -> SwapIndex:
@@ -130,6 +132,7 @@ class SwapIndex:
         """The underlying swap's fair rate, the at-the-money forward the
         volatility cubes read."""
         ...
+    def currency(self) -> Currency: ...
     def fixed_leg_tenor(self) -> Period: ...
     def exogenous_discount(self) -> bool: ...
 

--- a/crates/itofin-py/python/itofin/instruments.pyi
+++ b/crates/itofin-py/python/itofin/instruments.pyi
@@ -6,7 +6,7 @@ from itofin import Settings
 from itofin.cashflows import YoYInflationCoupon
 from itofin.indexes import (
     CpiInterpolationType,
-    Euribor,
+    IborIndex,
     OvernightIndex,
     YoYInflationIndex,
     ZeroInflationIndex,
@@ -101,7 +101,7 @@ class VanillaSwap:
         fixed_rate: float,
         fixed_day_count: DayCounter,
         float_schedule: Schedule,
-        ibor_index: Euribor,
+        ibor_index: IborIndex,
         spread: float,
         floating_day_count: DayCounter,
         settings: Settings,
@@ -121,7 +121,7 @@ class MakeVanillaSwap:
     def __init__(
         self,
         swap_tenor: Period,
-        ibor_index: Euribor,
+        ibor_index: IborIndex,
         settings: Settings,
         fixed_rate: float | None = None,
         forward_start: Period | None = None,
@@ -227,7 +227,7 @@ class CapFloor:
         self,
         cap_floor_type: CapFloorType,
         tenor: Period,
-        ibor_index: Euribor,
+        ibor_index: IborIndex,
         strike: float,
         forward_start: Period,
         settings: Settings,

--- a/crates/itofin-py/python/itofin/models.pyi
+++ b/crates/itofin-py/python/itofin/models.pyi
@@ -2,7 +2,7 @@
 # src/hullwhite.rs and src/calibration.rs (#517).
 
 from itofin import Settings
-from itofin.indexes import Euribor
+from itofin.indexes import IborIndex
 from itofin.instruments import OptionType
 from itofin.optimization import EndCriteria, LevenbergMarquardt
 from itofin.processes import HestonProcess
@@ -71,7 +71,7 @@ class SwaptionHelper:
         maturity: Period,
         length: Period,
         volatility: float,
-        index: Euribor,
+        index: IborIndex,
         fixed_leg_tenor: Period,
         fixed_leg_day_counter: DayCounter,
         floating_leg_day_counter: DayCounter,

--- a/crates/itofin-py/python/itofin/termstructures.pyi
+++ b/crates/itofin-py/python/itofin/termstructures.pyi
@@ -5,7 +5,6 @@
 from itofin import Settings
 from itofin.indexes import (
     CpiInterpolationType,
-    Euribor,
     IborIndex,
     OvernightIndex,
     SwapIndex,
@@ -292,7 +291,7 @@ class FuturesRateHelper(RateHelper):
     def from_index(
         price: SimpleQuote,
         ibor_start_date: Date,
-        index: Euribor,
+        index: IborIndex,
         conv_adj: SimpleQuote | None,
         futures_type: FuturesType,
     ) -> FuturesRateHelper: ...
@@ -319,7 +318,7 @@ class FraRateHelper(RateHelper):
         self,
         quote: SimpleQuote,
         period_to_start: Period,
-        index: Euribor,
+        index: IborIndex,
         use_indexed_coupon: bool = True,
         pillar: Pillar = ...,
     ) -> None: ...
@@ -327,7 +326,7 @@ class FraRateHelper(RateHelper):
     def from_rate(
         rate: float,
         period_to_start: Period,
-        index: Euribor,
+        index: IborIndex,
         use_indexed_coupon: bool = True,
         pillar: Pillar = ...,
     ) -> FraRateHelper: ...
@@ -335,7 +334,7 @@ class FraRateHelper(RateHelper):
     def from_months(
         quote: SimpleQuote,
         months_to_start: int,
-        index: Euribor,
+        index: IborIndex,
         use_indexed_coupon: bool = True,
         pillar: Pillar = ...,
     ) -> FraRateHelper: ...
@@ -344,7 +343,7 @@ class FraRateHelper(RateHelper):
         quote: SimpleQuote,
         start_date: Date,
         end_date: Date,
-        index: Euribor,
+        index: IborIndex,
         use_indexed_coupon: bool = True,
         pillar: Pillar = ...,
     ) -> FraRateHelper: ...
@@ -770,7 +769,7 @@ class OptionletStripper1:
     def __init__(
         self,
         term_vol_surface: CapFloorTermVolSurface,
-        ibor_index: Euribor,
+        ibor_index: IborIndex,
         volatility_type: VolatilityType,
         accuracy: float = 1e-6,
         max_iter: int = 100,

--- a/crates/itofin-py/src/capfloor.rs
+++ b/crates/itofin-py/src/capfloor.rs
@@ -24,7 +24,7 @@
 
 use crate::PyQlError;
 use crate::capfloorengine::PyBlackCapFloorEngine;
-use crate::hullwhite::PyEuribor;
+use crate::hullwhite::PyIborIndex;
 use crate::settings::PySettings;
 use crate::time::PyPeriod;
 use libitofin::instrument::Instrument;
@@ -83,7 +83,7 @@ impl PyCapFloor {
     fn new(
         cap_floor_type: PyCapFloorType,
         tenor: &PyPeriod,
-        ibor_index: &PyEuribor,
+        ibor_index: &PyIborIndex,
         strike: f64,
         forward_start: &PyPeriod,
         settings: &PySettings,

--- a/crates/itofin-py/src/currency.rs
+++ b/crates/itofin-py/src/currency.rs
@@ -8,9 +8,9 @@
 //! the full `ql/currencies/*` catalogue is deferred there (`currency.rs:9`).
 //!
 //! It is registered under `itofin.indexes` rather than a submodule of its own:
-//! the index constructors are its only consumers today, and
-//! [`PySwapIndex`](crate::swapindex::PySwapIndex) documents that gap as the one
-//! this facade closes.
+//! the index constructors are its only consumers today, both the general
+//! [`PyIborIndex`](crate::hullwhite::PyIborIndex) one and, since #868,
+//! [`PySwapIndex`](crate::swapindex::PySwapIndex), which used to hard-code EUR.
 
 use libitofin::currency::Currency;
 use pyo3::prelude::*;
@@ -66,5 +66,10 @@ impl PyCurrency {
     /// take a [`Currency`] by value.
     pub(crate) fn inner(&self) -> Currency {
         self.inner.clone()
+    }
+
+    /// Wraps a currency read back off a core index, for the facade getters.
+    pub(crate) fn from_inner(inner: Currency) -> Self {
+        PyCurrency { inner }
     }
 }

--- a/crates/itofin-py/src/helpers.rs
+++ b/crates/itofin-py/src/helpers.rs
@@ -16,7 +16,7 @@
 
 use crate::PyQlError;
 use crate::curve::PyYieldTermStructure;
-use crate::hullwhite::{PyEuribor, PyIborIndex};
+use crate::hullwhite::PyIborIndex;
 use crate::market::PySimpleQuote;
 use crate::settings::PySettings;
 use crate::time::{
@@ -312,7 +312,7 @@ impl PyFuturesRateHelper {
         py: Python<'_>,
         price: &PySimpleQuote,
         ibor_start_date: &PyDate,
-        index: &PyEuribor,
+        index: &PyIborIndex,
         conv_adj: Option<&PySimpleQuote>,
         futures_type: &PyFuturesType,
     ) -> PyResult<Py<Self>> {
@@ -415,7 +415,7 @@ impl PyFraRateHelper {
     fn new(
         quote: &PySimpleQuote,
         period_to_start: &PyPeriod,
-        index: &PyEuribor,
+        index: &PyIborIndex,
         use_indexed_coupon: bool,
         pillar: PyPillar,
     ) -> PyClassInitializer<Self> {
@@ -444,7 +444,7 @@ impl PyFraRateHelper {
         py: Python<'_>,
         rate: f64,
         period_to_start: &PyPeriod,
-        index: &PyEuribor,
+        index: &PyIborIndex,
         use_indexed_coupon: bool,
         pillar: PyPillar,
     ) -> PyResult<Py<Self>> {
@@ -475,7 +475,7 @@ impl PyFraRateHelper {
         py: Python<'_>,
         quote: &PySimpleQuote,
         months_to_start: Natural,
-        index: &PyEuribor,
+        index: &PyIborIndex,
         use_indexed_coupon: bool,
         pillar: PyPillar,
     ) -> PyResult<Py<Self>> {
@@ -509,7 +509,7 @@ impl PyFraRateHelper {
         quote: &PySimpleQuote,
         start_date: &PyDate,
         end_date: &PyDate,
-        index: &PyEuribor,
+        index: &PyIborIndex,
         use_indexed_coupon: bool,
         pillar: PyPillar,
     ) -> PyResult<Py<Self>> {

--- a/crates/itofin-py/src/hullwhite.rs
+++ b/crates/itofin-py/src/hullwhite.rs
@@ -147,13 +147,11 @@ impl PyHullWhite {
 /// the form the bootstrap rate helpers need, exactly as the C++ default
 /// `Handle<YieldTermStructure> h = {}` allows.
 ///
-/// It is the base of [`PyEuribor`], so the deposit and swap rate helpers take
-/// this type and accept either. Every other index consumer still takes
-/// `PyEuribor` concretely, including two in the rate-helper module itself: the
-/// four `FraRateHelper` constructors and `FuturesRateHelper::from_index`. So do
-/// the swap, swap-index, optionlet-volatility, cap/floor and swaption-helper
-/// facades. Widening them is deferred to its own follow-up; no bootstrap this
-/// ticket serves needs it.
+/// It is the base of [`PyEuribor`], and since #868 every Ibor-index consumer
+/// takes this type and accepts either: the deposit, swap, FRA and futures rate
+/// helpers, and the swap, swap-index, optionlet-volatility, cap/floor and
+/// swaption-helper facades. The OIS helper is not one of them; it takes the
+/// overnight [`PyEstr`](crate::helpers::PyEstr), which is not an `IborIndex`.
 #[pyclass(name = "IborIndex", subclass, unsendable)]
 pub struct PyIborIndex {
     inner: Shared<IborIndex>,
@@ -298,8 +296,8 @@ impl PyIborIndex {
 ///
 /// A subclass of [`PyIborIndex`], so a Euribor is accepted wherever the general
 /// index is. It retains its own clone of the index the base holds - the same
-/// object, not a rebuild - so the facades still typed on `PyEuribor` read
-/// exactly what the base reads.
+/// object, not a rebuild - so its own `fixing` reads exactly what the base
+/// reads.
 #[pyclass(name = "Euribor", extends = PyIborIndex, unsendable)]
 pub struct PyEuribor {
     inner: Shared<IborIndex>,
@@ -359,16 +357,9 @@ impl PyEuribor {
     }
 }
 
-impl PyEuribor {
-    /// A clone of the inner index for the swap/swaption facades.
-    pub(crate) fn inner(&self) -> Shared<IborIndex> {
-        Shared::clone(&self.inner)
-    }
-}
-
 /// The base/subclass initializer shared by the three Euribor constructors: one
-/// index object feeds both halves, so the base [`PyIborIndex`] the rate helpers
-/// read and the [`PyEuribor`] the swap facades read are the same core index.
+/// index object feeds both halves, so the base [`PyIborIndex`] every consumer
+/// reads and the [`PyEuribor`] the subclass holds are the same core index.
 fn init_euribor(index: Shared<IborIndex>) -> PyClassInitializer<PyEuribor> {
     let base = PyIborIndex {
         inner: Shared::clone(&index),
@@ -400,7 +391,7 @@ impl PySwaptionHelper {
         maturity: &PyPeriod,
         length: &PyPeriod,
         volatility: f64,
-        index: &PyEuribor,
+        index: &PyIborIndex,
         fixed_leg_tenor: &PyPeriod,
         fixed_leg_day_counter: &PyDayCounter,
         floating_leg_day_counter: &PyDayCounter,

--- a/crates/itofin-py/src/optionletvol.rs
+++ b/crates/itofin-py/src/optionletvol.rs
@@ -25,7 +25,7 @@
 use crate::PyQlError;
 use crate::capfloortermvol::PyCapFloorTermVolSurface;
 use crate::curve::PyYieldTermStructure;
-use crate::hullwhite::PyEuribor;
+use crate::hullwhite::PyIborIndex;
 use crate::market::PySimpleQuote;
 use crate::settings::PySettings;
 use crate::swaptionvol::PyVolatilityType;
@@ -269,7 +269,7 @@ impl PyOptionletStripper1 {
     #[pyo3(signature = (term_vol_surface, ibor_index, volatility_type, accuracy = 1e-6, max_iter = 100, displacement = 0.0, discount = None, optionlet_frequency = None))]
     fn new(
         term_vol_surface: &PyCapFloorTermVolSurface,
-        ibor_index: &PyEuribor,
+        ibor_index: &PyIborIndex,
         volatility_type: PyVolatilityType,
         accuracy: f64,
         max_iter: u32,

--- a/crates/itofin-py/src/swap.rs
+++ b/crates/itofin-py/src/swap.rs
@@ -8,7 +8,7 @@
 
 use crate::PyQlError;
 use crate::curve::PyYieldTermStructure;
-use crate::hullwhite::PyEuribor;
+use crate::hullwhite::PyIborIndex;
 use crate::settings::PySettings;
 use crate::time::{PyDate, PyDayCounter, PyPeriod, PySchedule};
 use libitofin::indexes::IborIndex;
@@ -72,7 +72,7 @@ impl PyVanillaSwap {
         fixed_rate: f64,
         fixed_day_count: &PyDayCounter,
         float_schedule: &PySchedule,
-        ibor_index: &PyEuribor,
+        ibor_index: &PyIborIndex,
         spread: f64,
         floating_day_count: &PyDayCounter,
         settings: &PySettings,
@@ -213,7 +213,7 @@ impl PyMakeVanillaSwap {
     ))]
     fn new(
         swap_tenor: &PyPeriod,
-        ibor_index: &PyEuribor,
+        ibor_index: &PyIborIndex,
         settings: &PySettings,
         fixed_rate: Option<f64>,
         forward_start: Option<&PyPeriod>,

--- a/crates/itofin-py/src/swapindex.rs
+++ b/crates/itofin-py/src/swapindex.rs
@@ -5,21 +5,23 @@
 //! read the at-the-money forward off them, so this is the index the cube facades
 //! stack on rather than one the Python user prices with directly.
 //!
-//! Deferred (visible): the currency is hard-coded to EUR. A
-//! [`PyCurrency`](crate::currency::PyCurrency) facade now exists (#815), so the
-//! general form is expressible; threading it through this constructor is left to
-//! the follow-up that widens the remaining `PyEuribor` consumers, since the
-//! index's currency is inert for every ported consumer - `underlying_swap` never
-//! reads it, and the cube's at-the-money forward is a fair rate, not an amount.
-//! The `clone` family (re-curving / re-tenoring) is deferred in the core itself.
+//! Both constructors take the currency as a [`PyCurrency`](crate::currency::PyCurrency)
+//! and the forecasting index as the general [`PyIborIndex`](crate::hullwhite::PyIborIndex)
+//! (#868). The currency stays inert for every ported consumer - `underlying_swap`
+//! never reads it, and the cube's at-the-money forward is a fair rate, not an
+//! amount - so [`currency`](PySwapIndex::currency) reads it back off the core
+//! index, which is the only place it shows.
+//!
+//! Deferred (visible): the `clone` family (re-curving / re-tenoring) is deferred
+//! in the core itself.
 
 use crate::PyQlError;
+use crate::currency::PyCurrency;
 use crate::curve::PyYieldTermStructure;
-use crate::hullwhite::PyEuribor;
+use crate::hullwhite::PyIborIndex;
 use crate::settings::PySettings;
 use crate::time::{PyBusinessDayConvention, PyCalendar, PyDate, PyDayCounter, PyPeriod};
-use libitofin::currency::Currency;
-use libitofin::indexes::{Index, SwapIndex};
+use libitofin::indexes::{Index, InterestRateIndex, SwapIndex};
 use libitofin::shared::{Shared, shared};
 use libitofin::types::Natural;
 use pyo3::prelude::*;
@@ -27,8 +29,8 @@ use pyo3::prelude::*;
 /// Python `SwapIndex`: the index whose fixing is the fair rate of an on-the-fly
 /// vanilla swap (`indexes::SwapIndex`).
 ///
-/// The swap is assembled from the index tenor, the forecasting `Euribor` index
-/// and the fixed-leg conventions, off the value date the fixing date implies.
+/// The swap is assembled from the index tenor, the forecasting `IborIndex` and
+/// the fixed-leg conventions, off the value date the fixing date implies.
 /// [`new`](PySwapIndex::new) forecasts and discounts off the ibor index's
 /// forwarding curve; [`with_exogenous_discount`](PySwapIndex::with_exogenous_discount)
 /// discounts off a separate curve.
@@ -44,16 +46,17 @@ impl PySwapIndex {
     /// observers.
     #[new]
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (family_name, tenor, settlement_days, calendar, fixed_leg_tenor, fixed_leg_convention, fixed_leg_day_counter, ibor_index, settings))]
+    #[pyo3(signature = (family_name, tenor, settlement_days, currency, calendar, fixed_leg_tenor, fixed_leg_convention, fixed_leg_day_counter, ibor_index, settings))]
     fn new(
         family_name: String,
         tenor: &PyPeriod,
         settlement_days: Natural,
+        currency: &PyCurrency,
         calendar: &PyCalendar,
         fixed_leg_tenor: &PyPeriod,
         fixed_leg_convention: &PyBusinessDayConvention,
         fixed_leg_day_counter: &PyDayCounter,
-        ibor_index: &PyEuribor,
+        ibor_index: &PyIborIndex,
         settings: &PySettings,
     ) -> Self {
         PySwapIndex {
@@ -61,7 +64,7 @@ impl PySwapIndex {
                 family_name,
                 tenor.inner(),
                 settlement_days,
-                Currency::eur(),
+                currency.inner(),
                 calendar.inner(),
                 fixed_leg_tenor.inner(),
                 fixed_leg_convention.inner(),
@@ -76,16 +79,17 @@ impl PySwapIndex {
     /// discounting off the separate `discount` curve, registering with both.
     #[staticmethod]
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (family_name, tenor, settlement_days, calendar, fixed_leg_tenor, fixed_leg_convention, fixed_leg_day_counter, ibor_index, discount, settings))]
+    #[pyo3(signature = (family_name, tenor, settlement_days, currency, calendar, fixed_leg_tenor, fixed_leg_convention, fixed_leg_day_counter, ibor_index, discount, settings))]
     fn with_exogenous_discount(
         family_name: String,
         tenor: &PyPeriod,
         settlement_days: Natural,
+        currency: &PyCurrency,
         calendar: &PyCalendar,
         fixed_leg_tenor: &PyPeriod,
         fixed_leg_convention: &PyBusinessDayConvention,
         fixed_leg_day_counter: &PyDayCounter,
-        ibor_index: &PyEuribor,
+        ibor_index: &PyIborIndex,
         discount: &PyYieldTermStructure,
         settings: &PySettings,
     ) -> Self {
@@ -94,7 +98,7 @@ impl PySwapIndex {
                 family_name,
                 tenor.inner(),
                 settlement_days,
-                Currency::eur(),
+                currency.inner(),
                 calendar.inner(),
                 fixed_leg_tenor.inner(),
                 fixed_leg_convention.inner(),
@@ -116,6 +120,11 @@ impl PySwapIndex {
             .inner
             .fixing(fixing_date.inner(), forecast_todays_fixing)
             .map_err(PyQlError::from)?)
+    }
+
+    /// The index currency, read back off the core index.
+    fn currency(&self) -> PyCurrency {
+        PyCurrency::from_inner(self.inner.currency().clone())
     }
 
     /// The fixed-leg tenor.

--- a/crates/itofin-py/tests/test_ibor_widening.py
+++ b/crates/itofin-py/tests/test_ibor_widening.py
@@ -1,0 +1,120 @@
+"""The remaining index consumers widened to the generic IborIndex, plus the
+SwapIndex currency thread (#868).
+
+Construction is the oracle. Every consumer exercised here took Euribor
+concretely, so handing it a bare IborIndex raised a TypeError; nothing numeric
+is pinned, because the re-type is a pure signature change - each body already
+read the same Shared<IborIndex> off either type. The regression arm re-runs the
+same consumers with a Euribor, which still passes as the subclass.
+
+The currency is the one part that is not a re-type: both SwapIndex constructors
+hard-coded EUR. It stays inert for every ported consumer - the underlying swap
+never reads it - so the new currency() getter, which reads it back off the core
+index rather than off a cached argument, is its only observable. Both
+constructors carry an arm, since a stale hard-code left behind in either one
+still compiles, and both a USD and a EUR arm run, so a fresh hard-code of
+either currency fails one of them.
+"""
+
+import pytest
+
+from itofin import Settings
+from itofin.indexes import Currency, Euribor, IborIndex, SwapIndex
+from itofin.instruments import MakeVanillaSwap
+from itofin.quotes import SimpleQuote
+from itofin.termstructures import FlatForward, FraRateHelper
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Period
+
+EVAL = Date(15, 1, 2026)
+START = Date(15, 1, 2028)
+
+
+def _fixture():
+    settings = Settings()
+    settings.set_evaluation_date(EVAL)
+    curve = FlatForward(EVAL, 0.03, DayCounter.actual365_fixed())
+    return settings, curve
+
+
+def _generic_index(currency, curve, settings):
+    """A 3M index spelled out field by field, outside every named family."""
+    return IborIndex(
+        "Generic3M",
+        Period(3, "Months"),
+        2,
+        currency,
+        Calendar.target(),
+        BusinessDayConvention.ModifiedFollowing,
+        True,
+        DayCounter.actual360(),
+        curve,
+        settings,
+    )
+
+
+def _swap_index(index, currency, settings, discount=None):
+    args = (
+        "GenericSwapIndex",
+        Period(5, "Years"),
+        2,
+        currency,
+        Calendar.target(),
+        Period(1, "Years"),
+        BusinessDayConvention.ModifiedFollowing,
+        DayCounter.thirty360_bond_basis(),
+        index,
+    )
+    if discount is None:
+        return SwapIndex(*args, settings)
+    return SwapIndex.with_exogenous_discount(*args, discount, settings)
+
+
+def test_make_vanilla_swap_takes_a_generic_index():
+    settings, curve = _fixture()
+    index = _generic_index(Currency.usd(), curve, settings)
+    swap = MakeVanillaSwap(
+        Period(5, "Years"),
+        index,
+        settings,
+        effective_date=START,
+        nominal=100.0,
+    ).build()
+    assert swap.nominal() == pytest.approx(100.0)
+
+
+def test_fra_rate_helper_takes_a_generic_index():
+    settings, curve = _fixture()
+    index = _generic_index(Currency.usd(), curve, settings)
+    helper = FraRateHelper(SimpleQuote(0.03), Period(3, "Months"), index)
+    assert helper is not None
+
+
+def test_swap_index_takes_a_generic_index_and_reports_its_currency():
+    settings, curve = _fixture()
+    index = _generic_index(Currency.usd(), curve, settings)
+    assert _swap_index(index, Currency.usd(), settings).currency().code() == "USD"
+
+
+def test_swap_index_currency_is_not_a_fresh_usd_hard_code():
+    settings, curve = _fixture()
+    index = _generic_index(Currency.eur(), curve, settings)
+    assert _swap_index(index, Currency.eur(), settings).currency().code() == "EUR"
+
+
+def test_exogenous_discount_swap_index_threads_its_own_currency():
+    settings, curve = _fixture()
+    index = _generic_index(Currency.usd(), curve, settings)
+    swap_index = _swap_index(index, Currency.gbp(), settings, discount=curve)
+    assert swap_index.exogenous_discount()
+    assert swap_index.currency().code() == "GBP"
+
+
+def test_euribor_still_reaches_every_widened_consumer():
+    settings, curve = _fixture()
+    index = Euribor.three_months(curve, settings)
+    swap = MakeVanillaSwap(
+        Period(5, "Years"), index, settings, effective_date=START, nominal=100.0
+    ).build()
+    assert swap.nominal() == pytest.approx(100.0)
+    assert FraRateHelper(SimpleQuote(0.03), Period(3, "Months"), index) is not None
+    assert _swap_index(index, Currency.eur(), settings).currency().code() == "EUR"

--- a/crates/itofin-py/tests/test_interpolated_swaption_cube.py
+++ b/crates/itofin-py/tests/test_interpolated_swaption_cube.py
@@ -45,7 +45,7 @@ ATM grid's last node, so the default would range-check against it.
 import pytest
 
 from itofin import ItofinError, Settings
-from itofin.indexes import Euribor, SwapIndex
+from itofin.indexes import Currency, Euribor, SwapIndex
 from itofin.instruments import (
     EuropeanExercise,
     SettlementMethod,
@@ -166,6 +166,7 @@ def _swap_index(tenor, ibor_index):
         "EuriborSwapIsdaFixA",
         tenor,
         2,
+        Currency.eur(),
         Calendar.target(),
         Period(1, "Years"),
         BDC,

--- a/crates/itofin-py/tests/test_sabr_swaption_cube.py
+++ b/crates/itofin-py/tests/test_sabr_swaption_cube.py
@@ -48,7 +48,7 @@ node plus the dense pass is the expensive part, and no arm mutates a quote.
 import pytest
 
 from itofin import ItofinError, Settings
-from itofin.indexes import Euribor, SwapIndex
+from itofin.indexes import Currency, Euribor, SwapIndex
 from itofin.instruments import (
     EuropeanExercise,
     SettlementMethod,
@@ -138,6 +138,7 @@ def _swap_index(tenor, ibor_index):
         "EuriborSwapIsdaFixA",
         tenor,
         2,
+        Currency.eur(),
         Calendar.target(),
         Period(1, "Years"),
         BDC,


### PR DESCRIPTION
Every Ibor-index consumer now takes the general `IborIndex` and accepts
either it or a `Euribor` subclass: the deposit, swap, FRA and futures
rate helpers, and the swap, swap-index, optionlet-volatility, cap/floor
and swaption-helper facades. The OIS helper is untouched: it takes the
overnight `Estr`, which is not an `IborIndex`.

`SwapIndex` now takes the currency as a `Currency` facade instead of
hard-coding EUR, exposed through a new `currency()` getter that reads it
back off the core index. Stubs, tests and docs are updated to match, and
a new `test_ibor_widening.py` covers the widened consumers.

close #868
