### PR TITLE
docs(crates): expand docstrings for index type stubs

### DIFF
--- a/crates/itofin-py/python/itofin/cashflows.pyi
+++ b/crates/itofin-py/python/itofin/cashflows.pyi
@@ -23,30 +23,130 @@ class YoYInflationCoupon:
     """
 
     def rate(self) -> float:
-        """The geared index fixing plus the spread; needs a pricer."""
+        """Return the rate the coupon accrues at: the geared index fixing plus the spread.
+
+        Returns:
+            float: The pricer's swaplet rate.
+
+        Raises:
+            ItofinError: If no pricer is attached, or resolving the fixing
+                fails - a missing history entry, or a forecast off an index with
+                no curve linked.
+        """
         ...
     def amount(self) -> float:
-        """rate() * accrual_period() * nominal()."""
+        """Return what the coupon pays on its payment date, undiscounted.
+
+        Returns:
+            float: rate() * accrual_period() * nominal().
+
+        Raises:
+            ItofinError: As rate().
+        """
         ...
     def fixing_date(self) -> Date:
-        """The observation publication date, not where the rate resolves."""
+        """Return the date the observation is published on.
+
+        The reference-period end moved back by the observation lag, then back
+        the fixing days. This is not the date the rate resolves at: an inflation
+        index has no fixing calendar, so with no fixing days the roll is inert.
+
+        Returns:
+            Date: The publication date.
+        """
         ...
     def index_fixing(self) -> float:
-        """The year-on-year rate observed, lagged off the accrual end."""
+        """Return the year-on-year rate observed, before gearing and spread.
+
+        It lags off accrual_end_date(), not off fixing_date(): a year-on-year
+        coupon overrides the base rule that reads the index at its fixing date.
+
+        Returns:
+            float: The observed rate.
+
+        Raises:
+            ItofinError: As rate(), bar the missing pricer.
+        """
         ...
-    def nominal(self) -> float: ...
-    def accrual_start_date(self) -> Date: ...
-    def accrual_end_date(self) -> Date: ...
-    def accrual_period(self) -> float: ...
+    def nominal(self) -> float:
+        """Return the nominal the coupon accrues on.
+
+        Returns:
+            float: The nominal.
+        """
+        ...
+    def accrual_start_date(self) -> Date:
+        """Return the start of the accrual period.
+
+        Returns:
+            Date: The accrual start.
+        """
+        ...
+    def accrual_end_date(self) -> Date:
+        """Return the end of the accrual period, which is also where the observation lags from.
+
+        Returns:
+            Date: The accrual end.
+        """
+        ...
+    def accrual_period(self) -> float:
+        """Return the whole accrual period as a fraction of a year.
+
+        Measured with day_counter() over the reference period.
+
+        Returns:
+            float: The year fraction.
+        """
+        ...
     def date(self) -> Date:
-        """The payment date."""
+        """Return the payment date: the accrual end rolled on the leg's payment calendar.
+
+        Returns:
+            Date: The payment date.
+        """
         ...
-    def day_counter(self) -> DayCounter: ...
-    def gearing(self) -> float: ...
-    def spread(self) -> float: ...
-    def observation_lag(self) -> Period: ...
-    def interpolation(self) -> CpiInterpolationType: ...
-    def fixing_days(self) -> int: ...
+    def day_counter(self) -> DayCounter:
+        """Return the day counter the accrual is measured with.
+
+        Returns:
+            DayCounter: The coupon day count.
+        """
+        ...
+    def gearing(self) -> float:
+        """Return the multiplicative coefficient applied to the index fixing.
+
+        Returns:
+            float: The gearing.
+        """
+        ...
+    def spread(self) -> float:
+        """Return the spread paid over the geared fixing.
+
+        Returns:
+            float: The spread.
+        """
+        ...
+    def observation_lag(self) -> Period:
+        """Return how far back the coupon observes the index.
+
+        Returns:
+            Period: The observation lag.
+        """
+        ...
+    def interpolation(self) -> CpiInterpolationType:
+        """Return how the observation interpolates between index fixings.
+
+        Returns:
+            CpiInterpolationType: Flat or Linear.
+        """
+        ...
+    def fixing_days(self) -> int:
+        """Return the number of business days the fixing date rolls back by.
+
+        Returns:
+            int: The fixing days.
+        """
+        ...
 
 class YoYInflationOptionletCouponPricer:
     """Values a capped or floored year-on-year coupon's optionlets off a
@@ -62,17 +162,56 @@ class YoYInflationOptionletCouponPricer:
     def black(
         volatility: ConstantYoYOptionletVolatility,
         nominal_ts: YieldTermStructure | None = None,
-    ) -> YoYInflationOptionletCouponPricer: ...
+    ) -> YoYInflationOptionletCouponPricer:
+        """Build a pricer valuing optionlets under the lognormal model.
+
+        Args:
+            volatility (ConstantYoYOptionletVolatility): The surface optionlet
+                volatilities are read off.
+            nominal_ts (YieldTermStructure | None): The discount curve; only the
+                discounted price path reads it.
+
+        Returns:
+            YoYInflationOptionletCouponPricer: The lognormal pricer.
+        """
+        ...
     @staticmethod
     def unit_displaced(
         volatility: ConstantYoYOptionletVolatility,
         nominal_ts: YieldTermStructure | None = None,
-    ) -> YoYInflationOptionletCouponPricer: ...
+    ) -> YoYInflationOptionletCouponPricer:
+        """Build a pricer valuing optionlets under the unit-displaced lognormal model.
+
+        Lognormal in 1 + rate, the usual quoting convention for an inflation
+        rate that may go negative.
+
+        Args:
+            volatility (ConstantYoYOptionletVolatility): The surface optionlet
+                volatilities are read off.
+            nominal_ts (YieldTermStructure | None): The discount curve; only the
+                discounted price path reads it.
+
+        Returns:
+            YoYInflationOptionletCouponPricer: The unit-displaced pricer.
+        """
+        ...
     @staticmethod
     def bachelier(
         volatility: ConstantYoYOptionletVolatility,
         nominal_ts: YieldTermStructure | None = None,
-    ) -> YoYInflationOptionletCouponPricer: ...
+    ) -> YoYInflationOptionletCouponPricer:
+        """Build a pricer valuing optionlets under the normal model.
+
+        Args:
+            volatility (ConstantYoYOptionletVolatility): The surface optionlet
+                volatilities are read off.
+            nominal_ts (YieldTermStructure | None): The discount curve; only the
+                discounted price path reads it.
+
+        Returns:
+            YoYInflationOptionletCouponPricer: The normal pricer.
+        """
+        ...
 
 class CappedFlooredYoYInflationCoupon:
     """A year-on-year inflation coupon with a cap and/or floor on its rate.
@@ -83,22 +222,77 @@ class CappedFlooredYoYInflationCoupon:
     """
 
     def rate(self) -> float:
-        """The swaplet rate plus the floorlet, less the caplet."""
+        """Return the rate the coupon accrues at.
+
+        The underlying's swaplet rate plus the floorlet, less the caplet.
+
+        Returns:
+            float: The capped and floored rate.
+
+        Raises:
+            ItofinError: If no pricer is attached, if resolving the fixing
+                fails, or if the surface refuses the volatility - a strike
+                outside its domain, or an observation before its base date.
+        """
         ...
     def amount(self) -> float:
-        """rate() * accrual_period() * nominal()."""
+        """Return what the coupon pays on its payment date, undiscounted.
+
+        Returns:
+            float: rate() * accrual_period() * nominal().
+
+        Raises:
+            ItofinError: As rate().
+        """
         ...
-    def is_capped(self) -> bool: ...
-    def is_floored(self) -> bool: ...
+    def is_capped(self) -> bool:
+        """Return whether a cap applies.
+
+        Returns:
+            bool: True if the stored cap level is set.
+        """
+        ...
+    def is_floored(self) -> bool:
+        """Return whether a floor applies.
+
+        Returns:
+            bool: True if the stored floor level is set.
+        """
+        ...
     def effective_cap(self) -> float:
-        """(cap - spread) / gearing, the strike the caplet is struck at."""
+        """Return the de-spread, de-geared cap the caplet is struck at.
+
+        Read off the stored level, so a negative gearing has already swapped the
+        two roles.
+
+        Returns:
+            float: (cap - spread) / gearing.
+        """
         ...
     def effective_floor(self) -> float:
-        """(floor - spread) / gearing, the strike the floorlet is struck at."""
+        """Return the de-spread, de-geared floor the floorlet is struck at.
+
+        Read off the stored level, so a negative gearing has already swapped the
+        two roles.
+
+        Returns:
+            float: (floor - spread) / gearing.
+        """
         ...
 
 class YoYInflationLeg:
