### PR TITLE
docs(itofin): add type annotations to type stub docstrings

### DIFF
--- a/crates/itofin-py/python/itofin/__init__.pyi
+++ b/crates/itofin-py/python/itofin/__init__.pyi
@@ -57,7 +57,7 @@ class Settings:
         observer that recomputes on the update reads the date that triggered it.
 
         Args:
-            date: The new evaluation date. Observers are notified only when this
+            date (time.Date): The new evaluation date. Observers are notified only when this
                 differs from the date already set.
         """
         ...
@@ -68,7 +68,7 @@ class Settings:
         The flag is three-valued, as in the core.
 
         Args:
-            value: True or False decides the question outright; None clears it,
+            value (bool | None): True or False decides the question outright; None clears it,
                 restoring the unset state in which each pricing site applies its
                 own default. The argument is required, so clearing is always
                 deliberate.
@@ -79,7 +79,7 @@ class Settings:
         """Return the current setting, or None while it is unset.
 
         Returns:
-            The three-valued flag last set, or None if it has never been set or
+            bool | None: The three-valued flag last set, or None if it has never been set or
             was cleared.
         """
         ...

--- a/crates/itofin-py/python/itofin/models.pyi
+++ b/crates/itofin-py/python/itofin/models.pyi
@@ -20,7 +20,7 @@ class HestonModel:
         """Seed the model from a process.
 
         Args:
-            process: The process whose five parameters seed the model.
+            process (HestonProcess): The process whose five parameters seed the model.
 
         Raises:
             ItofinError: If a seeded parameter violates its constraint: theta,
@@ -33,7 +33,7 @@ class HestonModel:
         """Return the long-run variance.
 
         Returns:
-            The current value of theta.
+            float: The current value of theta.
         """
         ...
 
@@ -41,7 +41,7 @@ class HestonModel:
         """Return the mean-reversion speed.
 
         Returns:
-            The current value of kappa.
+            float: The current value of kappa.
         """
         ...
 
@@ -49,7 +49,7 @@ class HestonModel:
         """Return the volatility of variance.
 
         Returns:
-            The current value of sigma.
+            float: The current value of sigma.
         """
         ...
 
@@ -57,7 +57,7 @@ class HestonModel:
         """Return the spot/variance correlation.
 
         Returns:
-            The current value of rho.
+            float: The current value of rho.
         """
         ...
 
@@ -65,7 +65,7 @@ class HestonModel:
         """Return the initial variance.
 
         Returns:
-            The current value of v0.
+            float: The current value of v0.
         """
         ...
 
@@ -84,10 +84,10 @@ class HestonModel:
         through the getters afterwards.
 
         Args:
-            helpers: The calibration instruments to fit; must not be empty.
-            method: The optimizer driving the fit.
-            end_criteria: The stopping rule handed to the optimizer.
-            integration_order: The order of the Gauss-Laguerre integration the
+            helpers (list[HestonModelHelper]): The calibration instruments to fit; must not be empty.
+            method (LevenbergMarquardt): The optimizer driving the fit.
+            end_criteria (EndCriteria): The stopping rule handed to the optimizer.
+            integration_order (int): The order of the Gauss-Laguerre integration the
                 engine uses; at most 192.
 
         Raises:
@@ -107,11 +107,11 @@ class HullWhite:
         """Fit the model to a term structure.
 
         Args:
-            curve: The term structure the model fits; its forward rate at 0 is
+            curve (YieldTermStructure): The term structure the model fits; its forward rate at 0 is
                 read at construction.
-            a: The mean-reversion speed, under the Vasicek positivity
+            a (float): The mean-reversion speed, under the Vasicek positivity
                 constraint.
-            sigma: The short-rate volatility, under the same constraint.
+            sigma (float): The short-rate volatility, under the same constraint.
 
         Raises:
             ItofinError: If the curve is empty or a parameter violates its
@@ -123,7 +123,7 @@ class HullWhite:
         """Return the mean-reversion speed.
 
         Returns:
