### PR TITLE
feat(itofin-py): expose BachelierSwaptionEngine bindings

### DIFF
--- a/crates/itofin-py/python/itofin/instruments.pyi
+++ b/crates/itofin-py/python/itofin/instruments.pyi
@@ -13,6 +13,7 @@ from itofin.indexes import (
 )
 from itofin.models import HestonModel, HullWhite
 from itofin.pricingengines import (
+    BachelierSwaptionEngine,
     BlackCapFloorEngine,
     BlackSwaptionEngine,
     DiscountingSwapEngine,
@@ -199,6 +200,10 @@ class Swaption:
     def set_black_engine(self, engine: BlackSwaptionEngine) -> None:
         """Price off a swaption volatility surface instead of a short-rate
         model. The engine must carry the same Settings object as this swaption."""
+        ...
+    def set_bachelier_engine(self, engine: BachelierSwaptionEngine) -> None:
+        """Price off a normal-volatility swaption surface. The engine must carry
+        the same Settings object as this swaption."""
         ...
     def npv(self) -> float: ...
 

--- a/crates/itofin-py/python/itofin/pricingengines.pyi
+++ b/crates/itofin-py/python/itofin/pricingengines.pyi
@@ -51,6 +51,37 @@ class BlackSwaptionEngine:
         evaluation date. displacement is that surface's lognormal shift."""
         ...
 
+class BachelierSwaptionEngine:
+    """The normal-volatility swaption engine, European-only.
+
+    The Bachelier spec of the template BlackSwaptionEngine instantiates: same
+    constructors, same settings requirement, same silent discounting engine on
+    the underlying swap. The surface's volatility type is checked against the
+    normal formula at pricing time, not construction, so a shifted-lognormal
+    surface raises from Swaption.npv()."""
+
+    def __init__(
+        self,
+        vol: SwaptionVolatilityStructure,
+        discount: YieldTermStructure,
+        settings: Settings,
+        model: CashAnnuityModel = ...,
+    ) -> None: ...
+    @staticmethod
+    def with_flat_vol(
+        discount: YieldTermStructure,
+        vol: SimpleQuote,
+        day_counter: DayCounter,
+        displacement: float,
+        settings: Settings,
+        model: CashAnnuityModel = ...,
+    ) -> BachelierSwaptionEngine:
+        """An engine over a flat normal volatility quote, wrapped internally in
+        a constant surface on a null calendar whose reference date tracks the
+        evaluation date. displacement is kept for parity with the Black engine
+        and is ignored by the normal model."""
+        ...
+
 class BlackCapFloorEngine:
     """The shifted-lognormal Black-formula cap/floor engine, one Black 1976
     optionlet per coupon.

--- a/crates/itofin-py/src/lib.rs
+++ b/crates/itofin-py/src/lib.rs
@@ -90,7 +90,7 @@ use smilesection::PySabrSmileSection;
 use swap::{PyMakeVanillaSwap, PySwapType, PyVanillaSwap};
 use swapindex::PySwapIndex;
 use swaption::{PyEuropeanExercise, PySettlementMethod, PySettlementType, PySwaption};
-use swaptionengine::{PyBlackSwaptionEngine, PyCashAnnuityModel};
+use swaptionengine::{PyBachelierSwaptionEngine, PyBlackSwaptionEngine, PyCashAnnuityModel};
 use swaptionvol::{
     PyConstantSwaptionVolatility, PyInterpolatedSwaptionVolatilityCube,
     PySabrSwaptionVolatilityCube, PySwaptionVolatilityMatrix, PySwaptionVolatilityStructure,
@@ -269,6 +269,7 @@ fn itofin(m: &Bound<'_, PyModule>) -> PyResult<()> {
     let pricingengines = PyModule::new(py, "pricingengines")?;
     pricingengines.add_class::<PyCashAnnuityModel>()?;
     pricingengines.add_class::<PyBlackSwaptionEngine>()?;
+    pricingengines.add_class::<PyBachelierSwaptionEngine>()?;
     pricingengines.add_class::<PyBlackCapFloorEngine>()?;
     pricingengines.add_class::<PyMidPointCdsEngine>()?;
     pricingengines.add_class::<PyIsdaCdsEngine>()?;

--- a/crates/itofin-py/src/swaption.rs
+++ b/crates/itofin-py/src/swaption.rs
@@ -15,7 +15,7 @@ use crate::PyQlError;
 use crate::hullwhite::PyHullWhite;
 use crate::settings::PySettings;
 use crate::swap::PyVanillaSwap;
-use crate::swaptionengine::PyBlackSwaptionEngine;
+use crate::swaptionengine::{PyBachelierSwaptionEngine, PyBlackSwaptionEngine};
 use crate::time::PyDate;
 use libitofin::exercise::{EuropeanExercise, Exercise};
 use libitofin::instrument::Instrument;
@@ -163,11 +163,23 @@ impl PySwaption {
         self.inner.base_mut().set_pricing_engine(engine.engine());
     }
 
+    /// Attaches a [`PyBachelierSwaptionEngine`] so the swaption prices off a
+    /// normal-volatility swaption surface.
+    ///
+    /// The same `Settings` requirement as [`set_black_engine`](Self::set_black_engine)
+    /// applies: the engine resolves its own evaluation date, and two different
+    /// settings would price the swap and the option on different dates without
+    /// any error being raised.
+    fn set_bachelier_engine(&mut self, engine: &PyBachelierSwaptionEngine) {
+        self.inner.base_mut().set_pricing_engine(engine.engine());
+    }
+
     /// The swaption NPV under the attached engine.
     ///
-    /// Fallible: an engine must be attached ([`set_jamshidian_engine`](Self::set_jamshidian_engine)
-    /// or [`set_black_engine`](Self::set_black_engine)) and the (settlement type,
-    /// method) pair consistent.
+    /// Fallible: an engine must be attached ([`set_jamshidian_engine`](Self::set_jamshidian_engine),
+    /// [`set_black_engine`](Self::set_black_engine) or
+    /// [`set_bachelier_engine`](Self::set_bachelier_engine)) and the (settlement
+    /// type, method) pair consistent.
     fn npv(&mut self) -> PyResult<f64> {
         Ok(self.inner.npv().map_err(PyQlError::from)?)
     }

--- a/crates/itofin-py/src/swaptionengine.rs
+++ b/crates/itofin-py/src/swaptionengine.rs
@@ -1,13 +1,11 @@
 //! Facade for the Black-style swaption pricing engines:
-//! [`PyCashAnnuityModel`] and [`PyBlackSwaptionEngine`].
+//! [`PyCashAnnuityModel`], [`PyBlackSwaptionEngine`] and
+//! [`PyBachelierSwaptionEngine`].
 //!
 //! The core engine is generic over a formula spec, which does not cross FFI
-//! (D7), so the shifted-lognormal `BlackSwaptionEngine` alias is wrapped as a
-//! concrete class here.
-//!
-//! Deferred (visible): `BachelierSwaptionEngine` (the normal/Bachelier spec of
-//! the same template) is not exposed; it lands with the normal-volatility
-//! surfaces in #616.
+//! (D7), so both spec instantiations - the shifted-lognormal
+//! `BlackSwaptionEngine` alias and the normal `BachelierSwaptionEngine` alias -
+//! are wrapped as concrete classes here.
 
 use crate::curve::PyYieldTermStructure;
 use crate::market::PySimpleQuote;
@@ -15,7 +13,9 @@ use crate::settings::PySettings;
 use crate::swaptionvol::PySwaptionVolatilityStructure;
 use crate::time::PyDayCounter;
 use libitofin::pricingengine::PricingEngine;
-use libitofin::pricingengines::swaption::{BlackSwaptionEngine, CashAnnuityModel};
+use libitofin::pricingengines::swaption::{
+    BachelierSwaptionEngine, BlackSwaptionEngine, CashAnnuityModel,
+};
 use libitofin::shared::{SharedMut, shared_mut};
 use pyo3::prelude::*;
 
@@ -107,6 +107,80 @@ impl PyBlackSwaptionEngine {
 }
 
 impl PyBlackSwaptionEngine {
+    /// The erased engine the instrument facades install via `set_pricing_engine`.
+    pub(crate) fn engine(&self) -> SharedMut<dyn PricingEngine> {
+        SharedMut::clone(&self.inner) as SharedMut<dyn PricingEngine>
+    }
+}
+
+/// Python `BachelierSwaptionEngine`: the normal-volatility swaption engine
+/// (`pricingengines::swaption::BachelierSwaptionEngine`), the Bachelier spec of
+/// the same template [`PyBlackSwaptionEngine`] instantiates.
+///
+/// European-only, and it prices the underlying swap itself: it installs its own
+/// discounting engine on the swap silently, so the swap needs none of its own.
+/// The `settings` handed here must be the same object driving the swaption and
+/// its swap, or the evaluation dates disagree and the NPV is silently wrong.
+///
+/// The surface's volatility type is checked against the normal formula at
+/// pricing time, not construction, so a shifted-lognormal surface surfaces as
+/// an `ItofinError` from `Swaption.npv()`.
+#[pyclass(name = "BachelierSwaptionEngine", unsendable)]
+pub struct PyBachelierSwaptionEngine {
+    inner: SharedMut<BachelierSwaptionEngine>,
+}
+
+#[pymethods]
+impl PyBachelierSwaptionEngine {
+    /// An engine reading normal volatilities off `vol` and discounting on
+    /// `discount`.
+    #[new]
+    #[pyo3(signature = (vol, discount, settings, model = PyCashAnnuityModel::SwapRate))]
+    fn new(
+        vol: &PySwaptionVolatilityStructure,
+        discount: &PyYieldTermStructure,
+        settings: &PySettings,
+        model: PyCashAnnuityModel,
+    ) -> Self {
+        PyBachelierSwaptionEngine {
+            inner: shared_mut(BachelierSwaptionEngine::new(
+                discount.handle(),
+                vol.handle(),
+                model.inner(),
+                settings.inner(),
+            )),
+        }
+    }
+
+    /// An engine over a flat normal volatility quote, which it wraps in a
+    /// constant surface on a null calendar whose reference date tracks the
+    /// evaluation date. `displacement` is kept for signature parity with
+    /// [`PyBlackSwaptionEngine::with_flat_vol`]; the normal model has no shift
+    /// and ignores it.
+    #[staticmethod]
+    #[pyo3(signature = (discount, vol, day_counter, displacement, settings, model = PyCashAnnuityModel::SwapRate))]
+    fn with_flat_vol(
+        discount: &PyYieldTermStructure,
+        vol: &PySimpleQuote,
+        day_counter: &PyDayCounter,
+        displacement: f64,
+        settings: &PySettings,
+        model: PyCashAnnuityModel,
+    ) -> Self {
+        PyBachelierSwaptionEngine {
+            inner: shared_mut(BachelierSwaptionEngine::with_flat_vol(
+                discount.handle(),
+                vol.handle(),
+                day_counter.inner(),
+                displacement,
+                model.inner(),
+                settings.inner(),
+            )),
+        }
+    }
+}
+
+impl PyBachelierSwaptionEngine {
     /// The erased engine the instrument facades install via `set_pricing_engine`.
     pub(crate) fn engine(&self) -> SharedMut<dyn PricingEngine> {
         SharedMut::clone(&self.inner) as SharedMut<dyn PricingEngine>

--- a/crates/itofin-py/tests/test_bachelier_swaption.py
+++ b/crates/itofin-py/tests/test_bachelier_swaption.py
@@ -1,0 +1,186 @@
+"""Oracle for the normal-vol Bachelier swaption engine facade (issue #616).
+
+The twin of ``test_black_swaption.py``, and for the same reason it pins
+CONSTRUCTION rather than an NPV literal: the core has no cached Bachelier
+swaption value at all. Its only Bachelier engine test
+(``blackswaptionengine.rs:1597``, ``swaption_delta_in_the_bachelier_model``) is
+a bump-and-revalue delta self-consistency check reading a greek accessor the
+Python facade does not expose, so there is no number to reproduce here.
+
+Three pins, all on one shared ``Settings`` (the engine, the swap and the
+swaption must agree on the evaluation date or the NPV is silently wrong):
+
+A. ``BachelierSwaptionEngine(surface)`` and
+   ``BachelierSwaptionEngine.with_flat_vol`` price the same swaption
+   identically. ``with_flat_vol`` wraps the quote in a MOVING constant surface
+   with 0 settlement days on a null calendar, so its reference date IS the
+   evaluation date - which is why arm A builds its fixed-reference surface at
+   exactly that date. Only then do the two routes run the identical float
+   sequence, so they are pinned bit-for-bit rather than to a tolerance.
+B. The same swaption on a surface referenced a month later prices differently.
+   The vol level is constant, so the NPV moves only through the option time
+   ``day_count(reference_date, exercise)``: a later reference shortens it,
+   shrinking the variance and the premium. This is what makes arm A
+   non-degenerate - it proves the engine prices rather than returning a
+   constant, and that the reference date the two routes agree on is
+   load-bearing.
+C. A ShiftedLognormal surface handed to the Bachelier engine raises at pricing
+   time, not construction (the inverse of the Black engine's refusal, and the
+   direct mirror of the core test
+   ``a_lognormal_volatility_surface_is_refused_by_the_bachelier_engine``,
+   ``blackswaptionengine.rs:1344``). The message keys on "requires normal input
+   volatility", which the Black refusal does not contain.
+
+The volatility is quoted in absolute rate terms, not as a proportion: 50 bp of
+normal vol against a 3% strike, where the lognormal twin quotes 20%.
+
+Every arm rebuilds its own swap and swaption. An ``Instrument`` caches its NPV,
+and the engine silently installs its own discounting engine on the swap it
+prices, so reusing one swaption across the engines would let arm A pass on a
+stale cached number.
+"""
+
+import math
+
+import pytest
+
+from itofin import ItofinError, Settings
+from itofin.indexes import Euribor
+from itofin.instruments import (
+    EuropeanExercise,
+    SettlementMethod,
+    SettlementType,
+    Swaption,
+    SwapType,
+    VanillaSwap,
+)
+from itofin.pricingengines import BachelierSwaptionEngine, CashAnnuityModel
+from itofin.quotes import SimpleQuote
+from itofin.termstructures import (
+    ConstantSwaptionVolatility,
+    FlatForward,
+    VolatilityType,
+)
+from itofin.time import (
+    BusinessDayConvention,
+    Calendar,
+    Date,
+    DayCounter,
+    Frequency,
+    Schedule,
+)
+
+EVAL = Date(15, 1, 2026)
+EXERCISE = Date(15, 1, 2027)
+START = Date(15, 1, 2028)
+END = Date(15, 1, 2033)
+
+NORMAL_VOL = 0.0050
+STRIKE = 0.03
+REFERENCE_OFFSET_DAYS = 30
+
+SETTINGS = Settings()
+SETTINGS.set_evaluation_date(EVAL)
+
+
+def _surface(reference_date, volatility_type=VolatilityType.Normal):
+    return ConstantSwaptionVolatility(
+        reference_date,
+        Calendar.null_calendar(),
+        BusinessDayConvention.Following,
+        NORMAL_VOL,
+        DayCounter.actual365_fixed(),
+        volatility_type,
+        0.0,
+    )
+
+
+def _fixture():
+    """A fresh curve/swap/swaption on the one shared ``Settings``."""
+    settings = SETTINGS
+    curve = FlatForward(EVAL, 0.03, DayCounter.actual365_fixed())
+    fixed = Schedule(
+        START, END, Frequency.Annual, Calendar.target(), BusinessDayConvention.Unadjusted
+    )
+    floating = Schedule(
+        START,
+        END,
+        Frequency.Semiannual,
+        Calendar.target(),
+        BusinessDayConvention.Unadjusted,
+    )
+    swap = VanillaSwap(
+        SwapType.Payer,
+        100.0,
+        fixed,
+        STRIKE,
+        DayCounter.thirty360_bond_basis(),
+        floating,
+        Euribor.six_months(curve, settings),
+        0.0,
+        DayCounter.actual360(),
+        settings,
+    )
+    swaption = Swaption(
+        swap,
+        EuropeanExercise(EXERCISE),
+        SettlementType.Physical,
+        SettlementMethod.PhysicalOTC,
+        settings,
+    )
+    return settings, curve, swaption
+
+
+def _npv_on_surface(reference_date):
+    settings, curve, swaption = _fixture()
+    engine = BachelierSwaptionEngine(
+        _surface(reference_date), curve, settings, CashAnnuityModel.SwapRate
+    )
+    swaption.set_bachelier_engine(engine)
+    return swaption.npv()
+
+
+def _npv_on_flat_vol():
+    settings, curve, swaption = _fixture()
+    engine = BachelierSwaptionEngine.with_flat_vol(
+        curve,
+        SimpleQuote(NORMAL_VOL),
+        DayCounter.actual365_fixed(),
+        0.0,
+        settings,
+        CashAnnuityModel.SwapRate,
+    )
+    swaption.set_bachelier_engine(engine)
+    return swaption.npv()
+
+
+def test_surface_and_flat_vol_engines_price_identically():
+    npv_a = _npv_on_surface(EVAL)
+    npv_b = _npv_on_flat_vol()
+    print(f"\nnpv_A = {npv_a!r}\nnpv_B = {npv_b!r}")
+    assert npv_a == npv_b, f"npv_A={npv_a!r} npv_B={npv_b!r}"
+    assert math.isfinite(npv_a)
+    assert npv_a > 0.0
+
+
+def test_a_later_reference_date_moves_the_npv():
+    npv_a = _npv_on_surface(EVAL)
+    npv_c = _npv_on_surface(EVAL + REFERENCE_OFFSET_DAYS)
+    print(
+        f"\nnpv_A (reference {EVAL!r}) = {npv_a!r}"
+        f"\nnpv_C (reference {EVAL + REFERENCE_OFFSET_DAYS!r}) = {npv_c!r}"
+        f"\ngap = {npv_a - npv_c!r}"
+    )
+    assert npv_c != npv_a
+    assert npv_c < npv_a
+
+
+def test_lognormal_surface_on_a_bachelier_engine_raises_at_pricing():
+    settings, curve, swaption = _fixture()
+    lognormal = _surface(EVAL, VolatilityType.ShiftedLognormal)
+    swaption.set_bachelier_engine(
+        BachelierSwaptionEngine(lognormal, curve, settings, CashAnnuityModel.SwapRate)
+    )
+    with pytest.raises(ItofinError) as raised:
+        swaption.npv()
+    assert "requires normal input volatility" in str(raised.value)


### PR DESCRIPTION
Wrap the normal/Bachelier spec of the swaption engine template as a
concrete Python class, alongside the existing shifted-lognormal
BlackSwaptionEngine.

**Engine bindings:**
* Added `PyBachelierSwaptionEngine` in swaptionengine.rs with the same
  `new` and `with_flat_vol` constructors as the Black engine; the flat-vol
  `displacement` is kept for signature parity and ignored by the normal
  model.
* Registered the class in the `pricingengines` module.

**Swaption integration:**
* Added `set_bachelier_engine` to the swaption facade so instruments can
  price off a normal-volatility surface.

**Type stubs:**
* Documented the new engine and `set_bachelier_engine` in the
  `pricingengines.pyi` and `instruments.pyi` stubs.

**Tests:**
* Added test_bachelier_swaption.py covering the new bindings.

Closes #616

close #616