-    """Builds a sequence of year-on-year inflation coupons from a schedule."""
+    """Builds a sequence of year-on-year inflation coupons from a schedule.
+
+    The core builder is a consumed-self fluent chain, which does not cross the
+    FFI boundary; this facade takes the whole configuration up front and
+    assembles the chain inside coupons(). An unset optional leaves the core
+    default in place: a ModifiedFollowing payment roll, no fixing days, a unit
+    gearing and no spread.
+
+    The caps and floors lists select which of the two coupon types the leg
+    produces: given either, coupons() hands back coupons the core deliberately
+    leaves unpriced and capped_floored_coupons is the intended entry.
+    """
 
     def __init__(
         self,
@@ -118,24 +312,79 @@ class YoYInflationLeg:
         spreads: list[float] | None = None,
         caps: list[float] | None = None,
         floors: list[float] | None = None,
-    ) -> None: ...
-    def coupons(self) -> list[YoYInflationCoupon]:
-        """The coupons, each carrying the default swaplet pricer.
+    ) -> None:
+        """Configure a leg over schedule paying index, observed observation_lag back.
 
-        Rebuilt on every call, so bind the list once rather than calling this
-        per read. Given caps or floors the coupons come back unpriced, and
-        capped_floored_coupons is the intended entry.
+        payment_day_counter is required here although the core takes it through
+        a setter, so a missing one is a build-time error rather than one raised
+        from coupons(). A notional is just as required by the core but stays
+        optional, since the per-coupon notionals list is the other way to supply
+        it; giving neither surfaces that error from coupons().
+
+        Args:
+            schedule (Schedule): The accrual schedule, one coupon per period.
+            payment_calendar (Calendar): The calendar payment dates roll on.
+            index (YoYInflationIndex): The index the coupons observe.
+            observation_lag (Period): How far back each coupon observes it.
+            interpolation (CpiInterpolationType): How the observation
+                interpolates between index fixings.
+            payment_day_counter (DayCounter): The day count the accruals are
+                measured with.
+            notional (float | None): One nominal for every coupon.
+            notionals (list[float] | None): A per-coupon nominal, the
+                alternative to notional.
+            payment_adjustment (BusinessDayConvention | None): The payment roll;
+                the core default is ModifiedFollowing.
+            fixing_days (int | None): The business days the fixing date rolls
+                back by; the core default is none.
+            gearing (float | None): One gearing for every coupon; the core
+                default is unit.
+            gearings (list[float] | None): A per-coupon gearing.
+            spread (float | None): One spread for every coupon; the core default
+                is none.
+            spreads (list[float] | None): A per-coupon spread.
+            caps (list[float] | None): A per-coupon cap level; given either
+                list, capped_floored_coupons is the intended entry.
+            floors (list[float] | None): A per-coupon floor level.
+        """
+        ...
+    def coupons(self) -> list[YoYInflationCoupon]:
+        """Return the coupons, each carrying the default swaplet pricer.
+
+        Every call rebuilds the leg, so the coupons handed back are fresh
+        objects each time: bind the list once rather than calling this per read,
+        or two reads compare different objects. Given caps or floors the coupons
+        come back unpriced, and capped_floored_coupons is the intended entry.
+
+        Returns:
+            list[YoYInflationCoupon]: The freshly built coupons.
+
+        Raises:
+            ItofinError: If the leg has no notional, the schedule holds fewer
+                than two dates, or there are more notionals, gearings or spreads
+                than the schedule has periods.
         """
         ...
     def capped_floored_coupons(
         self, pricer: YoYInflationOptionletCouponPricer
     ) -> list[CappedFlooredYoYInflationCoupon]:
-        """The coupons wrapped in the leg's per-coupon caps and floors, each
-        carrying pricer.
+        """Return the coupons wrapped in the leg's caps and floors, each carrying pricer.
 
-        The pricer is required: a capped leg withholds the core's default
-        swaplet pricer, and that pricer could not value the optionlets anyway.
-        Rebuilt on every call, as coupons() is.
+        The pricer is required rather than optional: the core withholds its
+        default swaplet pricer from a capped leg, and a swaplet pricer could not
+        value the optionlets anyway. One pricer is installed across every
+        coupon. Rebuilt on every call, as coupons() is.
+
+        Args:
+            pricer (YoYInflationOptionletCouponPricer): The pricer installed
+                across every coupon.
+
+        Returns:
+            list[CappedFlooredYoYInflationCoupon]: The freshly built coupons.
+
+        Raises:
+            ItofinError: As coupons(), plus more caps or floors than the
+                schedule has periods, and a cap sitting below its floor.
         """
         ...
 