-            The current value of a, read as the first calibrated-model
+            float: The current value of a, read as the first calibrated-model
             parameter.
         """
         ...
@@ -132,7 +132,7 @@ class HullWhite:
         """Return the short-rate volatility.
 
         Returns:
-            The current value of sigma, read as the second calibrated-model
+            float: The current value of sigma, read as the second calibrated-model
             parameter.
         """
         ...
@@ -141,7 +141,7 @@ class HullWhite:
         """Return the fitted initial short rate.
 
         Returns:
-            The short rate r0 implied by the fitted term structure.
+            float: The short rate r0 implied by the fitted term structure.
         """
         ...
 
@@ -151,14 +151,14 @@ class HullWhite:
         """Price a European option on a zero-coupon bond.
 
         Args:
-            option_type: Call or put.
-            strike: The option strike, as a bond price.
-            maturity: The option expiry, as a time in years.
-            bond_maturity: The maturity of the underlying zero-coupon bond, as a
+            option_type (OptionType): Call or put.
+            strike (float): The option strike, as a bond price.
+            maturity (float): The option expiry, as a time in years.
+            bond_maturity (float): The maturity of the underlying zero-coupon bond, as a
                 time in years.
 
         Returns:
-            The option price.
+            float: The option price.
 
         Raises:
             ItofinError: If the fitted curve is not linked or the arguments are
@@ -180,10 +180,10 @@ class HullWhite:
         the optimizer drives.
 
         Args:
-            helpers: The calibration instruments to fit; must not be empty.
-            method: The optimizer driving the fit.
-            end_criteria: The stopping rule handed to the optimizer.
-            fix_reversion: Pin the mean reversion a and free only sigma; when
+            helpers (list[SwaptionHelper]): The calibration instruments to fit; must not be empty.
+            method (LevenbergMarquardt): The optimizer driving the fit.
+            end_criteria (EndCriteria): The stopping rule handed to the optimizer.
+            fix_reversion (bool): Pin the mean reversion a and free only sigma; when
                 False both parameters are free.
 
         Raises:
@@ -215,20 +215,20 @@ class HestonModelHelper:
         """Build the helper from scalar market inputs.
 
         Args:
-            maturity: The option tenor.
-            calendar: The calendar the maturity rolls on.
-            s0: The spot level.
-            strike: The option strike.
-            volatility: The market Black volatility, held as a quote.
-            risk_free_rate: The flat risk-free rate, made into a curve compounded
+            maturity (Period): The option tenor.
+            calendar (Calendar): The calendar the maturity rolls on.
+            s0 (float): The spot level.
+            strike (float): The option strike.
+            volatility (float): The market Black volatility, held as a quote.
+            risk_free_rate (float): The flat risk-free rate, made into a curve compounded
                 continuously on an annual frequency.
-            dividend_yield: The flat dividend yield, made into a curve on the
+            dividend_yield (float): The flat dividend yield, made into a curve on the
                 same convention as the risk-free rate.
-            error_type: How the market and model prices are compared.
-            reference_date: The date the two flat curves are anchored on; it is
+            error_type (CalibrationErrorType): How the market and model prices are compared.
+            reference_date (Date): The date the two flat curves are anchored on; it is
                 used only to assemble them, not forwarded to the core.
-            day_counter: The day count the curves accrue on, used the same way.
-            settings: The evaluation-date store the helper reads.
+            day_counter (DayCounter): The day count the curves accrue on, used the same way.
+            settings (Settings): The evaluation-date store the helper reads.
         """
         ...
 
@@ -239,7 +239,7 @@ class HestonModelHelper:
         helper; the comparison follows the helper's error type.
 
         Returns:
-            The calibration error under the configured error type.
+            float: The calibration error under the configured error type.
 
         Raises:
             ItofinError: If the market or model valuation fails, or the implied