@@ -154,17 +403,76 @@ class IborLeg:
     constructor.
     """
 
-    def __init__(self, schedule: Schedule, index: IborIndex) -> None: ...
-    def with_notional(self, notional: float) -> IborLeg:
-        """Required: a leg with no notional raises from coupon_count()."""
+    def __init__(self, schedule: Schedule, index: IborIndex) -> None:
+        """Configure a leg over schedule paying index, on the schedule's own calendar.
+
+        Args:
+            schedule (Schedule): The accrual schedule, one coupon per period.
+            index (IborIndex): The index the floating coupons fix off.
+        """
         ...
-    def with_payment_day_counter(self, day_counter: DayCounter) -> IborLeg: ...
+    def with_notional(self, notional: float) -> IborLeg:
+        """Return the leg with notional on every coupon.
+
+        Required: a leg built without one reports "no notional given" from
+        coupon_count().
+
+        Args:
+            notional (float): The nominal every coupon accrues on.
+
+        Returns:
+            IborLeg: A new leg carrying the notional.
+        """
+        ...
+    def with_payment_day_counter(self, day_counter: DayCounter) -> IborLeg:
+        """Return the leg accruing with day_counter, overriding the index's.
+
+        Args:
+            day_counter (DayCounter): The day count the accruals are measured
+                with.
+
+        Returns:
+            IborLeg: A new leg carrying the day counter.
+        """
+        ...
     def with_payment_adjustment(
         self, convention: BusinessDayConvention
-    ) -> IborLeg: ...
-    def with_fixing_days(self, fixing_days: int) -> IborLeg: ...
+    ) -> IborLeg:
+        """Return the leg rolling its payment dates with convention.
+
+        Args:
+            convention (BusinessDayConvention): The payment roll, overriding the
+                core default of Following.
+
+        Returns:
+            IborLeg: A new leg carrying the convention.
+        """
+        ...
+    def with_fixing_days(self, fixing_days: int) -> IborLeg:
+        """Return the leg fixing fixing_days business days before each accrual start.
+
+        Overrides the index's own count.
+
+        Args:
+            fixing_days (int): The business days each coupon fixes ahead of its
+                accrual start.
+
+        Returns:
+            IborLeg: A new leg carrying the fixing days.
+        """
+        ...
     def coupon_count(self) -> int:
-        """The number of coupons a construction would produce, one per schedule
-        period. Raises ItofinError with no notional set, or on a schedule
-        holding fewer than two dates."""
+        """Return the number of coupons the leg builds, one per schedule period.
+
+        The leg is rebuilt on every call, here and in the cap/floor
+        constructors, so this counts the coupons a construction would produce
+        rather than a stored list.
+
+        Returns:
+            int: The coupon count.
+
+        Raises:
+            ItofinError: If the leg has no notional, the schedule holds fewer
+                than two dates, or a coupon's own preconditions reject.
+        """
         ...

--- a/crates/itofin-py/python/itofin/indexes.pyi
+++ b/crates/itofin-py/python/itofin/indexes.pyi
@@ -472,10 +472,13 @@ class SwapIndex:
         ...
 
 class CpiInterpolationType:
-    """How a CPI observation interpolates between the index fixings bracketing
-    it. Flat reads the fixing of the lagged period outright; Linear advances
-    from it to the next period's fixing by how far the observation date has run
-    into its own period."""
+    """How a CPI observation interpolates between the index fixings bracketing it.
+
+    Flat reads the fixing of the lagged period outright; Linear advances from it
+    to the next period's fixing by how far the observation date has run into its
+    own period. The core's deprecated AsIndex variant is not ported and so has
+    no counterpart here.
+    """
 
     Flat: CpiInterpolationType
     Linear: CpiInterpolationType
@@ -487,52 +490,135 @@ class ZeroInflationIndex:
     The curve is reached through a relinkable handle the index owns, so an
     index can be built before the curve it forecasts off exists. The handle
     starts empty and a forecast before any link raises ItofinError; link_to
-    fills it."""
+    fills it.
+    """
 
     @staticmethod
     def uk_rpi(settings: Settings) -> ZeroInflationIndex:
-        """The UK Retail Price Index: monthly, one-month availability lag."""
+        """Return the UK Retail Price Index: monthly, one-month availability lag.
+
+        Args:
+            settings (Settings): The explicit settings supplying the evaluation
+                date and the stored fixings.
+
+        Returns:
+            ZeroInflationIndex: The "UK RPI" index, over an empty curve handle.
+        """
         ...
     @staticmethod
     def uk_hicp(settings: Settings) -> ZeroInflationIndex:
-        """The UK harmonised index of consumer prices."""
+        """Return the UK harmonised index of consumer prices.
+
+        Args:
+            settings (Settings): The explicit settings supplying the evaluation
+                date and the stored fixings.
+
+        Returns:
+            ZeroInflationIndex: The UK HICP index, over an empty curve handle.
+        """
         ...
     @staticmethod
     def eu_hicp(settings: Settings) -> ZeroInflationIndex:
-        """The euro-area harmonised index of consumer prices."""
+        """Return the euro-area harmonised index of consumer prices.
+
+        Args:
+            settings (Settings): The explicit settings supplying the evaluation
+                date and the stored fixings.
+
+        Returns:
+            ZeroInflationIndex: The EU HICP index, over an empty curve handle.
+        """
         ...
-    def name(self) -> str: ...
+    def name(self) -> str:
+        """Return the index name, under which fixings are stored.
+
+        Returns:
+            str: The name, e.g. "UK RPI".
+        """
+        ...
     def add_fixing(self, fixing_date: Date, value: float) -> None:
-        """Records a published figure across the whole inflation period it
-        describes, so a later read on any day inside that period finds it."""
+        """Record a published figure across the whole inflation period.
+
+        The figure is stored on every date of the period fixing_date falls in,
+        so a later read on any day inside that period finds it.
+
+        Args:
+            fixing_date (Date): Any date inside the inflation period the figure
+                describes.
+            value (float): The published index level.
+
+        Raises:
+            ItofinError: If the index frequency has no expressible inflation
+                period, or a different figure is already stored on a date in
+                that period.
+        """
         ...
     def fixing(self, fixing_date: Date, forecast_todays_fixing: bool = False) -> float:
-        """The fixing at fixing_date, stored or forecast off the linked curve.
+        """Return the fixing at fixing_date, stored or forecast off the linked curve.
 
-        forecast_todays_fixing is accepted and ignored, as in the core:
-        needs_forecast alone decides between history and forecast. A date the
-        store should cover but does not is an error, and a forecast with no
-        curve linked raises the empty-handle error."""
+        Args:
+            fixing_date (Date): The date the level is read or forecast for.
+            forecast_todays_fixing (bool): Accepted and ignored, as in the core:
+                needs_forecast alone decides between history and forecast.
+
+        Returns:
+            float: The index level.
+
+        Raises:
+            ItofinError: If a date the store should cover has no figure, or a
+                forecast is asked for with no curve linked.
+        """
         ...
     def last_fixing_date(self) -> Date:
-        """The first day of the inflation period the latest stored figure
-        describes. Raises ItofinError on an index with no history."""
+        """Return the first day of the period the latest stored figure describes.
+
+        Returns:
+            Date: The start of that inflation period.
+
+        Raises:
+            ItofinError: If the index has no fixing history.
+        """
         ...
     def link_to(self, curve: ZeroInflationTermStructure) -> None:
-        """Points the index at curve, so every forecast from here on compounds
-        off it.
+        """Point the index at curve, so every forecast from here on compounds off it.
 
         Takes the ZeroInflationTermStructure base, so any subclass links. It is
         the curve behind that facade's handle at call time that is stored, not
         the handle itself: relinking the facade afterwards leaves this index on
-        the curve it was given, and a later link_to is how it moves."""
+        the curve it was given, and a later link_to is how it moves.
+
+        Args:
+            curve (ZeroInflationTermStructure): The curve forecasts compound
+                off.
+
+        Raises:
+            ItofinError: If curve somehow carries no link.
+        """
         ...
     def needs_forecast(self, fixing_date: Date) -> bool:
-        """Whether fixing_date has to be forecast rather than read from
-        history, decided against the latest period that could have been
-        published by the settings' evaluation date."""
+        """Return whether fixing_date has to be forecast rather than read from history.
+
+        Decided against the latest period that could have been published by the
+        settings' evaluation date.
+
+        Args:
+            fixing_date (Date): The date in question.
+
+        Returns:
+            bool: True if the date has to be forecast off the curve.
+
+        Raises:
+            ItofinError: If the evaluation date is unset, or the index frequency
+                has no expressible inflation period.
+        """
         ...
-    def __repr__(self) -> str: ...
+    def __repr__(self) -> str:
+        """Return the printable representation.
+
+        Returns:
+            str: A string of the form ZeroInflationIndex(UK RPI).
+        """
+        ...
 
 class YoYInflationIndex:
     """An index publishing one year-on-year inflation rate per period, read
@@ -549,7 +635,8 @@ class YoYInflationIndex:
 
     The quoted constructor spells its region and currency out as their component
     fields: neither core type has a Python facade, and defaulting the currency
-    metadata would put made-up values on the index."""
+    metadata would put made-up values on the index.
+    """
 
     def __init__(
         self,
@@ -566,42 +653,153 @@ class YoYInflationIndex:
         currency_fraction_symbol: str,
         currency_fractions_per_unit: int,
         settings: Settings,
-    ) -> None: ...
+    ) -> None:
+        """Build a quoted year-on-year index, keeping its own fixing history.
+
+        The rate is published in its own right rather than derived from a price
+        index, so fixings are filed here through add_fixing.
+
+        Args:
+            family_name (str): The index family the fixings are stored under.
+            region_name (str): The name of the region the index measures.
+            region_code (str): The region's code.
+            revised (bool): Whether the published figures are subject to
+                revision.
+            frequency (Frequency): How often the index publishes.
+            availability_lag (Period): How long after a period ends its figure
+                is published.
+            currency_name (str): The currency's name.
+            currency_code (str): The currency's ISO 4217 three-letter code.
+            currency_numeric_code (int): The currency's ISO 4217 numeric code.
+            currency_symbol (str): The currency's symbol.
+            currency_fraction_symbol (str): The symbol of the currency's
+                fractional unit.
+            currency_fractions_per_unit (int): How many fractional units make
+                one currency unit.
+            settings (Settings): The explicit settings supplying the evaluation
+                date and the stored fixings.
+        """
+        ...
     @staticmethod
     def from_underlying(underlying: ZeroInflationIndex) -> YoYInflationIndex:
-        """A ratio index over underlying, dividing that index's figure for a
-        period by its figure a year earlier. The metadata is inherited bar the
-        family name, which is prefixed YYR_, so a "UK RPI" underlying yields
-        "UK YYR_RPI"; fixings belong on the underlying."""
+        """Build a ratio index dividing a price index's figure by its figure a year earlier.
+
+        The metadata is inherited bar the family name, which is prefixed YYR_,
+        so a "UK RPI" underlying yields "UK YYR_RPI"; fixings belong on the
+        underlying.
+
+        Args:
+            underlying (ZeroInflationIndex): The price index whose consecutive
+                figures the rate is derived from.
+
+        Returns:
+            YoYInflationIndex: The ratio index, over an empty curve handle.
+        """
         ...
-    def name(self) -> str: ...
-    def ratio(self) -> bool: ...
+    def name(self) -> str:
+        """Return the index name, under which fixings are stored.
+
+        Returns:
+            str: The name, e.g. "UK YYR_RPI".
+        """
+        ...
+    def ratio(self) -> bool:
+        """Return whether this index is the ratio of two price-index fixings.
+
+        Returns:
+            bool: True for a ratio index, False for a quoted rate.
+        """
+        ...
     def underlying_index(self) -> ZeroInflationIndex | None:
-        """The price index a ratio index divides, None on a quoted one. This is
-        the very object from_underlying was handed, not a fresh facade around
-        the same core index."""
+        """Return the price index a ratio index divides, None on a quoted one.
+
+        This is the very object from_underlying was handed, not a fresh facade
+        around the same core index: a rebuilt one would carry a relinkable
+        handle this index never sees, so linking it would silently forecast off
+        nothing.
+
+        Returns:
+            ZeroInflationIndex | None: The underlying price index, or None.
+        """
         ...
     def add_fixing(self, fixing_date: Date, value: float) -> None:
-        """Records a published year-on-year rate across the whole inflation
-        period it describes. A ratio index reads the underlying's history, so
-        filing here records a figure it will never consult."""
+        """Record a published year-on-year rate across the whole inflation period.
+
+        A ratio index reads the underlying's history, so filing here records a
+        figure it will never consult.
+
+        Args:
+            fixing_date (Date): Any date inside the inflation period the rate
+                describes.
+            value (float): The published year-on-year rate.
+
+        Raises:
+            ItofinError: If the index frequency has no expressible inflation
+                period, or a different figure is already stored on a date in
+                that period.
+        """
         ...
     def fixing(self, fixing_date: Date, forecast_todays_fixing: bool = False) -> float:
-        """The rate at fixing_date, stored or forecast off the linked curve.
-        forecast_todays_fixing is accepted and ignored, as in the core."""
+        """Return the rate at fixing_date, stored or forecast off the linked curve.
+
+        Args:
+            fixing_date (Date): The date the rate is read or forecast for.
+            forecast_todays_fixing (bool): Accepted and ignored, as in the core:
+                needs_forecast alone decides between history and forecast.
+
+        Returns:
+            float: The year-on-year inflation rate.
+
+        Raises:
+            ItofinError: If a forecast is asked for with no curve linked.
+        """
         ...
     def last_fixing_date(self) -> Date:
-        """The first day of the inflation period the latest figure on record
-        describes, read off the underlying on a ratio index. Raises ItofinError
-        on an index with no history."""
+        """Return the first day of the period the latest figure on record describes.
+
+        Read off the underlying on a ratio index.
+
+        Returns:
+            Date: The start of that inflation period.
+
+        Raises:
+            ItofinError: If the index has no fixing history.
+        """
         ...
     def link_to(self, curve: YoYInflationTermStructure) -> None:
-        """Points the index at curve, so every forecast from here on reads it.
-        It is the curve behind that facade's handle at call time that is stored,
-        not the handle itself."""
+        """Point the index at curve, so every forecast from here on reads it.
+
+        Takes the YoYInflationTermStructure base, so any subclass links. It is
+        the curve behind that facade's handle at call time that is stored, not
+        the handle itself.
+
+        Args:
+            curve (YoYInflationTermStructure): The curve forecasts are read off.
+
+        Raises:
+            ItofinError: If curve somehow carries no link.
+        """
         ...
     def needs_forecast(self, fixing_date: Date) -> bool:
-        """Whether fixing_date has to be forecast rather than read from history,
-        a ratio index deferring the question to its underlying."""
+        """Return whether fixing_date has to be forecast rather than read from history.
+
+        A ratio index defers the question to its underlying.
+
+        Args:
+            fixing_date (Date): The date in question.
+
+        Returns:
+            bool: True if the date has to be forecast off the curve.
+
+        Raises:
+            ItofinError: If the evaluation date is unset, or the index frequency
+                has no expressible inflation period.
+        """
         ...
-    def __repr__(self) -> str: ...
+    def __repr__(self) -> str:
+        """Return the printable representation.
+
+        Returns:
+            str: A string of the form YoYInflationIndex(UK YYR_RPI).
+        """
+        ...

--- a/crates/itofin-py/python/itofin/indexes.pyi
+++ b/crates/itofin-py/python/itofin/indexes.pyi
@@ -20,23 +20,61 @@ class Currency:
 
     Only the three named currencies the core provides are exposed; the general
     constructor is omitted, as the core ports only the currencies its indexes
-    need and the full catalogue is deferred there."""
+    need and the full catalogue is deferred there.
+    """
 
     @staticmethod
-    def eur() -> Currency: ...
+    def eur() -> Currency:
+        """Return the European Euro.
+
+        Returns:
+            Currency: The euro, ISO code "EUR".
+        """
+        ...
     @staticmethod
-    def usd() -> Currency: ...
+    def usd() -> Currency:
+        """Return the U.S. dollar.
+
+        Returns:
+            Currency: The U.S. dollar, ISO code "USD".
+        """
+        ...
     @staticmethod
-    def gbp() -> Currency: ...
-    def code(self) -> str: ...
-    def __repr__(self) -> str: ...
+    def gbp() -> Currency:
+        """Return the British pound sterling.
+
+        Returns:
+            Currency: The pound sterling, ISO code "GBP".
+        """
+        ...
+    def code(self) -> str:
+        """Return the ISO 4217 three-letter code.
+
+        Returns:
+            str: The three-letter code, e.g. "EUR".
+        """
+        ...
+    def __repr__(self) -> str:
+        """Return the printable representation, which prints the ISO code.
+
+        Returns:
+            str: A string of the form Currency(EUR).
+        """
+        ...
 
 class IborIndex:
     """A general Inter-Bank-Offered-Rate index, spelling out every convention.
 
     The form for an index outside the named families (the USD-3M IsdaIbor the
     ISDA CDS curve bootstraps off, say). Pass forwarding=None to build it over
-    an empty handle, the form the bootstrap rate helpers need."""
+    an empty handle, the form the bootstrap rate helpers need.
+
+    It is the base of Euribor, and every Ibor-index consumer takes this type and
+    accepts either: the deposit, swap, FRA and futures rate helpers, and the
+    swap, swap-index, optionlet-volatility, cap/floor and swaption-helper
+    facades. The OIS helper is not one of them; it takes the overnight Estr,
+    which is not an IborIndex.
+    """
 
     def __init__(
         self,
@@ -50,28 +88,204 @@ class IborIndex:
         day_counter: DayCounter,
         forwarding: YieldTermStructure | None,
         settings: Settings,
-    ) -> None: ...
-    def fixing(self, fixing_date: Date, forecast_todays_fixing: bool) -> float: ...
-    def value_date(self, fixing_date: Date) -> Date: ...
-    def fixing_date(self, value_date: Date) -> Date: ...
-    def maturity_date(self, value_date: Date) -> Date: ...
-    def tenor(self) -> Period: ...
-    def day_counter(self) -> DayCounter: ...
-    def fixing_calendar(self) -> Calendar: ...
-    def business_day_convention(self) -> BusinessDayConvention: ...
-    def end_of_month(self) -> bool: ...
+    ) -> None:
+        """Build an index spelling out every convention the core constructor takes.
+
+        The index fixes settlement_days before its value date on the fixing
+        calendar, rolls to maturity under convention and end_of_month, accrues
+        on day_counter and forecasts off forwarding.
+
+        Args:
+            family_name (str): The index family the fixings are stored under.
+            tenor (Period): The index tenor, normalized at construction.
+            settlement_days (int): The business days between the fixing date and
+                the value date.
+            currency (Currency): The currency the index is quoted in.
+            fixing_calendar (Calendar): The calendar the fixing and value dates
+                roll on.
+            convention (BusinessDayConvention): The convention applied when
+                rolling the value date to maturity.
+            end_of_month (bool): Whether the maturity roll keeps to month ends.
+            day_counter (DayCounter): The day count the index accrues on.
+            forwarding (YieldTermStructure | None): The curve fixings are
+                forecast off; None builds the index over an empty handle, the
+                form the bootstrap rate helpers need.
+            settings (Settings): The explicit settings supplying the evaluation
+                date and the stored fixings.
+        """
+        ...
+    def fixing(self, fixing_date: Date, forecast_todays_fixing: bool) -> float:
+        """Return the index fixing for fixing_date.
+
+        Forecast off the forwarding curve for a future date, or read from the
+        stored fixings for a past one.
+
+        Args:
+            fixing_date (Date): The date the fixing is read or forecast for.
+            forecast_todays_fixing (bool): Whether a fixing dated today is
+                forecast rather than looked up.
+
+        Returns:
+            float: The fixing rate.
+
+        Raises:
+            ItofinError: If the forwarding handle is empty or the evaluation
+                date is unset.
+        """
+        ...
+    def value_date(self, fixing_date: Date) -> Date:
+        """Return the value date of the loan fixed on fixing_date.
+
+        The fixing date moved forward by the index's fixing days on the fixing
+        calendar.
+
+        Args:
+            fixing_date (Date): The fixing date to advance.
+
+        Returns:
+            Date: The value date.
+
+        Raises:
+            ItofinError: If fixing_date is not a business day on the fixing
+                calendar.
+        """
+        ...
+    def fixing_date(self, value_date: Date) -> Date:
+        """Return the fixing date of the loan starting on value_date.
+
+        The value date moved back by the index's fixing days, the inverse of
+        value_date.
+
+        Args:
+            value_date (Date): The value date to step back from.
+
+        Returns:
+            Date: The fixing date.
+        """
+        ...
+    def maturity_date(self, value_date: Date) -> Date:
+        """Return the maturity of the loan starting on value_date.
+
+        The value date rolled on by the index tenor under the index's own
+        convention and end-of-month flag.
+
+        Args:
+            value_date (Date): The date the loan starts on.
+
+        Returns:
+            Date: The maturity date.
+
+        Raises:
+            ItofinError: If the core rejects the roll.
+        """
+        ...
+    def tenor(self) -> Period:
+        """Return the index tenor, normalized at construction.
+
+        Returns:
+            Period: The index tenor.
+        """
+        ...
+    def day_counter(self) -> DayCounter:
+        """Return the day counter the index accrues on.
+
+        Returns:
+            DayCounter: The index day count.
+        """
+        ...
+    def fixing_calendar(self) -> Calendar:
+        """Return the calendar the fixing and value dates roll on.
+
+        Returns:
+            Calendar: The fixing calendar.
+        """
+        ...
+    def business_day_convention(self) -> BusinessDayConvention:
+        """Return the convention applied when rolling the value date to maturity.
+
+        Returns:
+            BusinessDayConvention: The stored convention.
+        """
+        ...
+    def end_of_month(self) -> bool:
+        """Return whether the maturity roll keeps to month ends.
+
+        Returns:
+            bool: True if the roll is end-of-month.
+        """
+        ...
 
 class Euribor(IborIndex):