@@ -272,16 +272,16 @@ class SwaptionHelper:
         """Build the helper and the swaption underlying it.
 
         Args:
-            maturity: The option tenor, the time to the swaption expiry.
-            length: The tenor of the underlying swap.
-            volatility: The market volatility, held as a quote.
-            index: The index the floating leg fixes on.
-            fixed_leg_tenor: The payment tenor of the fixed leg.
-            fixed_leg_day_counter: The day count the fixed leg accrues on.
-            floating_leg_day_counter: The day count the floating leg accrues on.
-            curve: The discount curve.
-            error_type: How the market and model prices are compared.
-            nominal: The notional of the underlying swap.
+            maturity (Period): The option tenor, the time to the swaption expiry.
+            length (Period): The tenor of the underlying swap.
+            volatility (float): The market volatility, held as a quote.
+            index (IborIndex): The index the floating leg fixes on.
+            fixed_leg_tenor (Period): The payment tenor of the fixed leg.
+            fixed_leg_day_counter (DayCounter): The day count the fixed leg accrues on.
+            floating_leg_day_counter (DayCounter): The day count the floating leg accrues on.
+            curve (YieldTermStructure): The discount curve.
+            error_type (CalibrationErrorType): How the market and model prices are compared.
+            nominal (float): The notional of the underlying swap.
         """
         ...
 
@@ -292,7 +292,7 @@ class SwaptionHelper:
         helper; the comparison follows the helper's error type.
 
         Returns:
-            The calibration error under the configured error type.
+            float: The calibration error under the configured error type.
 
         Raises:
             ItofinError: If the market or model valuation fails, or the implied

--- a/crates/itofin-py/python/itofin/optimization.pyi
+++ b/crates/itofin-py/python/itofin/optimization.pyi
@@ -18,11 +18,11 @@ class LevenbergMarquardt:
         """Initialize the optimizer; the defaults are QuantLib's.
 
         Args:
-            epsfcn: The finite-difference step seed used when the Jacobian is
+            epsfcn (float): The finite-difference step seed used when the Jacobian is
                 computed by differences.
-            xtol: The tolerance on the independent variable.
-            gtol: The tolerance on the gradient.
-            use_cost_functions_jacobian: Use the cost function's own jacobian
+            xtol (float): The tolerance on the independent variable.
+            gtol (float): The tolerance on the gradient.
+            use_cost_functions_jacobian (bool): Use the cost function's own jacobian
                 method (a central difference, order 2 but costlier) instead of
                 the built-in forward-difference scheme.
         """
@@ -46,16 +46,16 @@ class EndCriteria:
         """Initialize the criteria.
 
         Args:
-            max_iterations: The iteration count at which the run stops.
-            max_stationary_state_iterations: How many consecutive stationary
+            max_iterations (int): The iteration count at which the run stops.
+            max_stationary_state_iterations (int | None): How many consecutive stationary
                 iterations are tolerated before the run is called converged;
                 None defaults to min(max_iterations / 2, 100).
-            root_epsilon: The variation of the independent variable below which
+            root_epsilon (float): The variation of the independent variable below which
                 an iteration counts as stationary.
-            function_epsilon: The variation of the function value below which an
+            function_epsilon (float): The variation of the function value below which an
                 iteration counts as stationary, and, for a cost function known
                 to be positive, the value below which the run has converged.
-            gradient_norm_epsilon: The gradient norm below which the run has
+            gradient_norm_epsilon (float | None): The gradient norm below which the run has
                 converged; None defaults to function_epsilon.
 
         Raises:

--- a/crates/itofin-py/python/itofin/processes.pyi
+++ b/crates/itofin-py/python/itofin/processes.pyi
@@ -25,14 +25,14 @@ class BlackScholesProcess:
         """Build a flat-market process from scalar inputs.
 
         Args:
-            spot: The spot level, held as a quote.
-            risk_free_rate: The flat risk-free rate, made into a curve
+            spot (float): The spot level, held as a quote.
+            risk_free_rate (float): The flat risk-free rate, made into a curve
                 compounded continuously on an annual frequency.