-    """The Euribor IBOR index family."""
+    """The Euribor IBOR index family.
+
+    A subclass of IborIndex, so a Euribor is accepted wherever the general index
+    is. It retains its own clone of the index the base holds - the same object,
+    not a rebuild - so its own fixing reads exactly what the base reads.
+    """
 
     def __init__(
         self, tenor: Period, curve: YieldTermStructure | None, settings: Settings
-    ) -> None: ...
+    ) -> None:
+        """Build a Euribor index of the given tenor.
+
+        Args:
+            tenor (Period): The index tenor.
+            curve (YieldTermStructure | None): The forwarding curve; None builds
+                the index over an empty handle, the form the bootstrap rate
+                helpers need.
+            settings (Settings): The explicit settings supplying the evaluation
+                date and the stored fixings.
+
+        Raises:
+            ItofinError: If tenor is a daily tenor, which needs the dedicated
+                daily-tenor constructor the core keeps separate.
+        """
+        ...
     @staticmethod
-    def three_months(curve: YieldTermStructure, settings: Settings) -> Euribor: ...
+    def three_months(curve: YieldTermStructure, settings: Settings) -> Euribor:
+        """Return the 3-month Euribor index forwarding off curve.
+
+        Args:
+            curve (YieldTermStructure): The forwarding curve.
+            settings (Settings): The explicit settings supplying the evaluation
+                date and the stored fixings.
+
+        Returns:
+            Euribor: The Euribor3M index.
+        """
+        ...
     @staticmethod
-    def six_months(curve: YieldTermStructure, settings: Settings) -> Euribor: ...
-    def fixing(self, fixing_date: Date, forecast_todays_fixing: bool) -> float: ...
+    def six_months(curve: YieldTermStructure, settings: Settings) -> Euribor:
+        """Return the 6-month Euribor index forwarding off curve.
+
+        Args:
+            curve (YieldTermStructure): The forwarding curve.
+            settings (Settings): The explicit settings supplying the evaluation
+                date and the stored fixings.
+
+        Returns:
+            Euribor: The Euribor6M index.
+        """
+        ...
+    def fixing(self, fixing_date: Date, forecast_todays_fixing: bool) -> float:
+        """Return the index fixing for fixing_date.
+
+        Forecast off the forwarding curve for a future date, or read from the
+        stored fixings for a past one.
+
+        Args:
+            fixing_date (Date): The date the fixing is read or forecast for.
+            forecast_todays_fixing (bool): Whether a fixing dated today is
+                forecast rather than looked up.
+
+        Returns:
+            float: The fixing rate.
+
+        Raises:
+            ItofinError: If the forwarding handle is empty or the evaluation
+                date is unset.
+        """
+        ...
 
 class OvernightIndex:
     """The base of the overnight index families.
@@ -79,22 +293,66 @@ class OvernightIndex:
     Abstract: it has no constructor, because the core builds an overnight index
     only through a family factory such as Estr. It exists so OISRateHelper and
     MakeOis name one type and accept any family. The fixing accessor stays on
-    the family facade; lifting it here is deferred."""
+    the family facade; lifting it here is deferred.
+    """
 
 class Estr(OvernightIndex):
-    """The Euro Short-Term Rate overnight index. Pass curve=None to build it over
-    an empty forwarding handle (the form the OIS bootstrap needs)."""
+    """The Euro Short-Term Rate overnight index.
 
-    def __init__(self, curve: YieldTermStructure | None, settings: Settings) -> None: ...
-    def fixing(self, fixing_date: Date, forecast_todays_fixing: bool) -> float: ...
+    A subclass of OvernightIndex, so an ESTR index is accepted wherever the
+    general overnight index is. It retains its own clone of the index the base
+    holds - the same object, not a rebuild - so a facade typed on either half
+    reads exactly the same core index.
+    """
+
+    def __init__(self, curve: YieldTermStructure | None, settings: Settings) -> None:
+        """Build an ESTR index forwarding off curve.
+
+        Infallible, unlike the Euribor constructor: the overnight tenor is fixed
+        to one day by the base rather than taken from the caller.
+
+        Args:
+            curve (YieldTermStructure | None): The forwarding curve; None builds
+                the index over an empty forwarding handle, the form the OIS
+                bootstrap needs.
+            settings (Settings): The explicit settings supplying the evaluation
+                date and the stored fixings.
+        """
+        ...
+    def fixing(self, fixing_date: Date, forecast_todays_fixing: bool) -> float:
+        """Return the index fixing for fixing_date.
+
+        Forecast off the forwarding curve for a future date, or read from the
+        stored fixings for a past one.
+
+        Args:
+            fixing_date (Date): The date the fixing is read or forecast for.
+            forecast_todays_fixing (bool): Whether a fixing dated today is
+                forecast rather than looked up.
+
+        Returns:
+            float: The fixing rate.
+
+        Raises:
+            ItofinError: If the forwarding handle is empty or the evaluation
+                date is unset.
+        """
+        ...
 
 class SwapIndex:
     """The index whose fixing is the fair rate of an on-the-fly vanilla swap,
     assembled from the index tenor, the forecasting Ibor index and the fixed-leg
     conventions.
 
+    The swap is assembled off the value date the fixing date implies. The
+    swaption volatility cubes take two of these (a long and a short base) and
+    read the at-the-money forward off them, so this is the index the cube
+    facades stack on rather than one priced with directly.
+
     The currency is inert for every ported consumer, so currency() reading it
-    back off the core index is the only place it shows."""
+    back off the core index is the only place it shows. Deferred (visible): the
+    clone family (re-curving / re-tenoring) is deferred in the core itself.
+    """
 
     def __init__(
         self,
@@ -109,7 +367,28 @@ class SwapIndex:
         ibor_index: IborIndex,
         settings: Settings,
     ) -> None:
-        """Forecasts and discounts off the ibor index's forwarding curve."""
+        """Build a swap index forecasting and discounting off one curve.
+
+        Both legs use the ibor index's forwarding curve. The index registers
+        with that index, so a relinked curve notifies observers.
+
+        Args:
+            family_name (str): The index family the fixings are stored under.
+            tenor (Period): The tenor of the underlying swap.
+            settlement_days (int): The business days between the fixing date and
+                the swap's start.
+            currency (Currency): The index currency, inert for every ported
+                consumer and read back only by currency().
+            calendar (Calendar): The calendar the swap's dates roll on.
+            fixed_leg_tenor (Period): The fixed leg's payment tenor.
+            fixed_leg_convention (BusinessDayConvention): The fixed leg's
+                business-day convention.
+            fixed_leg_day_counter (DayCounter): The fixed leg's day count.
+            ibor_index (IborIndex): The index forecasting the floating leg,
+                whose forwarding curve also discounts.
+            settings (Settings): The explicit settings supplying the evaluation
+                date and the stored fixings.
+        """
         ...
     @staticmethod
     def with_exogenous_discount(
@@ -125,16 +404,72 @@ class SwapIndex:
         discount: YieldTermStructure,
         settings: Settings,
     ) -> SwapIndex:
-        """Forecasts off the ibor index's forwarding curve but discounts off the
-        separate discount curve."""
+        """Build a swap index discounting off a separate curve.
+
+        The floating leg is still forecast off the ibor index's forwarding
+        curve, but discounting uses discount. The index registers with both.
+
+        Args:
+            family_name (str): The index family the fixings are stored under.
+            tenor (Period): The tenor of the underlying swap.
+            settlement_days (int): The business days between the fixing date and
+                the swap's start.
+            currency (Currency): The index currency, inert for every ported
+                consumer and read back only by currency().
+            calendar (Calendar): The calendar the swap's dates roll on.
+            fixed_leg_tenor (Period): The fixed leg's payment tenor.
+            fixed_leg_convention (BusinessDayConvention): The fixed leg's
+                business-day convention.
+            fixed_leg_day_counter (DayCounter): The fixed leg's day count.
+            ibor_index (IborIndex): The index forecasting the floating leg.
+            discount (YieldTermStructure): The separate curve both legs are
+                discounted on.
+            settings (Settings): The explicit settings supplying the evaluation
+                date and the stored fixings.
+
+        Returns:
+            SwapIndex: The index discounting off the exogenous curve.
+        """
         ...
     def fixing(self, fixing_date: Date, forecast_todays_fixing: bool = False) -> float:
-        """The underlying swap's fair rate, the at-the-money forward the
-        volatility cubes read."""
+        """Return the underlying swap's fair rate for fixing_date.
+
+        This is the at-the-money forward the volatility cubes read.
+
+        Args:
+            fixing_date (Date): The date the underlying swap is struck off.
+            forecast_todays_fixing (bool): Whether a fixing dated today is
+                forecast rather than looked up.
+
+        Returns:
+            float: The fair rate of the underlying swap.
+
+        Raises:
+            ItofinError: If the forwarding handle is empty, the evaluation date
+                is unset, or the fixing date is invalid.
+        """
         ...
-    def currency(self) -> Currency: ...
-    def fixed_leg_tenor(self) -> Period: ...
-    def exogenous_discount(self) -> bool: ...
+    def currency(self) -> Currency:
+        """Return the index currency, read back off the core index.
+
+        Returns:
+            Currency: The currency the index was built with.
+        """
+        ...
+    def fixed_leg_tenor(self) -> Period:
+        """Return the fixed leg's payment tenor.
+
+        Returns:
+            Period: The fixed-leg tenor.
+        """
+        ...
+    def exogenous_discount(self) -> bool:
+        """Return whether the index discounts off a separate curve.
+
+        Returns:
+            bool: True if the index was built by with_exogenous_discount.
+        """
+        ...
 
 class CpiInterpolationType:
     """How a CPI observation interpolates between the index fixings bracketing

--- a/crates/itofin-py/python/itofin/indexes.pyi
+++ b/crates/itofin-py/python/itofin/indexes.pyi
@@ -129,8 +129,9 @@ class IborIndex:
             float: The fixing rate.
 
         Raises:
-            ItofinError: If the forwarding handle is empty or the evaluation
-                date is unset.
+            ItofinError: If the fixing date is not a valid one, the evaluation
+                date is unset, a past fixing is missing from the store, or the
+                forwarding handle is empty on a forecast.
         """
         ...
     def value_date(self, fixing_date: Date) -> Date:
@@ -174,9 +175,6 @@ class IborIndex:
 
         Returns:
             Date: The maturity date.
-
-        Raises:
-            ItofinError: If the core rejects the roll.
         """
         ...
     def tenor(self) -> Period:
@@ -282,8 +280,9 @@ class Euribor(IborIndex):
             float: The fixing rate.
 
         Raises:
-            ItofinError: If the forwarding handle is empty or the evaluation
-                date is unset.
+            ItofinError: If the fixing date is not a valid one, the evaluation
+                date is unset, a past fixing is missing from the store, or the
+                forwarding handle is empty on a forecast.
         """
         ...
 
@@ -334,8 +333,9 @@ class Estr(OvernightIndex):
             float: The fixing rate.
 
         Raises:
-            ItofinError: If the forwarding handle is empty or the evaluation
-                date is unset.
+            ItofinError: If the fixing date is not a valid one, the evaluation
+                date is unset, a past fixing is missing from the store, or the
+                forwarding handle is empty on a forecast.
         """
         ...
 

--- a/crates/itofin-py/python/itofin/pricingengines.pyi
+++ b/crates/itofin-py/python/itofin/pricingengines.pyi
@@ -15,8 +15,13 @@ from itofin.termstructures import (
 from itofin.time import DayCounter
 
 class CashAnnuityModel:
-    """Which date a cash-settled par-yield annuity discounts to. Only the
-    (Cash, ParYieldCurve) settlement pair reads it."""
+    """Which date a cash-settled par-yield annuity discounts to.
+
+    Only the (Cash, ParYieldCurve) settlement pair reads it; every other pair
+    takes the fixed-leg BPS annuity and is insensitive to the choice. The
+    swaption engines default to SwapRate, the branch every ported core test
+    exercises, where C++ defaults to DiscountCurve.
+    """
 
     SwapRate: CashAnnuityModel
     DiscountCurve: CashAnnuityModel
@@ -28,7 +33,9 @@ class BlackSwaptionEngine:
     own. The settings passed here must be the same object driving the swaption
     and its swap: a mismatch prices the two on different evaluation dates with
     no error raised. The surface's volatility type is checked against the Black
-    formula at pricing time, not construction."""
+    formula at pricing time, not construction, so a normal-volatility surface
+    raises from Swaption.npv().
+    """
 
     def __init__(
         self,
@@ -36,7 +43,20 @@ class BlackSwaptionEngine:
         discount: YieldTermStructure,
         settings: Settings,
         model: CashAnnuityModel = ...,
-    ) -> None: ...
+    ) -> None:
+        """Build an engine reading volatilities off vol and discounting on discount.
+
+        Args:
+            vol (SwaptionVolatilityStructure): The surface volatilities are read
+                off.
+            discount (YieldTermStructure): The curve both legs are discounted
+                on.
+            settings (Settings): The explicit settings; must be the same object
+                driving the swaption and its swap.
+            model (CashAnnuityModel): Which date a cash-settled par-yield
+                annuity discounts to. Defaults to SwapRate.
+        """
+        ...
     @staticmethod
     def with_flat_vol(
         discount: YieldTermStructure,
@@ -46,9 +66,26 @@ class BlackSwaptionEngine:
         settings: Settings,
         model: CashAnnuityModel = ...,
     ) -> BlackSwaptionEngine:
-        """An engine over a flat volatility quote, wrapped internally in a
-        constant surface on a null calendar whose reference date tracks the
-        evaluation date. displacement is that surface's lognormal shift."""
+        """Build an engine over a flat volatility quote.
+
+        The quote is wrapped internally in a constant surface on a null calendar
+        whose reference date tracks the evaluation date.
+
+        Args:
+            discount (YieldTermStructure): The curve both legs are discounted
+                on.
+            vol (SimpleQuote): The flat Black volatility.
+            day_counter (DayCounter): The day count the constant surface
+                measures time on.
+            displacement (float): The constant surface's lognormal shift.
+            settings (Settings): The explicit settings; must be the same object
+                driving the swaption and its swap.
+            model (CashAnnuityModel): Which date a cash-settled par-yield
+                annuity discounts to. Defaults to SwapRate.
+
+        Returns:
+            BlackSwaptionEngine: The engine over the flat surface.
+        """
         ...
 
 class BachelierSwaptionEngine:
@@ -58,7 +95,8 @@ class BachelierSwaptionEngine:
     constructors, same settings requirement, same silent discounting engine on
     the underlying swap. The surface's volatility type is checked against the
     normal formula at pricing time, not construction, so a shifted-lognormal
-    surface raises from Swaption.npv()."""
+    surface raises from Swaption.npv().
+    """
 
     def __init__(
         self,
@@ -66,7 +104,20 @@ class BachelierSwaptionEngine:
         discount: YieldTermStructure,
         settings: Settings,
         model: CashAnnuityModel = ...,
-    ) -> None: ...
+    ) -> None:
+        """Build an engine reading normal volatilities off vol.
+
+        Args:
+            vol (SwaptionVolatilityStructure): The surface normal volatilities
+                are read off.
+            discount (YieldTermStructure): The curve both legs are discounted
+                on.
+            settings (Settings): The explicit settings; must be the same object
+                driving the swaption and its swap.
+            model (CashAnnuityModel): Which date a cash-settled par-yield
+                annuity discounts to. Defaults to SwapRate.
+        """
+        ...
     @staticmethod
     def with_flat_vol(
         discount: YieldTermStructure,
@@ -76,10 +127,27 @@ class BachelierSwaptionEngine:
         settings: Settings,
         model: CashAnnuityModel = ...,
     ) -> BachelierSwaptionEngine:
-        """An engine over a flat normal volatility quote, wrapped internally in
-        a constant surface on a null calendar whose reference date tracks the
-        evaluation date. displacement is kept for parity with the Black engine
-        and is ignored by the normal model."""
+        """Build an engine over a flat normal volatility quote.
+
+        The quote is wrapped internally in a constant surface on a null calendar
+        whose reference date tracks the evaluation date.
+
+        Args:
+            discount (YieldTermStructure): The curve both legs are discounted
+                on.
+            vol (SimpleQuote): The flat normal volatility.
+            day_counter (DayCounter): The day count the constant surface
+                measures time on.
+            displacement (float): Kept for signature parity with the Black
+                engine; the normal model has no shift and ignores it.
+            settings (Settings): The explicit settings; must be the same object
+                driving the swaption and its swap.
+            model (CashAnnuityModel): Which date a cash-settled par-yield
+                annuity discounts to. Defaults to SwapRate.
+
+        Returns:
+            BachelierSwaptionEngine: The engine over the flat surface.
+        """
         ...
 
 class BlackCapFloorEngine:
@@ -89,7 +157,8 @@ class BlackCapFloorEngine:
     Only the shifted-lognormal path is priced in the core, so a normal-volatility
     surface is rejected by the constructor rather than bound to a Bachelier
     engine. The instrument this engine prices must resolve its dates against the
-    same Settings object the engine does."""
+    same Settings object the engine does.
+    """
 
     def __init__(
         self,
@@ -97,9 +166,23 @@ class BlackCapFloorEngine:
         discount: YieldTermStructure,
         displacement: float | None = None,
     ) -> None:
-        """Raises ItofinError on a normal-volatility surface, and when a given
-        displacement differs from the surface's own. None adopts the surface's
-        displacement."""
+        """Build an engine reading volatilities off vol and discounting on discount.
+
+        Fallible at construction, unlike the swaption engines.
+
+        Args:
+            vol (OptionletVolatilityStructure): The optionlet surface
+                volatilities are read off; must be shifted-lognormal.
+            discount (YieldTermStructure): The curve the optionlets are
+                discounted on.
+            displacement (float | None): The lognormal shift; None adopts the
+                surface's own.
+
+        Raises:
+            ItofinError: If the surface handle is empty, the surface is
+                normal-volatility, or a given displacement differs from the
+                surface's own.
+        """
         ...
     @staticmethod
     def with_flat_vol(
@@ -109,12 +192,34 @@ class BlackCapFloorEngine:
         displacement: float,
         settings: Settings,
     ) -> BlackCapFloorEngine:
-        """An engine over a flat volatility quote, wrapped internally in a
-        constant optionlet surface on a null calendar whose reference date
-        tracks the evaluation date. displacement is that surface's lognormal
-        shift."""
+        """Build an engine over a flat volatility quote.
+
+        The quote is wrapped internally in a constant optionlet surface on a
+        null calendar whose reference date tracks the evaluation date.
+        displacement carries no default, mirroring the swaption engine: a
+        trailing settings cannot follow a defaulted argument.
+
+        Args:
+            discount (YieldTermStructure): The curve the optionlets are
+                discounted on.
+            vol (SimpleQuote): The flat Black volatility.
+            day_counter (DayCounter): The day count the constant surface
+                measures time on.
+            displacement (float): The constant surface's lognormal shift.
+            settings (Settings): The explicit settings the constant surface's
+                reference date tracks.
+
+        Returns:
+            BlackCapFloorEngine: The engine over the flat surface.
+        """
         ...
-    def displacement(self) -> float: ...
+    def displacement(self) -> float:
+        """Return the lognormal shift the engine applies to forwards and strikes.
+
+        Returns:
+            float: The displacement.
+        """
+        ...
 
 class MidPointCdsEngine:
     """The mid-point credit-default-swap engine: each live premium period is
@@ -125,7 +230,8 @@ class MidPointCdsEngine:
     unset evaluation date) is reported when the contract is priced. The core's
     include_settlement_date_flows override is not exposed and is always None,
     so the settlement-date flow decision follows the settings' own flags. The
-    contract this engine prices must carry the same Settings object."""
+    contract this engine prices must carry the same Settings object.
+    """
 
     def __init__(
         self,
@@ -133,32 +239,51 @@ class MidPointCdsEngine:
         recovery: float,
         discount: YieldTermStructure,
         settings: Settings,
-    ) -> None: ...
+    ) -> None:
+        """Build an engine over a default-probability curve and a discount curve.
+
+        Args:
+            probability (DefaultProbabilityTermStructure): The curve default
+                probabilities are read off.
+            recovery (float): The recovery rate; a default pays 1 - recovery of
+                the notional.
+            discount (YieldTermStructure): The curve both legs are discounted
+                on.
+            settings (Settings): The explicit settings; must be the same object
+                the contract this engine prices was built with.
+        """
+        ...
 
 class NumericalFix:
-    """How the ISDA engine keeps the integrands' f + h denominators away from
-    zero. NoFix adds 10^-50 to them instead; Taylor, the default, replaces the
-    quotient by its Taylor expansion once f + h falls below 10^-4. Spelled
-    NoFix rather than C++'s None, which Python cannot name."""
+    """How the ISDA engine keeps the integrands' f + h denominators away from zero.
+
+    NoFix adds 10^-50 to them instead; Taylor, the default, replaces the
+    quotient by its Taylor expansion once f + h falls below 10^-4. Spelled NoFix
+    rather than C++'s None, which Python cannot name.
+    """
 
     NoFix: NumericalFix
     Taylor: NumericalFix
 
 class AccrualBias:
-    """Whether the premium leg carries the standard model's half-day accrual
-    bias, which shifts the accrual's tstart back by 1/730 of a year.
-    HalfDayBias, the default, includes it as the model's C code does before
-    version 1.8.2; NoBias leaves it out, as from 1.8.2 on."""
+    """Whether the premium leg carries the standard model's half-day accrual bias.
+
+    The bias shifts the accrual's tstart back by 1/730 of a year. HalfDayBias,
+    the default, includes it as the model's C code does before version 1.8.2;
+    NoBias leaves it out, as from 1.8.2 on.
+    """
 
     HalfDayBias: AccrualBias
     NoBias: AccrualBias
 
 class ForwardsInCouponPeriod:
     """How the ISDA engine treats forward rates inside a coupon period.
+
     Piecewise, the default, subdivides each period at the integration grid's own
     nodes; Flat integrates each period in a single step. The two part only where
     the grid has nodes strictly inside a coupon period, so two flat curves price
-    identically under either."""
+    identically under either.
+    """
 
     Flat: ForwardsInCouponPeriod
     Piecewise: ForwardsInCouponPeriod
@@ -179,7 +304,8 @@ class IsdaCdsEngine:
     without them prices as before; they are taken here rather than through a
     with_fidelity method because the core builder consumes the engine while
     set_isda_engine has already cloned it into the contract. The contract this
-    engine prices must carry the same Settings object."""
+    engine prices must carry the same Settings object.
+    """
 
     def __init__(
         self,
@@ -190,7 +316,28 @@ class IsdaCdsEngine:
         numerical_fix: NumericalFix = ...,
         accrual_bias: AccrualBias = ...,
         forwards_in_coupon_period: ForwardsInCouponPeriod = ...,
-    ) -> None: ...
+    ) -> None:
+        """Build an ISDA standard-model engine under the three fidelity flags.
+
+        Args:
+            probability (DefaultProbabilityTermStructure): The curve default
+                probabilities are read off; must count Act/365 (Fixed) and be
+                referenced at the evaluation date, checked at pricing time.
+            recovery (float): The recovery rate; a default pays 1 - recovery of
+                the notional.
+            discount (YieldTermStructure): The curve both legs are discounted
+                on, under the same shape requirement.
+            settings (Settings): The explicit settings; must be the same object
+                the contract this engine prices was built with.
+            numerical_fix (NumericalFix): How the integrand denominators are
+                kept away from zero. Defaults to Taylor.
+            accrual_bias (AccrualBias): Whether the premium leg carries the
+                half-day accrual bias. Defaults to HalfDayBias.
+            forwards_in_coupon_period (ForwardsInCouponPeriod): How forward
+                rates inside a coupon period are integrated. Defaults to
+                Piecewise.
+        """
+        ...
 
 class DiscountingSwapEngine:
     """Discounts every leg of a swap over a single yield curve.
@@ -200,9 +347,21 @@ class DiscountingSwapEngine:
     include_settlement_date_flows, settlement_date and npv_date overrides are
     not exposed and are always None, so the flow decision follows the settings'
     own flags and both dates fall back to the curve reference date. The swap
-    this engine prices must carry the same Settings object."""
+    this engine prices must carry the same Settings object.
+    """
 