-            dividend_yield: The flat dividend yield, made into a curve on the
+            dividend_yield (float): The flat dividend yield, made into a curve on the
                 same convention as the risk-free rate.
-            volatility: The flat Black volatility.
-            reference_date: The date the three flat curves are anchored on.
-            day_counter: The day count the curves accrue on.
+            volatility (float): The flat Black volatility.
+            reference_date (Date): The date the three flat curves are anchored on.
+            day_counter (DayCounter): The day count the curves accrue on.
         """
         ...
 
@@ -50,13 +50,13 @@ class BlackScholesProcess:
         scalar constructor guards against.
 
         Args:
-            spot: The spot level, held as a quote.
-            risk_free: The risk-free discount curve.
-            dividend: The dividend curve.
-            vol: The Black volatility surface.
+            spot (float): The spot level, held as a quote.
+            risk_free (YieldTermStructure): The risk-free discount curve.
+            dividend (YieldTermStructure): The dividend curve.
+            vol (BlackVolTermStructure): The Black volatility surface.
 
         Returns:
-            A process over the three supplied term structures.
+            BlackScholesProcess: A process over the three supplied term structures.
         """
         ...
 
@@ -64,7 +64,7 @@ class BlackScholesProcess:
         """Return the risk-free rate carried by the process.
 
         Returns:
-            The continuously compounded zero rate on the risk-free curve at the
+            float: The continuously compounded zero rate on the risk-free curve at the
             reference date.
         """
         ...
@@ -73,7 +73,7 @@ class BlackScholesProcess:
         """Return the dividend yield carried by the process.
 
         Returns:
-            The continuously compounded zero rate on the dividend curve at the
+            float: The continuously compounded zero rate on the dividend curve at the
             reference date.
         """
         ...
@@ -101,18 +101,18 @@ class HestonProcess:
         """Build the process from scalar market inputs and the five parameters.
 
         Args:
-            risk_free_rate: The flat risk-free rate, made into a curve
+            risk_free_rate (float): The flat risk-free rate, made into a curve
                 compounded continuously on an annual frequency.
-            dividend_yield: The flat dividend yield, made into a curve on the
+            dividend_yield (float): The flat dividend yield, made into a curve on the
                 same convention as the risk-free rate.
-            spot: The spot level, held as a quote.
-            v0: The initial variance.
-            kappa: The mean-reversion speed.
-            theta: The long-run variance.
-            sigma: The volatility of variance.
-            rho: The spot/variance correlation.
-            reference_date: The date the two flat curves are anchored on.
-            day_counter: The day count the curves accrue on.
+            spot (float): The spot level, held as a quote.
+            v0 (float): The initial variance.
+            kappa (float): The mean-reversion speed.
+            theta (float): The long-run variance.
+            sigma (float): The volatility of variance.
+            rho (float): The spot/variance correlation.
+            reference_date (Date): The date the two flat curves are anchored on.
+            day_counter (DayCounter): The day count the curves accrue on.
         """
         ...
 
@@ -120,7 +120,7 @@ class HestonProcess:
         """Return the initial variance.
 
         Returns:
-            The initial variance v0.
+            float: The initial variance v0.
         """
         ...
 
@@ -128,7 +128,7 @@ class HestonProcess:
         """Return the mean-reversion speed.
 
         Returns:
-            The mean-reversion speed kappa.
+            float: The mean-reversion speed kappa.
         """
         ...
 
@@ -136,7 +136,7 @@ class HestonProcess:
         """Return the long-run variance.
 
         Returns:
-            The long-run variance theta.
+            float: The long-run variance theta.
         """
         ...
 
@@ -144,7 +144,7 @@ class HestonProcess:
         """Return the volatility of variance.
 
         Returns:
-            The volatility of variance sigma.
+            float: The volatility of variance sigma.
         """
         ...
 