-    def __init__(self, discount: YieldTermStructure, settings: Settings) -> None: ...
+    def __init__(self, discount: YieldTermStructure, settings: Settings) -> None:
+        """Build an engine discounting every leg on discount.
+
+        Args:
+            discount (YieldTermStructure): The curve every leg is discounted on;
+                the engine registers as an observer of it.
+            settings (Settings): The explicit settings; must be the same object
+                the swap this engine prices was built with, or the two resolve
+                their dates against different evaluation dates and the NPV is
+                silently wrong.
+        """
+        ...
 
 class MCEuropeanEngine:
     """The Monte Carlo engine for European payoffs, over the pseudo-random RNG
@@ -210,7 +369,8 @@ class MCEuropeanEngine:
 
     Pricing is seeded and deterministic: the same seed reproduces the NPV
     bitwise, and the standard error is read back through
-    VanillaOption.error_estimate()."""
+    VanillaOption.error_estimate().
+    """
 
     def __init__(
         self,
@@ -223,10 +383,31 @@ class MCEuropeanEngine:
         seed: int | None = None,
         antithetic: bool | None = None,
     ) -> None:
-        """Raises ItofinError when neither or both of steps / steps_per_year are
-        given, when both samples and absolute_tolerance are given, and when
-        antithetic is True: the antithetic variate is not yet supported by the
-        core engine (#772)."""
+        """Build an engine over process, configured through the core factory.
+
+        Every argument past process is left unset when omitted, so the core's
+        own validation reports the illegal combinations.
+
+        Args:
+            process (BlackScholesProcess): The process paths are drawn from.
+            steps (int | None): The fixed number of time steps per path.
+            steps_per_year (int | None): The time steps per year, the
+                alternative to steps.
+            samples (int | None): The fixed number of paths to draw.
+            absolute_tolerance (float | None): The target standard error, the
+                alternative to samples.
+            max_samples (int | None): The cap on paths drawn when running to a
+                tolerance.
+            seed (int | None): The RNG seed; the same seed reproduces the NPV
+                bitwise.
+            antithetic (bool | None): The antithetic variate, not yet supported
+                by the core engine (#772).
+
+        Raises:
+            ItofinError: If neither or both of steps and steps_per_year are
+                given, if both samples and absolute_tolerance are given, or if
+                antithetic is True.
+        """
         ...
 
 class MCEuropeanHestonEngine:
@@ -237,7 +418,8 @@ class MCEuropeanHestonEngine:
 
     Pricing is seeded and deterministic: the same seed reproduces the NPV
     bitwise, and the standard error is read back through
-    VanillaOption.error_estimate()."""
+    VanillaOption.error_estimate().
+    """
 
     def __init__(
         self,
@@ -250,8 +432,30 @@ class MCEuropeanHestonEngine:
         seed: int | None = None,
         antithetic: bool | None = None,
     ) -> None:
-        """Raises ItofinError when neither or both of steps / steps_per_year are
-        given, and when both samples and absolute_tolerance are given."""
+        """Build an engine over process, configured through the core factory.
+
+        Every argument past process is left unset when omitted, so the core's
+        own validation reports the illegal combinations.
+
+        Args:
+            process (HestonProcess): The Heston process paths are drawn from.
+            steps (int | None): The fixed number of time steps per path.
+            steps_per_year (int | None): The time steps per year, the
+                alternative to steps.
+            samples (int | None): The fixed number of paths to draw.
+            absolute_tolerance (float | None): The target standard error, the
+                alternative to samples.
+            max_samples (int | None): The cap on paths drawn when running to a
+                tolerance.
+            seed (int | None): The RNG seed; the same seed reproduces the NPV
+                bitwise.
+            antithetic (bool | None): The antithetic variate, supported here;
+                the core cached oracle prices with it on.
+
+        Raises:
+            ItofinError: If neither or both of steps and steps_per_year are
+                given, or if both samples and absolute_tolerance are given.
+        """
         ...
 
 class MCAmericanEngine:
@@ -267,7 +471,8 @@ class MCAmericanEngine:
     Pricing is seeded and deterministic: the same seed reproduces the NPV
     bitwise, the standard error is read back through
     VanillaOption.error_estimate() and the early-exercise fraction through
-    VanillaOption.exercise_probability()."""
+    VanillaOption.exercise_probability().
+    """
 
     def __init__(
         self,
@@ -282,9 +487,34 @@ class MCAmericanEngine:
         polynomial_order: int | None = None,
         calibration_samples: int | None = None,
     ) -> None:
-        """Raises ItofinError when neither or both of steps / steps_per_year are
-        given, and when both samples and absolute_tolerance are given. The
-        polynomial order defaults to 2 and the calibration samples to 2048."""
+        """Build an engine over process, configured through the core factory.
+
+        Every argument past process is left unset when omitted, so the core's
+        own validation reports the illegal combinations.
+
+        Args:
+            process (BlackScholesProcess): The process paths are drawn from.
+            steps (int | None): The fixed number of time steps per path.
+            steps_per_year (int | None): The time steps per year, the
+                alternative to steps.
+            samples (int | None): The fixed number of paths to draw.
+            absolute_tolerance (float | None): The target standard error, the
+                alternative to samples.
+            max_samples (int | None): The cap on paths drawn when running to a
+                tolerance.
+            seed (int | None): The RNG seed; the same seed reproduces the NPV
+                bitwise.
+            antithetic (bool | None): The antithetic variate, supported here;
+                the core oracle prices with it on.
+            polynomial_order (int | None): The order of the Monomial regression
+                basis. The core default is 2.
+            calibration_samples (int | None): The paths the regression is fitted
+                on. The core default is 2048.
+
+        Raises:
+            ItofinError: If neither or both of steps and steps_per_year are
+                given, or if both samples and absolute_tolerance are given.
+        """
         ...
 
 class YoYInflationCapFloorEngine:
@@ -301,26 +531,73 @@ class YoYInflationCapFloorEngine:
     against different evaluation dates and the NPV is silently wrong.
 
     An engine carries the arguments and results of the contract it last priced,
-    so a cap and a floor priced together want one engine each."""
+    so a cap and a floor priced together want one engine each.
+    """
 
     @staticmethod
     def black(
         index: YoYInflationIndex,
         volatility: ConstantYoYOptionletVolatility,
         nominal_ts: YieldTermStructure,
-    ) -> YoYInflationCapFloorEngine: ...
+    ) -> YoYInflationCapFloorEngine:
+        """Build an engine valuing optionlets under the lognormal model.
+
+        Args:
+            index (YoYInflationIndex): The index forwards are read off.
+            volatility (ConstantYoYOptionletVolatility): The surface optionlet
+                volatilities are read off.
+            nominal_ts (YieldTermStructure): The nominal curve optionlets are
+                discounted on.
+
+        Returns:
+            YoYInflationCapFloorEngine: The lognormal engine.
+        """
+        ...
     @staticmethod
     def unit_displaced(
         index: YoYInflationIndex,
         volatility: ConstantYoYOptionletVolatility,
         nominal_ts: YieldTermStructure,
-    ) -> YoYInflationCapFloorEngine: ...
+    ) -> YoYInflationCapFloorEngine:
+        """Build an engine valuing optionlets under the unit-displaced lognormal model.
+
+        Lognormal in 1 + rate, the usual quoting convention for a rate that may
+        be negative.
+
+        Args:
+            index (YoYInflationIndex): The index forwards are read off.
+            volatility (ConstantYoYOptionletVolatility): The surface optionlet
+                volatilities are read off.
+            nominal_ts (YieldTermStructure): The nominal curve optionlets are
+                discounted on.
+
+        Returns:
+            YoYInflationCapFloorEngine: The unit-displaced lognormal engine.
+        """
+        ...
     @staticmethod
     def bachelier(
         index: YoYInflationIndex,
         volatility: ConstantYoYOptionletVolatility,
         nominal_ts: YieldTermStructure,
-    ) -> YoYInflationCapFloorEngine: ...
+    ) -> YoYInflationCapFloorEngine:
+        """Build an engine valuing optionlets under the normal model.
+
+        Args:
+            index (YoYInflationIndex): The index forwards are read off.
+            volatility (ConstantYoYOptionletVolatility): The surface optionlet
+                volatilities are read off.
+            nominal_ts (YieldTermStructure): The nominal curve optionlets are
+                discounted on.
+
+        Returns:
+            YoYInflationCapFloorEngine: The normal engine.
+        """
+        ...
     def distribution(self) -> str:
-        """"black", "unit_displaced" or "bachelier"."""
+        """Return the distribution optionlets are valued under.
+
+        Returns:
+            str: "black", "unit_displaced" or "bachelier".
+        """
         ...


### PR DESCRIPTION
- **docs(crates): expand docstrings for index type stubs**
- **docs(crates): expand inflation index type stub docstrings**
- **docs(crates): expand pricing engine type stub docstrings**
- **docs(crates): expand YoY inflation and Ibor leg type stub docstrings**
- **docs(indexes): clarify fixing rate error conditions in type stubs**

close #883