@@ -152,6 +152,6 @@ class HestonProcess:
         """Return the spot/variance correlation.
 
         Returns:
-            The spot/variance correlation rho.
+            float: The spot/variance correlation rho.
         """
         ...

--- a/crates/itofin-py/python/itofin/quotes.pyi
+++ b/crates/itofin-py/python/itofin/quotes.pyi
@@ -11,7 +11,7 @@ class SimpleQuote:
         """Initialize the quote.
 
         Args:
-            value: The initial market value.
+            value (float): The initial market value.
         """
         ...
 
@@ -19,7 +19,7 @@ class SimpleQuote:
         """Return the current value.
 
         Returns:
-            The quote's current market value.
+            float: The quote's current market value.
         """
         ...
 
@@ -27,7 +27,7 @@ class SimpleQuote:
         """Set a new value and notify observers.
 
         Args:
-            value: The new value; observers are notified when it actually
+            value (float): The new value; observers are notified when it actually
                 changes, so dependent valuations recompute on next access.
         """
         ...

--- a/crates/itofin-py/python/itofin/time.pyi
+++ b/crates/itofin-py/python/itofin/time.pyi
@@ -9,12 +9,12 @@ def is_imm_date(date: Date, main_cycle: bool = False) -> bool:
     September or December only when main_cycle is set.
 
     Args:
-        date: The date to test.
-        main_cycle: Restrict the test to the March/June/September/December
+        date (Date): The date to test.
+        main_cycle (bool): Restrict the test to the March/June/September/December
             cycle.
 
     Returns:
-        True when date is an IMM date under the selected cycle.
+        bool: True when date is an IMM date under the selected cycle.
     """
     ...
 
@@ -22,12 +22,12 @@ def next_imm_date(date: Date, main_cycle: bool = False) -> Date:
     """The next IMM date strictly following date.
 
     Args:
-        date: The date to start from; the result is strictly after it.
-        main_cycle: Restrict the result to the March/June/September/December
+        date (Date): The date to start from; the result is strictly after it.
+        main_cycle (bool): Restrict the result to the March/June/September/December
             cycle.
 
     Returns:
-        The next IMM date under the selected cycle.
+        Date: The next IMM date under the selected cycle.
     """
     ...
 
@@ -42,9 +42,9 @@ class Date:
         """Build a date from its three components.
 
         Args:
-            day: The day of the month, within the length of that month.
-            month: The month, from 1 to 12.
-            year: The year, from 1901 to 2199.
+            day (int): The day of the month, within the length of that month.
+            month (int): The month, from 1 to 12.
+            year (int): The year, from 1901 to 2199.
 
         Raises:
             ItofinError: If month is outside [1, 12], year is outside
@@ -71,10 +71,10 @@ class Date:
         """Shift the date forward by a number of calendar days.
 
         Args:
-            days: The number of calendar days to add.
+            days (int): The number of calendar days to add.
 
         Returns:
-            The shifted date.
+            Date: The shifted date.
 
         Raises:
             ItofinError: If the result falls outside the representable date
@@ -87,10 +87,10 @@ class Date:
         """Shift the date back by a number of calendar days.
 
         Args:
-            days: The number of calendar days to subtract.
+            days (int): The number of calendar days to subtract.
 
         Returns:
-            The shifted date.
+            Date: The shifted date.
 
         Raises:
             ItofinError: If the result falls outside the representable date
@@ -103,10 +103,10 @@ class Date:
         """The signed number of days from other to this date.
 
         Args:
-            other: The date to measure from.
+            other (Date): The date to measure from.
 
         Returns:
-            The signed day count between the two dates.
+            int: The signed day count between the two dates.
         """
         ...
 
@@ -114,10 +114,10 @@ class Date:
         """Whether the two dates are the same calendar day.
 
         Args:
-            other: The date to compare against.
+            other (object): The date to compare against.
 
         Returns:
-            True when both stand for the same day.
+            bool: True when both stand for the same day.
         """
         ...
 
@@ -125,7 +125,7 @@ class Date:
         """Return the constructor form of the date.
 
         Returns:
-            The date as Date(day, month, year).
+            str: The date as Date(day, month, year).
         """
         ...
 
@@ -136,8 +136,8 @@ class Period:
         """Build a period of n units.
 
         Args:
-            n: The length, which may be negative.
-            unit: One of "Days", "Weeks", "Months", "Years".
+            n (int): The length, which may be negative.
+            unit (str): One of "Days", "Weeks", "Months", "Years".
 
         Raises:
             ItofinError: If unit is not one of the four accepted strings.
@@ -149,10 +149,10 @@ class Period:
         while an undecidable pair such as 30 Days against 1 Month is not equal.
 
         Args:
-            other: The period to compare against.
+            other (object): The period to compare against.
 
         Returns:
-            True when the two lengths are decidably the same.
+            bool: True when the two lengths are decidably the same.
         """
         ...
 
@@ -163,7 +163,7 @@ class Period:
         every zero length onto 0 Days before the hash is taken.
 
         Returns:
-            The hash of the normalized length and unit.
+            int: The hash of the normalized length and unit.
         """
         ...
 
@@ -171,7 +171,7 @@ class Period:
         """Return the constructor form of the period.
 
         Returns:
-            The period as Period(length, unit).
+            str: The period as Period(length, unit).
         """
         ...
 
@@ -183,7 +183,7 @@ class Calendar:
         """The TARGET calendar.
 
         Returns:
-            The TARGET business-day calendar.
+            Calendar: The TARGET business-day calendar.
         """
         ...
 
@@ -192,7 +192,7 @@ class Calendar:
         """The calendar holding no holidays at all.
 
         Returns:
-            The null calendar, on which every day is a business day.
+            Calendar: The null calendar, on which every day is a business day.
         """
         ...
 
@@ -205,7 +205,7 @@ class Calendar:
         all, nor by a national calendar, which adds public holidays.
 
         Returns:
-            The weekends-only calendar.
+            Calendar: The weekends-only calendar.
         """
         ...
 
@@ -216,7 +216,7 @@ class Calendar:
         the core and differ solely in their name.
 
         Returns:
-            The UK settlement calendar.
+            Calendar: The UK settlement calendar.
         """
         ...
 
@@ -224,11 +224,11 @@ class Calendar:
         """Roll a date to the nearest business day.
 
         Args:
-            date: The date to roll.
-            convention: The rolling rule to apply.
+            date (Date): The date to roll.
+            convention (BusinessDayConvention): The rolling rule to apply.
 
         Returns:
-            The adjusted date, unchanged when it is already a business day.
+            Date: The adjusted date, unchanged when it is already a business day.
         """
         ...
 
@@ -243,15 +243,15 @@ class Calendar:
         """Advance a date by n units and adjust the result.
 
         Args:
-            date: The date to advance from.
-            n: The number of units to advance, which may be negative.
-            unit: One of "Days", "Weeks", "Months", "Years".
-            convention: The rule the advanced date is rolled under.
-            end_of_month: Keep the result on the month end when the starting
+            date (Date): The date to advance from.
+            n (int): The number of units to advance, which may be negative.
+            unit (str): One of "Days", "Weeks", "Months", "Years".
+            convention (BusinessDayConvention): The rule the advanced date is rolled under.
+            end_of_month (bool): Keep the result on the month end when the starting
                 date is one.
 
         Returns:
-            The advanced and adjusted date.
+            Date: The advanced and adjusted date.
 
         Raises:
             ItofinError: If unit is not one of the four accepted strings.
@@ -262,7 +262,7 @@ class Calendar:
         """Return the calendar and its name.
 
         Returns:
-            The calendar as Calendar(name).
+            str: The calendar as Calendar(name).
         """
         ...
 
@@ -274,7 +274,7 @@ class DayCounter:
         """The Actual/360 convention.
 
         Returns:
-            An Actual/360 day counter.
+            DayCounter: An Actual/360 day counter.
         """
         ...
 
@@ -283,7 +283,7 @@ class DayCounter:
         """The Actual/365 (Fixed) convention.
 
         Returns:
-            An Actual/365 (Fixed) day counter.
+            DayCounter: An Actual/365 (Fixed) day counter.
         """
         ...
 
@@ -292,7 +292,7 @@ class DayCounter:
         """The Actual/Actual (ISDA) convention.
 
         Returns:
-            An Actual/Actual day counter on the ISDA convention.
+            DayCounter: An Actual/Actual day counter on the ISDA convention.
         """
         ...
 
@@ -301,7 +301,7 @@ class DayCounter:
         """The 30/360 (Bond Basis) convention.
 
         Returns:
-            A 30/360 day counter on the bond-basis convention.
+            DayCounter: A 30/360 day counter on the bond-basis convention.
         """
         ...
 
@@ -309,11 +309,11 @@ class DayCounter:
         """The period [d1, d2] as a fraction of a year under this convention.
 
         Args:
-            d1: The start of the period.
-            d2: The end of the period.
+            d1 (Date): The start of the period.
+            d2 (Date): The end of the period.
 
         Returns:
-            The year fraction between the two dates.
+            float: The year fraction between the two dates.
         """
         ...
 
@@ -322,10 +322,10 @@ class DayCounter:
         are equal.
 
         Args:
-            other: The day counter to compare against.
+            other (object): The day counter to compare against.
 
         Returns:
-            True when both carry the same convention name.
+            bool: True when both carry the same convention name.
         """
         ...
 
@@ -333,7 +333,7 @@ class DayCounter:
         """Hashes the convention name, the field equality compares.
 
         Returns:
-            The hash of the convention name, so equal day counters hash equal.
+            int: The hash of the convention name, so equal day counters hash equal.
         """
         ...
 
@@ -341,7 +341,7 @@ class DayCounter:
         """Return the day counter and its convention name.
 
         Returns:
-            The day counter as DayCounter(name).
+            str: The day counter as DayCounter(name).
         """
         ...
 
@@ -410,13 +410,13 @@ class Schedule:
         """Build the schedule.
 
         Args:
-            start: The effective date, which must be strictly before end.
-            end: The termination date.
-            frequency: The coupon frequency the interior dates are spaced at.
-            calendar: The calendar the dates roll on.
-            convention: The rule every date but the last is rolled under.
-            rule: The date-generation rule; defaults to Forward.
-            termination_convention: The rule the last date is rolled under;
+            start (Date): The effective date, which must be strictly before end.
+            end (Date): The termination date.
+            frequency (Frequency): The coupon frequency the interior dates are spaced at.
+            calendar (Calendar): The calendar the dates roll on.
+            convention (BusinessDayConvention): The rule every date but the last is rolled under.
+            rule (DateGeneration): The date-generation rule; defaults to Forward.
+            termination_convention (BusinessDayConvention | None): The rule the last date is rolled under;
                 None applies convention to it as well.
 
         Raises:
@@ -428,7 +428,7 @@ class Schedule:
         """The number of dates in the schedule.
 
         Returns:
-            The date count, one more than the number of periods.
+            int: The date count, one more than the number of periods.
         """
         ...
 
@@ -436,10 +436,10 @@ class Schedule:
         """The i-th date in the schedule.
 
         Args:
-            i: The zero-based index into the dates.
+            i (int): The zero-based index into the dates.
 
         Returns:
-            The date at that index.
+            Date: The date at that index.
 
         Raises:
             ItofinError: If i is out of range.
@@ -450,6 +450,6 @@ class Schedule:
         """All the schedule dates.
 
         Returns:
-            The dates in order, from the effective date to the termination date.
+            list[Date]: The dates in order, from the effective date to the termination date.
         """
         ...


### PR DESCRIPTION
Annotate every Args and Returns entry in the `.pyi` type stubs with its
type, so the documented signatures state the parameter and return types
directly alongside their descriptions.

Closes #891
