### PR TITLE
refactor(itofin-py): use absolute imports in type stub

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,13 @@
+[settings]
+py_version=3
+line_length=120
+sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+ensure_newline_before_comments=True
+known_first_party=itofin
+import_heading_stdlib=standard library
+import_heading_firstparty=itofin library
+import_heading_thirdparty=pypi/conda library

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,11 @@
 repos:
+    - repo: https://github.com/timothycrosley/isort
+      rev: 9.0.0b5
+      hooks:
+        - id: isort
+          name: isort
+          args:
+            - --settings-path=.isort.cfg
     - repo: https://github.com/benbenbang/pre-commit-rust
       rev: v1.0.0
       hooks:

--- a/crates/itofin-py/python/itofin/__init__.pyi
+++ b/crates/itofin-py/python/itofin/__init__.pyi
@@ -17,17 +17,17 @@
 #   results       <- src/results.rs
 """Python bindings for libitofin, a Rust port of QuantLib."""
 
-from . import cashflows as cashflows
-from . import indexes as indexes
-from . import instruments as instruments
-from . import models as models
-from . import optimization as optimization
-from . import pricingengines as pricingengines
-from . import processes as processes
-from . import quotes as quotes
-from . import results as results
-from . import termstructures as termstructures
-from . import time as time
+from itofin import cashflows as cashflows
+from itofin import indexes as indexes
+from itofin import instruments as instruments
+from itofin import models as models
+from itofin import optimization as optimization
+from itofin import pricingengines as pricingengines
+from itofin import processes as processes
+from itofin import quotes as quotes
+from itofin import results as results
+from itofin import termstructures as termstructures
+from itofin import time as time
 
 __version__: str
 

--- a/crates/itofin-py/python/itofin/__init__.pyi
+++ b/crates/itofin-py/python/itofin/__init__.pyi
@@ -17,6 +17,7 @@
 #   results       <- src/results.rs
 """Python bindings for libitofin, a Rust port of QuantLib."""
 
+# itofin library
 from itofin import cashflows as cashflows
 from itofin import indexes as indexes
 from itofin import instruments as instruments

--- a/crates/itofin-py/python/itofin/cashflows.pyi
+++ b/crates/itofin-py/python/itofin/cashflows.pyi
@@ -1,19 +1,10 @@
 # Hand-written stubs for itofin.cashflows; sync manually with src/cashflows.rs
 # (#517, #848, #863, #626).
 
+# itofin library
 from itofin.indexes import CpiInterpolationType, IborIndex, YoYInflationIndex
-from itofin.termstructures import (
-    ConstantYoYOptionletVolatility,
-    YieldTermStructure,
-)
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DayCounter,
-    Period,
-    Schedule,
-)
+from itofin.termstructures import ConstantYoYOptionletVolatility, YieldTermStructure
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Period, Schedule
 
 class YoYInflationCoupon:
     """One coupon of a year-on-year inflation leg.

--- a/crates/itofin-py/python/itofin/indexes.pyi
+++ b/crates/itofin-py/python/itofin/indexes.pyi
@@ -1,19 +1,10 @@
 # Hand-written stubs for itofin.indexes; sync manually with src/hullwhite.rs, src/helpers.rs,
 # src/swapindex.rs, src/currency.rs and src/inflation.rs (#517).
 
+# itofin library
 from itofin import Settings
-from itofin.termstructures import (
-    YieldTermStructure,
-    YoYInflationTermStructure,
-    ZeroInflationTermStructure,
-)
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DayCounter,
-    Period,
-)
+from itofin.termstructures import YieldTermStructure, YoYInflationTermStructure, ZeroInflationTermStructure
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Period
 
 class Currency:
     """An ISO 4217 currency specification.

--- a/crates/itofin-py/python/itofin/instruments.pyi
+++ b/crates/itofin-py/python/itofin/instruments.pyi
@@ -653,9 +653,19 @@ class MakeOis:
         ...
 
 class EuropeanExercise:
-    """A single-date exercise schedule."""
+    """A single-date exercise schedule.
 
-    def __init__(self, date: Date) -> None: ...
+    Held as the exercise trait object the swaption constructor takes, so the
+    same value reaches the instrument.
+    """
+
+    def __init__(self, date: Date) -> None:
+        """Build the exercise schedule.
+
+        Args:
+            date (Date): The single date the option may be exercised on.
+        """
+        ...
 
 class SettlementType:
     """How a swaption settles on exercise."""
@@ -664,7 +674,13 @@ class SettlementType:
     Cash: SettlementType
 
 class SettlementMethod:
-    """The settlement mechanics under a settlement type."""
+    """The settlement mechanics under a settlement type.
+
+    Physical pairs with PhysicalOTC or PhysicalCleared, cash with
+    CollateralizedCashPrice or ParYieldCurve. The consistency check runs at
+    pricing time, not construction, so a mismatched pair only surfaces from
+    npv().
+    """
 
     PhysicalOTC: SettlementMethod
     PhysicalCleared: SettlementMethod
@@ -672,7 +688,12 @@ class SettlementMethod:
     ParYieldCurve: SettlementMethod
 
 class Swaption:
-    """A European option to enter a vanilla swap."""
+    """A European option to enter a vanilla swap.
+
+    The swaption registers with the underlying swap and with the evaluation
+    date on the Settings it was built with (D5). Pricing needs an engine: call
+    one of the three setters before npv.
+    """
 
     def __init__(
         self,
@@ -681,29 +702,109 @@ class Swaption:
         settlement_type: SettlementType,
         settlement_method: SettlementMethod,
         settings: Settings,
-    ) -> None: ...
-    def set_jamshidian_engine(self, model: HullWhite) -> None: ...
+    ) -> None:
+        """Build the swaption over swap.
+
+        Args:
+            swap (VanillaSwap): The swap the option enters; it needs no
+                discounting engine of its own, the swaption engine reading its
+                arguments instead.
+            exercise (EuropeanExercise): The single exercise date.
+            settlement_type (SettlementType): Whether exercise settles
+                physically or in cash.
+            settlement_method (SettlementMethod): The mechanics under that
+                type; an inconsistent pair surfaces from npv(), not here.
+            settings (Settings): The explicit settings supplying the evaluation
+                date the swaption prices against.
+        """
+        ...
+    def set_jamshidian_engine(self, model: HullWhite) -> None:
+        """Attach a Jamshidian engine so the swaption prices off Hull-White.
+
+        The engine is European-only: a non-European exercise errors at pricing
+        time.
+
+        Args:
+            model (HullWhite): The short-rate model supplying the dynamics.
+        """
+        ...
     def set_black_engine(self, engine: BlackSwaptionEngine) -> None:
-        """Price off a swaption volatility surface instead of a short-rate
-        model. The engine must carry the same Settings object as this swaption."""
+        """Attach a Black engine, pricing off a swaption volatility surface.
+
+        The engine is built separately, so the same one can be shared across
+        swaptions. It must carry the same Settings object as this swaption: two
+        different settings would price the swap and the option on different
+        dates with no error raised.
+
+        Args:
+            engine (BlackSwaptionEngine): The engine and its volatility
+                surface.
+        """
         ...
     def set_bachelier_engine(self, engine: BachelierSwaptionEngine) -> None:
-        """Price off a normal-volatility swaption surface. The engine must carry
-        the same Settings object as this swaption."""
+        """Attach a Bachelier engine, pricing off a normal-volatility surface.
+
+        The same-Settings requirement as set_black_engine applies.
+
+        Args:
+            engine (BachelierSwaptionEngine): The engine and its
+                normal-volatility surface.
+        """
         ...
     def calculate(self) -> None:
-        """Forces the valuation, which also surfaces an inconsistent (settlement
-        type, method) pair."""
+        """Force the valuation. Idempotent.
+
+        Raises:
+            ItofinError: If no engine is attached, no evaluation date is set,
+                or the (settlement type, method) pair is inconsistent, which
+                the core checks here rather than at construction.
+        """
         ...
-    def is_calculated(self) -> bool: ...
+    def is_calculated(self) -> bool:
+        """Return whether the cached results are currently valid.
+
+        Returns:
+            bool: True when the next accessor reads the cache.
+        """
+        ...
     def price(self, engine: BlackSwaptionEngine) -> float:
-        """set_black_engine followed by npv, in one call. Black is the primary;
-        the Jamshidian and Bachelier engines keep their own setters."""
+        """Attach the Black engine and return the NPV.
+
+        set_black_engine followed by npv, in one call. Black is the primary
+        because it is the standard swaption engine; the Jamshidian and
+        Bachelier engines keep their own setters.
+
+        Args:
+            engine (BlackSwaptionEngine): The engine to install and price on.
+
+        Returns:
+            float: The swaption value.
+
+        Raises:
+            ItofinError: On anything that makes the valuation fail.
+        """
         ...
     def results(self) -> Results:
-        """A frozen snapshot of the valuation, calculating first."""
+        """Return a frozen snapshot of the valuation, calculating first.
+
+        Returns:
+            Results: A copy of the valuation results.
+
+        Raises:
+            ItofinError: On anything that makes the valuation fail.
+        """
         ...
-    def npv(self) -> float: ...
+    def npv(self) -> float:
+        """Return the swaption NPV under the attached engine.
+
+        Returns:
+            float: The present value.
+
+        Raises:
+            ItofinError: If no engine is attached or the (settlement type,
+                method) pair is inconsistent.
+        """
+        ...
 
 class CapFloorType:
     """Whether the instrument caps, floors or collars its floating leg.
@@ -739,17 +840,68 @@ class CapFloor:
         strike: float,
         forward_start: Period,
         settings: Settings,
-    ) -> None: ...
+    ) -> None:
+        """Build a standard market cap or floor through MakeCapFloor.
+
+        Args:
+            cap_floor_type (CapFloorType): Cap or Floor; the builder refuses
+                Collar.
+            tenor (Period): The length of the capped leg.
+            ibor_index (IborIndex): The index the floating leg fixes off.
+            strike (float): The single strike, padded across every coupon.
+            forward_start (Period): The delay before the leg starts; a zero
+                period excludes the spot caplet.
+            settings (Settings): The explicit settings supplying the evaluation
+                date and the stored fixings.
+
+        Raises:
+            ItofinError: If cap_floor_type is Collar, if the derived schedule
+                is degenerate, or if the start has to be derived and no
+                evaluation date is set.
+        """
+        ...
     @staticmethod
     def cap(leg: IborLeg, cap_rates: list[float], settings: Settings) -> CapFloor:
-        """A cap over the coupons leg builds. Raises ItofinError on an empty
-        cap_rates list, or on whatever building the coupons rejects."""
+        """Build a cap over the coupons leg builds, struck at cap_rates.
+
+        Unlike the constructor this keeps whatever leg it is given: the spot
+        caplet stays, and the leg's own notional, day counter and fixing days
+        reach the coupons.
+
+        Args:
+            leg (IborLeg): The leg whose coupons are capped.
+            cap_rates (list[float]): The cap strikes, padded to the leg length
+                by repeating the last entry.
+            settings (Settings): The explicit settings the instrument resolves
+                its dates against.
+
+        Returns:
+            CapFloor: The cap over that leg.
+
+        Raises:
+            ItofinError: On an empty cap_rates list, or on whatever building
+                the leg's coupons reports, a missing notional above all.
+        """
         ...
     @staticmethod
     def floor(
         leg: IborLeg, floor_rates: list[float], settings: Settings
     ) -> CapFloor:
-        """A floor over the coupons leg builds. Fallible as cap()."""
+        """Build a floor over the coupons leg builds, struck at floor_rates.
+
+        Args:
+            leg (IborLeg): The leg whose coupons are floored.
+            floor_rates (list[float]): The floor strikes, padded as cap() pads.
+            settings (Settings): The explicit settings the instrument resolves
+                its dates against.
+
+        Returns:
+            CapFloor: The floor over that leg.
+
+        Raises:
+            ItofinError: Fallible as cap(), on an empty list or a leg whose
+                coupons cannot be built.
+        """
         ...
     @staticmethod
     def collar(
@@ -758,32 +910,111 @@ class CapFloor:
         floor_rates: list[float],
         settings: Settings,
     ) -> CapFloor:
-        """Long the cap at cap_rates, short the floor at floor_rates, so it is
-        worth the one less the other. Both lists are required."""
+        """Build a collar: long the cap at cap_rates, short the floor at floor_rates.
+
+        The collar is worth the one less the other, and this is the only route
+        to one over a floating leg.
+
+        Args:
+            leg (IborLeg): The leg whose coupons are collared.
+            cap_rates (list[float]): The cap strikes, padded as cap() pads.
+            floor_rates (list[float]): The floor strikes, padded the same way.
+            settings (Settings): The explicit settings the instrument resolves
+                its dates against.
+
+        Returns:
+            CapFloor: The collar over that leg.
+
+        Raises:
+            ItofinError: On either list being empty, both being required, or on
+                a leg whose coupons cannot be built.
+        """
         ...
-    def cap_rates(self) -> list[float]: ...
-    def floor_rates(self) -> list[float]: ...
-    def coupon_count(self) -> int: ...
+    def cap_rates(self) -> list[float]:
+        """Return the cap strikes, one per coupon.
+
+        Returns:
+            list[float]: The cap strikes; empty for a floor.
+        """
+        ...
+    def floor_rates(self) -> list[float]:
+        """Return the floor strikes, one per coupon.
+
+        Returns:
+            list[float]: The floor strikes; empty for a cap.
+        """
+        ...
+    def coupon_count(self) -> int:
+        """Return the number of optionlets.
+
+        Returns:
+            int: One per floating coupon on the leg.
+        """
+        ...
     def set_black_engine(self, engine: BlackCapFloorEngine) -> None:
-        """Price each optionlet off an optionlet volatility surface. The engine
-        must resolve its dates against the same Settings object as this
-        cap/floor."""
+        """Attach a Black engine, pricing each optionlet off a volatility surface.
+
+        The engine is built separately, so the same one can be shared across
+        instruments. It must resolve its dates against the same Settings object
+        as this cap/floor: two different settings would price the leg and the
+        optionlets on different dates with no error raised.
+
+        Args:
+            engine (BlackCapFloorEngine): The engine and its optionlet
+                volatility surface.
+        """
         ...
     def calculate(self) -> None:
-        """Forces the valuation. Idempotent."""
+        """Force the valuation. Idempotent.
+
+        Raises:
+            ItofinError: If no engine is attached, no evaluation date is set,
+                or the engine refuses the instrument.
+        """
         ...
     def is_calculated(self) -> bool:
-        """Whether the cached results are currently valid. Moving a quote the
-        attached engine was built over flips this back to False."""
+        """Return whether the cached results are currently valid.
+
+        The Black engine observes its volatility handle, so moving a quote the
+        engine was built over reaches the cap and flips this back to False.
+
+        Returns:
+            bool: True when the next accessor reads the cache.
+        """
         ...
     def price(self, engine: BlackCapFloorEngine) -> float:
-        """set_black_engine followed by npv, in one call."""
+        """Attach engine and return the NPV.
+
+        Args:
+            engine (BlackCapFloorEngine): The engine to install and price on.
+
+        Returns:
+            float: The cap/floor value.
+
+        Raises:
+            ItofinError: On anything that makes the valuation fail.
+        """
         ...
     def results(self) -> Results:
-        """A frozen snapshot of the valuation, calculating first."""
+        """Return a frozen snapshot of the valuation, calculating first.
+
+        Returns:
+            Results: A copy of the valuation results.
+
+        Raises:
+            ItofinError: On anything that makes the valuation fail.
+        """
         ...
     def npv(self) -> float:
-        """Raises ItofinError with no engine attached."""
+        """Return the cap/floor NPV under the attached engine.
+
+        Returns:
+            float: The present value.
+
+        Raises:
+            ItofinError: If no engine is attached, which the core reports as
+                "null pricing engine".
+        """
         ...
 
 class ProtectionSide:

--- a/crates/itofin-py/python/itofin/instruments.pyi
+++ b/crates/itofin-py/python/itofin/instruments.pyi
@@ -1057,7 +1057,31 @@ class CreditDefaultSwap:
         settles_accrual: bool,
         pays_at_default_time: bool,
         settings: Settings,
-    ) -> None: ...
+    ) -> None:
+        """Build a contract on the C++ default terms.
+
+        Args:
+            side (ProtectionSide): Whether protection is bought or sold.
+            notional (float): The notional the premium and protection are
+                quoted on.
+            spread (float): The running spread the premium leg pays.
+            schedule (Schedule): The premium leg's payment schedule.
+            payment_convention (BusinessDayConvention): The roll applied to the
+                premium payment dates.
+            day_counter (DayCounter): The day count the premium accrues on.
+            settles_accrual (bool): Whether the accrued coupon settles on
+                default.
+            pays_at_default_time (bool): Whether the protection pays at default
+                rather than at maturity.
+            settings (Settings): The explicit settings supplying the evaluation
+                date the contract prices against.
+
+        Raises:
+            ItofinError: If the schedule is empty, if the protection start
+                follows the first accrual date under a pre-Big-Bang
+                date-generation rule, or if the premium leg cannot be built.
+        """
+        ...
     @staticmethod
     def with_terms(
         side: ProtectionSide,
@@ -1072,60 +1096,189 @@ class CreditDefaultSwap:
         pays_at_default_time: bool = True,
         rebates_accrual: bool = True,
     ) -> CreditDefaultSwap:
-        """A contract quoting the terms __init__ defaults. protection_start is
-        the first date a default triggers the contract; None takes the
-        schedule's first date, which is what __init__ does. settings precedes
-        the defaulted terms because a required argument cannot follow an
-        optional one."""
+        """Build a contract quoting the terms __init__ defaults.
+
+        The three flags carry the core defaults verbatim, so calling this with
+        only the positional arguments builds exactly what __init__ builds.
+
+        Args:
+            side (ProtectionSide): Whether protection is bought or sold.
+            notional (float): The notional the premium and protection are
+                quoted on.
+            spread (float): The running spread the premium leg pays.
+            schedule (Schedule): The premium leg's payment schedule.
+            payment_convention (BusinessDayConvention): The roll applied to the
+                premium payment dates.
+            day_counter (DayCounter): The day count the premium accrues on.
+            settings (Settings): The explicit settings; it precedes the
+                defaulted terms because a Python signature cannot put a
+                required argument after an optional one.
+            protection_start (Date | None): The first date a default triggers
+                the contract; None takes the schedule's first date, which is
+                what __init__ does.
+            settles_accrual (bool): Whether the accrued coupon settles on
+                default.
+            pays_at_default_time (bool): Whether the protection pays at default
+                rather than at maturity.
+            rebates_accrual (bool): Whether the protection seller rebates the
+                accrued current coupon.
+
+        Returns:
+            CreditDefaultSwap: The contract on those terms.
+
+        Raises:
+            ItofinError: On the same conditions __init__ reports.
+        """
         ...
     def set_engine(self, engine: MidPointCdsEngine) -> None:
-        """Price the contract off a default-probability and a discount curve.
-        The engine must resolve its dates against the same Settings object as
-        this contract."""
+        """Attach a mid-point engine so the contract prices.
+
+        The engine is built separately, so one engine can be shared across
+        contracts. It must resolve its dates against the same Settings object
+        as this contract.
+
+        Args:
+            engine (MidPointCdsEngine): The engine and its default-probability
+                and discount curves.
+        """
         ...
     def set_isda_engine(self, engine: IsdaCdsEngine) -> None:
-        """Price the contract under the ISDA standard model. A separate setter
-        because the two engine classes are unrelated; the same same-Settings
-        rule applies, and the ISDA engine additionally refuses curves outside
-        its specification when the contract prices."""
+        """Attach an ISDA engine so the contract prices under the standard model.
+
+        A separate setter rather than a widened set_engine: the two engine
+        facades are unrelated classes, so one argument cannot name both. The
+        same sharing and same-Settings rules apply, and the ISDA engine
+        additionally refuses curves outside its specification when the contract
+        prices.
+
+        Args:
+            engine (IsdaCdsEngine): The ISDA engine and its curves.
+        """
         ...
     def calculate(self) -> None:
-        """Forces the valuation. Idempotent."""
+        """Force the valuation. Idempotent.
+
+        Raises:
+            ItofinError: If no engine is attached, no evaluation date is set,
+                or the engine refuses the contract.
+        """
         ...
-    def is_calculated(self) -> bool: ...
+    def is_calculated(self) -> bool:
+        """Return whether the cached results are currently valid.
+
+        Returns:
+            bool: True when the next accessor reads the cache.
+        """
+        ...
     def price(self, engine: MidPointCdsEngine) -> float:
-        """set_engine followed by npv, in one call. The mid-point engine is the
-        primary; set_isda_engine stays a separate setter."""
+        """Attach the mid-point engine and return the NPV.
+
+        set_engine followed by npv, in one call. The mid-point engine is the
+        primary because it is the core's own default CDS engine;
+        set_isda_engine stays a separate setter.
+
+        Args:
+            engine (MidPointCdsEngine): The engine to install and price on.
+
+        Returns:
+            float: The contract value.
+
+        Raises:
+            ItofinError: On anything that makes the valuation fail.
+        """
         ...
-    def results(self) -> Results: ...
+    def results(self) -> Results:
+        """Return a frozen snapshot of the valuation, calculating first.
+
+        Returns:
+            Results: A copy of the valuation results.
+
+        Raises:
+            ItofinError: On anything that makes the valuation fail.
+        """
+        ...
     def npv(self) -> float:
-        """Raises ItofinError with no engine attached."""
+        """Return the contract NPV under the attached engine.
+
+        Returns:
+            float: The present value.
+
+        Raises:
+            ItofinError: If no engine is attached, which the core reports as
+                "null pricing engine".
+        """
         ...
     def fair_spread(self) -> float:
-        """The running spread that prices the contract at zero. Raises
-        ItofinError with no engine attached, and when the engine priced a
-        worthless premium leg and so provided no fair spread."""
+        """Return the running spread that prices the contract at zero.
+
+        Returns:
+            float: The fair running spread.
+
+        Raises:
+            ItofinError: If no engine is attached, and when the engine priced a
+                worthless premium leg and so provided no fair spread.
+        """
         ...
     def fair_upfront(self) -> float:
-        """The upfront that prices the contract at zero, as a fraction of the
-        notional. Raises ItofinError as fair_spread does."""
+        """Return the upfront that prices the contract at zero.
+
+        Returns:
+            float: The fair upfront, as a fraction of the notional.
+
+        Raises:
+            ItofinError: On the same conditions fair_spread reports.
+        """
         ...
     def notional(self) -> float:
-        """The notional the premium and the protection are quoted on."""
+        """Return the notional the premium and the protection are quoted on.
+
+        Returns:
+            float: The contract notional.
+        """
         ...
     def accrual_rebate_amount(self) -> float | None:
-        """The accrued coupon the protection seller rebates, or None when the
-        contract does not rebate accrual at all. A contract traded in the past
-        still carries the flow, with a real amount but a past settlement date
-        that keeps it out of the value, so None means the flag rather than a
-        stale trade."""
+        """Return the accrued coupon the protection seller rebates.
+
+        A contract traded in the past still carries the flow: the core builds
+        it whenever the flag is set, regardless of the trade date, so None here
+        means the flag was off, never a stale trade. Such a flow carries a real
+        accrued amount but settled on a past date, so it no longer reaches the
+        value. The amount is returned bare rather than behind a cash-flow
+        facade, there being none.
+
+        Returns:
+            float | None: The rebated amount, or None when the contract does
+                not rebate accrual at all.
+        """
         ...
     def accrual_rebate_date(self) -> Date | None:
-        """The date the accrual rebate settles on, the same cash-settlement date
-        the upfront pays on. None on the same terms as accrual_rebate_amount."""
+        """Return the date the accrual rebate settles on.
+
+        Returns:
+            Date | None: The cash-settlement date the upfront also pays on, or
+                None on the same terms as accrual_rebate_amount.
+        """
         ...
-    def coupon_leg_npv(self) -> float: ...
-    def default_leg_npv(self) -> float: ...
+    def coupon_leg_npv(self) -> float:
+        """Return the premium leg's NPV.
+
+        Returns:
+            float: The present value of the premium leg.
+
+        Raises:
+            ItofinError: On the same conditions fair_spread reports.
+        """
+        ...
+    def default_leg_npv(self) -> float:
+        """Return the protection leg's NPV.
+
+        Returns:
+            float: The present value of the protection leg.
+
+        Raises:
+            ItofinError: On the same conditions fair_spread reports.
+        """
+        ...
     def implied_hazard_rate(
         self,
         target_npv: float,
@@ -1135,16 +1288,32 @@ class CreditDefaultSwap:
         accuracy: float,
         model: PricingModel,
     ) -> float:
-        """The flat hazard rate at which this contract is worth target_npv.
+        """Return the flat hazard rate at which this contract is worth target_npv.
 
         The solve stands on its own engine rather than on whichever one
-        set_engine attached, so there is no probability-curve argument:
-        day_counter counts the flat curve the solve builds, not the contract.
-        Under PricingModel.Isda both it and discount must count Act/365 (Fixed),
-        which is what the ISDA engine requires of its curves.
+        set_engine attached: it builds a flat, quote-backed probability curve
+        and prices on model against discount. There is therefore no
+        probability-curve argument - the curve being solved for is the one the
+        core builds.
 
-        Raises ItofinError on a malformed contract and when the solve does not
-        converge, which includes a pricing failure at some hazard rate."""
+        Args:
+            target_npv (float): The value the contract is solved to.
+            discount (YieldTermStructure): The curve the flows discount on.
+            day_counter (DayCounter): The day count of the internal flat curve,
+                not of the contract. Under PricingModel.Isda both it and
+                discount must count Act/365 (Fixed), which is what the ISDA
+                engine requires of its curves.
+            recovery_rate (float): The recovery assumed on default.
+            accuracy (float): The tolerance the solve stops at, on the rate.
+            model (PricingModel): The model the contract is inverted under.
+
+        Returns:
+            float: The flat hazard rate.
+
+        Raises:
+            ItofinError: On a malformed contract, and when the solve does not
+                converge, which includes a pricing failure at some hazard rate.
+        """
         ...
 
 class MakeCreditDefaultSwap:
@@ -1169,12 +1338,41 @@ class MakeCreditDefaultSwap:
         side: ProtectionSide | None = None,
         trade_date: Date | None = None,
     ) -> None:
-        """trade_date overrides the evaluation date the trade is otherwise dated
-        off, which is how a contract traded in the past is built."""
+        """Store the configuration the chain is assembled from in build().
+
+        Each build() runs a fresh chain, so one builder object cannot carry a
+        setting into a later contract.
+
+        Args:
+            term_date (Date): The maturity the premium schedule is derived
+                from.
+            running_spread (float): The running spread the premium leg pays.
+            settings (Settings): The explicit settings supplying the evaluation
+                date the trade is dated off.
+            nominal (float | None): The notional; None keeps the core default
+                of 1.
+            upfront_rate (float | None): The upfront as a fraction of the
+                notional; None keeps the core default of none.
+            side (ProtectionSide | None): Which side the contract holds; None
+                keeps the core default of Buyer.
+            trade_date (Date | None): Overrides the evaluation date the trade
+                is otherwise dated off, which is how a contract traded in the
+                past is built.
+        """
         ...
     def build(self) -> CreditDefaultSwap:
-        """The built contract, which carries no engine. Raises ItofinError with
-        no evaluation date set, the trade date being derived from it."""
+        """Build the contract, which carries no engine.
+
+        Attach one with set_engine or set_isda_engine before pricing.
+
+        Returns:
+            CreditDefaultSwap: The contract on the market conventions.
+
+        Raises:
+            ItofinError: If no evaluation date is set, the trade date being
+                derived from it, and on whatever the contract construction
+                rejects.
+        """
         ...
 
 class ZeroCouponInflationSwap:

--- a/crates/itofin-py/python/itofin/instruments.pyi
+++ b/crates/itofin-py/python/itofin/instruments.pyi
@@ -291,13 +291,20 @@ class VanillaOption:
         ...
 
 class SwapType:
-    """Which side of the named leg the swap is seen from."""
+    """Which side of the named leg the swap is seen from.
+
+    A fieldless enum; the signed leg multiplier the two variants stand for
+    stays in the core.
+    """
 
     Payer: SwapType
     Receiver: SwapType
 
 class VanillaSwap:
-    """A fixed-vs-Ibor interest-rate swap."""
+    """A fixed-vs-Ibor interest-rate swap.
+
+    Pricing needs an engine: call set_engine before fair_rate or npv.
+    """
 
     def __init__(
         self,
@@ -311,27 +318,137 @@ class VanillaSwap:
         spread: float,
         floating_day_count: DayCounter,
         settings: Settings,
-    ) -> None: ...
-    def set_engine(self, curve: YieldTermStructure, settings: Settings) -> None: ...
+    ) -> None:
+        """Build the swap from both schedules spelled out.
+
+        Args:
+            swap_type (SwapType): Whether the fixed leg is paid or received.
+            nominal (float): The notional both legs accrue on.
+            fixed_schedule (Schedule): The fixed leg's payment schedule.
+            fixed_rate (float): The rate the fixed leg accrues at.
+            fixed_day_count (DayCounter): The day count of the fixed leg.
+            float_schedule (Schedule): The floating leg's payment schedule.
+            ibor_index (IborIndex): The index the floating leg fixes off.
+            spread (float): The spread added to every floating fixing.
+            floating_day_count (DayCounter): The day count of the floating leg.
+            settings (Settings): The explicit settings supplying the evaluation
+                date and the stored fixings.
+
+        Raises:
+            ItofinError: If the floating leg cannot be built, a degenerate leg
+                being the usual cause.
+        """
+        ...
+    def set_engine(self, curve: YieldTermStructure, settings: Settings) -> None:
+        """Attach a discounting engine over curve so the swap prices.
+
+        The engine is built with the settings-driven flow defaults, leaving the
+        settlement date, the NPV date and the settlement-date-flows flag unset.
+
+        Args:
+            curve (YieldTermStructure): The curve the flows discount on.
+            settings (Settings): The settings the engine resolves its dates
+                against.
+        """
+        ...
     def calculate(self) -> None:
-        """Forces the valuation. Idempotent."""
+        """Force the valuation. Idempotent.
+
+        Raises:
+            ItofinError: If no engine is attached, no evaluation date is set,
+                or the attached engine refuses the swap.
+        """
         ...
-    def is_calculated(self) -> bool: ...
+    def is_calculated(self) -> bool:
+        """Return whether the cached results are currently valid.
+
+        Returns:
+            bool: True when the next accessor reads the cache.
+        """
+        ...
     def price(self, curve: YieldTermStructure, settings: Settings) -> float:
-        """set_engine followed by npv, in one call, and it takes the same two
-        arguments for the same reason."""
+        """Attach a discounting engine over curve and return the NPV.
+
+        set_engine followed by npv, in one call, and it takes the same two
+        arguments for the same reason.
+
+        Args:
+            curve (YieldTermStructure): The curve the flows discount on.
+            settings (Settings): The settings the engine resolves its dates
+                against.
+
+        Returns:
+            float: The swap value under the freshly built engine.
+
+        Raises:
+            ItofinError: On anything that makes the valuation fail.
+        """
         ...
-    def results(self) -> Results: ...
-    def fair_rate(self) -> float: ...
-    def npv(self) -> float: ...
-    def nominal(self) -> float: ...
-    def fixed_rate(self) -> float: ...
+    def results(self) -> Results:
+        """Return a frozen snapshot of the valuation, calculating first.
+
+        Returns:
+            Results: A copy of the valuation results.
+
+        Raises:
+            ItofinError: On anything that makes the valuation fail.
+        """
+        ...
+    def fair_rate(self) -> float:
+        """Return the fixed rate that zeroes the swap NPV.
+
+        Returns:
+            float: The fair fixed rate.
+
+        Raises:
+            ItofinError: If no engine is attached or the swap has expired.
+        """
+        ...
+    def npv(self) -> float:
+        """Return the swap NPV under the attached engine.
+
+        Returns:
+            float: The present value.
+
+        Raises:
+            ItofinError: If no engine is attached.
+        """
+        ...
+    def nominal(self) -> float:
+        """Return the notional both legs accrue on.
+
+        Returns:
+            float: The single nominal.
+
+        Raises:
+            ItofinError: If the legs carry per-coupon nominals, which leaves no
+                single one to report.
+        """
+        ...
+    def fixed_rate(self) -> float:
+        """Return the fixed-leg rate.
+
+        Returns:
+            float: The rate the fixed leg accrues at.
+        """
+        ...
 
 class MakeVanillaSwap:
-    """Market-convention builder for a VanillaSwap: derives both schedules, the
-    fixed-leg tenor and day count and the discounting engine from a swap tenor
-    and an Ibor index. ``fixed_rate=None`` builds a par swap. The built swap
-    already carries its DiscountingSwapEngine."""
+    """Market-convention builder for a VanillaSwap.
+
+    Derives the start and end dates, both schedules, the fixed-leg tenor and
+    day count and the discounting engine from a swap tenor and an Ibor index,
+    so the caller states conventions instead of hand-building two schedules.
+    ``fixed_rate=None`` builds a par swap: the fair rate is computed and written
+    into the fixed leg, so the result prices to a zero NPV.
+
+    The core builder is a consumed-self fluent chain, which does not cross the
+    FFI boundary; this facade takes the overrides as constructor keywords and
+    assembles the chain inside build(). Only four overrides are exposed; every
+    other core one keeps its default, so the discounting curve is always the
+    index's forwarding curve. The built swap already carries its
+    DiscountingSwapEngine.
+    """
 
     def __init__(
         self,
@@ -344,8 +461,41 @@ class MakeVanillaSwap:
         nominal: float | None = None,
         fixed_leg_tenor: Period | None = None,
         fixed_leg_day_count: DayCounter | None = None,
-    ) -> None: ...
-    def build(self) -> VanillaSwap: ...
+    ) -> None:
+        """Store the configuration the chain is assembled from in build().
+
+        Args:
+            swap_tenor (Period): The length of the swap.
+            ibor_index (IborIndex): The index the floating leg fixes off, and
+                whose forwarding curve discounts.
+            settings (Settings): The explicit settings supplying the evaluation
+                date and the stored fixings.
+            fixed_rate (float | None): The rate of the fixed leg; None builds a
+                par swap.
+            forward_start (Period | None): The delay before the swap starts;
+                None starts it spot, at a zero-day period.
+            effective_date (Date | None): The start date; None derives it from
+                the evaluation date.
+            nominal (float | None): The notional; None keeps the core default.
+            fixed_leg_tenor (Period | None): The fixed-leg payment tenor; None
+                takes the currency's market convention.
+            fixed_leg_day_count (DayCounter | None): The fixed-leg day count;
+                None takes the currency's market convention.
+        """
+        ...
+    def build(self) -> VanillaSwap:
+        """Build the priced swap.
+
+        Returns:
+            VanillaSwap: The swap, already carrying its discounting engine.
+
+        Raises:
+            ItofinError: If effective_date is unset and no evaluation date is
+                set to derive the start from; if the index is neither EUR nor
+                USD, the two the fixed-leg defaults are known for; or if the
+                par-rate fill fails to price.
+        """
+        ...
 
 class OvernightIndexedSwap:
     """A fixed leg versus a compounded overnight leg.
@@ -354,25 +504,103 @@ class OvernightIndexedSwap:
     set_engine and no raw constructor (both deferred with the two-schedule
     master ctor)."""
 
-    def fair_rate(self) -> float: ...
+    def fair_rate(self) -> float:
+        """Return the fixed rate that zeroes the swap NPV.
+
+        Returns:
+            float: The fair fixed rate, read through the swap's base.
+
+        Raises:
+            ItofinError: If the swap has expired or its engine fails to price.
+        """
+        ...
     def calculate(self) -> None:
-        """Forces the valuation. Idempotent."""
+        """Force the valuation. Idempotent.
+
+        Raises:
+            ItofinError: If no evaluation date is set or the engine refuses the
+                swap.
+        """
         ...
-    def is_calculated(self) -> bool: ...
+    def is_calculated(self) -> bool:
+        """Return whether the cached results are currently valid.
+
+        Returns:
+            bool: True when the next accessor reads the cache.
+        """
+        ...
     def price(self) -> float:
-        """Prices and returns the NPV. The only no-argument price(): MakeOis
-        already attached the discounting engine, so none is left to install."""
+        """Price the swap and return the NPV.
+
+        The only no-argument price(): MakeOis already attached the discounting
+        engine, so none is left to install.
+
+        Returns:
+            float: The present value.
+
+        Raises:
+            ItofinError: On anything that makes the valuation fail, including
+                the "null pricing engine" a swap that somehow arrived without
+                one reports.
+        """
         ...
-    def results(self) -> Results: ...
-    def npv(self) -> float: ...
-    def nominal(self) -> float: ...
-    def fixed_rate(self) -> float: ...
+    def results(self) -> Results:
+        """Return a frozen snapshot of the valuation, calculating first.
+
+        Returns:
+            Results: A copy of the valuation results.
+
+        Raises:
+            ItofinError: On anything that makes the valuation fail.
+        """
+        ...
+    def npv(self) -> float:
+        """Return the swap NPV under the engine the builder attached.
+
+        Returns:
+            float: The present value.
+
+        Raises:
+            ItofinError: On anything that makes the valuation fail.
+        """
+        ...
+    def nominal(self) -> float:
+        """Return the notional both legs accrue on.
+
+        Returns:
+            float: The single nominal, read through the swap's base.
+
+        Raises:
+            ItofinError: If the legs carry per-coupon nominals, which leaves no
+                single one to report.
+        """
+        ...
+    def fixed_rate(self) -> float:
+        """Return the fixed-leg rate.
+
+        Returns:
+            float: The rate given to the builder, or the fair rate it filled in
+                for a par swap.
+        """
+        ...
 
 class MakeOis:
-    """Market-convention builder for an OvernightIndexedSwap: derives both
-    schedules and the discounting engine from a swap tenor and an overnight
-    index. ``fixed_rate=None`` builds a par swap. The built swap already carries
-    its DiscountingSwapEngine."""
+    """Market-convention builder for an OvernightIndexedSwap.
+
+    Derives the start and end dates, both schedules and the discounting engine
+    from a swap tenor and an overnight index, so the caller states conventions
+    instead of hand-building two schedules. ``fixed_rate=None`` builds a par
+    swap: the fair rate is computed off a temporary swap and written into the
+    fixed leg, so the result prices to a zero NPV.
+
+    The core builder is a consumed-self fluent chain, which does not cross the
+    FFI boundary; this facade takes the overrides as constructor keywords and
+    assembles the chain inside build(). Only five overrides are exposed; every
+    other core one keeps its default, and the four the core rejects outright
+    (telescopic value dates, lookback, lockout and observation shift) are
+    unreachable from here by construction. The built swap already carries its
+    DiscountingSwapEngine.
+    """
 
     def __init__(
         self,
@@ -386,8 +614,43 @@ class MakeOis:
         payment_lag: int | None = None,
         discounting_term_structure: YieldTermStructure | None = None,
         averaging_method: RateAveraging | None = None,
-    ) -> None: ...
-    def build(self) -> OvernightIndexedSwap: ...
+    ) -> None:
+        """Store the configuration the chain is assembled from in build().
+
+        Args:
+            swap_tenor (Period): The length of the swap.
+            overnight_index (OvernightIndex): The index the overnight leg
+                compounds.
+            settings (Settings): The explicit settings supplying the evaluation
+                date and the stored fixings.
+            fixed_rate (float | None): The rate of the fixed leg; None builds a
+                par swap.
+            forward_start (Period | None): The delay before the swap starts;
+                None starts it spot, at a zero-day period.
+            effective_date (Date | None): The start date; None derives it from
+                the evaluation date.
+            nominal (float | None): The notional; None keeps the core default.
+            payment_lag (int | None): The days between accrual end and payment;
+                None keeps the core default.
+            discounting_term_structure (YieldTermStructure | None): The curve
+                the flows discount on; None keeps the core default.
+            averaging_method (RateAveraging | None): Whether the overnight
+                fixings compound or are averaged; None keeps the core default.
+        """
+        ...
+    def build(self) -> OvernightIndexedSwap:
+        """Build the priced swap.
+
+        Returns:
+            OvernightIndexedSwap: The swap, already carrying its discounting
+                engine.
+
+        Raises:
+            ItofinError: If effective_date is unset and no evaluation date is
+                set to derive the start from; if the schedule or the overnight
+                leg is degenerate; or if the par-rate fill fails to price.
+        """
+        ...
 
 class EuropeanExercise:
     """A single-date exercise schedule."""

--- a/crates/itofin-py/python/itofin/instruments.pyi
+++ b/crates/itofin-py/python/itofin/instruments.pyi
@@ -1799,12 +1799,56 @@ class MakeYoYInflationCapFloor:
         first_caplet_excluded: bool = False,
         strike: float | None = None,
         atm_strike: YieldTermStructure | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Store the configuration the chain is assembled from in build().
+
+        Args:
+            cap_floor_type (CapFloorType): Cap or Floor; Collar has no path
+                here.
+            index (YoYInflationIndex): The index the optionlets fix off.
+            length (int): The length of the derived annual leg, in years.
+            calendar (Calendar): The calendar the payments roll on.
+            observation_lag (Period): How far back each coupon's fixings are
+                observed.
+            interpolation (CpiInterpolationType): How the observed fixings are
+                interpolated.
+            settings (Settings): The explicit settings supplying the evaluation
+                date and the stored fixings.
+            nominal (float | None): The notional; None keeps the core default
+                of 1,000,000.
+            effective_date (Date | None): The start date; None derives it from
+                the evaluation date.
+            payment_day_counter (DayCounter | None): The day count; None keeps
+                the core default of 30/360 bond basis.
+            payment_adjustment (BusinessDayConvention | None): The payment
+                roll; None keeps the core default of ModifiedFollowing.
+            fixing_days (int | None): The fixing days of the coupons; None
+                keeps the core default of none.
+            engine (YoYInflationCapFloorEngine | None): An engine installed on
+                the built instrument; None leaves it unpriced.
+            as_optionlet (bool): Whether to keep only the last optionlet.
+            forward_start (Period | None): The delay before the leg starts;
+                None keeps the core default of no forward start.
+            first_caplet_excluded (bool): Whether to drop the front optionlet.
+            strike (float | None): The explicit strike; exactly one of this and
+                atm_strike is required.
+            atm_strike (YieldTermStructure | None): The curve the at-the-money
+                strike is filled off; exactly one of this and strike is
+                required.
+        """
+        ...
     def build(self) -> YoYInflationCapFloor:
-        """Raises ItofinError when both strike and atm_strike are given and when
-        neither is; when the start date has to be derived and no evaluation date
-        is set; and on whatever the leg construction and the at-the-money fill
-        report."""
+        """Build the cap/floor, which already carries its engine when one was given.
+
+        Returns:
+            YoYInflationCapFloor: The built instrument.
+
+        Raises:
+            ItofinError: If both strike and atm_strike are given or neither is;
+                if the start date has to be derived and no evaluation date is
+                set; and on whatever the leg construction and the at-the-money
+                fill report.
+        """
         ...
 
 class YoYInflationCapFloor:
@@ -1828,23 +1872,70 @@ class YoYInflationCapFloor:
         floor_rates: list[float],
         settings: Settings,
     ) -> YoYInflationCapFloor:
-        """Each strike vector is padded to the leg length by repeating its last
-        entry. Raises ItofinError on an empty leg, and on a strike vector the
-        type needs and did not get: a cap or a collar needs cap rates, a floor
-        or a collar floor rates."""
+        """Build an instrument of cap_floor_type over coupons, struck at both vectors.
+
+        Each strike vector is padded to the leg length by repeating its last
+        entry, so a single strike stands for every optionlet.
+
+        Args:
+            cap_floor_type (CapFloorType): Cap, Floor or Collar.
+            coupons (list[YoYInflationCoupon]): The leg the optionlets sit on.
+            cap_rates (list[float]): The cap strikes.
+            floor_rates (list[float]): The floor strikes.
+            settings (Settings): The explicit settings the instrument resolves
+                its dates against.
+
+        Returns:
+            YoYInflationCapFloor: The built instrument.
+
+        Raises:
+            ItofinError: On an empty leg, and on a strike vector the type needs
+                and did not get: a cap or a collar needs cap rates, a floor or
+                a collar floor rates.
+        """
         ...
     @staticmethod
     def cap(
         coupons: list[YoYInflationCoupon],
         strikes: list[float],
         settings: Settings,
-    ) -> YoYInflationCapFloor: ...
+    ) -> YoYInflationCapFloor:
+        """Build a cap over coupons struck at strikes.
+
+        Args:
+            coupons (list[YoYInflationCoupon]): The leg the optionlets sit on.
+            strikes (list[float]): The cap strikes, padded as new() pads.
+            settings (Settings): The explicit settings the instrument resolves
+                its dates against.
+
+        Returns:
+            YoYInflationCapFloor: The cap over that leg.
+
+        Raises:
+            ItofinError: On the same conditions new() reports.
+        """
+        ...
     @staticmethod
     def floor(
         coupons: list[YoYInflationCoupon],
         strikes: list[float],
         settings: Settings,
-    ) -> YoYInflationCapFloor: ...
+    ) -> YoYInflationCapFloor:
+        """Build a floor over coupons struck at strikes.
+
+        Args:
+            coupons (list[YoYInflationCoupon]): The leg the optionlets sit on.
+            strikes (list[float]): The floor strikes, padded as new() pads.
+            settings (Settings): The explicit settings the instrument resolves
+                its dates against.
+
+        Returns:
+            YoYInflationCapFloor: The floor over that leg.
+
+        Raises:
+            ItofinError: On the same conditions new() reports.
+        """
+        ...
     @staticmethod
     def collar(
         coupons: list[YoYInflationCoupon],
@@ -1852,7 +1943,21 @@ class YoYInflationCapFloor:
         floor_rates: list[float],
         settings: Settings,
     ) -> YoYInflationCapFloor:
-        """Long the cap at cap_rates, short the floor at floor_rates."""
+        """Build a collar: long the cap at cap_rates, short the floor at floor_rates.
+
+        Args:
+            coupons (list[YoYInflationCoupon]): The leg the optionlets sit on.
+            cap_rates (list[float]): The cap strikes, padded as new() pads.
+            floor_rates (list[float]): The floor strikes, padded the same way.
+            settings (Settings): The explicit settings the instrument resolves
+                its dates against.
+
+        Returns:
+            YoYInflationCapFloor: The collar over that leg.
+
+        Raises:
+            ItofinError: On the same conditions new() reports.
+        """
         ...
     @staticmethod
     def with_strikes(
@@ -1861,31 +1966,144 @@ class YoYInflationCapFloor:
         strikes: list[float],
         settings: Settings,
     ) -> YoYInflationCapFloor:
-        """strikes are cap rates for a Cap and floor rates for a Floor. Raises
-        ItofinError on an empty strikes and on a Collar, which needs two vectors
-        and has collar() for a constructor."""
+        """Build a cap or a floor from a single strike vector.
+
+        Args:
+            cap_floor_type (CapFloorType): Cap or Floor.
+            coupons (list[YoYInflationCoupon]): The leg the optionlets sit on.
+            strikes (list[float]): Cap rates for a Cap and floor rates for a
+                Floor.
+            settings (Settings): The explicit settings the instrument resolves
+                its dates against.
+
+        Returns:
+            YoYInflationCapFloor: The built instrument.
+
+        Raises:
+            ItofinError: On an empty strikes, on a Collar - which needs two
+                vectors, so collar() is its constructor - and on the same
+                conditions new() reports.
+        """
         ...
-    def cap_rates(self) -> list[float]: ...
-    def floor_rates(self) -> list[float]: ...
-    def coupon_count(self) -> int: ...
-    def start_date(self) -> Date: ...
-    def maturity_date(self) -> Date: ...
+    def cap_rates(self) -> list[float]:
+        """Return the cap strikes, one per coupon.
+
+        Returns:
+            list[float]: The cap strikes; empty on a floor.
+        """
+        ...
+    def floor_rates(self) -> list[float]:
+        """Return the floor strikes, one per coupon.
+
+        Returns:
+            list[float]: The floor strikes; empty on a cap.
+        """
+        ...
+    def coupon_count(self) -> int:
+        """Return the number of optionlets.
+
+        Returns:
+            int: One per year-on-year coupon on the leg.
+        """
+        ...
+    def start_date(self) -> Date:
+        """Return the leg's earliest accrual start.
+
+        Returns:
+            Date: The first accrual start date.
+
+        Raises:
+            ItofinError: On an empty leg, which the constructors already
+                refuse.
+        """
+        ...
+    def maturity_date(self) -> Date:
+        """Return the leg's latest accrual end.
+
+        Returns:
+            Date: The last accrual end date.
+
+        Raises:
+            ItofinError: On the same conditions start_date reports.
+        """
+        ...
     def atm_rate(self, discount_curve: YieldTermStructure) -> float:
-        """The strike at which the leg reprices on discount_curve. Raises
-        ItofinError on an unlinked curve, a curve with no reference date and a
-        leg with no basis-point sensitivity to solve over."""
+        """Return the strike at which the leg reprices on discount_curve.
+
+        The core takes the curve itself rather than a handle, so the link is
+        resolved for the call.
+
+        Args:
+            discount_curve (YieldTermStructure): The curve the leg reprices on.
+
+        Returns:
+            float: The at-the-money rate.
+
+        Raises:
+            ItofinError: On an unlinked discount_curve, a curve with no
+                reference date, and a leg with no basis-point sensitivity to
+                solve over.
+        """
         ...
     def set_engine(self, engine: YoYInflationCapFloorEngine) -> None:
-        """The engine must resolve its dates against the same Settings object
-        this cap/floor was built with."""
+        """Attach an engine, replacing whatever the factory installed.
+
+        Args:
+            engine (YoYInflationCapFloorEngine): The engine, which must resolve
+                its dates against the same Settings object this cap/floor was
+                built with: two different ones would price the leg and the
+                optionlets on different dates with no error raised.
+        """
         ...
     def calculate(self) -> None:
-        """Forces the valuation. Idempotent."""
+        """Force the valuation. Idempotent.
+
+        Raises:
+            ItofinError: If no engine is attached, no evaluation date is set,
+                or the engine refuses the instrument.
+        """
         ...
-    def is_calculated(self) -> bool: ...
+    def is_calculated(self) -> bool:
+        """Return whether the cached results are currently valid.
+
+        Returns:
+            bool: True when the next accessor reads the cache.
+        """
+        ...
     def price(self, engine: YoYInflationCapFloorEngine) -> float:
-        """set_engine followed by npv, in one call, replacing whatever engine
-        the factory installed."""
+        """Attach engine and return the NPV.
+
+        Replaces whatever engine the factory installed.
+
+        Args:
+            engine (YoYInflationCapFloorEngine): The engine to install and
+                price on.
+
+        Returns:
+            float: The cap/floor value.
+
+        Raises:
+            ItofinError: On anything that makes the valuation fail.
+        """
         ...
-    def results(self) -> Results: ...
-    def npv(self) -> float: ...
+    def results(self) -> Results:
+        """Return a frozen snapshot of the valuation, calculating first.
+
+        Returns:
+            Results: A copy of the valuation results.
+
+        Raises:
+            ItofinError: On anything that makes the valuation fail.
+        """
+        ...
+    def npv(self) -> float:
+        """Return the cap/floor NPV under the attached engine.
+
+        Returns:
+            float: The present value.
+
+        Raises:
+            ItofinError: If no engine is attached, which the core reports as
+                "null pricing engine", and on whatever the engine reports.
+        """
+        ...

--- a/crates/itofin-py/python/itofin/instruments.pyi
+++ b/crates/itofin-py/python/itofin/instruments.pyi
@@ -37,18 +37,36 @@ from itofin.time import (
 )
 
 class OptionType:
-    """The call/put flag."""
+    """The call/put flag.
+
+    A fieldless enum mirroring the core option type; the signed discriminant
+    convention behind the two variants stays in the core.
+    """
 
     Call: OptionType
     Put: OptionType
 
 class VanillaOption:
-    """A single-asset vanilla option: European by construction, American
-    through the american classmethod."""
+    """A single-asset vanilla option: European by construction, American through american().
+
+    Valuation is lazy: an accessor reprices only once an observed input - the
+    attached engine, or the evaluation date on the Settings the option
+    registered with - has notified it.
+    """
 
     def __init__(
         self, option_type: OptionType, strike: float, expiry: Date, settings: Settings
-    ) -> None: ...
+    ) -> None:
+        """Build the European-exercise option, exercisable only at expiry.
+
+        Args:
+            option_type (OptionType): Whether the payoff is a call or a put.
+            strike (float): The strike of the plain vanilla payoff.
+            expiry (Date): The single date the option may be exercised on.
+            settings (Settings): The explicit settings supplying the evaluation
+                date the option prices against.
+        """
+        ...
     @classmethod
     def american(
         cls,
@@ -58,46 +76,218 @@ class VanillaOption:
         latest: Date,
         settings: Settings,
     ) -> VanillaOption:
-        """The option exercisable at any time over [earliest, latest], paying on
-        exercise. Raises ItofinError when earliest is after latest."""
+        """Build the option exercisable at any time over [earliest, latest].
+
+        The option pays on exercise rather than at expiry. This is the exercise
+        the Monte Carlo American engine requires; the analytic European engine
+        rejects it.
+
+        Args:
+            option_type (OptionType): Whether the payoff is a call or a put.
+            strike (float): The strike of the plain vanilla payoff.
+            earliest (Date): The first date the option may be exercised on.
+            latest (Date): The last date the option may be exercised on.
+            settings (Settings): The explicit settings supplying the evaluation
+                date the option prices against.
+
+        Returns:
+            VanillaOption: The American-exercise option.
+
+        Raises:
+            ItofinError: If earliest is after latest.
+        """
         ...
-    def set_engine(self, process: BlackScholesProcess) -> None: ...
-    def set_heston_engine(self, model: HestonModel, integration_order: int) -> None: ...
-    def set_mc_engine(self, engine: MCEuropeanEngine) -> None: ...
-    def set_mc_heston_engine(self, engine: MCEuropeanHestonEngine) -> None: ...
+    def set_engine(self, process: BlackScholesProcess) -> None:
+        """Attach an analytic European engine built on process.
+
+        Args:
+            process (BlackScholesProcess): The process the engine prices on;
+                the exact object this Python instance holds is threaded in.
+        """
+        ...
+    def set_heston_engine(self, model: HestonModel, integration_order: int) -> None:
+        """Attach an analytic Heston engine built on model.
+
+        The analytic Heston engine fills only the value, so npv() works but the
+        greeks raise on this path.
+
+        Args:
+            model (HestonModel): The calibrated Heston model to price under.
+            integration_order (int): The order of the Gauss-Laguerre
+                integration.
+
+        Raises:
+            ItofinError: If integration_order exceeds 192.
+        """
+        ...
+    def set_mc_engine(self, engine: MCEuropeanEngine) -> None:
+        """Attach the Monte Carlo European engine.
+
+        Args:
+            engine (MCEuropeanEngine): The engine, which already holds the
+                process it prices on.
+        """
+        ...
+    def set_mc_heston_engine(self, engine: MCEuropeanHestonEngine) -> None:
+        """Attach the Monte Carlo Heston engine.
+
+        Args:
+            engine (MCEuropeanHestonEngine): The engine, which already holds
+                the Heston process it prices on.
+        """
+        ...
     def set_mc_american_engine(self, engine: MCAmericanEngine) -> None:
-        """Attaches the Monte Carlo American engine. A European-exercise option
-        raises ItofinError ("wrong exercise given") when priced on it."""
+        """Attach the Monte Carlo American engine.
+
+        The option must have been built through american(): a European-exercise
+        option raises ItofinError ("wrong exercise given") from npv().
+
+        Args:
+            engine (MCAmericanEngine): The engine, which already holds the
+                process it prices on.
+        """
         ...
     def calculate(self) -> None:
-        """Forces the valuation. Idempotent: the option reprices only once an
-        observed input notified it."""
+        """Force the valuation, so a later accessor reads a warm cache.
+
+        Idempotent: the core short-circuits on a valid cache, and the option
+        reprices only once an observed input notified it.
+
+        Raises:
+            ItofinError: If no engine is attached, no evaluation date is set,
+                or the attached engine refuses the option.
+        """
         ...
     def is_calculated(self) -> bool:
-        """Whether the cached results are currently valid."""
+        """Return whether the cached results are currently valid.
+
+        Returns:
+            bool: True when the next accessor reads the cache rather than
+                repricing.
+        """
         ...
     def price(self, process: BlackScholesProcess) -> float:
-        """Attaches an analytic European engine on process and returns the NPV:
-        set_engine followed by npv, in one call."""
+        """Attach an analytic European engine on process and return the NPV.
+
+        The one-shot form of set_engine followed by npv. The other engines keep
+        their own setters and compose with calculate and npv as before.
+
+        Args:
+            process (BlackScholesProcess): The process the engine prices on.
+
+        Returns:
+            float: The present value under the analytic European engine.
+
+        Raises:
+            ItofinError: If no evaluation date is set or the engine refuses the
+                option.
+        """
         ...
     def results(self) -> Results:
-        """A frozen snapshot of the valuation, calculating first."""
+        """Return a frozen snapshot of the valuation, calculating first.
+
+        The snapshot does not track the option: once taken, an evaluation-date
+        or engine change reprices the live accessors and leaves it alone.
+
+        Returns:
+            Results: A copy of the valuation results.
+
+        Raises:
+            ItofinError: On anything that makes the valuation fail.
+        """
         ...
-    def npv(self) -> float: ...
-    def delta(self) -> float: ...
-    def gamma(self) -> float: ...
-    def theta(self) -> float: ...
-    def vega(self) -> float: ...
-    def rho(self) -> float: ...
-    def dividend_rho(self) -> float: ...
+    def npv(self) -> float:
+        """Return the present value.
+
+        Returns:
+            float: The option value under the attached engine.
+
+        Raises:
+            ItofinError: If no evaluation date or no engine is set.
+        """
+        ...
+    def delta(self) -> float:
+        """Return the option delta.
+
+        Returns:
+            float: The sensitivity to the underlying spot.
+
+        Raises:
+            ItofinError: If the attached engine does not provide it, which the
+                analytic Heston engine does not.
+        """
+        ...
+    def gamma(self) -> float:
+        """Return the option gamma.
+
+        Returns:
+            float: The second-order sensitivity to the underlying spot.
+
+        Raises:
+            ItofinError: If the attached engine does not provide it.
+        """
+        ...
+    def theta(self) -> float:
+        """Return the option theta.
+
+        Returns:
+            float: The sensitivity to the passage of time.
+
+        Raises:
+            ItofinError: If the attached engine does not provide it.
+        """
+        ...
+    def vega(self) -> float:
+        """Return the option vega.
+
+        Returns:
+            float: The sensitivity to the volatility.
+
+        Raises:
+            ItofinError: If the attached engine does not provide it.
+        """
+        ...
+    def rho(self) -> float:
+        """Return the option rho.
+
+        Returns:
+            float: The sensitivity to the risk-free rate.
+
+        Raises:
+            ItofinError: If the attached engine does not provide it.
+        """
+        ...
+    def dividend_rho(self) -> float:
+        """Return the option dividend rho.
+
+        Returns:
+            float: The sensitivity to the dividend yield.
+
+        Raises:
+            ItofinError: If the attached engine does not provide it.
+        """
+        ...
     def error_estimate(self) -> float:
-        """The standard error on the present value. Raises ItofinError on the
-        engines that do not produce one, which is every analytic engine here."""
+        """Return the standard error on the present value.
+
+        Returns:
+            float: The Monte Carlo standard error.
+
+        Raises:
+            ItofinError: On the engines that do not produce one, which is every
+                analytic engine here.
+        """
         ...
     def exercise_probability(self) -> float:
-        """The fraction of simulated paths exercised before expiry. Raises
-        ItofinError on every engine that does not report it - only
-        MCAmericanEngine does."""
+        """Return the fraction of simulated paths exercised before expiry.
+
+        Returns:
+            float: The exercise probability reported by the engine.
+
+        Raises:
+            ItofinError: On every engine that does not report it - only
+                MCAmericanEngine does.
+        """
         ...
 
 class SwapType:

--- a/crates/itofin-py/python/itofin/instruments.pyi
+++ b/crates/itofin-py/python/itofin/instruments.pyi
@@ -1376,8 +1376,7 @@ class MakeCreditDefaultSwap:
         ...
 
 class ZeroCouponInflationSwap:
-    """One fixed flow against one inflation-indexed flow, both exchanged at
-    maturity.
+    """One fixed flow against one inflation-indexed flow, both exchanged at maturity.
 
     fixed_rate is the K that at inception matches the inflation growth.
     SwapType names the inflation leg, so a Payer pays inflation and receives
@@ -1409,54 +1408,174 @@ class ZeroCouponInflationSwap:
         inflation_convention: BusinessDayConvention | None,
         settings: Settings,
     ) -> None:
-        """Raises ItofinError when the observation lag is too short for the
-        index to observe fixings that exist."""
+        """Build the swap from its two exchanged flows.
+
+        Args:
+            swap_type (SwapType): Which side the inflation leg is seen from; a
+                Payer pays inflation and receives fixed.
+            nominal (float): The notional both flows are quoted on.
+            start_date (Date): The inception the index ratio is measured from.
+            maturity (Date): The raw, pre-adjustment maturity.
+            fixed_calendar (Calendar): The calendar the fixed payment rolls on.
+            fixed_convention (BusinessDayConvention): The roll applied to the
+                fixed payment date.
+            day_counter (DayCounter): The day count behind the fixed amount,
+                which stays on the raw maturity.
+            fixed_rate (float): The K that at inception matches the inflation
+                growth.
+            inflation_index (ZeroInflationIndex): The index the indexed flow
+                observes.
+            observation_lag (Period): How far back the maturity fixing is
+                observed.
+            observation_interpolation (CpiInterpolationType): How the observed
+                fixing is interpolated.
+            inflation_calendar (Calendar | None): The calendar the inflation
+                payment rolls on; None falls back to fixed_calendar.
+            inflation_convention (BusinessDayConvention | None): The roll
+                applied to the inflation payment date; None falls back to
+                fixed_convention.
+            settings (Settings): The explicit settings supplying the evaluation
+                date and the stored fixings.
+
+        Raises:
+            ItofinError: If the observation lag is too short for the index to
+                observe fixings that exist, which under Linear interpolation
+                costs a further publication period.
+        """
         ...
     def set_engine(self, engine: DiscountingSwapEngine) -> None:
-        """Price the swap off a discount curve. The engine must resolve its
-        dates against the same Settings object as this swap."""
+        """Attach a discounting engine so the swap prices.
+
+        Args:
+            engine (DiscountingSwapEngine): The engine, which must resolve its
+                dates against the same Settings object as this swap.
+        """
         ...
     def calculate(self) -> None:
-        """Forces the valuation. Idempotent."""
+        """Force the valuation. Idempotent.
+
+        Raises:
+            ItofinError: If no engine is attached, no evaluation date is set,
+                or the engine refuses the swap.
+        """
         ...
-    def is_calculated(self) -> bool: ...
+    def is_calculated(self) -> bool:
+        """Return whether the cached results are currently valid.
+
+        Returns:
+            bool: True when the next accessor reads the cache.
+        """
+        ...
     def price(self, engine: DiscountingSwapEngine) -> float:
-        """set_engine followed by npv, in one call."""
+        """Attach engine and return the NPV.
+
+        Args:
+            engine (DiscountingSwapEngine): The engine to install and price on.
+
+        Returns:
+            float: The swap value.
+
+        Raises:
+            ItofinError: On anything that makes the valuation fail.
+        """
         ...
-    def results(self) -> Results: ...
+    def results(self) -> Results:
+        """Return a frozen snapshot of the valuation, calculating first.
+
+        Returns:
+            Results: A copy of the valuation results.
+
+        Raises:
+            ItofinError: On anything that makes the valuation fail.
+        """
+        ...
     def npv(self) -> float:
-        """Raises ItofinError with no engine attached, and with no curve linked
-        into the index."""
+        """Return the swap NPV under the attached engine.
+
+        Returns:
+            float: The present value.
+
+        Raises:
+            ItofinError: If no engine is attached, and if no curve is linked
+                into the index, which leaves the indexed flow unforecastable.
+        """
         ...
     def fair_rate(self) -> float:
-        """The index ratio de-compounded over the swap's own year fraction.
+        """Return the index ratio de-compounded over the swap's own year fraction.
 
         Needs no engine - it reads the indexed flow rather than any priced
-        result - but does need the index linked to a curve."""
+        result.
+
+        Returns:
+            float: The rate that would price the swap at zero.
+
+        Raises:
+            ItofinError: If no curve is linked into the index, the flow's
+                amount being a forecast off the inflation curve.
+        """
         ...
-    def fixed_leg_npv(self) -> float: ...
-    def inflation_leg_npv(self) -> float: ...
+    def fixed_leg_npv(self) -> float:
+        """Return the fixed leg's NPV, priced on demand.
+
+        Returns:
+            float: The present value of the fixed flow.
+
+        Raises:
+            ItofinError: On the same conditions npv reports.
+        """
+        ...
+    def inflation_leg_npv(self) -> float:
+        """Return the inflation leg's NPV, priced on demand.
+
+        Returns:
+            float: The present value of the indexed flow.
+
+        Raises:
+            ItofinError: On the same conditions npv reports.
+        """
+        ...
     def fixed_leg_bps(self) -> float:
-        """The fixed leg's sensitivity to a basis point on the quoted rate,
-        computed in closed form rather than read off the engine, whose own leg
-        BPS is zero for a non-coupon flow."""
+        """Return the fixed leg's sensitivity to a basis point on the quoted rate.
+
+        Computed in closed form rather than read off the engine, whose own leg
+        BPS is zero for a non-coupon flow.
+
+        Returns:
+            float: The basis-point value of the fixed flow.
+
+        Raises:
+            ItofinError: On the same conditions npv reports, the calculation
+                needing the engine's discount factor at the fixed leg's end
+                date.
+        """
         ...
     def maturity_date(self) -> Date:
-        """The contract maturity, raw and pre-adjustment - not either leg's
-        payment date."""
+        """Return the contract maturity, raw and pre-adjustment.
+
+        Returns:
+            Date: The maturity, which is not either leg's payment date.
+        """
         ...
     def obs_date(self) -> Date:
-        """The date the maturity fixing is observed at, maturity less the
-        observation lag, unsnapped."""
+        """Return the date the maturity fixing is observed at.
+
+        Returns:
+            Date: The maturity less the observation lag, unsnapped.
+        """
         ...
     def inflation_fixing_date(self) -> Date:
-        """The same date as obs_date, read off the indexed flow rather than off
-        the swap. Both names are kept because both exist in the core."""
+        """Return the observation date, read off the indexed flow.
+
+        Both names are kept because both exist in the core, and the oracle
+        asserts they coincide.
+
+        Returns:
+            Date: The same date as obs_date.
+        """
         ...
 
 class YearOnYearInflationSwap:
-    """A fixed leg against a leg of year-on-year inflation coupons, both paid
-    over a schedule.
+    """A fixed leg against a leg of year-on-year inflation coupons, both paid over a schedule.
 
     SwapType names the fixed leg, so a Payer pays fixed and receives inflation -
     the opposite reading from ZeroCouponInflationSwap, where it names the
@@ -1487,34 +1606,154 @@ class YearOnYearInflationSwap:
         payment_convention: BusinessDayConvention,
         settings: Settings,
     ) -> None:
-        """Raises ItofinError when either leg cannot be built, notably from an
-        observation lag that leaves a coupon unbuildable."""
+        """Build the swap from its two schedules.
+
+        Args:
+            swap_type (SwapType): Which side the fixed leg is seen from; a
+                Payer pays fixed and receives inflation.
+            nominal (float): The notional both legs accrue on.
+            fixed_schedule (Schedule): The fixed leg's payment schedule, which
+                also supplies its payment calendar.
+            fixed_rate (float): The rate the fixed leg accrues at.
+            fixed_day_count (DayCounter): The day count of the fixed leg.
+            yoy_schedule (Schedule): The year-on-year leg's schedule.
+            yoy_index (YoYInflationIndex): The index the coupons fix off.
+            observation_lag (Period): How far back each coupon's fixings are
+                observed.
+            interpolation (CpiInterpolationType): How the observed fixings are
+                interpolated.
+            spread (float): Added to every forecast rate on the year-on-year
+                leg.
+            yoy_day_count (DayCounter): The day count of the year-on-year leg.
+            payment_calendar (Calendar): The calendar the year-on-year leg pays
+                on.
+            payment_convention (BusinessDayConvention): The roll both legs
+                adjust their payment dates with.
+            settings (Settings): The explicit settings supplying the evaluation
+                date and the stored fixings.
+
+        Raises:
+            ItofinError: If either leg cannot be built, notably from an
+                observation lag that leaves a coupon unbuildable.
+        """
         ...
     def set_engine(self, engine: DiscountingSwapEngine) -> None:
-        """The engine must resolve its dates against the same Settings object
-        this swap was built with."""
+        """Attach a discounting engine so the swap prices.
+
+        Args:
+            engine (DiscountingSwapEngine): The engine, which must resolve its
+                dates against the same Settings object this swap was built
+                with.
+        """
         ...
     def calculate(self) -> None:
-        """Forces the valuation. Idempotent."""
+        """Force the valuation. Idempotent.
+
+        Raises:
+            ItofinError: If no engine is attached, no evaluation date is set,
+                or the engine refuses the swap.
+        """
         ...
-    def is_calculated(self) -> bool: ...
+    def is_calculated(self) -> bool:
+        """Return whether the cached results are currently valid.
+
+        Returns:
+            bool: True when the next accessor reads the cache.
+        """
+        ...
     def price(self, engine: DiscountingSwapEngine) -> float:
-        """set_engine followed by npv, in one call."""
+        """Attach engine and return the NPV.
+
+        Args:
+            engine (DiscountingSwapEngine): The engine to install and price on.
+
+        Returns:
+            float: The swap value.
+
+        Raises:
+            ItofinError: On anything that makes the valuation fail.
+        """
         ...
-    def results(self) -> Results: ...
-    def npv(self) -> float: ...
+    def results(self) -> Results:
+        """Return a frozen snapshot of the valuation, calculating first.
+
+        Returns:
+            Results: A copy of the valuation results.
+
+        Raises:
+            ItofinError: On anything that makes the valuation fail.
+        """
+        ...
+    def npv(self) -> float:
+        """Return the swap NPV under the attached engine.
+
+        Returns:
+            float: The present value.
+
+        Raises:
+            ItofinError: If no engine is attached, and if no curve is linked
+                into the index, which leaves the coupons unforecastable.
+        """
+        ...
     def fair_rate(self) -> float:
-        """The fixed rate that would price the swap at zero, recovered from the
-        NPV and the fixed leg's BPS."""
+        """Return the fixed rate that would price the swap at zero.
+
+        Recovered from the NPV and the fixed leg's BPS, so it prices on demand
+        and needs an engine.
+
+        Returns:
+            float: The fair fixed rate.
+
+        Raises:
+            ItofinError: On the same conditions npv reports.
+        """
         ...
     def fair_spread(self) -> float:
-        """The spread over the index that would price the swap at zero,
-        recovered off the year-on-year leg."""
+        """Return the spread over the index that would price the swap at zero.
+
+        Recovered off the year-on-year leg.
+
+        Returns:
+            float: The fair spread.
+
+        Raises:
+            ItofinError: On the same conditions fair_rate reports.
+        """
         ...
-    def fixed_leg_npv(self) -> float: ...
-    def yoy_leg_npv(self) -> float: ...
-    def fixed_rate(self) -> float: ...
-    def spread(self) -> float: ...
+    def fixed_leg_npv(self) -> float:
+        """Return the fixed leg's NPV, priced on demand.
+
+        Returns:
+            float: The present value of the fixed leg.
+
+        Raises:
+            ItofinError: On the same conditions npv reports.
+        """
+        ...
+    def yoy_leg_npv(self) -> float:
+        """Return the year-on-year leg's NPV, priced on demand.
+
+        Returns:
+            float: The present value of the inflation leg.
+
+        Raises:
+            ItofinError: On the same conditions npv reports.
+        """
+        ...
+    def fixed_rate(self) -> float:
+        """Return the quoted fixed rate the swap was struck at.
+
+        Returns:
+            float: The fixed-leg rate.
+        """
+        ...
+    def spread(self) -> float:
+        """Return the spread the year-on-year coupons carry over the index.
+
+        Returns:
+            float: The quoted spread.
+        """
+        ...
 
 class MakeYoYInflationCapFloor:
     """The standard market builder for a year-on-year inflation cap or floor.

--- a/crates/itofin-py/python/itofin/instruments.pyi
+++ b/crates/itofin-py/python/itofin/instruments.pyi
@@ -2,15 +2,10 @@
 # src/swap.rs, src/ois.rs, src/swaption.rs, src/capfloor.rs, src/credit.rs and
 # src/inflation.rs (#517).
 
+# itofin library
 from itofin import Settings
 from itofin.cashflows import IborLeg, YoYInflationCoupon
-from itofin.indexes import (
-    CpiInterpolationType,
-    IborIndex,
-    OvernightIndex,
-    YoYInflationIndex,
-    ZeroInflationIndex,
-)
+from itofin.indexes import CpiInterpolationType, IborIndex, OvernightIndex, YoYInflationIndex, ZeroInflationIndex
 from itofin.models import HestonModel, HullWhite
 from itofin.pricingengines import (
     BachelierSwaptionEngine,
@@ -27,14 +22,7 @@ from itofin.pricingengines import (
 from itofin.processes import BlackScholesProcess
 from itofin.results import Results
 from itofin.termstructures import RateAveraging, YieldTermStructure
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DayCounter,
-    Period,
-    Schedule,
-)
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Period, Schedule
 
 class OptionType:
     """The call/put flag.

--- a/crates/itofin-py/python/itofin/models.pyi
+++ b/crates/itofin-py/python/itofin/models.pyi
@@ -1,6 +1,7 @@
 # Hand-written stubs for itofin.models; sync manually with src/heston.rs,
 # src/hullwhite.rs and src/calibration.rs (#517).
 
+# itofin library
 from itofin import Settings
 from itofin.indexes import IborIndex
 from itofin.instruments import OptionType

--- a/crates/itofin-py/python/itofin/pricingengines.pyi
+++ b/crates/itofin-py/python/itofin/pricingengines.pyi
@@ -1,6 +1,7 @@
 # Hand-written stubs for itofin.pricingengines; sync manually with src/swaptionengine.rs,
 # src/capfloorengine.rs, src/creditengine.rs, src/inflation.rs and src/mcengine.rs (#517).
 
+# itofin library
 from itofin import Settings
 from itofin.indexes import YoYInflationIndex
 from itofin.processes import BlackScholesProcess, HestonProcess

--- a/crates/itofin-py/python/itofin/processes.pyi
+++ b/crates/itofin-py/python/itofin/processes.pyi
@@ -1,6 +1,7 @@
 # Hand-written stubs for itofin.processes; sync manually with src/market.rs and
 # src/heston.rs (#517).
 
+# itofin library
 from itofin.termstructures import BlackVolTermStructure, YieldTermStructure
 from itofin.time import Date, DayCounter
 

--- a/crates/itofin-py/python/itofin/results.pyi
+++ b/crates/itofin-py/python/itofin/results.pyi
@@ -3,10 +3,12 @@
 from itofin.time import Date
 
 class Results:
-    """A read-only snapshot of one instrument valuation, handed back by every
-    instrument facade's results(). It holds a copy, not a view: once taken, an
-    input change reprices the instrument's live accessors and leaves the
-    snapshot reporting the valuation it was taken from.
+    """A read-only snapshot of one instrument valuation.
+
+    Handed back by every instrument facade's results(), which forces the
+    calculation and then copies the four fields out. It holds a copy, not a
+    view: once taken, an input change reprices the instrument's live accessors
+    and leaves the snapshot reporting the valuation it was taken from.
 
     Every field is optional because the core stores it that way - an engine
     fills what it computes and leaves the rest unset. The analytic European
@@ -19,10 +21,37 @@ class Results:
     at."""
 
     @property
-    def npv(self) -> float | None: ...
+    def npv(self) -> float | None:
+        """The net present value.
+
+        Returns:
+            float | None: The value, or None when the engine provided none.
+        """
+        ...
     @property
-    def error_estimate(self) -> float | None: ...
+    def error_estimate(self) -> float | None:
+        """The standard error on the value.
+
+        Returns:
+            float | None: The standard error, or None on the engines that do
+                not produce one, which is every analytic engine here.
+        """
+        ...
     @property
-    def valuation_date(self) -> Date | None: ...
+    def valuation_date(self) -> Date | None:
+        """The date the value refers to.
+
+        Returns:
+            Date | None: The valuation date, or None when the engine did not
+                say.
+        """
+        ...
     @property
-    def additional_results(self) -> dict[str, float]: ...
+    def additional_results(self) -> dict[str, float]:
+        """The engine's extra named outputs, restricted to the real-valued tags.
+
+        Returns:
+            dict[str, float]: The real-valued tags; see the class docs for why
+                the others are omitted.
+        """
+        ...

--- a/crates/itofin-py/python/itofin/results.pyi
+++ b/crates/itofin-py/python/itofin/results.pyi
@@ -1,5 +1,6 @@
 # Hand-written stubs for itofin.results; sync manually with src/results.rs (#517).
 
+# itofin library
 from itofin.time import Date
 
 class Results:

--- a/crates/itofin-py/python/itofin/termstructures.pyi
+++ b/crates/itofin-py/python/itofin/termstructures.pyi
@@ -2094,15 +2094,56 @@ class OptionletStripper1:
         discount: YieldTermStructure | None = None,
         optionlet_frequency: Period | None = None,
     ) -> None:
-        """discount None falls back to the index's own forwarding curve;
-        optionlet_frequency None uses the index tenor as the caplet step."""
+        """Build the stripper over a term-volatility surface and an index.
+
+        It prices a cap at each of its own lengths off term_vol_surface,
+        differences consecutive prices into a single caplet price, and inverts
+        that for the caplet's implied volatility.
+
+        Args:
+            term_vol_surface (CapFloorTermVolSurface): The market term
+                volatilities; it must be one of the moving forms, a
+                pinned-reference surface carrying no settlement days.
+            ibor_index (IborIndex): The index the caplets fix off.
+            volatility_type (VolatilityType): The quoting convention; Normal is
+                deferred and fails at the strip, not here.
+            accuracy (float): The tolerance of the implied-volatility solve.
+            max_iter (int): The iteration cap of that solve.
+            displacement (float): The lognormal shift applied to forwards and
+                strikes.
+            discount (YieldTermStructure | None): The curve the caps are priced
+                on; None falls back to the index's own forwarding curve.
+            optionlet_frequency (Period | None): The caplet step; None uses the
+                index tenor.
+
+        Raises:
+            ItofinError: On whatever the core rejects about the surface, the
+                index or the solve parameters.
+        """
         ...
     def switch_strike(self) -> float:
-        """The mean at-the-money caplet rate, which decides whether each strike
-        is stripped out of caps or out of floors. The first call strips."""
+        """Return the floating switch strike, the mean at-the-money caplet rate.
+
+        It decides whether each strike is stripped out of caps or out of
+        floors. The first call triggers the strip.
+
+        Returns:
+            float: The switch strike.
+
+        Raises:
+            ItofinError: On a stripping failure, which a Normal volatility_type
+                always is.
+        """
         ...
     def atm_optionlet_rates(self) -> list[float]:
-        """The at-the-money forward rate of each caplet, one per maturity."""
+        """Return the at-the-money forward rate of each caplet.
+
+        Returns:
+            list[float]: One rate per maturity.
+
+        Raises:
+            ItofinError: On a stripping failure.
+        """
         ...
 
 class StrippedOptionletAdapter(OptionletVolatilityStructure):
@@ -2118,9 +2159,22 @@ class StrippedOptionletAdapter(OptionletVolatilityStructure):
     enable_extrapolation()."""
 
     def __init__(self, stripper: OptionletStripper1, settings: Settings) -> None:
-        """Strips eagerly, to snapshot the strike domain and maximum date.
-        Raises ItofinError on a stripper whose term-volatility surface carries
-        no settlement days."""
+        """Build the interpolated surface over a stripper.
+
+        It strips eagerly: the constructor reads the caplet strikes and fixing
+        dates to snapshot its strike domain and maximum date.
+
+        Args:
+            stripper (OptionletStripper1): The stripper whose caplet grid is
+                served.
+            settings (Settings): The explicit settings supplying the evaluation
+                date the reference date floats off.
+
+        Raises:
+            ItofinError: On a stripper whose term-volatility surface carries no
+                settlement days, which is every pinned-reference surface, and
+                on a stripping failure.
+        """
         ...
 
 class DefaultProbabilityTermStructure:

--- a/crates/itofin-py/python/itofin/termstructures.pyi
+++ b/crates/itofin-py/python/itofin/termstructures.pyi
@@ -1481,24 +1481,105 @@ class SabrSmileSection:
         shift: float = 0.0,
         volatility_type: VolatilityType = ...,
     ) -> None:
-        """Raises ItofinError on a non-zero shift or a Normal volatility_type
-        (both deferred to #586), on a non-positive shifted forward, and on SABR
-        parameters outside alpha > 0, beta in [0, 1], nu >= 0, rho^2 < 1."""
+        """Build the smile at a given exercise time and forward.
+
+        Only the exercise-time form is wrapped; the date-anchored one differs
+        from it only in computing that time from a reference date and a day
+        counter, which a caller can do with DayCounter.year_fraction.
+
+        Args:
+            exercise_time (float): The option's exercise time, in years.
+            forward (float): The forward the smile is centred on.
+            alpha (float): The SABR alpha, which must be positive.
+            beta (float): The SABR beta, which must lie in [0, 1].
+            nu (float): The SABR nu, which must be non-negative.
+            rho (float): The SABR rho, whose square must be below 1.
+            shift (float): The lognormal shift; a non-zero shift is deferred
+                and refused.
+            volatility_type (VolatilityType): The quoting convention; Normal is
+                deferred and refused.
+
+        Raises:
+            ItofinError: On a non-zero shift or a Normal volatility_type, both
+                deferred; on a non-positive shifted forward; and on SABR
+                parameters outside their admissible ranges.
+        """
         ...
-    def volatility(self, strike: float) -> float: ...
-    def variance(self, strike: float) -> float: ...
+    def volatility(self, strike: float) -> float:
+        """Return the volatility at strike.
+
+        Args:
+            strike (float): The strike; strikes below the shifted domain floor
+                are clamped to it rather than rejected, as the core does.
+
+        Returns:
+            float: The Hagan SABR volatility.
+
+        Raises:
+            ItofinError: On whatever the closed-form evaluation rejects.
+        """
+        ...
+    def variance(self, strike: float) -> float:
+        """Return the Black variance at strike.
+
+        Args:
+            strike (float): The strike the variance is read at.
+
+        Returns:
+            float: The squared volatility times the exercise time.
+
+        Raises:
+            ItofinError: On whatever the closed-form evaluation rejects.
+        """
+        ...
     @property
-    def exercise_time(self) -> float: ...
+    def exercise_time(self) -> float:
+        """The exercise time the smile was built for.
+
+        Returns:
+            float: The exercise time, in years.
+        """
+        ...
     @property
-    def atm_level(self) -> float: ...
+    def atm_level(self) -> float:
+        """The at-the-money level.
+
+        Returns:
+            float: The forward the smile is centred on.
+        """
+        ...
     @property
-    def alpha(self) -> float: ...
+    def alpha(self) -> float:
+        """The SABR alpha parameter.
+
+        Returns:
+            float: The alpha the smile was built with.
+        """
+        ...
     @property
-    def beta(self) -> float: ...
+    def beta(self) -> float:
+        """The SABR beta parameter.
+
+        Returns:
+            float: The beta the smile was built with.
+        """
+        ...
     @property
-    def nu(self) -> float: ...
+    def nu(self) -> float:
+        """The SABR nu parameter.
+
+        Returns:
+            float: The nu the smile was built with.
+        """
+        ...
     @property
-    def rho(self) -> float: ...
+    def rho(self) -> float:
+        """The SABR rho parameter.
+
+        Returns:
+            float: The rho the smile was built with.
+        """
+        ...
 
 class SabrSwaptionVolatilityCube(SwaptionVolatilityStructure):
     """A smile cube whose every node is a SABR smile fitted to the at-the-money
@@ -1542,10 +1623,66 @@ class SabrSwaptionVolatilityCube(SwaptionVolatilityStructure):
         use_max_error: bool = False,
         max_guesses: int = 50,
         cutoff_strike: float = 0.0001,
-    ) -> None: ...
+    ) -> None:
+        """Build the cube, calibrating every node on construction.
+
+        The end criteria, the maximum error tolerance, the optimisation method
+        and the accepted error are left at the core's C++ defaults.
+
+        Args:
+            atm_vol (SwaptionVolatilityStructure): The at-the-money surface the
+                fitted smiles are anchored on.
+            option_tenors (list[Period]): The option axis of the node grid.
+            swap_tenors (list[Period]): The swap axis of the node grid.
+            strike_spreads (list[float]): The moneyness offsets each smile is
+                quoted at.
+            vol_spreads (list[list[SimpleQuote]]): The spread quotes, row-major
+                over the nodes with one quote per strike spread.
+            swap_index_base (SwapIndex): The long base swap index.
+            short_swap_index_base (SwapIndex): The short base swap index.
+            parameters_guess (list[list[SimpleQuote]]): The SABR starting
+                values, row-major over the nodes, each row holding alpha, beta,
+                nu and rho in that order.
+            is_parameter_fixed (list[bool]): Which of the four parameters are
+                pinned at their guess across every node, in that same order.
+            is_atm_calibrated (bool): Whether a second dense pass re-anchors
+                the fitted smiles on the at-the-money surface.
+            settings (Settings): The explicit settings supplying the evaluation
+                date and the stored fixings.
+            vega_weighted_smile_fit (bool): Whether the smile fit is
+                vega-weighted.
+            use_max_error (bool): Whether the fit is judged on the maximum
+                error rather than the aggregate one.
+            max_guesses (int): How many starting guesses a node may try.
+            cutoff_strike (float): The strike floor the fit is evaluated above.
+
+        Raises:
+            ItofinError: On an empty or ragged vol_spreads or parameters_guess
+                grid, on a row count that is not one per node, on an
+                is_parameter_fixed list that is not four entries long, on a
+                normal at-the-money surface, which needs the deferred normal
+                SABR formula, and on a calibration failure.
+        """
+        ...
     def atm_strike_from_tenor(self, option_tenor: Period, swap_tenor: Period) -> float:
-        """The at-the-money strike for an option tenor and swap tenor: the strike
-        the fitted smile is centred on."""
+        """Return the at-the-money strike for an option tenor and swap tenor.
+
+        The fixing of whichever base swap index the swap tenor selects, and the
+        strike the fitted smile is centred on, so it is what a caller needs to
+        place a query at a given moneyness.
+
+        Args:
+            option_tenor (Period): The option's tenor.
+            swap_tenor (Period): The underlying swap's tenor, which selects the
+                base index.
+
+        Returns:
+            float: The at-the-money strike.
+
+        Raises:
+            ItofinError: On whatever the selected index's fixing reports, an
+                unset evaluation date or an unlinked forwarding curve included.
+        """
         ...
 
 class OptionletVolatilityStructure:

--- a/crates/itofin-py/python/itofin/termstructures.pyi
+++ b/crates/itofin-py/python/itofin/termstructures.pyi
@@ -3025,19 +3025,91 @@ class YoYInflationTermStructure:
     base_rate is answered here where the zero base defers it: a year-on-year
     curve carries the rate observed over the period ending on its base date."""
 
-    def yoy_rate(self, t: float, extrapolate: bool = False) -> float: ...
-    def yoy_rate_date(self, date: Date, extrapolate: bool = False) -> float: ...
-    def base_date(self) -> Date: ...
-    def base_rate(self) -> float: ...
-    def frequency(self) -> Frequency: ...
+    def yoy_rate(self, t: float, extrapolate: bool = False) -> float:
+        """Return the year-on-year inflation rate at year-fraction t.
+
+        Args:
+            t (float): The year fraction, measured with the curve's own day
+                counter; it is negative for the base period.
+            extrapolate (bool): Whether to answer past the curve's range.
+
+        Returns:
+            float: The year-on-year rate, which is not the year-on-year swap
+                rate: that comes from the instrument.
+
+        Raises:
+            ItofinError: If t is past the curve's range and extrapolation is
+                not allowed.
+        """
+        ...
+    def yoy_rate_date(self, date: Date, extrapolate: bool = False) -> float:
+        """Return the year-on-year rate for the inflation period containing date.
+
+        The date is quantized to that period's first day before both the range
+        check and the time conversion. Any seasonality correction is folded in
+        last, at the original date rather than the period start, as C++ does on
+        this path.
+
+        Args:
+            date (Date): The date the rate is read at.
+            extrapolate (bool): Whether to answer past the curve's range.
+
+        Returns:
+            float: The year-on-year rate for that period.
+
+        Raises:
+            ItofinError: If the period is past the curve's range and
+                extrapolation is not allowed.
+        """
+        ...
+    def base_date(self) -> Date:
+        """Return the base date, the last date for which the fixing is known.
+
+        Returns:
+            Date: The base date; it precedes the reference date, so its year
+                fraction is negative.
+        """
+        ...
+    def base_rate(self) -> float:
+        """Return the rate observed over the period ending on the base date.
+
+        Returns:
+            float: The base rate, which node zero is seeded with and keeps.
+
+        Raises:
+            ItofinError: On a curve that carries no base rate.
+        """
+        ...
+    def frequency(self) -> Frequency:
+        """Return the frequency of the inflation fixings the curve is built on.
+
+        Returns:
+            Frequency: The fixing frequency.
+        """
+        ...
     def set_seasonality(
         self, seasonality: MultiplicativePriceSeasonality | None
     ) -> None:
-        """Installs seasonality on the curve, replacing whatever it carried;
-        None clears it. Raises ItofinError from the consistency gate, leaving a
-        rejected correction installed as C++ does."""
+        """Install seasonality on the curve, replacing whatever it carried.
+
+        Args:
+            seasonality (MultiplicativePriceSeasonality | None): The correction
+                to install; None clears it.
+
+        Raises:
+            ItofinError: From the consistency gate, which leaves a rejected
+                correction installed as C++ does; see the zero-curve base for
+                the full account.
+        """
         ...
-    def has_seasonality(self) -> bool: ...
+    def has_seasonality(self) -> bool:
+        """Return whether the curve carries a seasonality correction.
+
+        Returns:
+            bool: True also for a correction left installed by a
+                set_seasonality that raised.
+        """
+        ...
 
 class InterpolatedYoYInflationCurve(YoYInflationTermStructure):
     """A year-on-year inflation curve built from (date, year-on-year rate)
@@ -3056,13 +3128,46 @@ class InterpolatedYoYInflationCurve(YoYInflationTermStructure):
         frequency: Frequency,
         day_counter: DayCounter,
     ) -> None:
-        """Raises ItofinError on fewer than two dates, a dates/rates count
-        mismatch, or a rate at or below -100 % from the second node on - the
-        base rate is left unconstrained."""
+        """Build the curve through the rates quoted at dates.
+
+        Args:
+            reference_date (Date): The curve's reference date, given separately
+                and normally following the base date.
+            dates (list[Date]): The node dates, the first being the base date.
+            rates (list[float]): The year-on-year rate at each node; the first
+                is the base rate the curve publishes.
+            frequency (Frequency): The frequency of the inflation fixings.
+            day_counter (DayCounter): The day count turning dates into times.
+
+        Raises:
+            ItofinError: On fewer than two dates, a dates and rates count
+                mismatch, or a rate at or below -100 per cent from the second
+                node on; the base rate is left unconstrained.
+        """
         ...
-    def times(self) -> list[float]: ...
-    def dates(self) -> list[Date]: ...
-    def nodes(self) -> list[tuple[Date, float]]: ...
+    def times(self) -> list[float]:
+        """Return the node times, measured from the reference date.
+
+        Returns:
+            list[float]: The node times; the first is negative whenever the
+                base date precedes the reference date.
+        """
+        ...
+    def dates(self) -> list[Date]:
+        """Return the node dates.
+
+        Returns:
+            list[Date]: The nodes, the first of which is the base date.
+        """
+        ...
+    def nodes(self) -> list[tuple[Date, float]]:
+        """Return the curve's nodes as pairs.
+
+        Returns:
+            list[tuple[Date, float]]: One (date, year-on-year rate) pair per
+                node.
+        """
+        ...
 
 class YoYInflationHelper:
     """Shared base for every year-on-year bootstrap helper: the two dates the
@@ -3071,8 +3176,20 @@ class YoYInflationHelper:
     Concrete helpers such as YearOnYearInflationSwapHelper subclass this and
     supply only their constructor."""
 
-    def pillar_date(self) -> Date: ...
-    def latest_date(self) -> Date: ...
+    def pillar_date(self) -> Date:
+        """Return the date the curve node this helper sets sits at.
+
+        Returns:
+            Date: The pillar date.
+        """
+        ...
+    def latest_date(self) -> Date:
+        """Return the latest date the helper needs curve data at.
+
+        Returns:
+            Date: The latest date, equal to the pillar date.
+        """
+        ...
 
 class YearOnYearInflationSwapHelper(YoYInflationHelper):
     """The bootstrap helper fitting a year-on-year inflation swap quoted as a
@@ -3106,9 +3223,37 @@ class YearOnYearInflationSwapHelper(YoYInflationHelper):
         settings: Settings,
         pillar: Pillar = ...,
     ) -> None:
-        """Raises ItofinError on CpiInterpolationType.Linear, which the core
-        refuses outright pending the interpolated branch (#847), and on an
-        observation lag the helper's own swap legs cannot be built under."""
+        """Build the helper on a swap maturing at maturity.
+
+        Args:
+            quote (SimpleQuote): The quoted swap rate; the caller keeps it, so
+                a later set_value re-drives the bootstrap.
+            swap_obs_lag (Period): How far back each coupon's fixings are
+                observed.
+            maturity (Date): The swap's maturity.
+            calendar (Calendar): The calendar the payments roll on.
+            payment_convention (BusinessDayConvention): The roll applied to the
+                payment dates.
+            day_counter (DayCounter): The day count the legs accrue on.
+            index (YoYInflationIndex): The index observed; the helper prices
+                through a copy linked to a handle of its own, so the caller's
+                index need not be linked to any curve.
+            interpolation (CpiInterpolationType): How the observed fixings are
+                interpolated.
+            nominal_term_structure (YieldTermStructure): The discount curve,
+                which this helper does need: its legs pay on a schedule of
+                dates rather than one, so their discount factors do not cancel.
+            settings (Settings): The explicit settings supplying the evaluation
+                date the swap starts at, which must be set before this
+                constructor runs.
+            pillar (Pillar): Accepted for signature parity but never read; it
+                only ever discriminates on the interpolated path.
+
+        Raises:
+            ItofinError: On Linear interpolation, which the core refuses
+                outright pending the interpolated branch, and on an observation
+                lag the helper's own swap legs cannot be built under.
+        """
         ...
 
 class PiecewiseYoYInflationCurve(YoYInflationTermStructure):
@@ -3132,12 +3277,64 @@ class PiecewiseYoYInflationCurve(YoYInflationTermStructure):
         day_counter: DayCounter,
         helpers: list[YoYInflationHelper],
     ) -> None:
-        """Raises ItofinError on an empty helper list."""
+        """Build the curve over helpers, registering on them without solving.
+
+        Args:
+            reference_date (Date): The curve's reference date.
+            base_date (Date): The last date for which a fixing is known, where
+                node zero sits.
+            base_yoy_rate (float): The rate node zero is seeded with and keeps,
+                rather than solved for.
+            frequency (Frequency): The frequency of the inflation fixings.
+            day_counter (DayCounter): The day count turning dates into times.
+            helpers (list[YoYInflationHelper]): The bootstrap instruments.
+
+        Raises:
+            ItofinError: On an empty helper list.
+        """
         ...
-    def calculate(self) -> None: ...
-    def times(self) -> list[float]: ...
-    def dates(self) -> list[Date]: ...
-    def nodes(self) -> list[tuple[Date, float]]: ...
+    def calculate(self) -> None:
+        """Run the bootstrap if the cache is stale.
+
+        Calling it explicitly makes a solver failure surface here rather than
+        inside a later query.
+
+        Raises:
+            ItofinError: On a bootstrap failure.
+        """
+        ...
+    def times(self) -> list[float]:
+        """Return the node times, triggering the bootstrap.
+
+        Returns:
+            list[float]: The nodes measured from the reference date; the first
+                is negative, node zero sitting on the base date.
+
+        Raises:
+            ItofinError: On a bootstrap failure.
+        """
+        ...
+    def dates(self) -> list[Date]:
+        """Return the node dates, triggering the bootstrap.
+
+        Returns:
+            list[Date]: The nodes, the first of which is the base date.
+
+        Raises:
+            ItofinError: On a bootstrap failure.
+        """
+        ...
+    def nodes(self) -> list[tuple[Date, float]]:
+        """Return the solved nodes as pairs, triggering the bootstrap.
+
+        Returns:
+            list[tuple[Date, float]]: One (date, year-on-year rate) pair per
+                node.
+
+        Raises:
+            ItofinError: On a bootstrap failure.
+        """
+        ...
 
 class ConstantYoYOptionletVolatility:
     """One year-on-year optionlet volatility for every strike and every date.

--- a/crates/itofin-py/python/itofin/termstructures.pyi
+++ b/crates/itofin-py/python/itofin/termstructures.pyi
@@ -2624,18 +2624,61 @@ class MultiplicativePriceSeasonality:
         frequency: Frequency,
         seasonality_factors: list[float],
     ) -> None:
-        """Raises ItofinError on a frequency outside semiannual-through-daily
-        (Frequency.Annual among them), an empty factor set, or a factor count
-        that is not a whole multiple of the frequency."""
+        """Build the correction from a factor set anchored on a base date.
+
+        Args:
+            seasonality_base_date (Date): The date the factor set is anchored
+                on.
+            frequency (Frequency): The frequency the factors step at.
+            seasonality_factors (list[float]): The factors, in order from the
+                base date.
+
+        Raises:
+            ItofinError: On a frequency outside semiannual-through-daily,
+                Frequency.Annual among them; on an empty factor set; and on a
+                factor count that is not a whole multiple of the frequency.
+        """
         ...
-    def seasonality_base_date(self) -> Date: ...
-    def frequency(self) -> Frequency: ...
-    def seasonality_factors(self) -> list[float]: ...
+    def seasonality_base_date(self) -> Date:
+        """Return the date the factor set is anchored on.
+
+        Returns:
+            Date: The seasonality base date.
+        """
+        ...
+    def frequency(self) -> Frequency:
+        """Return the frequency the factors step at.
+
+        Returns:
+            Frequency: The stepping frequency.
+        """
+        ...
+    def seasonality_factors(self) -> list[float]:
+        """Return the factors, in order from the seasonality base date.
+
+        Returns:
+            list[float]: The factor set as given.
+        """
+        ...
     def seasonality_factor(self, to: Date) -> float:
-        """The raw factor covering `to`, before any normalization against a
-        reference date - not the correction the curve applies. The offset is
-        counted in whole factor periods from the seasonality base date and
-        wraps modulo the factor count, in both directions."""
+        """Return the raw factor covering to, before any normalization.
+
+        This is not the correction the curve applies, which is normalized
+        against a reference date. The offset from the seasonality base date is
+        counted in whole factor periods and wrapped modulo the factor count, so
+        a set shorter than the span repeats and dates before the anchor wrap
+        backwards.
+
+        Args:
+            to (Date): The date the factor is read at.
+
+        Returns:
+            float: The raw seasonality factor.
+
+        Raises:
+            ItofinError: On a year-based factor period, which cannot express
+                seasonality.
+        """
         ...
 
 class ZeroInflationTermStructure:
@@ -2649,23 +2692,89 @@ class ZeroInflationTermStructure:
     under the curve's own day counter and quantizes nothing. Only the first
     folds in any seasonality."""
 
-    def zero_rate(self, t: float, extrapolate: bool = False) -> float: ...
-    def zero_rate_date(self, date: Date, extrapolate: bool = False) -> float: ...
-    def base_date(self) -> Date: ...
-    def frequency(self) -> Frequency: ...
+    def zero_rate(self, t: float, extrapolate: bool = False) -> float:
+        """Return the zero-coupon inflation rate at year-fraction t.
+
+        Quoted on the yearly compounding zero-coupon swaps assume. Nothing here
+        accounts for observation lags or period interpolation: the caller
+        manages those.
+
+        Args:
+            t (float): The year fraction, measured with the curve's own day
+                counter; it is negative for the base period.
+            extrapolate (bool): Whether to answer past the curve's range.
+
+        Returns:
+            float: The zero-coupon inflation rate.
+
+        Raises:
+            ItofinError: If t is past the curve's range and extrapolation is
+                not allowed.
+        """
+        ...
+    def zero_rate_date(self, date: Date, extrapolate: bool = False) -> float:
+        """Return the zero-coupon inflation rate for the period containing date.
+
+        The date is quantized to that period's first day before both the range
+        check and the time conversion, so every day inside one period reads the
+        same rate. This is the only form that folds in seasonality.
+
+        Args:
+            date (Date): The date the rate is read at.
+            extrapolate (bool): Whether to answer past the curve's range.
+
+        Returns:
+            float: The zero-coupon inflation rate for that period.
+
+        Raises:
+            ItofinError: If the period is past the curve's range and
+                extrapolation is not allowed.
+        """
+        ...
+    def base_date(self) -> Date:
+        """Return the base date, the last date for which the fixing is known.
+
+        Returns:
+            Date: The base date; it precedes the reference date, so its year
+                fraction is negative.
+        """
+        ...
+    def frequency(self) -> Frequency:
+        """Return the frequency of the inflation fixings the curve is built on.
+
+        Returns:
+            Frequency: The fixing frequency.
+        """
+        ...
     def set_seasonality(
         self, seasonality: MultiplicativePriceSeasonality | None
     ) -> None:
-        """Installs seasonality on the curve, replacing whatever it carried;
-        None clears it. A bootstrapped curve is invalidated here, so the next
-        read re-solves against the new correction.
+        """Install seasonality on the curve, replacing whatever it carried.
 
-        Raises ItofinError from the consistency gate, which a multi-year factor
-        set fails (a documented core deferral, #807). The store happens before
-        the gate runs, as C++'s does, so a rejected correction is left
-        installed - clear it with None before reading the curve again."""
+        A curve that caches anything derived from the correction - every
+        bootstrapped one does - is invalidated here, so the next read re-solves
+        against the new correction.
+
+        Args:
+            seasonality (MultiplicativePriceSeasonality | None): The correction
+                to install; None clears it.
+
+        Raises:
+            ItofinError: From the consistency gate, which a multi-year factor
+                set fails, that comparison being a documented core deferral.
+                The store happens before the gate runs, as C++'s does, so a
+                rejected correction is left installed and unannounced: clear it
+                with None before reading the curve again.
+        """
         ...
-    def has_seasonality(self) -> bool: ...
+    def has_seasonality(self) -> bool:
+        """Return whether the curve carries a seasonality correction.
+
+        Returns:
+            bool: True also for a correction left installed by a
+                set_seasonality that raised.
+        """
+        ...
 
 class InterpolatedZeroInflationCurve(ZeroInflationTermStructure):
     """A zero-coupon inflation curve built from (date, zero-rate) nodes,
@@ -2683,13 +2792,47 @@ class InterpolatedZeroInflationCurve(ZeroInflationTermStructure):
         frequency: Frequency,
         day_counter: DayCounter,
     ) -> None:
-        """Raises ItofinError on fewer than two dates, a dates/rates count
-        mismatch, a rate at or below -100 % from the second node on, or
-        unsorted dates."""
+        """Build the curve through the rates quoted at dates.
+
+        Linear is pinned at the boundary: it is the interpolator the C++ zero
+        inflation curve typedef fixes, so no interpolation argument is offered.
+
+        Args:
+            reference_date (Date): The curve's reference date, given separately
+                and normally following the base date.
+            dates (list[Date]): The node dates, the first being the base date.
+            rates (list[float]): The zero rate at each node.
+            frequency (Frequency): The frequency of the inflation fixings.
+            day_counter (DayCounter): The day count turning dates into times.
+
+        Raises:
+            ItofinError: On fewer than two dates, a dates and rates count
+                mismatch, a rate at or below -100 per cent from the second node
+                on, or unsorted dates.
+        """
         ...
-    def times(self) -> list[float]: ...
-    def dates(self) -> list[Date]: ...
-    def nodes(self) -> list[tuple[Date, float]]: ...
+    def times(self) -> list[float]:
+        """Return the node times, measured from the reference date.
+
+        Returns:
+            list[float]: The node times; the first is negative whenever the
+                base date precedes the reference date.
+        """
+        ...
+    def dates(self) -> list[Date]:
+        """Return the node dates.
+
+        Returns:
+            list[Date]: The nodes, the first of which is the base date.
+        """
+        ...
+    def nodes(self) -> list[tuple[Date, float]]:
+        """Return the curve's nodes as pairs.
+
+        Returns:
+            list[tuple[Date, float]]: One (date, zero rate) pair per node.
+        """
+        ...
 
 class ZeroInflationHelper:
     """Shared base for every zero-inflation bootstrap helper: the two dates the
@@ -2698,8 +2841,20 @@ class ZeroInflationHelper:
     Concrete helpers such as ZeroCouponInflationSwapHelper subclass this and
     supply only their constructor."""
 
-    def pillar_date(self) -> Date: ...
-    def latest_date(self) -> Date: ...
+    def pillar_date(self) -> Date:
+        """Return the date the curve node this helper sets sits at.
+
+        Returns:
+            Date: The pillar date.
+        """
+        ...
+    def latest_date(self) -> Date:
+        """Return the latest date the helper needs curve data at.
+
+        Returns:
+            Date: The latest date, equal to the pillar date.
+        """
+        ...
 
 class ZeroCouponInflationSwapHelper(ZeroInflationHelper):
     """The bootstrap helper fitting a zero-coupon inflation swap quoted as a
@@ -2729,14 +2884,56 @@ class ZeroCouponInflationSwapHelper(ZeroInflationHelper):
         settings: Settings,
         pillar: Pillar = ...,
     ) -> None:
-        """Raises ItofinError on an observation lag the index cannot observe
-        through, and under CpiInterpolationType.Linear on one that leaves less
-        than a whole index period over the index's availability lag."""
+        """Build the helper on a swap maturing at maturity.
+
+        It needs no nominal curve, building itself a flat zero-rate one,
+        because both legs pay on the same adjusted maturity and their discount
+        factors cancel out of the fair rate.
+
+        Args:
+            quote (SimpleQuote): The quoted swap rate; the caller keeps it, so
+                a later set_value re-drives the bootstrap.
+            swap_obs_lag (Period): How far back the maturity fixing is
+                observed.
+            maturity (Date): The swap's maturity.
+            calendar (Calendar): The calendar the payment rolls on.
+            payment_convention (BusinessDayConvention): The roll applied to the
+                payment date.
+            day_counter (DayCounter): The day count the fixed amount accrues
+                on.
+            index (ZeroInflationIndex): The index observed; the helper prices
+                through a copy linked to a handle of its own, so the caller's
+                index need not be linked to any curve.
+            observation_interpolation (CpiInterpolationType): How the observed
+                fixing is interpolated.
+            settings (Settings): The explicit settings supplying the evaluation
+                date the swap starts at, which must be set before this
+                constructor runs.
+            pillar (Pillar): Which of the two nodes an interpolated swap
+                straddles the helper fits; a flat swap reads a single fixing
+                and ignores it.
+
+        Raises:
+            ItofinError: On an observation lag the index cannot observe
+                through, and under Linear interpolation on one that leaves less
+                than a whole index period over the index's availability lag.
+        """
         ...
     def inflation_fixing_date(self) -> Date:
-        """The maturity observation date on the helper's own swap: maturity less
-        the observation lag, unsnapped. Not pillar_date, which is the first day
-        of the period containing it."""
+        """Return the maturity observation date on the helper's own swap.
+
+        Read off the cached contract's indexed flow, so it reports the date the
+        helper actually prices at rather than one recomputed here. It is not
+        pillar_date, which is the first day of the period containing it, that
+        quantization being the helper's rounding and not the contract's.
+
+        Returns:
+            Date: The maturity less the observation lag, unsnapped.
+
+        Raises:
+            ItofinError: If the cached swap carries the error that stopped it
+                being built, notably an evaluation date that was never set.
+        """
         ...
 
 class PiecewiseZeroInflationCurve(ZeroInflationTermStructure):
@@ -2758,12 +2955,61 @@ class PiecewiseZeroInflationCurve(ZeroInflationTermStructure):
         day_counter: DayCounter,
         helpers: list[ZeroInflationHelper],
     ) -> None:
-        """Raises ItofinError on an empty helper list."""
+        """Build the curve over helpers, registering on them without solving.
+
+        Args:
+            reference_date (Date): The curve's reference date.
+            base_date (Date): The last date for which a fixing is known, where
+                node zero sits.
+            frequency (Frequency): The frequency of the inflation fixings.
+            day_counter (DayCounter): The day count turning dates into times.
+            helpers (list[ZeroInflationHelper]): The bootstrap instruments.
+
+        Raises:
+            ItofinError: On an empty helper list.
+        """
         ...
-    def calculate(self) -> None: ...
-    def times(self) -> list[float]: ...
-    def dates(self) -> list[Date]: ...
-    def nodes(self) -> list[tuple[Date, float]]: ...
+    def calculate(self) -> None:
+        """Run the bootstrap if the cache is stale.
+
+        Calling it explicitly makes a solver failure surface here rather than
+        inside a later query.
+
+        Raises:
+            ItofinError: On a bootstrap failure.
+        """
+        ...
+    def times(self) -> list[float]:
+        """Return the node times, triggering the bootstrap.
+
+        Returns:
+            list[float]: The nodes measured from the reference date; the first
+                is negative, node zero sitting on the base date.
+
+        Raises:
+            ItofinError: On a bootstrap failure.
+        """
+        ...
+    def dates(self) -> list[Date]:
+        """Return the node dates, triggering the bootstrap.
+
+        Returns:
+            list[Date]: The nodes, the first of which is the base date.
+
+        Raises:
+            ItofinError: On a bootstrap failure.
+        """
+        ...
+    def nodes(self) -> list[tuple[Date, float]]:
+        """Return the solved nodes as pairs, triggering the bootstrap.
+
+        Returns:
+            list[tuple[Date, float]]: One (date, zero rate) pair per node.
+
+        Raises:
+            ItofinError: On a bootstrap failure.
+        """
+        ...
 
 class YoYInflationTermStructure:
     """Shared base for every year-on-year inflation curve: the year-on-year

--- a/crates/itofin-py/python/itofin/termstructures.pyi
+++ b/crates/itofin-py/python/itofin/termstructures.pyi
@@ -712,26 +712,114 @@ class BlackVarianceSurface(BlackVolTermStructure):
         ...
 
 class RateHelper:
-    """Shared base for every bootstrap helper: implied/market quotes and dates."""
+    """Shared base for every bootstrap helper: implied/market quotes and dates.
 
-    def implied_quote(self) -> float: ...
-    def quote_error(self) -> float: ...
-    def quote_value(self) -> float: ...
-    def maturity_date(self) -> Date: ...
-    def pillar_date(self) -> Date: ...
-    def earliest_date(self) -> Date: ...
-    def latest_date(self) -> Date: ...
-    def latest_relevant_date(self) -> Date: ...
+    A rate helper wraps a market quote plus the schedule of a single
+    instrument; a piecewise curve is bootstrapped so every helper reprices its
+    own quote. Concrete helpers subclass this and supply only their
+    constructor.
+    """
+
+    def implied_quote(self) -> float:
+        """Return the quote implied by the curve the helper is linked to.
+
+        Returns:
+            float: The curve-implied quote.
+
+        Raises:
+            ItofinError: With no curve set, the pre-bootstrap state, there
+                being nothing to imply from.
+        """
+        ...
+    def quote_error(self) -> float:
+        """Return the bootstrap root: market quote minus implied quote.
+
+        Returns:
+            float: The residual the solver drives to zero.
+
+        Raises:
+            ItofinError: On the same condition implied_quote reports.
+        """
+        ...
+    def quote_value(self) -> float:
+        """Return the current value of the market quote the helper fits.
+
+        Reads back through the retained quote handle, so a set_value on the
+        SimpleQuote passed to the constructor is observed here: the same-object
+        wiring the laziness contract relies on.
+
+        Returns:
+            float: The market quote's current value.
+        """
+        ...
+    def maturity_date(self) -> Date:
+        """Return the instrument's maturity date.
+
+        Returns:
+            Date: The maturity.
+        """
+        ...
+    def pillar_date(self) -> Date:
+        """Return the date the curve node this helper sets sits at.
+
+        Returns:
+            Date: The pillar date.
+        """
+        ...
+    def earliest_date(self) -> Date:
+        """Return the earliest date the helper needs curve data at.
+
+        Returns:
+            Date: The earliest relevant date.
+        """
+        ...
+    def latest_date(self) -> Date:
+        """Return the latest date the helper needs curve data at.
+
+        Returns:
+            Date: The latest date, equal to the pillar date.
+        """
+        ...
+    def latest_relevant_date(self) -> Date:
+        """Return the latest date whose data the helper is relevant for.
+
+        Returns:
+            Date: The latest relevant date.
+        """
+        ...
 
 class DepositRateHelper(RateHelper):
     """A helper fitting a deposit rate."""
 
-    def __init__(self, quote: SimpleQuote, index: IborIndex) -> None: ...
+    def __init__(self, quote: SimpleQuote, index: IborIndex) -> None:
+        """Build the helper over a live quote.
+
+        Args:
+            quote (SimpleQuote): The deposit rate; the caller keeps it, and
+                mutating it later invalidates the bootstrap.
+            index (IborIndex): The index supplying the deposit's schedule.
+        """
+        ...
     @staticmethod
-    def from_rate(rate: float, index: IborIndex) -> DepositRateHelper: ...
+    def from_rate(rate: float, index: IborIndex) -> DepositRateHelper:
+        """Build the helper over a fixed rate.
+
+        Args:
+            rate (float): The deposit rate, wrapped in an internal quote the
+                caller cannot later mutate.
+            index (IborIndex): The index supplying the deposit's schedule.
+
+        Returns:
+            DepositRateHelper: The helper fitting that rate.
+        """
+        ...
 
 class SwapRateHelper(RateHelper):
-    """A helper fitting a par swap rate (spot-starting, no spread)."""
+    """A helper fitting a par swap rate (spot-starting, no spread).
+
+    The spot-starting form the curve-consistency oracle builds: no spread, no
+    forward start, no exogenous discounting curve, and the default pillar.
+    """
 
     def __init__(
         self,
@@ -742,7 +830,19 @@ class SwapRateHelper(RateHelper):
         fixed_convention: BusinessDayConvention,
         fixed_day_count: DayCounter,
         ibor_index: IborIndex,
-    ) -> None: ...
+    ) -> None:
+        """Build the helper over the schedule of a spot-starting swap.
+
+        Args:
+            quote (SimpleQuote): The par swap rate the helper fits.
+            tenor (Period): The length of the swap.
+            calendar (Calendar): The calendar the schedule rolls on.
+            fixed_frequency (Frequency): The fixed leg's payment frequency.
+            fixed_convention (BusinessDayConvention): The fixed leg's roll.
+            fixed_day_count (DayCounter): The fixed leg's day count.
+            ibor_index (IborIndex): The index the floating leg fixes off.
+        """
+        ...
 
 class FuturesType:
     """The date convention an interest-rate future settles on.
@@ -757,10 +857,13 @@ class FuturesType:
     Custom: FuturesType
 
 class FuturesRateHelper(RateHelper):
-    """A helper fitting an exchange-traded interest-rate future's quoted price at
-    a fixed IMM/ASX window. The window is absolute (never rebuilt on an
-    evaluation-date change). Pass conv_adj=None for an empty (zero) convexity
-    adjustment."""
+    """A helper fitting an exchange-traded interest-rate future's quoted price.
+
+    Unlike the deposit and swap helpers the window is absolute: it is computed
+    once from the supplied dates and never rebuilt on an evaluation-date
+    change. The convexity adjustment is usually absent; pass conv_adj=None to
+    leave it empty, which reports a zero adjustment.
+    """
 
     def __init__(
         self,
@@ -773,7 +876,29 @@ class FuturesRateHelper(RateHelper):
         day_counter: DayCounter,
         conv_adj: SimpleQuote | None,
         futures_type: FuturesType,
-    ) -> None: ...
+    ) -> None:
+        """Build the helper over a length-in-months window off the start date.
+
+        Args:
+            price (SimpleQuote): The future's quoted price.
+            ibor_start_date (Date): The window's start.
+            length_in_months (int): The months the start is advanced by to
+                reach maturity.
+            calendar (Calendar): The calendar the maturity rolls on.
+            convention (BusinessDayConvention): The roll applied to the
+                maturity.
+            end_of_month (bool): Whether the maturity roll keeps to month ends.
+            day_counter (DayCounter): The day count the year fraction uses.
+            conv_adj (SimpleQuote | None): The convexity quote, or None for an
+                empty, zero adjustment.
+            futures_type (FuturesType): The date convention the future settles
+                on.
+
+        Raises:
+            ItofinError: If an Imm or Asx start is not a valid date of that
+                convention.
+        """
+        ...
     @staticmethod
     def from_end_date(
         price: SimpleQuote,
@@ -782,7 +907,30 @@ class FuturesRateHelper(RateHelper):
         day_counter: DayCounter,
         conv_adj: SimpleQuote | None,
         futures_type: FuturesType,
-    ) -> FuturesRateHelper: ...
+    ) -> FuturesRateHelper:
+        """Build the helper over an explicit window.
+
+        Args:
+            price (SimpleQuote): The future's quoted price.
+            ibor_start_date (Date): The window's start.
+            ibor_end_date (Date | None): The window's end, which must be past
+                the start; None puts the maturity three IMM/ASX periods past
+                the start.
+            day_counter (DayCounter): The day count the year fraction uses.
+            conv_adj (SimpleQuote | None): The convexity quote, or None for an
+                empty, zero adjustment.
+            futures_type (FuturesType): The date convention the future settles
+                on.
+
+        Returns:
+            FuturesRateHelper: The helper over that window.
+
+        Raises:
+            ItofinError: On a Custom helper with no end date - a divergence
+                from C++, which builds a null-maturity helper instead - and on
+                a start that is not a valid date of the chosen convention.
+        """
+        ...
     @staticmethod
     def from_index(
         price: SimpleQuote,
@@ -790,8 +938,36 @@ class FuturesRateHelper(RateHelper):
         index: IborIndex,
         conv_adj: SimpleQuote | None,
         futures_type: FuturesType,
-    ) -> FuturesRateHelper: ...
-    def convexity_adjustment(self) -> float: ...
+    ) -> FuturesRateHelper:
+        """Build the helper with a window following the index's conventions.
+
+        The maturity is the start advanced by the index tenor on the index's
+        fixing calendar, and the year fraction uses the index day counter.
+
+        Args:
+            price (SimpleQuote): The future's quoted price.
+            ibor_start_date (Date): The window's start.
+            index (IborIndex): The index supplying the conventions.
+            conv_adj (SimpleQuote | None): The convexity quote, or None for an
+                empty, zero adjustment.
+            futures_type (FuturesType): The date convention the future settles
+                on.
+
+        Returns:
+            FuturesRateHelper: The helper over that window.
+
+        Raises:
+            ItofinError: If the start is not a valid date of the chosen
+                convention.
+        """
+        ...
+    def convexity_adjustment(self) -> float:
+        """Return the convexity adjustment applied to the forward.
+
+        Returns:
+            float: The convexity quote's value, or zero when none was supplied.
+        """
+        ...
 
 class Pillar:
     """The date the curve node a helper fits sits at.

--- a/crates/itofin-py/python/itofin/termstructures.pyi
+++ b/crates/itofin-py/python/itofin/termstructures.pyi
@@ -124,20 +124,145 @@ class YieldTermStructure:
         ...
 
 class BlackVolTermStructure:
-    """Shared base for every Black-volatility surface: spot and forward vol/variance."""
+    """Shared base for every Black-volatility surface: spot and forward vol/variance.
 
-    def black_vol(self, t: float, strike: float, extrapolate: bool = False) -> float: ...
-    def black_vol_date(self, date: Date, strike: float, extrapolate: bool = False) -> float: ...
-    def black_variance(self, t: float, strike: float, extrapolate: bool = False) -> float: ...
-    def black_variance_date(self, date: Date, strike: float, extrapolate: bool = False) -> float: ...
-    def black_forward_vol(self, t1: float, t2: float, strike: float, extrapolate: bool = False) -> float: ...
-    def black_forward_variance(self, t1: float, t2: float, strike: float, extrapolate: bool = False) -> float: ...
-    def min_strike(self) -> float: ...
-    def max_strike(self) -> float: ...
-    def max_date(self) -> Date: ...
-    def allows_extrapolation(self) -> bool: ...
-    def enable_extrapolation(self) -> None: ...
-    def disable_extrapolation(self) -> None: ...
+    Concrete surfaces subclass this and supply only their constructor; the
+    whole query surface below is inherited, along with the strike domain and
+    the extrapolation toggles.
+    """
+
+    def black_vol(self, t: float, strike: float, extrapolate: bool = False) -> float:
+        """Return the spot Black volatility at year-fraction t and strike.
+
+        Args:
+            t (float): The year fraction, in the surface's own day count.
+            strike (float): The strike the volatility is read at.
+            extrapolate (bool): Whether to answer outside the surface's grid.
+
+        Returns:
+            float: The Black volatility.
+
+        Raises:
+            ItofinError: If the query falls outside the grid and extrapolation
+                is not allowed.
+        """
+        ...
+    def black_vol_date(self, date: Date, strike: float, extrapolate: bool = False) -> float:
+        """Return the spot Black volatility at date and strike.
+
+        Args:
+            date (Date): The expiry the volatility is read at.
+            strike (float): The strike the volatility is read at.
+            extrapolate (bool): Whether to answer outside the surface's grid.
+
+        Returns:
+            float: The Black volatility.
+
+        Raises:
+            ItofinError: If the query falls outside the grid and extrapolation
+                is not allowed.
+        """
+        ...
+    def black_variance(self, t: float, strike: float, extrapolate: bool = False) -> float:
+        """Return the spot Black variance at year-fraction t and strike.
+
+        Args:
+            t (float): The year fraction, in the surface's own day count.
+            strike (float): The strike the variance is read at.
+            extrapolate (bool): Whether to answer outside the surface's grid.
+
+        Returns:
+            float: The Black variance.
+
+        Raises:
+            ItofinError: If the query falls outside the grid and extrapolation
+                is not allowed.
+        """
+        ...
+    def black_variance_date(self, date: Date, strike: float, extrapolate: bool = False) -> float:
+        """Return the spot Black variance at date and strike.
+
+        Args:
+            date (Date): The expiry the variance is read at.
+            strike (float): The strike the variance is read at.
+            extrapolate (bool): Whether to answer outside the surface's grid.
+
+        Returns:
+            float: The Black variance.
+
+        Raises:
+            ItofinError: If the query falls outside the grid and extrapolation
+                is not allowed.
+        """
+        ...
+    def black_forward_vol(self, t1: float, t2: float, strike: float, extrapolate: bool = False) -> float:
+        """Return the forward Black volatility between year-fractions t1 and t2.
+
+        Args:
+            t1 (float): The start year fraction.
+            t2 (float): The end year fraction.
+            strike (float): The strike the volatility is read at.
+            extrapolate (bool): Whether to answer outside the surface's grid.
+
+        Returns:
+            float: The forward Black volatility.
+
+        Raises:
+            ItofinError: If the query falls outside the grid and extrapolation
+                is not allowed.
+        """
+        ...
+    def black_forward_variance(self, t1: float, t2: float, strike: float, extrapolate: bool = False) -> float:
+        """Return the forward Black variance between year-fractions t1 and t2.
+
+        Args:
+            t1 (float): The start year fraction.
+            t2 (float): The end year fraction.
+            strike (float): The strike the variance is read at.
+            extrapolate (bool): Whether to answer outside the surface's grid.
+
+        Returns:
+            float: The forward Black variance.
+
+        Raises:
+            ItofinError: If the query falls outside the grid and extrapolation
+                is not allowed.
+        """
+        ...
+    def min_strike(self) -> float:
+        """Return the minimum strike for which the surface can return volatilities.
+
+        Returns:
+            float: The lower bound of the strike domain.
+        """
+        ...
+    def max_strike(self) -> float:
+        """Return the maximum strike for which the surface can return volatilities.
+
+        Returns:
+            float: The upper bound of the strike domain.
+        """
+        ...
+    def max_date(self) -> Date:
+        """Return the latest date for which the surface can return values.
+
+        Returns:
+            Date: The surface's maximum date.
+        """
+        ...
+    def allows_extrapolation(self) -> bool:
+        """Return whether the surface answers dates and times beyond its maximum.
+
+        Returns:
+            bool: True when extrapolation is enabled on the surface itself.
+        """
+        ...
+    def enable_extrapolation(self) -> None:
+        """Allow extrapolation past the maximum date and time."""
+        ...
+    def disable_extrapolation(self) -> None:
+        """Forbid extrapolation past the maximum date and time."""
+        ...
 
 class FlatForward(YieldTermStructure):
     """A flat continuously-compounded yield curve behind a Handle.
@@ -480,7 +605,11 @@ class PiecewiseFlatForward(YieldTermStructure):
         ...
 
 class BlackConstantVol(BlackVolTermStructure):
-    """A flat Black volatility, constant in strike and time."""
+    """A flat Black volatility, constant in strike and time.
+
+    Unbounded in both time and strike, so queries never need extrapolation
+    enabled.
+    """
 
     def __init__(
         self,
@@ -488,7 +617,16 @@ class BlackConstantVol(BlackVolTermStructure):
         volatility: float,
         day_counter: DayCounter,
         calendar: Calendar | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Build the flat surface.
+
+        Args:
+            reference_date (Date): The date times are measured from.
+            volatility (float): The single volatility answered everywhere.
+            day_counter (DayCounter): The day count turning dates into times.
+            calendar (Calendar | None): The surface's calendar, if any.
+        """
+        ...
 
 class BlackVolTimeExtrapolation:
     """How a variance curve extrapolates past its last node.
@@ -503,9 +641,13 @@ class BlackVolTimeExtrapolation:
     LinearVariance: BlackVolTimeExtrapolation
 
 class BlackVarianceCurve(BlackVolTermStructure):
-    """A term structure of Black volatility (no strike dimension), interpolating
-    linearly on variance. Finite in time: enable extrapolation past the last date,
-    where ``time_extrapolation`` picks the rule."""
+    """A term structure of Black volatility with no strike dimension.
+
+    Interpolates linearly on variance. Finite in time: the last date is the
+    maximum, so queries past it require enable_extrapolation(), and
+    time_extrapolation picks the rule applied there. The interpolation itself
+    stays linear; only the extrapolation axis is exposed.
+    """
 
     def __init__(
         self,
@@ -515,11 +657,33 @@ class BlackVarianceCurve(BlackVolTermStructure):
         day_counter: DayCounter,
         force_monotone_variance: bool,
         time_extrapolation: BlackVolTimeExtrapolation = ...,
-    ) -> None: ...
+    ) -> None:
+        """Build the variance curve over its (date, volatility) nodes.
+
+        Args:
+            reference_date (Date): The date times are measured from.
+            dates (list[Date]): The node dates.
+            black_vol_curve (list[float]): The Black volatility at each node.
+            day_counter (DayCounter): The day count turning dates into times.
+            force_monotone_variance (bool): Whether to require the implied
+                variance to increase across the nodes.
+            time_extrapolation (BlackVolTimeExtrapolation): The rule applied
+                past the last node; defaults to FlatVolatility, the C++
+                default. Selecting UseInterpolator constructs fine and answers
+                in-range queries, then errors on an extrapolating one.
+
+        Raises:
+            ItofinError: On whatever the core rejects about the nodes, a
+                non-monotone variance under force_monotone_variance included.
+        """
+        ...
 
 class BlackVarianceSurface(BlackVolTermStructure):
-    """A Black volatility surface in strike and expiry, interpolating bilinearly
-    on variance. black_vol_matrix has one row per strike and one column per date."""
+    """A Black volatility surface in strike and expiry, interpolating bilinearly.
+
+    Finite in both time and strike, so out-of-grid queries require
+    enable_extrapolation().
+    """
 
     def __init__(
         self,
@@ -529,7 +693,23 @@ class BlackVarianceSurface(BlackVolTermStructure):
         black_vol_matrix: list[list[float]],
         day_counter: DayCounter,
         calendar: Calendar | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Build the surface over its strike-by-expiry grid.
+
+        Args:
+            reference_date (Date): The date times are measured from.
+            dates (list[Date]): The expiry grid, one per matrix column.
+            strikes (list[float]): The strike grid, one per matrix row.
+            black_vol_matrix (list[list[float]]): The volatilities, one row per
+                strike and one column per date.
+            day_counter (DayCounter): The day count turning dates into times.
+            calendar (Calendar | None): The surface's calendar, if any.
+
+        Raises:
+            ItofinError: On an empty or ragged matrix, and on whatever the core
+                rejects about the grid dimensions.
+        """
+        ...
 
 class RateHelper:
     """Shared base for every bootstrap helper: implied/market quotes and dates."""

--- a/crates/itofin-py/python/itofin/termstructures.pyi
+++ b/crates/itofin-py/python/itofin/termstructures.pyi
@@ -1501,8 +1501,8 @@ class SabrSmileSection:
 
         Raises:
             ItofinError: On a non-zero shift or a Normal volatility_type, both
-                deferred; on a non-positive shifted forward; and on SABR
-                parameters outside their admissible ranges.
+                deferred to #586; on a non-positive shifted forward; and on
+                SABR parameters outside their admissible ranges.
         """
         ...
     def volatility(self, strike: float) -> float:
@@ -2761,10 +2761,10 @@ class ZeroInflationTermStructure:
 
         Raises:
             ItofinError: From the consistency gate, which a multi-year factor
-                set fails, that comparison being a documented core deferral.
-                The store happens before the gate runs, as C++'s does, so a
-                rejected correction is left installed and unannounced: clear it
-                with None before reading the curve again.
+                set fails, that comparison being a documented core deferral
+                (#807). The store happens before the gate runs, as C++'s does,
+                so a rejected correction is left installed and unannounced:
+                clear it with None before reading the curve again.
         """
         ...
     def has_seasonality(self) -> bool:
@@ -3251,8 +3251,9 @@ class YearOnYearInflationSwapHelper(YoYInflationHelper):
 
         Raises:
             ItofinError: On Linear interpolation, which the core refuses
-                outright pending the interpolated branch, and on an observation
-                lag the helper's own swap legs cannot be built under.
+                outright pending the interpolated branch (#847), and on an
+                observation lag the helper's own swap legs cannot be built
+                under.
         """
         ...
 

--- a/crates/itofin-py/python/itofin/termstructures.pyi
+++ b/crates/itofin-py/python/itofin/termstructures.pyi
@@ -23,17 +23,105 @@ from itofin.time import (
 )
 
 class YieldTermStructure:
-    """Shared base for every yield curve: discount factors, zero and forward rates."""
+    """Shared base for every yield curve: discount factors, zero and forward rates.
 
-    def discount(self, t: float, extrapolate: bool = False) -> float: ...
-    def discount_date(self, date: Date, extrapolate: bool = False) -> float: ...
-    def zero_rate(self, t: float, extrapolate: bool = False) -> float: ...
-    def forward_rate(self, t1: float, t2: float, extrapolate: bool = False) -> float: ...
-    def reference_date(self) -> Date: ...
-    def max_date(self) -> Date: ...
-    def allows_extrapolation(self) -> bool: ...
-    def enable_extrapolation(self) -> None: ...
-    def disable_extrapolation(self) -> None: ...
+    Concrete curves subclass this and supply only their constructor; the whole
+    query surface below is inherited.
+    """
+
+    def discount(self, t: float, extrapolate: bool = False) -> float:
+        """Return the discount factor at year-fraction t.
+
+        Args:
+            t (float): The year fraction, in the curve's own day count.
+            extrapolate (bool): Whether to answer past the curve's max date.
+
+        Returns:
+            float: The discount factor.
+
+        Raises:
+            ItofinError: If t is past the curve's range and neither extrapolate
+                nor the curve's own extrapolation flag allows it.
+        """
+        ...
+    def discount_date(self, date: Date, extrapolate: bool = False) -> float:
+        """Return the discount factor from date back to the reference date.
+
+        Args:
+            date (Date): The date discounted from.
+            extrapolate (bool): Whether to answer past the curve's max date.
+
+        Returns:
+            float: The discount factor.
+
+        Raises:
+            ItofinError: If date is past the curve's range and extrapolation is
+                not allowed.
+        """
+        ...
+    def zero_rate(self, t: float, extrapolate: bool = False) -> float:
+        """Return the continuously-compounded zero rate at year-fraction t.
+
+        Args:
+            t (float): The year fraction, in the curve's own day count.
+            extrapolate (bool): Whether to answer past the curve's max date.
+
+        Returns:
+            float: The zero rate, continuously compounded at annual frequency.
+
+        Raises:
+            ItofinError: If t is past the curve's range and extrapolation is
+                not allowed.
+        """
+        ...
+    def forward_rate(self, t1: float, t2: float, extrapolate: bool = False) -> float:
+        """Return the continuously-compounded forward rate between t1 and t2.
+
+        Args:
+            t1 (float): The start year fraction.
+            t2 (float): The end year fraction.
+            extrapolate (bool): Whether to answer past the curve's max date.
+
+        Returns:
+            float: The forward rate, continuously compounded at annual
+                frequency.
+
+        Raises:
+            ItofinError: If either time is past the curve's range and
+                extrapolation is not allowed.
+        """
+        ...
+    def reference_date(self) -> Date:
+        """Return the date at which the discount factor is 1.0.
+
+        Returns:
+            Date: The curve's reference date.
+
+        Raises:
+            ItofinError: On a curve whose reference date moves with an
+                evaluation date that is not set.
+        """
+        ...
+    def max_date(self) -> Date:
+        """Return the latest date for which the curve can return values.
+
+        Returns:
+            Date: The curve's maximum date.
+        """
+        ...
+    def allows_extrapolation(self) -> bool:
+        """Return whether the curve answers dates and times beyond its maximum.
+
+        Returns:
+            bool: True when extrapolation is enabled on the curve itself.
+        """
+        ...
+    def enable_extrapolation(self) -> None:
+        """Allow extrapolation past the maximum date and time."""
+        ...
+    def disable_extrapolation(self) -> None:
+        """Forbid extrapolation past the maximum date and time."""
+        ...
 
 class BlackVolTermStructure:
     """Shared base for every Black-volatility surface: spot and forward vol/variance."""
@@ -52,14 +140,30 @@ class BlackVolTermStructure:
     def disable_extrapolation(self) -> None: ...
 
 class FlatForward(YieldTermStructure):
-    """A flat continuously-compounded yield curve behind a Handle."""
+    """A flat continuously-compounded yield curve behind a Handle.
 
-    def __init__(self, reference_date: Date, rate: float, day_counter: DayCounter) -> None: ...
+    Built at annual frequency with continuous compounding, the convention every
+    downstream Heston and Hull-White oracle assumes.
+    """
+
+    def __init__(self, reference_date: Date, rate: float, day_counter: DayCounter) -> None:
+        """Build the flat curve.
+
+        Args:
+            reference_date (Date): The date at which the discount factor is
+                1.0.
+            rate (float): The flat rate, continuously compounded at annual
+                frequency.
+            day_counter (DayCounter): The day count times are measured in.
+        """
+        ...
 
 class ZeroCurve(YieldTermStructure):
-    """A yield curve interpolating continuously-compounded zero rates between
-    nodes. The first date is the reference date; finite in time. interpolation is
-    "Linear" (default) or "Cubic"."""
+    """A yield curve interpolating continuously-compounded zero rates between nodes.
+
+    The first date is the reference date. Finite in time: queries past the last
+    node require enable_extrapolation() or extrapolate=True.
+    """
 
     def __init__(
         self,
@@ -67,12 +171,30 @@ class ZeroCurve(YieldTermStructure):
         yields: list[float],
         day_counter: DayCounter,
         interpolation: str = "Linear",
-    ) -> None: ...
+    ) -> None:
+        """Build the curve over its (date, zero-rate) nodes.
+
+        Args:
+            dates (list[Date]): The node dates, the first being the reference
+                date.
+            yields (list[float]): The continuously-compounded zero rate at each
+                node.
+            day_counter (DayCounter): The day count turning dates into times.
+            interpolation (str): "Linear", the shipped behaviour, or "Cubic",
+                the Kruger cubic factory, which is non-monotonic.
+
+        Raises:
+            ItofinError: On an unknown interpolation name, and on whatever the
+                core rejects about the nodes.
+        """
+        ...
 
 class DiscountCurve(YieldTermStructure):
-    """A yield curve interpolating discount factors between nodes. The first date
-    is the reference date and its discount must be 1.0. interpolation is
-    "LogLinear" (default, piecewise-constant forwards) or "Cubic"."""
+    """A yield curve interpolating discount factors between nodes.
+
+    The first date is the reference date and its discount must be 1.0. Finite
+    in time: queries past the last node require extrapolation.
+    """
 
     def __init__(
         self,
@@ -81,23 +203,68 @@ class DiscountCurve(YieldTermStructure):
         day_counter: DayCounter,
         calendar: Calendar | None = None,
         interpolation: str = "LogLinear",
-    ) -> None: ...
+    ) -> None:
+        """Build the curve over its (date, discount-factor) nodes.
+
+        Args:
+            dates (list[Date]): The node dates, the first being the reference
+                date.
+            discounts (list[float]): The discount factor at each node; the
+                first must be 1.0.
+            day_counter (DayCounter): The day count turning dates into times.
+            calendar (Calendar | None): The curve's calendar; unlike the other
+                two node curves this constructor accepts one.
+            interpolation (str): "LogLinear", the shipped behaviour, giving
+                piecewise-constant forwards, or "Cubic", which is
+                non-monotonic.
+
+        Raises:
+            ItofinError: On an unknown interpolation name, and on whatever the
+                core rejects about the nodes.
+        """
+        ...
 
 class ForwardCurve(YieldTermStructure):
     """A yield curve interpolating instantaneous forward rates backward-flat.
-    The first date is the reference date; finite in time."""
+
+    The first date is the reference date. Finite in time. Unlike ZeroCurve and
+    DiscountCurve this curve offers no cubic option, QuantLib-SWIG exposing its
+    cubic curve on the zero and discount curves only.
+    """
 
     def __init__(
         self,
         dates: list[Date],
         forwards: list[float],
         day_counter: DayCounter,
-    ) -> None: ...
+    ) -> None:
+        """Build the curve over its (date, forward-rate) nodes.
+
+        Args:
+            dates (list[Date]): The node dates, the first being the reference
+                date.
+            forwards (list[float]): The instantaneous forward rate at each
+                node.
+            day_counter (DayCounter): The day count turning dates into times.
+
+        Raises:
+            ItofinError: On whatever the core rejects about the nodes.
+        """
+        ...
 
 class PiecewiseYieldCurve(YieldTermStructure):
-    """A yield curve bootstrapped from a strip of rate helpers, one node per
-    helper maturity. The bootstrap is lazy: it runs on the first query, not at
-    construction. interpolation is "LogLinear" (default) or "Linear"."""
+    """A yield curve bootstrapped from a strip of rate helpers, one node per maturity.
+
+    Every helper is solved so it reprices its own market quote off the curve.
+    This string-dispatch alias covers the Discount convention; the other
+    bootstrap conventions are reached through the named Piecewise* classes,
+    which also expose node introspection.
+
+    The bootstrap is lazy: construction only rejects an empty helper list, and
+    the solver runs on the first query, re-running after a helper-quote or
+    evaluation-date change. A bootstrap failure therefore surfaces from the
+    query methods, not from the constructor.
+    """
 
     def __init__(
         self,
@@ -105,63 +272,212 @@ class PiecewiseYieldCurve(YieldTermStructure):
         helpers: list[RateHelper],
         day_counter: DayCounter,
         interpolation: str = "LogLinear",
-    ) -> None: ...
+    ) -> None:
+        """Build the curve over helpers with a fixed reference date.
+
+        Args:
+            reference_date (Date): The curve's reference date, typically the
+                settlement date the caller computed.
+            helpers (list[RateHelper]): The bootstrap instruments; any
+                RateHelper subclass is accepted.
+            day_counter (DayCounter): The day count turning dates into times.
+            interpolation (str): "LogLinear" or "Linear". "Cubic" is refused: a
+                global interpolator cannot converge under the single-pass
+                bootstrap, and it is available on ZeroCurve and DiscountCurve
+                instead.
+
+        Raises:
+            ItofinError: On an empty helper list and on an unknown or refused
+                interpolation name.
+        """
+        ...
 
 class PiecewiseLogLinearDiscount(YieldTermStructure):
-    """A curve bootstrapped in discount-factor space with log-linear interpolation
-    (PiecewiseYieldCurve<Discount, LogLinear>). data() are discount factors, so
-    data()[0] is the reference node's 1.0."""
+    """A curve bootstrapped in discount-factor space with log-linear interpolation.
+
+    The verbatim QuantLib-SWIG name for the blessed (Discount, LogLinear)
+    combination. Unlike the PiecewiseYieldCurve alias, the named class retains
+    the concrete curve so it can expose the node introspection the erased
+    handle discards. data() are discount factors, so data()[0] is the reference
+    node's 1.0.
+    """
 
     def __init__(
         self,
         reference_date: Date,
         helpers: list[RateHelper],
         day_counter: DayCounter,
-    ) -> None: ...
-    def dates(self) -> list[Date]: ...
-    def data(self) -> list[float]: ...
+    ) -> None:
+        """Build the curve over helpers with a fixed reference date.
+
+        Args:
+            reference_date (Date): The curve's reference date.
+            helpers (list[RateHelper]): The bootstrap instruments; any
+                RateHelper subclass is accepted.
+            day_counter (DayCounter): The day count turning dates into times.
+
+        Raises:
+            ItofinError: On an empty helper list.
+        """
+        ...
+    def dates(self) -> list[Date]:
+        """Return the bootstrapped node dates, triggering the lazy bootstrap.
+
+        Returns:
+            list[Date]: One date per helper maturity, plus the reference node.
+
+        Raises:
+            ItofinError: On a bootstrap failure.
+        """
+        ...
+    def data(self) -> list[float]:
+        """Return the bootstrapped node values, triggering the lazy bootstrap.
+
+        Returns:
+            list[float]: The discount factors, the first being 1.0.
+
+        Raises:
+            ItofinError: On a bootstrap failure.
+        """
+        ...
 
 class PiecewiseLinearZero(YieldTermStructure):
-    """A curve bootstrapped in zero-rate space with linear interpolation
-    (PiecewiseYieldCurve<ZeroYield, Linear>). data() are zero rates."""
+    """A curve bootstrapped in zero-rate space with linear interpolation.
+
+    The verbatim QuantLib-SWIG name for the blessed (ZeroYield, Linear)
+    combination. data() are continuously-compounded zero rates, so data()[0]
+    mirrors the first solved pillar's rate rather than a 1.0 discount.
+    """
 
     def __init__(
         self,
         reference_date: Date,
         helpers: list[RateHelper],
         day_counter: DayCounter,
-    ) -> None: ...
-    def dates(self) -> list[Date]: ...
-    def data(self) -> list[float]: ...
+    ) -> None:
+        """Build the curve over helpers with a fixed reference date.
+
+        Args:
+            reference_date (Date): The curve's reference date.
+            helpers (list[RateHelper]): The bootstrap instruments.
+            day_counter (DayCounter): The day count turning dates into times.
+
+        Raises:
+            ItofinError: On an empty helper list.
+        """
+        ...
+    def dates(self) -> list[Date]:
+        """Return the bootstrapped node dates, triggering the lazy bootstrap.
+
+        Returns:
+            list[Date]: One date per helper maturity, plus the reference node.
+
+        Raises:
+            ItofinError: On a bootstrap failure.
+        """
+        ...
+    def data(self) -> list[float]:
+        """Return the bootstrapped node values, triggering the lazy bootstrap.
+
+        Returns:
+            list[float]: The zero rates at the nodes.
+
+        Raises:
+            ItofinError: On a bootstrap failure.
+        """
+        ...
 
 class PiecewiseLinearForward(YieldTermStructure):
-    """A curve bootstrapped in instantaneous forward-rate space with linear
-    interpolation (PiecewiseYieldCurve<ForwardRate, Linear>). data() are forward
-    rates."""
+    """A curve bootstrapped in instantaneous forward-rate space, interpolating linearly.
+
+    The verbatim QuantLib-SWIG name for the blessed (ForwardRate, Linear)
+    combination. data() are instantaneous forward rates.
+    """
 
     def __init__(
         self,
         reference_date: Date,
         helpers: list[RateHelper],
         day_counter: DayCounter,
-    ) -> None: ...
-    def dates(self) -> list[Date]: ...
-    def data(self) -> list[float]: ...
+    ) -> None:
+        """Build the curve over helpers with a fixed reference date.
+
+        Args:
+            reference_date (Date): The curve's reference date.
+            helpers (list[RateHelper]): The bootstrap instruments.
+            day_counter (DayCounter): The day count turning dates into times.
+
+        Raises:
+            ItofinError: On an empty helper list.
+        """
+        ...
+    def dates(self) -> list[Date]:
+        """Return the bootstrapped node dates, triggering the lazy bootstrap.
+
+        Returns:
+            list[Date]: One date per helper maturity, plus the reference node.
+
+        Raises:
+            ItofinError: On a bootstrap failure.
+        """
+        ...
+    def data(self) -> list[float]:
+        """Return the bootstrapped node values, triggering the lazy bootstrap.
+
+        Returns:
+            list[float]: The instantaneous forward rates at the nodes.
+
+        Raises:
+            ItofinError: On a bootstrap failure.
+        """
+        ...
 
 class PiecewiseFlatForward(YieldTermStructure):
-    """A curve bootstrapped in instantaneous forward-rate space with backward-flat
-    interpolation (PiecewiseYieldCurve<ForwardRate, BackwardFlat>). Numerically
-    identical to PiecewiseLogLinearDiscount under every query; only data() (forward
-    rates vs discount factors) tells them apart."""
+    """A curve bootstrapped in forward-rate space, interpolating backward-flat.
+
+    The verbatim QuantLib-SWIG name for the blessed (ForwardRate, BackwardFlat)
+    combination. Piecewise-constant instantaneous forwards make it numerically
+    identical to PiecewiseLogLinearDiscount under every query; only data(),
+    forward rates against discount factors, tells the two apart.
+    """
 
     def __init__(
         self,
         reference_date: Date,
         helpers: list[RateHelper],
         day_counter: DayCounter,
-    ) -> None: ...
-    def dates(self) -> list[Date]: ...
-    def data(self) -> list[float]: ...
+    ) -> None:
+        """Build the curve over helpers with a fixed reference date.
+
+        Args:
+            reference_date (Date): The curve's reference date.
+            helpers (list[RateHelper]): The bootstrap instruments.
+            day_counter (DayCounter): The day count turning dates into times.
+
+        Raises:
+            ItofinError: On an empty helper list.
+        """
+        ...
+    def dates(self) -> list[Date]:
+        """Return the bootstrapped node dates, triggering the lazy bootstrap.
+
+        Returns:
+            list[Date]: One date per helper maturity, plus the reference node.
+
+        Raises:
+            ItofinError: On a bootstrap failure.
+        """
+        ...
+    def data(self) -> list[float]:
+        """Return the bootstrapped node values, triggering the lazy bootstrap.
+
+        Returns:
+            list[float]: The instantaneous forward rates at the nodes.
+
+        Raises:
+            ItofinError: On a bootstrap failure.
+        """
+        ...
 
 class BlackConstantVol(BlackVolTermStructure):
     """A flat Black volatility, constant in strike and time."""

--- a/crates/itofin-py/python/itofin/termstructures.pyi
+++ b/crates/itofin-py/python/itofin/termstructures.pyi
@@ -1154,19 +1154,67 @@ class SwaptionVolatilityStructure:
         swap_tenor: Period,
         strike: float,
         extrapolate: bool = False,
-    ) -> float: ...
+    ) -> float:
+        """Return the volatility for an option tenor, swap tenor and strike.
+
+        Args:
+            option_tenor (Period): The option's tenor, resolved against the
+                surface's reference date and calendar.
+            swap_tenor (Period): The underlying swap's tenor.
+            strike (float): The strike the volatility is read at.
+            extrapolate (bool): Whether to answer outside the surface's grid.
+
+        Returns:
+            float: The volatility, in whichever type the surface quotes.
+
+        Raises:
+            ItofinError: If the query falls outside the grid and extrapolation
+                is not allowed.
+        """
+        ...
     def black_variance(
         self,
         option_tenor: Period,
         swap_tenor: Period,
         strike: float,
         extrapolate: bool = False,
-    ) -> float: ...
+    ) -> float:
+        """Return the Black variance, the squared volatility times option time.
+
+        Args:
+            option_tenor (Period): The option's tenor.
+            swap_tenor (Period): The underlying swap's tenor.
+            strike (float): The strike the variance is read at.
+            extrapolate (bool): Whether to answer outside the surface's grid.
+
+        Returns:
+            float: The Black variance.
+
+        Raises:
+            ItofinError: If the query falls outside the grid and extrapolation
+                is not allowed.
+        """
+        ...
     def shift(
         self, option_date: Date, swap_length: float, extrapolate: bool = False
     ) -> float:
-        """The lognormal shift, in the date form: the core has no tenor overload
-        for the shift. Errors on a normal-volatility surface."""
+        """Return the lognormal shift, in the date form.
+
+        Taken in the date form because the core trait has no tenor overload for
+        the shift, unlike the volatility and variance queries above.
+
+        Args:
+            option_date (Date): The option date the shift is read at.
+            swap_length (float): The underlying swap's length, in years.
+            extrapolate (bool): Whether to answer outside the surface's grid.
+
+        Returns:
+            float: The lognormal shift.
+
+        Raises:
+            ItofinError: On a normal-volatility surface, where a shift has no
+                meaning, and on an out-of-grid query without extrapolation.
+        """
         ...
 
 class VolatilityType:
@@ -1192,7 +1240,24 @@ class ConstantSwaptionVolatility(SwaptionVolatilityStructure):
         day_counter: DayCounter,
         volatility_type: VolatilityType,
         shift: float = 0.0,
-    ) -> None: ...
+    ) -> None:
+        """Build the surface at a fixed volatility.
+
+        Args:
+            reference_date (Date): The date every query's option time runs
+                from.
+            calendar (Calendar): The calendar option tenors resolve on.
+            business_day_convention (BusinessDayConvention): The roll applied
+                when resolving a tenor to a date.
+            volatility (float): The single volatility answered everywhere,
+                wrapped in an internal quote the caller cannot later mutate.
+            day_counter (DayCounter): The day count option times are measured
+                in.
+            volatility_type (VolatilityType): Whether the quote is
+                shifted-lognormal or normal.
+            shift (float): The lognormal shift.
+        """
+        ...
     @staticmethod
     def with_quote(
         reference_date: Date,
@@ -1203,8 +1268,25 @@ class ConstantSwaptionVolatility(SwaptionVolatilityStructure):
         volatility_type: VolatilityType,
         shift: float = 0.0,
     ) -> ConstantSwaptionVolatility:
-        """Reads the volatility from the caller's quote; a later set_value
-        notifies the surface's observers."""
+        """Build the surface reading its volatility from a live quote.
+
+        Args:
+            reference_date (Date): The date every query's option time runs
+                from.
+            calendar (Calendar): The calendar option tenors resolve on.
+            business_day_convention (BusinessDayConvention): The roll applied
+                when resolving a tenor to a date.
+            volatility (SimpleQuote): The volatility; a later set_value
+                notifies the surface's observers.
+            day_counter (DayCounter): The day count option times are measured
+                in.
+            volatility_type (VolatilityType): Whether the quote is
+                shifted-lognormal or normal.
+            shift (float): The lognormal shift.
+
+        Returns:
+            ConstantSwaptionVolatility: The surface over that quote.
+        """
         ...
 
 class SwaptionVolatilityMatrix(SwaptionVolatilityStructure):
@@ -1230,8 +1312,35 @@ class SwaptionVolatilityMatrix(SwaptionVolatilityStructure):
         shifts: list[list[float]] | None = None,
         flat_extrapolation: bool = False,
     ) -> None:
-        """Pins the reference date, so every query's option time runs from
-        reference_date rather than the evaluation date."""
+        """Build the grid on a pinned reference date over fixed volatilities.
+
+        Every query's option time runs from reference_date rather than from the
+        evaluation date.
+
+        Args:
+            reference_date (Date): The date option times run from.
+            calendar (Calendar): The calendar option tenors resolve on.
+            business_day_convention (BusinessDayConvention): The roll applied
+                when resolving a tenor to a date.
+            option_tenors (list[Period]): The option axis, one per grid row.
+            swap_tenors (list[Period]): The swap axis, one per grid column.
+            volatilities (list[list[float]]): The at-the-money volatilities,
+                one row per option tenor.
+            day_counter (DayCounter): The day count option times are measured
+                in.
+            volatility_type (VolatilityType): Whether the grid is
+                shifted-lognormal or normal.
+            shifts (list[list[float]] | None): The lognormal shifts in the same
+                shape as volatilities; None means all-zero shifts.
+            flat_extrapolation (bool): Whether a query past the grid clamps to
+                the nearest edge or corner vol instead of extending the
+                boundary surface.
+
+        Raises:
+            ItofinError: On an empty or ragged grid, a shifts grid that does
+                not match the volatilities shape, and on whatever the core
+                rejects about the axes.
+        """
         ...
     @staticmethod
     def moving(
@@ -1246,9 +1355,38 @@ class SwaptionVolatilityMatrix(SwaptionVolatilityStructure):
         shifts: list[list[float]] | None = None,
         flat_extrapolation: bool = False,
     ) -> SwaptionVolatilityMatrix:
-        """A grid whose reference date floats off the evaluation date, reading
-        each node from the caller's quote: a later set_value on any of them
-        rebuilds the interpolation and notifies the grid's observers."""
+        """Build a grid whose reference date floats off the evaluation date.
+
+        The reference date sits at zero settlement days from the evaluation
+        date, and each node is read from the caller's quote.
+
+        Args:
+            calendar (Calendar): The calendar option tenors resolve on.
+            business_day_convention (BusinessDayConvention): The roll applied
+                when resolving a tenor to a date.
+            option_tenors (list[Period]): The option axis, one per grid row.
+            swap_tenors (list[Period]): The swap axis, one per grid column.
+            volatilities (list[list[SimpleQuote]]): The at-the-money volatility
+                quotes; a later set_value on any of them rebuilds the
+                interpolation and notifies the grid's observers.
+            day_counter (DayCounter): The day count option times are measured
+                in.
+            volatility_type (VolatilityType): Whether the grid is
+                shifted-lognormal or normal.
+            settings (Settings): The explicit settings supplying the evaluation
+                date the reference date floats off.
+            shifts (list[list[float]] | None): The lognormal shifts in the same
+                shape as volatilities; None means all-zero shifts.
+            flat_extrapolation (bool): Whether a query past the grid clamps to
+                the nearest edge or corner vol.
+
+        Returns:
+            SwaptionVolatilityMatrix: The moving grid.
+
+        Raises:
+            ItofinError: On an empty or ragged grid, a mismatched shifts shape,
+                and on whatever the core rejects about the axes.
+        """
         ...
 
 class InterpolatedSwaptionVolatilityCube(SwaptionVolatilityStructure):
@@ -1275,10 +1413,53 @@ class InterpolatedSwaptionVolatilityCube(SwaptionVolatilityStructure):
         short_swap_index_base: SwapIndex,
         settings: Settings,
         vega_weighted_smile_fit: bool = False,
-    ) -> None: ...
+    ) -> None:
+        """Build the cube over an at-the-money surface and its vol spreads.
+
+        Args:
+            atm_vol (SwaptionVolatilityStructure): The at-the-money surface the
+                spreads are added to.
+            option_tenors (list[Period]): The option axis of the node grid.
+            swap_tenors (list[Period]): The swap axis of the node grid.
+            strike_spreads (list[float]): The moneyness offsets each smile is
+                quoted at.
+            vol_spreads (list[list[SimpleQuote]]): The spread quotes, row-major
+                over the nodes with one quote per strike spread; a later
+                set_value rebuilds the per-strike interpolators.
+            swap_index_base (SwapIndex): The long base swap index.
+            short_swap_index_base (SwapIndex): The short base swap index, whose
+                tenor must not exceed the long one's.
+            settings (Settings): The explicit settings supplying the evaluation
+                date and the stored fixings.
+            vega_weighted_smile_fit (bool): Whether the smile fit is
+                vega-weighted.
+
+        Raises:
+            ItofinError: On an empty or ragged vol_spreads grid, on a row count
+                that is not one per node or a row length that is not one per
+                strike spread, and on whatever the core rejects.
+        """
+        ...
     def atm_strike_from_tenor(self, option_tenor: Period, swap_tenor: Period) -> float:
-        """The at-the-money strike for an option tenor and swap tenor: the fixing
-        of whichever base swap index the swap tenor selects."""
+        """Return the at-the-money strike for an option tenor and swap tenor.
+
+        The fixing of whichever base swap index the swap tenor selects, off the
+        option date the tenor resolves to against the cube's reference date and
+        calendar. It lives on the concrete cube rather than the inherited base
+        because it belongs to the cube framework, not the volatility structure.
+
+        Args:
+            option_tenor (Period): The option's tenor.
+            swap_tenor (Period): The underlying swap's tenor, which selects the
+                base index.
+
+        Returns:
+            float: The at-the-money strike a query is centred on.
+
+        Raises:
+            ItofinError: On whatever the selected index's fixing reports, an
+                unset evaluation date or an unlinked forwarding curve included.
+        """
         ...
 
 class SabrSmileSection:

--- a/crates/itofin-py/python/itofin/termstructures.pyi
+++ b/crates/itofin-py/python/itofin/termstructures.pyi
@@ -2182,14 +2182,128 @@ class DefaultProbabilityTermStructure:
     the default density and the hazard rate, each in a year-fraction and a date
     form."""
 
-    def survival_probability(self, t: float, extrapolate: bool = False) -> float: ...
-    def survival_probability_date(self, date: Date, extrapolate: bool = False) -> float: ...
-    def default_probability(self, t: float, extrapolate: bool = False) -> float: ...
-    def default_probability_date(self, date: Date, extrapolate: bool = False) -> float: ...
-    def default_density(self, t: float, extrapolate: bool = False) -> float: ...
-    def default_density_date(self, date: Date, extrapolate: bool = False) -> float: ...
-    def hazard_rate(self, t: float, extrapolate: bool = False) -> float: ...
-    def hazard_rate_date(self, date: Date, extrapolate: bool = False) -> float: ...
+    def survival_probability(self, t: float, extrapolate: bool = False) -> float:
+        """Return the survival probability from the reference date to year-fraction t.
+
+        Args:
+            t (float): The year fraction, in the curve's own day count.
+            extrapolate (bool): Whether to answer past the curve's max date.
+
+        Returns:
+            float: The probability of surviving to t.
+
+        Raises:
+            ItofinError: If t is past the curve's range and extrapolation is
+                not allowed.
+        """
+        ...
+    def survival_probability_date(self, date: Date, extrapolate: bool = False) -> float:
+        """Return the survival probability from the reference date to date.
+
+        Args:
+            date (Date): The date survived to.
+            extrapolate (bool): Whether to answer past the curve's max date.
+
+        Returns:
+            float: The survival probability.
+
+        Raises:
+            ItofinError: If date is past the curve's range and extrapolation is
+                not allowed.
+        """
+        ...
+    def default_probability(self, t: float, extrapolate: bool = False) -> float:
+        """Return the default probability from the reference date to year-fraction t.
+
+        Args:
+            t (float): The year fraction, in the curve's own day count.
+            extrapolate (bool): Whether to answer past the curve's max date.
+
+        Returns:
+            float: The probability of defaulting by t.
+
+        Raises:
+            ItofinError: If t is past the curve's range and extrapolation is
+                not allowed.
+        """
+        ...
+    def default_probability_date(self, date: Date, extrapolate: bool = False) -> float:
+        """Return the default probability from the reference date to date.
+
+        Args:
+            date (Date): The date defaulted by.
+            extrapolate (bool): Whether to answer past the curve's max date.
+
+        Returns:
+            float: The default probability.
+
+        Raises:
+            ItofinError: If date is past the curve's range and extrapolation is
+                not allowed.
+        """
+        ...
+    def default_density(self, t: float, extrapolate: bool = False) -> float:
+        """Return the default density at year-fraction t.
+
+        Args:
+            t (float): The year fraction, in the curve's own day count.
+            extrapolate (bool): Whether to answer past the curve's max date.
+
+        Returns:
+            float: The default density.
+
+        Raises:
+            ItofinError: If t is past the curve's range and extrapolation is
+                not allowed.
+        """
+        ...
+    def default_density_date(self, date: Date, extrapolate: bool = False) -> float:
+        """Return the default density at date.
+
+        Args:
+            date (Date): The date the density is read at.
+            extrapolate (bool): Whether to answer past the curve's max date.
+
+        Returns:
+            float: The default density.
+
+        Raises:
+            ItofinError: If date is past the curve's range and extrapolation is
+                not allowed.
+        """
+        ...
+    def hazard_rate(self, t: float, extrapolate: bool = False) -> float:
+        """Return the hazard rate at year-fraction t.
+
+        Args:
+            t (float): The year fraction, in the curve's own day count.
+            extrapolate (bool): Whether to answer past the curve's max date.
+
+        Returns:
+            float: The hazard rate, at annual frequency and continuous
+                compounding.
+
+        Raises:
+            ItofinError: If t is past the curve's range and extrapolation is
+                not allowed.
+        """
+        ...
+    def hazard_rate_date(self, date: Date, extrapolate: bool = False) -> float:
+        """Return the hazard rate at date.
+
+        Args:
+            date (Date): The date the rate is read at.
+            extrapolate (bool): Whether to answer past the curve's max date.
+
+        Returns:
+            float: The hazard rate, at annual frequency and continuous
+                compounding.
+
+        Raises:
+            ItofinError: If date is past the curve's range and extrapolation is
+                not allowed.
+        """
+        ...
 
 class FlatHazardRate(DefaultProbabilityTermStructure):
     """A credit curve quoting one hazard rate for every maturity, whose survival
@@ -2202,11 +2316,32 @@ class FlatHazardRate(DefaultProbabilityTermStructure):
 
     def __init__(
         self, reference_date: Date, hazard_rate: SimpleQuote, day_counter: DayCounter
-    ) -> None: ...
+    ) -> None:
+        """Build a curve reading its hazard rate live, on a pinned reference date.
+
+        Args:
+            reference_date (Date): The date times are measured from.
+            hazard_rate (SimpleQuote): The hazard rate; the caller keeps it, so
+                a later set_value moves the curve.
+            day_counter (DayCounter): The day count turning dates into times.
+        """
+        ...
     @staticmethod
     def with_rate(
         reference_date: Date, rate: float, day_counter: DayCounter
-    ) -> FlatHazardRate: ...
+    ) -> FlatHazardRate:
+        """Build a curve at a fixed rate, on a pinned reference date.
+
+        Args:
+            reference_date (Date): The date times are measured from.
+            rate (float): The hazard rate, wrapped in a fresh, un-retained
+                quote.
+            day_counter (DayCounter): The day count turning dates into times.
+
+        Returns:
+            FlatHazardRate: The curve at that rate.
+        """
+        ...
     @staticmethod
     def moving(
         settlement_days: int,
@@ -2215,8 +2350,25 @@ class FlatHazardRate(DefaultProbabilityTermStructure):
         day_counter: DayCounter,
         settings: Settings,
     ) -> FlatHazardRate:
-        """Raises ItofinError on any query made before settings carries an
-        evaluation date."""
+        """Build a curve reading its hazard rate live, on a floating reference date.
+
+        The reference date sits settlement_days business days past the
+        evaluation date, so a query made before settings carries one raises
+        rather than falling back to a system clock.
+
+        Args:
+            settlement_days (int): The business days the reference date sits
+                past the evaluation date.
+            calendar (Calendar): The calendar those days are counted on.
+            hazard_rate (SimpleQuote): The hazard rate; the caller keeps it, so
+                a later set_value moves the curve.
+            day_counter (DayCounter): The day count turning dates into times.
+            settings (Settings): The explicit settings supplying the evaluation
+                date.
+
+        Returns:
+            FlatHazardRate: The moving curve.
+        """
         ...
     @staticmethod
     def moving_with_rate(
@@ -2226,8 +2378,24 @@ class FlatHazardRate(DefaultProbabilityTermStructure):
         day_counter: DayCounter,
         settings: Settings,
     ) -> FlatHazardRate:
-        """Raises ItofinError on any query made before settings carries an
-        evaluation date."""
+        """Build a curve at a fixed rate, on a floating reference date.
+
+        As moving(), a query made before settings carries an evaluation date
+        raises rather than falling back to a system clock.
+
+        Args:
+            settlement_days (int): The business days the reference date sits
+                past the evaluation date.
+            calendar (Calendar): The calendar those days are counted on.
+            rate (float): The hazard rate, wrapped in a fresh, un-retained
+                quote.
+            day_counter (DayCounter): The day count turning dates into times.
+            settings (Settings): The explicit settings supplying the evaluation
+                date.
+
+        Returns:
+            FlatHazardRate: The moving curve at that rate.
+        """
         ...
 
 class InterpolatedHazardRateCurve(DefaultProbabilityTermStructure):
@@ -2246,21 +2414,75 @@ class InterpolatedHazardRateCurve(DefaultProbabilityTermStructure):
         hazard_rates: list[float],
         day_counter: DayCounter,
     ) -> None:
-        """Raises ItofinError on too few dates, a dates/hazard_rates count
-        mismatch, a negative hazard rate or unsorted dates."""
+        """Build the curve over its (date, hazard-rate) nodes.
+
+        Backward-flat is pinned at the boundary: it is the only interpolator
+        the credit side wires, so no interpolation argument is offered.
+
+        Args:
+            dates (list[Date]): The node dates, the first being the reference
+                date.
+            hazard_rates (list[float]): The hazard rate at each node.
+            day_counter (DayCounter): The day count turning dates into times.
+
+        Raises:
+            ItofinError: On too few dates, a dates and hazard_rates count
+                mismatch, a negative hazard rate, or unsorted dates.
+        """
         ...
-    def dates(self) -> list[Date]: ...
-    def hazard_rates(self) -> list[float]: ...
-    def nodes(self) -> list[tuple[Date, float]]: ...
+    def dates(self) -> list[Date]:
+        """Return the node dates.
+
+        Returns:
+            list[Date]: The nodes, the first of which is the reference date.
+        """
+        ...
+    def hazard_rates(self) -> list[float]:
+        """Return the node hazard rates.
+
+        Returns:
+            list[float]: The rate at each node.
+        """
+        ...
+    def nodes(self) -> list[tuple[Date, float]]:
+        """Return the curve's nodes as pairs.
+
+        Returns:
+            list[tuple[Date, float]]: One (date, hazard rate) pair per node.
+        """
+        ...
 
 class DefaultProbabilityHelper:
-    """Shared base for every credit bootstrap helper."""
+    """Shared base for every credit bootstrap helper.
 
-    def pillar_date(self) -> Date: ...
-    def latest_date(self) -> Date: ...
+    A credit helper fits a default-probability curve rather than a yield curve,
+    so it is a separate hierarchy from RateHelper. It exposes the two dates the
+    bootstrap places a curve node by.
+    """
+
+    def pillar_date(self) -> Date:
+        """Return the date the curve node this helper sets sits at.
+
+        Returns:
+            Date: The pillar date.
+        """
+        ...
+    def latest_date(self) -> Date:
+        """Return the latest date the helper needs curve data at.
+
+        Returns:
+            Date: The latest date, equal to the pillar date.
+        """
+        ...
 
 class SpreadCdsHelper(DefaultProbabilityHelper):
-    """Bootstrap helper fitting a CDS quoted as a running spread."""
+    """Bootstrap helper fitting a CDS quoted as a running spread.
+
+    The helper rebuilds its schedule and its contract off the evaluation date
+    held by settings, so it tracks that date rather than freezing a maturity at
+    construction. It retains the caller's quote, so a later set_value re-drives
+    the bootstrap, and it observes the discount curve.
+    """
 
     def __init__(
         self,
@@ -2276,8 +2498,32 @@ class SpreadCdsHelper(DefaultProbabilityHelper):
         discount_curve: YieldTermStructure,
         settings: Settings,
     ) -> None:
-        """Raises ItofinError on the post-Big-Bang rules DateGeneration.OldCDS,
-        .CDS and .CDS2015, whose maturity rule the core has not ported."""
+        """Build the helper on the C++ default CDS terms.
+
+        Args:
+            running_spread (SimpleQuote): The quoted spread the helper fits.
+            tenor (Period): The length of the contract.
+            settlement_days (int): The days between the evaluation date and the
+                contract's start.
+            calendar (Calendar): The calendar the schedule rolls on.
+            frequency (Frequency): The premium payment frequency.
+            payment_convention (BusinessDayConvention): The roll applied to the
+                payment dates.
+            rule (DateGeneration): The schedule generation rule.
+            day_counter (DayCounter): The day count the premium accrues on.
+            recovery_rate (float): The recovery assumed on default.
+            discount_curve (YieldTermStructure): The curve the flows discount
+                on; the helper observes it.
+            settings (Settings): The explicit settings supplying the evaluation
+                date the schedule is rebuilt off.
+
+        Raises:
+            ItofinError: Under the three post-Big-Bang rules OldCDS, CDS and
+                CDS2015, whose maturity is rolled by the CDS maturity rule: it
+                refuses a tenor it cannot roll, or one it rolls to a contract
+                that has already matured, rather than building a schedule that
+                ends on the wrong date.
+        """
         ...
 
 class PiecewiseDefaultCurve(DefaultProbabilityTermStructure):
@@ -2294,13 +2540,68 @@ class PiecewiseDefaultCurve(DefaultProbabilityTermStructure):
         helpers: list[DefaultProbabilityHelper],
         day_counter: DayCounter,
     ) -> None:
-        """Raises ItofinError on an empty helper list."""
+        """Build the curve over helpers with a fixed reference date.
+
+        Args:
+            reference_date (Date): The curve's reference date.
+            helpers (list[DefaultProbabilityHelper]): The bootstrap
+                instruments; any subclass is accepted.
+            day_counter (DayCounter): The day count turning dates into times.
+
+        Raises:
+            ItofinError: On an empty helper list.
+        """
         ...
-    def calculate(self) -> None: ...
-    def times(self) -> list[float]: ...
-    def dates(self) -> list[Date]: ...
-    def data(self) -> list[float]: ...
-    def nodes(self) -> list[tuple[Date, float]]: ...
+    def calculate(self) -> None:
+        """Run the bootstrap if the cache is stale.
+
+        Calling it explicitly makes a solver failure surface here rather than
+        inside a later query.
+
+        Raises:
+            ItofinError: On a bootstrap failure.
+        """
+        ...
+    def times(self) -> list[float]:
+        """Return the node times, triggering the bootstrap.
+
+        Returns:
+            list[float]: The nodes in the curve's own day count.
+
+        Raises:
+            ItofinError: On a bootstrap failure.
+        """
+        ...
+    def dates(self) -> list[Date]:
+        """Return the node dates, triggering the bootstrap.
+
+        Returns:
+            list[Date]: The nodes, the first of which is the reference date.
+
+        Raises:
+            ItofinError: On a bootstrap failure.
+        """
+        ...
+    def data(self) -> list[float]:
+        """Return the solved node hazard rates, triggering the bootstrap.
+
+        Returns:
+            list[float]: The rate solved at each node.
+
+        Raises:
+            ItofinError: On a bootstrap failure.
+        """
+        ...
+    def nodes(self) -> list[tuple[Date, float]]:
+        """Return the solved nodes as pairs, triggering the bootstrap.
+
+        Returns:
+            list[tuple[Date, float]]: One (date, hazard rate) pair per node.
+
+        Raises:
+            ItofinError: On a bootstrap failure.
+        """
+        ...
 
 class MultiplicativePriceSeasonality:
     """The seasonal correction a price index carries, whose factors multiply

--- a/crates/itofin-py/python/itofin/termstructures.pyi
+++ b/crates/itofin-py/python/itofin/termstructures.pyi
@@ -1694,22 +1694,89 @@ class OptionletVolatilityStructure:
 
     def volatility(
         self, option_tenor: Period, strike: float, extrapolate: bool = False
-    ) -> float: ...
+    ) -> float:
+        """Return the caplet volatility for an option tenor and strike.
+
+        Args:
+            option_tenor (Period): The option's tenor, resolved against the
+                surface's reference date and calendar.
+            strike (float): The strike the volatility is read at.
+            extrapolate (bool): Whether to answer outside the surface's grid.
+
+        Returns:
+            float: The caplet volatility.
+
+        Raises:
+            ItofinError: If the query falls outside the grid and extrapolation
+                is not allowed.
+        """
+        ...
     def volatility_date(
         self, option_date: Date, strike: float, extrapolate: bool = False
-    ) -> float: ...
+    ) -> float:
+        """Return the caplet volatility for an option date and strike.
+
+        The date form the optionlet stripper and the cap/floor engine use, both
+        addressing the surface by a coupon's fixing date.
+
+        Args:
+            option_date (Date): The option date the volatility is read at.
+            strike (float): The strike the volatility is read at.
+            extrapolate (bool): Whether to answer outside the surface's grid.
+
+        Returns:
+            float: The caplet volatility.
+
+        Raises:
+            ItofinError: If the query falls outside the grid and extrapolation
+                is not allowed.
+        """
+        ...
     def black_variance(
         self, option_tenor: Period, strike: float, extrapolate: bool = False
-    ) -> float: ...
-    def allows_extrapolation(self) -> bool: ...
-    def enable_extrapolation(self) -> None:
-        """A stripped surface ends at its last optionlet fixing, so a cap whose
-        own last caplet fixes there queries the boundary."""
+    ) -> float:
+        """Return the Black variance, the squared volatility times option time.
+
+        Args:
+            option_tenor (Period): The option's tenor.
+            strike (float): The strike the variance is read at.
+            extrapolate (bool): Whether to answer outside the surface's grid.
+
+        Returns:
+            float: The Black variance.
+
+        Raises:
+            ItofinError: If the query falls outside the grid and extrapolation
+                is not allowed.
+        """
         ...
-    def disable_extrapolation(self) -> None: ...
+    def allows_extrapolation(self) -> bool:
+        """Return whether the surface answers dates and times beyond its maximum.
+
+        Returns:
+            bool: True when extrapolation is enabled on the surface itself.
+        """
+        ...
+    def enable_extrapolation(self) -> None:
+        """Allow extrapolation past the maximum date and time.
+
+        A stripped surface ends at its last optionlet fixing, so a cap whose
+        own last caplet fixes there queries the boundary.
+        """
+        ...
+    def disable_extrapolation(self) -> None:
+        """Forbid extrapolation past the maximum date and time."""
+        ...
     def displacement(self) -> float:
-        """The lognormal shift applied to forwards and strikes. This is what
-        BlackCapFloorEngine checks a caller-supplied displacement against."""
+        """Return the lognormal shift applied to forwards and strikes.
+
+        This is what BlackCapFloorEngine checks a caller-supplied displacement
+        against, so it is the number to read before pinning one on the engine.
+
+        Returns:
+            float: The shift; zero for the unshifted lognormal and the normal
+                model.
+        """
         ...
 
 class ConstantOptionletVolatility(OptionletVolatilityStructure):
@@ -1728,7 +1795,25 @@ class ConstantOptionletVolatility(OptionletVolatilityStructure):
         day_counter: DayCounter,
         volatility_type: VolatilityType,
         displacement: float = 0.0,
-    ) -> None: ...
+    ) -> None:
+        """Build the surface at a fixed volatility.
+
+        Args:
+            reference_date (Date): The date every query's option time runs
+                from.
+            calendar (Calendar): The calendar option tenors resolve on.
+            business_day_convention (BusinessDayConvention): The roll applied
+                when resolving a tenor to a date.
+            volatility (float): The single volatility answered everywhere,
+                wrapped in an internal quote the caller cannot later mutate.
+            day_counter (DayCounter): The day count option times are measured
+                in.
+            volatility_type (VolatilityType): Whether the quote is
+                shifted-lognormal or normal.
+            displacement (float): The lognormal shift applied to forwards and
+                strikes.
+        """
+        ...
     @staticmethod
     def with_quote(
         reference_date: Date,
@@ -1739,8 +1824,26 @@ class ConstantOptionletVolatility(OptionletVolatilityStructure):
         volatility_type: VolatilityType,
         displacement: float = 0.0,
     ) -> ConstantOptionletVolatility:
-        """Reads the volatility from the caller's quote; a later set_value
-        notifies the surface's observers."""
+        """Build the surface reading its volatility from a live quote.
+
+        Args:
+            reference_date (Date): The date every query's option time runs
+                from.
+            calendar (Calendar): The calendar option tenors resolve on.
+            business_day_convention (BusinessDayConvention): The roll applied
+                when resolving a tenor to a date.
+            volatility (SimpleQuote): The volatility; a later set_value
+                notifies the surface's observers.
+            day_counter (DayCounter): The day count option times are measured
+                in.
+            volatility_type (VolatilityType): Whether the quote is
+                shifted-lognormal or normal.
+            displacement (float): The lognormal shift applied to forwards and
+                strikes.
+
+        Returns:
+            ConstantOptionletVolatility: The surface over that quote.
+        """
         ...
 
 class CapFloorTermVolSurface:
@@ -1772,9 +1875,30 @@ class CapFloorTermVolSurface:
         volatilities: list[list[float]],
         day_counter: DayCounter,
     ) -> None:
-        """Raises ItofinError on an empty or ragged grid, on a grid whose shape
-        does not match the tenors and strikes, and on a non-increasing tenor or
-        strike axis."""
+        """Build the surface on a pinned reference date over fixed volatilities.
+
+        Every query's option time runs from reference_date, not from the
+        evaluation date, and no later mutation can reach the grid.
+
+        Args:
+            reference_date (Date): The date option times run from.
+            calendar (Calendar): The calendar cap tenors resolve on.
+            business_day_convention (BusinessDayConvention): The roll applied
+                when resolving a tenor to a date.
+            option_tenors (list[Period]): The cap-length axis, one per grid
+                row; strictly increasing.
+            strikes (list[float]): The strike axis, one per grid column;
+                strictly increasing.
+            volatilities (list[list[float]]): The flat cap volatilities, one
+                row per option tenor.
+            day_counter (DayCounter): The day count option times are measured
+                in.
+
+        Raises:
+            ItofinError: On an empty or ragged grid, on a grid whose shape does
+                not match the tenors and strikes, and on a non-increasing tenor
+                or strike axis.
+        """
         ...
     @staticmethod
     def with_quotes(
@@ -1786,8 +1910,28 @@ class CapFloorTermVolSurface:
         volatilities: list[list[SimpleQuote]],
         day_counter: DayCounter,
     ) -> CapFloorTermVolSurface:
-        """Reads each node from the caller's quote; a later set_value rebuilds
-        the interpolation and notifies the surface's observers."""
+        """Build the pinned-reference surface over live quotes.
+
+        Args:
+            reference_date (Date): The date option times run from.
+            calendar (Calendar): The calendar cap tenors resolve on.
+            business_day_convention (BusinessDayConvention): The roll applied
+                when resolving a tenor to a date.
+            option_tenors (list[Period]): The cap-length axis, strictly
+                increasing.
+            strikes (list[float]): The strike axis, strictly increasing.
+            volatilities (list[list[SimpleQuote]]): The volatility quotes, one
+                row per option tenor; a later set_value rebuilds the
+                interpolation and notifies the surface's observers.
+            day_counter (DayCounter): The day count option times are measured
+                in.
+
+        Returns:
+            CapFloorTermVolSurface: The surface over those quotes.
+
+        Raises:
+            ItofinError: On the same conditions __init__ reports.
+        """
         ...
     @staticmethod
     def moving(
@@ -1800,9 +1944,34 @@ class CapFloorTermVolSurface:
         day_counter: DayCounter,
         settings: Settings,
     ) -> CapFloorTermVolSurface:
-        """The reference date floats settlement_days business days off the
-        evaluation date. This is the form OptionletStripper1 and
-        StrippedOptionletAdapter need."""
+        """Build a surface whose reference date floats off the evaluation date.
+
+        This is the form the optionlet stripping pipeline needs: unlike the
+        pinned-reference constructors, it carries the settlement days
+        StrippedOptionletAdapter reads back off the stripper.
+
+        Args:
+            settlement_days (int): The business days the reference date sits
+                past the evaluation date.
+            calendar (Calendar): The calendar cap tenors resolve on.
+            business_day_convention (BusinessDayConvention): The roll applied
+                when resolving a tenor to a date.
+            option_tenors (list[Period]): The cap-length axis, strictly
+                increasing.
+            strikes (list[float]): The strike axis, strictly increasing.
+            volatilities (list[list[float]]): The flat cap volatilities, one
+                row per option tenor.
+            day_counter (DayCounter): The day count option times are measured
+                in.
+            settings (Settings): The explicit settings supplying the evaluation
+                date the reference date floats off.
+
+        Returns:
+            CapFloorTermVolSurface: The floating-reference surface.
+
+        Raises:
+            ItofinError: On the same conditions __init__ reports.
+        """
         ...
     @staticmethod
     def moving_with_quotes(
@@ -1815,19 +1984,90 @@ class CapFloorTermVolSurface:
         day_counter: DayCounter,
         settings: Settings,
     ) -> CapFloorTermVolSurface:
-        """The floating-reference surface over the caller's quotes."""
+        """Build the floating-reference surface over live quotes.
+
+        Args:
+            settlement_days (int): The business days the reference date sits
+                past the evaluation date.
+            calendar (Calendar): The calendar cap tenors resolve on.
+            business_day_convention (BusinessDayConvention): The roll applied
+                when resolving a tenor to a date.
+            option_tenors (list[Period]): The cap-length axis, strictly
+                increasing.
+            strikes (list[float]): The strike axis, strictly increasing.
+            volatilities (list[list[SimpleQuote]]): The volatility quotes, one
+                row per option tenor.
+            day_counter (DayCounter): The day count option times are measured
+                in.
+            settings (Settings): The explicit settings supplying the evaluation
+                date the reference date floats off.
+
+        Returns:
+            CapFloorTermVolSurface: The floating-reference surface over those
+                quotes.
+
+        Raises:
+            ItofinError: On the same conditions __init__ reports.
+        """
         ...
     def volatility(
         self, option_tenor: Period, strike: float, extrapolate: bool = False
-    ) -> float: ...
+    ) -> float:
+        """Return the flat cap volatility for a cap tenor and strike.
+
+        The tenor form resolves against the surface's own calendar and
+        business-day convention, so it is the one to reach for unless a date is
+        already in hand.
+
+        Args:
+            option_tenor (Period): The cap's length.
+            strike (float): The strike the volatility is read at.
+            extrapolate (bool): Whether to answer outside the surface's grid.
+
+        Returns:
+            float: The flat cap volatility.
+
+        Raises:
+            ItofinError: If the query falls outside the grid and extrapolation
+                is not allowed.
+        """
+        ...
     def volatility_date(
         self, end_date: Date, strike: float, extrapolate: bool = False
-    ) -> float: ...
+    ) -> float:
+        """Return the flat cap volatility for a cap end date and strike.
+
+        Args:
+            end_date (Date): The cap's end date.
+            strike (float): The strike the volatility is read at.
+            extrapolate (bool): Whether to answer outside the surface's grid.
+
+        Returns:
+            float: The flat cap volatility.
+
+        Raises:
+            ItofinError: If the query falls outside the grid and extrapolation
+                is not allowed.
+        """
+        ...
     def volatility_time(
         self, length: float, strike: float, extrapolate: bool = False
     ) -> float:
-        """length is a year fraction off the reference date in the surface's own
-        day count."""
+        """Return the flat cap volatility for a cap end time and strike.
+
+        Args:
+            length (float): A year fraction off the reference date, in the
+                surface's own day count.
+            strike (float): The strike the volatility is read at.
+            extrapolate (bool): Whether to answer outside the surface's grid.
+
+        Returns:
+            float: The flat cap volatility.
+
+        Raises:
+            ItofinError: If the query falls outside the grid and extrapolation
+                is not allowed.
+        """
         ...
 
 class OptionletStripper1:

--- a/crates/itofin-py/python/itofin/termstructures.pyi
+++ b/crates/itofin-py/python/itofin/termstructures.pyi
@@ -3363,7 +3363,34 @@ class ConstantYoYOptionletVolatility:
         min_strike: float,
         max_strike: float,
         settings: Settings,
-    ) -> None: ...
+    ) -> None:
+        """Build a flat surface at a fixed volatility.
+
+        Nothing is resolved here: the reference date, the base date and the
+        strike range are all read at query time, so an unset evaluation date
+        surfaces then rather than now.
+
+        Args:
+            volatility (float): The single volatility answered everywhere.
+            settlement_days (int): The business days the reference date sits
+                past the evaluation date.
+            calendar (Calendar): The calendar those days are counted on.
+            business_day_convention (BusinessDayConvention): The roll applied
+                when resolving a date.
+            day_counter (DayCounter): The day count times are measured in.
+            observation_lag (Period): The lag the surface itself observes
+                inflation with.
+            frequency (Frequency): How often the observed index publishes.
+            index_is_interpolated (bool): Whether the observed index
+                interpolates between publications.
+            min_strike (float): The lower bound of the strike domain; C++
+                defaults it to -1.0 and the port carries no default arguments.
+            max_strike (float): The upper bound of the strike domain; C++
+                defaults it to 100.0.
+            settings (Settings): The explicit settings supplying the evaluation
+                date the reference date moves with.
+        """
+        ...
     @staticmethod
     def with_quote(
         volatility: SimpleQuote,
@@ -3378,25 +3405,106 @@ class ConstantYoYOptionletVolatility:
         max_strike: float,
         settings: Settings,
     ) -> ConstantYoYOptionletVolatility:
-        """A flat surface quoted by volatility: a later set_value on the quote
-        notifies the surface's observers, so anything priced off it reprices at
-        the new level. Otherwise as __init__."""
+        """Build a flat surface reading its volatility from a live quote.
+
+        The quote is retained rather than read once, so a later set_value on it
+        notifies the surface's observers and anything priced off the surface
+        reprices at the new level. Otherwise as __init__, which the arguments
+        after the first mirror exactly.
+
+        Args:
+            volatility (SimpleQuote): The volatility answered everywhere.
+            settlement_days (int): The business days the reference date sits
+                past the evaluation date.
+            calendar (Calendar): The calendar those days are counted on.
+            business_day_convention (BusinessDayConvention): The roll applied
+                when resolving a date.
+            day_counter (DayCounter): The day count times are measured in.
+            observation_lag (Period): The lag the surface itself observes
+                inflation with.
+            frequency (Frequency): How often the observed index publishes.
+            index_is_interpolated (bool): Whether the observed index
+                interpolates between publications.
+            min_strike (float): The lower bound of the strike domain.
+            max_strike (float): The upper bound of the strike domain.
+            settings (Settings): The explicit settings supplying the evaluation
+                date the reference date moves with.
+
+        Returns:
+            ConstantYoYOptionletVolatility: The surface over that quote.
+        """
         ...
-    def observation_lag(self) -> Period: ...
-    def frequency(self) -> Frequency: ...
-    def index_is_interpolated(self) -> bool: ...
+    def observation_lag(self) -> Period:
+        """Return the lag the surface itself observes inflation with.
+
+        Returns:
+            Period: The observation lag, which is what to pass as obs_lag for
+                the surface's own.
+        """
+        ...
+    def frequency(self) -> Frequency:
+        """Return how often the observed index publishes.
+
+        Returns:
+            Frequency: The publication frequency.
+        """
+        ...
+    def index_is_interpolated(self) -> bool:
+        """Return whether the observed index interpolates between publications.
+
+        Returns:
+            bool: True when the index interpolates.
+        """
+        ...
     def base_date(self) -> Date:
-        """The date the surface measures its variance from. Raises ItofinError
-        on an unset evaluation date, and on a frequency admitting no publication
-        period."""
+        """Return the date the surface measures its variance from.
+
+        The reference date pulled back by the surface's own observation lag,
+        snapped to the start of the publication period unless the index is
+        interpolated.
+
+        Returns:
+            Date: The base date.
+
+        Raises:
+            ItofinError: On an unset evaluation date, and on a frequency
+                admitting no publication period.
+        """
         ...
     def volatility(self, date: Date, strike: float, obs_lag: Period) -> float:
-        """The lag is explicit rather than defaulted: pass observation_lag() for
-        the surface's own. Raises ItofinError when the observed date falls before
-        base_date(), or strike lies outside the strike domain."""
+        """Return the volatility for an exercise on date struck at strike.
+
+        Args:
+            date (Date): The exercise date.
+            strike (float): The strike the volatility is read at.
+            obs_lag (Period): How far back inflation is observed; the lag is
+                explicit rather than defaulted, because C++ substitutes the
+                surface's own for a sentinel period and the port has no
+                sentinel to carry. Pass observation_lag() for that behaviour.
+
+        Returns:
+            float: The optionlet volatility.
+
+        Raises:
+            ItofinError: On an observed date before base_date(), and on a
+                strike outside the surface's strike domain.
+        """
         ...
     def total_variance(self, date: Date, strike: float, obs_lag: Period) -> float:
-        """The total integrated variance, the figure that scales time out of the
-        optionlet formulae without committing to a distribution. Raises as
-        volatility()."""
+        """Return the total integrated variance for an exercise on date.
+
+        The figure that scales time out of the optionlet formulae without
+        committing to the distribution reading it.
+
+        Args:
+            date (Date): The exercise date.
+            strike (float): The strike the variance is read at.
+            obs_lag (Period): How far back inflation is observed.
+
+        Returns:
+            float: The total integrated variance.
+
+        Raises:
+            ItofinError: On the same conditions volatility() reports.
+        """
         ...

--- a/crates/itofin-py/python/itofin/termstructures.pyi
+++ b/crates/itofin-py/python/itofin/termstructures.pyi
@@ -993,7 +993,21 @@ class FraRateHelper(RateHelper):
         index: IborIndex,
         use_indexed_coupon: bool = True,
         pillar: Pillar = ...,
-    ) -> None: ...
+    ) -> None:
+        """Build the helper over the window period_to_start past spot.
+
+        Args:
+            quote (SimpleQuote): The FRA rate; the caller keeps it, so a later
+                set_value re-drives the bootstrap.
+            period_to_start (Period): How long after spot the window starts.
+            index (IborIndex): The index whose tenor the window spans.
+            use_indexed_coupon (bool): True selects the indexed implied-quote
+                mode, the index fixing forecast off the curve; False is the par
+                simple forward over the raw window.
+            pillar (Pillar): The date the curve node sits at; defaults to
+                LastRelevantDate.
+        """
+        ...
     @staticmethod
     def from_rate(
         rate: float,
@@ -1001,7 +1015,21 @@ class FraRateHelper(RateHelper):
         index: IborIndex,
         use_indexed_coupon: bool = True,
         pillar: Pillar = ...,
-    ) -> FraRateHelper: ...
+    ) -> FraRateHelper:
+        """Build the helper over a fixed rate.
+
+        Args:
+            rate (float): The FRA rate, wrapped in an internal quote the caller
+                cannot later mutate.
+            period_to_start (Period): How long after spot the window starts.
+            index (IborIndex): The index whose tenor the window spans.
+            use_indexed_coupon (bool): The implied-quote mode; see __init__.
+            pillar (Pillar): The date the curve node sits at.
+
+        Returns:
+            FraRateHelper: The helper fitting that rate.
+        """
+        ...
     @staticmethod
     def from_months(
         quote: SimpleQuote,
@@ -1009,7 +1037,21 @@ class FraRateHelper(RateHelper):
         index: IborIndex,
         use_indexed_coupon: bool = True,
         pillar: Pillar = ...,
-    ) -> FraRateHelper: ...
+    ) -> FraRateHelper:
+        """Build the helper with a start given in months after spot.
+
+        Args:
+            quote (SimpleQuote): The FRA rate the helper fits.
+            months_to_start (int): How many months after spot the window
+                starts.
+            index (IborIndex): The index whose tenor the window spans.
+            use_indexed_coupon (bool): The implied-quote mode; see __init__.
+            pillar (Pillar): The date the curve node sits at.
+
+        Returns:
+            FraRateHelper: The helper over that window.
+        """
+        ...
     @staticmethod
     def from_dates(
         quote: SimpleQuote,
@@ -1018,7 +1060,24 @@ class FraRateHelper(RateHelper):
         index: IborIndex,
         use_indexed_coupon: bool = True,
         pillar: Pillar = ...,
-    ) -> FraRateHelper: ...
+    ) -> FraRateHelper:
+        """Build the helper over an explicit window.
+
+        The schedule is fixed at construction and does not shift when the
+        evaluation date changes.
+
+        Args:
+            quote (SimpleQuote): The FRA rate the helper fits.
+            start_date (Date): The window's start.
+            end_date (Date): The window's end.
+            index (IborIndex): The index the forward is read off.
+            use_indexed_coupon (bool): The implied-quote mode; see __init__.
+            pillar (Pillar): The date the curve node sits at.
+
+        Returns:
+            FraRateHelper: The helper over that window.
+        """
+        ...
 
 class RateAveraging:
     """How an overnight coupon combines its daily fixings.
@@ -1055,7 +1114,35 @@ class OISRateHelper(RateHelper):
         overnight_spread: SimpleQuote | None = None,
         pillar: Pillar = ...,
         averaging_method: RateAveraging = ...,
-    ) -> None: ...
+    ) -> None:
+        """Build the helper over the schedule of a spot-starting OIS.
+
+        Args:
+            settlement_days (int): The days after the evaluation date the swap
+                starts.
+            tenor (Period): The length of the swap.
+            quote (SimpleQuote): The OIS rate; the caller keeps it, so a later
+                set_value re-drives the bootstrap.
+            overnight_index (OvernightIndex): The index the floating leg
+                compounds.
+            payment_lag (int): The days between accrual end and payment.
+            payment_convention (BusinessDayConvention): The roll applied to the
+                payment dates.
+            payment_frequency (Frequency): The payment frequency.
+            forward_start (Period): How long after spot the swap starts.
+            settings (Settings): The explicit settings supplying the evaluation
+                date and the stored fixings.
+            discounting_curve (YieldTermStructure | None): The curve the flows
+                discount on; None discounts off the bootstrapping curve.
+            overnight_spread (SimpleQuote | None): The spread over the index;
+                None leaves it empty, so zero. The caller keeps it, and
+                mutating it re-drives the bootstrap.
+            pillar (Pillar): The date the curve node sits at; defaults to
+                LastRelevantDate.
+            averaging_method (RateAveraging): How the daily fixings combine;
+                defaults to Compound.
+        """
+        ...
 
 class SwaptionVolatilityStructure:
     """Shared base for every swaption volatility surface: volatility, Black

--- a/crates/itofin-py/python/itofin/termstructures.pyi
+++ b/crates/itofin-py/python/itofin/termstructures.pyi
@@ -2,6 +2,7 @@
 # src/helpers.rs, src/swaptionvol.rs, src/optionletvol.rs, src/smilesection.rs and
 # src/credit.rs, src/credithelpers.rs and src/inflation.rs (#517).
 
+# itofin library
 from itofin import Settings
 from itofin.indexes import (
     CpiInterpolationType,
@@ -12,15 +13,7 @@ from itofin.indexes import (
     ZeroInflationIndex,
 )
 from itofin.quotes import SimpleQuote
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DateGeneration,
-    DayCounter,
-    Frequency,
-    Period,
-)
+from itofin.time import BusinessDayConvention, Calendar, Date, DateGeneration, DayCounter, Frequency, Period
 
 class YieldTermStructure:
     """Shared base for every yield curve: discount factors, zero and forward rates.

--- a/crates/itofin-py/python/itofin/time.pyi
+++ b/crates/itofin-py/python/itofin/time.pyi
@@ -1,5 +1,6 @@
 # Hand-written stubs for itofin.time; sync manually with src/time.rs (#517).
 
+# standard library
 from typing import overload
 
 def is_imm_date(date: Date, main_cycle: bool = False) -> bool:

--- a/crates/itofin-py/scripts/gen_submodule_shims.py
+++ b/crates/itofin-py/scripts/gen_submodule_shims.py
@@ -20,6 +20,7 @@ matching the autofix hook convention.
 
 from __future__ import annotations
 
+# standard library
 import sys
 from pathlib import Path
 

--- a/crates/itofin-py/tests/test_accept_any_curve.py
+++ b/crates/itofin-py/tests/test_accept_any_curve.py
@@ -10,32 +10,17 @@ flat-scalar constructor's European NPV to 1e-12; a mis-wired handle (or a
 swapped r/q) would not.
 """
 
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.indexes import Euribor
-from itofin.instruments import (
-    OptionType,
-    SwapType,
-    VanillaOption,
-    VanillaSwap,
-)
+from itofin.instruments import OptionType, SwapType, VanillaOption, VanillaSwap
 from itofin.models import HullWhite
 from itofin.processes import BlackScholesProcess
-from itofin.termstructures import (
-    BlackVarianceSurface,
-    FlatForward,
-    YieldTermStructure,
-    ZeroCurve,
-)
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DayCounter,
-    Frequency,
-    Schedule,
-)
+from itofin.termstructures import BlackVarianceSurface, FlatForward, YieldTermStructure, ZeroCurve
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Frequency, Schedule
 
 REF = Date(15, 6, 2026)
 R = 0.05

--- a/crates/itofin-py/tests/test_bachelier_swaption.py
+++ b/crates/itofin-py/tests/test_bachelier_swaption.py
@@ -40,35 +40,20 @@ prices, so reusing one swaption across the engines would let arm A pass on a
 stale cached number.
 """
 
+# standard library
 import math
 
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.indexes import Euribor
-from itofin.instruments import (
-    EuropeanExercise,
-    SettlementMethod,
-    SettlementType,
-    Swaption,
-    SwapType,
-    VanillaSwap,
-)
+from itofin.instruments import EuropeanExercise, SettlementMethod, SettlementType, Swaption, SwapType, VanillaSwap
 from itofin.pricingengines import BachelierSwaptionEngine, CashAnnuityModel
 from itofin.quotes import SimpleQuote
-from itofin.termstructures import (
-    ConstantSwaptionVolatility,
-    FlatForward,
-    VolatilityType,
-)
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DayCounter,
-    Frequency,
-    Schedule,
-)
+from itofin.termstructures import ConstantSwaptionVolatility, FlatForward, VolatilityType
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Frequency, Schedule
 
 EVAL = Date(15, 1, 2026)
 EXERCISE = Date(15, 1, 2027)

--- a/crates/itofin-py/tests/test_black_swaption.py
+++ b/crates/itofin-py/tests/test_black_swaption.py
@@ -27,34 +27,17 @@ prices, so reusing one swaption across the three engines would let arm B pass on
 a stale cached number.
 """
 
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.indexes import Euribor
-from itofin.instruments import (
-    EuropeanExercise,
-    SettlementMethod,
-    SettlementType,
-    Swaption,
-    SwapType,
-    VanillaSwap,
-)
+from itofin.instruments import EuropeanExercise, SettlementMethod, SettlementType, Swaption, SwapType, VanillaSwap
 from itofin.pricingengines import BlackSwaptionEngine, CashAnnuityModel
 from itofin.quotes import SimpleQuote
-from itofin.termstructures import (
-    ConstantSwaptionVolatility,
-    FlatForward,
-    VolatilityType,
-)
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DayCounter,
-    Frequency,
-    Period,
-    Schedule,
-)
+from itofin.termstructures import ConstantSwaptionVolatility, FlatForward, VolatilityType
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Frequency, Period, Schedule
 
 EVAL = Date(15, 1, 2026)
 EXERCISE = Date(15, 1, 2027)

--- a/crates/itofin-py/tests/test_black_vol.py
+++ b/crates/itofin-py/tests/test_black_vol.py
@@ -1,7 +1,10 @@
+# standard library
 import math
 
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import ItofinError
 from itofin.termstructures import (
     BlackConstantVol,

--- a/crates/itofin-py/tests/test_black_vol_pricing.py
+++ b/crates/itofin-py/tests/test_black_vol_pricing.py
@@ -1,5 +1,7 @@
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import Settings
 from itofin.instruments import OptionType, VanillaOption
 from itofin.processes import BlackScholesProcess

--- a/crates/itofin-py/tests/test_capfloor.py
+++ b/crates/itofin-py/tests/test_capfloor.py
@@ -80,30 +80,21 @@ every instrument and every engine, or the leg and the optionlets date
 differently with no error raised.
 """
 
+# standard library
 import math
 
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.cashflows import IborLeg
 from itofin.indexes import Euribor
 from itofin.instruments import CapFloor, CapFloorType
 from itofin.pricingengines import BlackCapFloorEngine
 from itofin.quotes import SimpleQuote
-from itofin.termstructures import (
-    ConstantOptionletVolatility,
-    FlatForward,
-    VolatilityType,
-)
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DayCounter,
-    Frequency,
-    Period,
-    Schedule,
-)
+from itofin.termstructures import ConstantOptionletVolatility, FlatForward, VolatilityType
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Frequency, Period, Schedule
 
 EVAL = Date(15, 1, 2026)
 

--- a/crates/itofin-py/tests/test_capfloor_term_vol.py
+++ b/crates/itofin-py/tests/test_capfloor_term_vol.py
@@ -47,14 +47,17 @@ E. The two MOVING constructors (#623), whose reference date floats
    REFERENCE, so they must recover exactly the pinned surface's nodes.
 """
 
+# standard library
 import datetime
 
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.quotes import SimpleQuote
 from itofin.termstructures import CapFloorTermVolSurface
-from itofin.time import BusinessDayConvention, Calendar, DayCounter, Date, Period
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Period
 
 REFERENCE = Date(15, 6, 2026)
 BDC = BusinessDayConvention.ModifiedFollowing

--- a/crates/itofin-py/tests/test_credit_bootstrap.py
+++ b/crates/itofin-py/tests/test_credit_bootstrap.py
@@ -25,22 +25,16 @@ Three things the milestone depends on and that a looser fixture would hide:
   schedule's first date, which the twentieth-IMM rule puts ten days later.
 """
 
+# pypi/conda library
 import pytest
+
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.instruments import CreditDefaultSwap, ProtectionSide
 from itofin.pricingengines import MidPointCdsEngine
 from itofin.quotes import SimpleQuote
 from itofin.termstructures import FlatForward, PiecewiseDefaultCurve, SpreadCdsHelper
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DateGeneration,
-    DayCounter,
-    Frequency,
-    Period,
-    Schedule,
-)
+from itofin.time import BusinessDayConvention, Calendar, Date, DateGeneration, DayCounter, Frequency, Period, Schedule
 
 TODAY = Date(9, 6, 2006)
 QUOTES = [0.005, 0.006, 0.007, 0.009]

--- a/crates/itofin-py/tests/test_credit_cds.py
+++ b/crates/itofin-py/tests/test_credit_cds.py
@@ -17,20 +17,16 @@ the same 21 dates and price identically, so the Python path is the same
 contract, not a lookalike.
 """
 
+# pypi/conda library
 import pytest
+
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.instruments import CreditDefaultSwap, ProtectionSide
 from itofin.pricingengines import MidPointCdsEngine
 from itofin.quotes import SimpleQuote
 from itofin.termstructures import FlatForward, FlatHazardRate
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DayCounter,
-    Frequency,
-    Schedule,
-)
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Frequency, Schedule
 
 TODAY = Date(9, 6, 2006)
 ISSUE = Date(9, 6, 2005)

--- a/crates/itofin-py/tests/test_credit_flat_hazard.py
+++ b/crates/itofin-py/tests/test_credit_flat_hazard.py
@@ -14,9 +14,13 @@ year fraction 1.0 exactly and the date-form methods are comparable to the same
 closed form.
 """
 
+# standard library
 import math
 
+# pypi/conda library
 import pytest
+
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.instruments import ProtectionSide
 from itofin.quotes import SimpleQuote

--- a/crates/itofin-py/tests/test_credit_helper.py
+++ b/crates/itofin-py/tests/test_credit_helper.py
@@ -20,20 +20,14 @@ repricing oracle would not discriminate:
   the flag moves a price is A5's.
 """
 
+# pypi/conda library
 import pytest
+
+# itofin library
 from itofin import Settings
 from itofin.quotes import SimpleQuote
 from itofin.termstructures import FlatForward, SpreadCdsHelper
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DateGeneration,
-    DayCounter,
-    Frequency,
-    Period,
-    Schedule,
-)
+from itofin.time import BusinessDayConvention, Calendar, Date, DateGeneration, DayCounter, Frequency, Period, Schedule
 
 TODAY = Date(15, 5, 2007)
 END = Date(15, 5, 2012)

--- a/crates/itofin-py/tests/test_european_option.py
+++ b/crates/itofin-py/tests/test_european_option.py
@@ -1,5 +1,7 @@
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.instruments import OptionType, VanillaOption
 from itofin.processes import BlackScholesProcess

--- a/crates/itofin-py/tests/test_fra_rate_helper.py
+++ b/crates/itofin-py/tests/test_fra_rate_helper.py
@@ -16,17 +16,14 @@ bug inside advance itself is not caught here (the deposit and futures tests acce
 the same limitation); the Rust oracles pin that math directly.
 """
 
+# standard library
 import datetime
 
+# itofin library
 from itofin import Settings
 from itofin.indexes import Euribor
 from itofin.quotes import SimpleQuote
-from itofin.termstructures import (
-    DepositRateHelper,
-    FraRateHelper,
-    PiecewiseLogLinearDiscount,
-    Pillar,
-)
+from itofin.termstructures import DepositRateHelper, FraRateHelper, PiecewiseLogLinearDiscount, Pillar
 from itofin.time import BusinessDayConvention as BDC
 from itofin.time import Calendar, Date, DayCounter, Period
 

--- a/crates/itofin-py/tests/test_futures_rate_helper.py
+++ b/crates/itofin-py/tests/test_futures_rate_helper.py
@@ -10,24 +10,18 @@ exact Actual360 fraction the core bootstrap uses (integer day count / 360), so i
 reproduces the same f64 rather than a rounded literal.
 """
 
+# standard library
 import datetime
 
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.indexes import Euribor
 from itofin.quotes import SimpleQuote
-from itofin.termstructures import (
-    FuturesRateHelper,
-    FuturesType,
-    PiecewiseYieldCurve,
-)
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DayCounter,
-)
+from itofin.termstructures import FuturesRateHelper, FuturesType, PiecewiseYieldCurve
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter
 from itofin.time import Period as P
 from itofin.time import is_imm_date, next_imm_date
 

--- a/crates/itofin-py/tests/test_heston_calibration.py
+++ b/crates/itofin-py/tests/test_heston_calibration.py
@@ -1,7 +1,10 @@
+# standard library
 import math
 
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.models import CalibrationErrorType, HestonModel, HestonModelHelper
 from itofin.optimization import EndCriteria, LevenbergMarquardt

--- a/crates/itofin-py/tests/test_heston_pricing.py
+++ b/crates/itofin-py/tests/test_heston_pricing.py
@@ -1,5 +1,7 @@
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.instruments import OptionType, VanillaOption
 from itofin.models import HestonModel

--- a/crates/itofin-py/tests/test_hullwhite_calibration.py
+++ b/crates/itofin-py/tests/test_hullwhite_calibration.py
@@ -1,5 +1,7 @@
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.indexes import Euribor
 from itofin.models import CalibrationErrorType, HullWhite, SwaptionHelper

--- a/crates/itofin-py/tests/test_hullwhite_model.py
+++ b/crates/itofin-py/tests/test_hullwhite_model.py
@@ -1,5 +1,7 @@
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.indexes import Euribor
 from itofin.instruments import OptionType

--- a/crates/itofin-py/tests/test_ibor_index.py
+++ b/crates/itofin-py/tests/test_ibor_index.py
@@ -14,24 +14,15 @@ those flags bite, and test_wrong_conventions_do_diverge proves they bite by
 showing a deliberately mis-specified index diverging at exactly those dates.
 """
 
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import Settings
 from itofin.indexes import Currency, Euribor, IborIndex
 from itofin.quotes import SimpleQuote
-from itofin.termstructures import (
-    DepositRateHelper,
-    PiecewiseLogLinearDiscount,
-    SwapRateHelper,
-)
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DayCounter,
-    Frequency,
-    Period,
-)
+from itofin.termstructures import DepositRateHelper, PiecewiseLogLinearDiscount, SwapRateHelper
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Frequency, Period
 
 DEPOSIT_RATE = 0.04557
 

--- a/crates/itofin-py/tests/test_ibor_inspectors.py
+++ b/crates/itofin-py/tests/test_ibor_inspectors.py
@@ -7,8 +7,10 @@ the end-of-month flag each change the answer; the divergence guards keep those
 reconstructions from going inert if the core roll ever changes.
 """
 
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import Settings
 from itofin.indexes import Currency, Euribor, IborIndex
 from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Period

--- a/crates/itofin-py/tests/test_ibor_leg.py
+++ b/crates/itofin-py/tests/test_ibor_leg.py
@@ -21,20 +21,15 @@ C. The setters return a NEW leg and leave the receiver alone. This is the shape
    silently change under a later call.
 """
 
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.cashflows import IborLeg
 from itofin.indexes import Euribor
 from itofin.termstructures import FlatForward
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DayCounter,
-    Frequency,
-    Schedule,
-)
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Frequency, Schedule
 
 EVAL = Date(15, 1, 2026)
 END = Date(15, 1, 2031)

--- a/crates/itofin-py/tests/test_ibor_widening.py
+++ b/crates/itofin-py/tests/test_ibor_widening.py
@@ -16,8 +16,10 @@ still compiles, and both a USD and a EUR arm run, so a fresh hard-code of
 either currency fails one of them.
 """
 
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import Settings
 from itofin.indexes import Currency, Euribor, IborIndex, SwapIndex
 from itofin.instruments import MakeVanillaSwap

--- a/crates/itofin-py/tests/test_implied_hazard.py
+++ b/crates/itofin-py/tests/test_implied_hazard.py
@@ -32,24 +32,16 @@ hazard guess fails to price, and Brent reports an opaque non-convergence.
 15-Jun-2026 is a Monday and no TARGET holiday.
 """
 
+# pypi/conda library
 import pytest
+
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.instruments import CreditDefaultSwap, PricingModel, ProtectionSide
 from itofin.pricingengines import IsdaCdsEngine, MidPointCdsEngine
 from itofin.quotes import SimpleQuote
-from itofin.termstructures import (
-    FlatForward,
-    FlatHazardRate,
-    InterpolatedHazardRateCurve,
-)
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DayCounter,
-    Frequency,
-    Schedule,
-)
+from itofin.termstructures import FlatForward, FlatHazardRate, InterpolatedHazardRateCurve
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Frequency, Schedule
 
 TODAY = Date(15, 6, 2026)
 H1 = 0.30

--- a/crates/itofin-py/tests/test_inflation_curve.py
+++ b/crates/itofin-py/tests/test_inflation_curve.py
@@ -16,7 +16,10 @@ period, so a node read reaches that node's time exactly and returns its rate
 with no interpolation.
 """
 
+# pypi/conda library
 import pytest
+
+# itofin library
 from itofin import ItofinError
 from itofin.termstructures import InterpolatedZeroInflationCurve, ZeroInflationTermStructure
 from itofin.time import Date, DayCounter, Frequency

--- a/crates/itofin-py/tests/test_inflation_helper.py
+++ b/crates/itofin-py/tests/test_inflation_helper.py
@@ -22,7 +22,10 @@ chosen so they cannot be confused. 13 August 2008 less three months is 13 May
 the first day of its monthly inflation period, and puts its curve node there.
 """
 
+# pypi/conda library
 import pytest
+
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.indexes import CpiInterpolationType, ZeroInflationIndex
 from itofin.quotes import SimpleQuote
@@ -33,14 +36,7 @@ from itofin.termstructures import (
     ZeroInflationHelper,
     ZeroInflationTermStructure,
 )
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DayCounter,
-    Frequency,
-    Period,
-)
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Frequency, Period
 
 TODAY = Date(13, 8, 2007)
 MATURITY = Date(13, 8, 2008)

--- a/crates/itofin-py/tests/test_inflation_index.py
+++ b/crates/itofin-py/tests/test_inflation_index.py
@@ -6,7 +6,10 @@ crates/libitofin/src/indexes/inflation/ukrpi.rs
 block of `testZeroIndex` in inflation.cpp:230-311).
 """
 
+# pypi/conda library
 import pytest
+
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.indexes import ZeroInflationIndex
 from itofin.pricingengines import DiscountingSwapEngine

--- a/crates/itofin-py/tests/test_instrument_ergonomics.py
+++ b/crates/itofin-py/tests/test_instrument_ergonomics.py
@@ -36,17 +36,13 @@ strike and the spot - are checked against the numbers the fixture was built
 with, so a snapshot that copied the keys but garbled the values fails.
 """
 
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.cashflows import IborLeg
-from itofin.indexes import (
-    CpiInterpolationType,
-    Estr,
-    Euribor,
-    YoYInflationIndex,
-    ZeroInflationIndex,
-)
+from itofin.indexes import CpiInterpolationType, Estr, Euribor, YoYInflationIndex, ZeroInflationIndex
 from itofin.instruments import (
     CapFloor,
     CapFloorType,
@@ -82,16 +78,7 @@ from itofin.termstructures import (
     InterpolatedYoYInflationCurve,
     InterpolatedZeroInflationCurve,
 )
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DateGeneration,
-    DayCounter,
-    Frequency,
-    Period,
-    Schedule,
-)
+from itofin.time import BusinessDayConvention, Calendar, Date, DateGeneration, DayCounter, Frequency, Period, Schedule
 
 REF = Date(15, 1, 2026)
 EXPIRY = Date(15, 1, 2027)

--- a/crates/itofin-py/tests/test_interpolated_curves.py
+++ b/crates/itofin-py/tests/test_interpolated_curves.py
@@ -1,14 +1,12 @@
+# standard library
 import math
 
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import ItofinError
-from itofin.termstructures import (
-    DiscountCurve,
-    ForwardCurve,
-    YieldTermStructure,
-    ZeroCurve,
-)
+from itofin.termstructures import DiscountCurve, ForwardCurve, YieldTermStructure, ZeroCurve
 from itofin.time import Date, DayCounter
 
 REF = Date(15, 6, 2026)

--- a/crates/itofin-py/tests/test_interpolated_hazard.py
+++ b/crates/itofin-py/tests/test_interpolated_hazard.py
@@ -17,9 +17,13 @@ Backward-flat reads the RIGHT-hand node on each segment, so the hazard rate is
 exp(-integral) over that step function.
 """
 
+# standard library
 import math
 
+# pypi/conda library
 import pytest
+
+# itofin library
 from itofin import ItofinError
 from itofin.termstructures import InterpolatedHazardRateCurve
 from itofin.time import Date, DayCounter

--- a/crates/itofin-py/tests/test_interpolated_swaption_cube.py
+++ b/crates/itofin-py/tests/test_interpolated_swaption_cube.py
@@ -42,18 +42,13 @@ The core asserts 1e-16 on arms A-C; this pass keeps 1e-12. Every query passes
 ATM grid's last node, so the default would range-check against it.
 """
 
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.indexes import Currency, Euribor, SwapIndex
-from itofin.instruments import (
-    EuropeanExercise,
-    SettlementMethod,
-    SettlementType,
-    Swaption,
-    SwapType,
-    VanillaSwap,
-)
+from itofin.instruments import EuropeanExercise, SettlementMethod, SettlementType, Swaption, SwapType, VanillaSwap
 from itofin.pricingengines import BlackSwaptionEngine, CashAnnuityModel
 from itofin.quotes import SimpleQuote
 from itofin.termstructures import (
@@ -62,15 +57,7 @@ from itofin.termstructures import (
     SwaptionVolatilityMatrix,
     VolatilityType,
 )
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DayCounter,
-    Frequency,
-    Period,
-    Schedule,
-)
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Frequency, Period, Schedule
 
 EVAL = Date(15, 6, 2026)
 BDC = BusinessDayConvention.ModifiedFollowing

--- a/crates/itofin-py/tests/test_isda_cds.py
+++ b/crates/itofin-py/tests/test_isda_cds.py
@@ -20,25 +20,15 @@ still distinct from the mid-point engine's period-by-period integration - hence
 the discriminator below.
 """
 
+# pypi/conda library
 import pytest
+
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.instruments import CreditDefaultSwap, ProtectionSide
-from itofin.pricingengines import (
-    AccrualBias,
-    ForwardsInCouponPeriod,
-    IsdaCdsEngine,
-    MidPointCdsEngine,
-    NumericalFix,
-)
+from itofin.pricingengines import AccrualBias, ForwardsInCouponPeriod, IsdaCdsEngine, MidPointCdsEngine, NumericalFix
 from itofin.termstructures import FlatForward, FlatHazardRate
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DayCounter,
-    Frequency,
-    Schedule,
-)
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Frequency, Schedule
 
 TODAY = Date(15, 6, 2026)
 MATURITY = Date(15, 6, 2029)

--- a/crates/itofin-py/tests/test_isda_fidelity.py
+++ b/crates/itofin-py/tests/test_isda_fidelity.py
@@ -22,25 +22,15 @@ facades on this machine; each is recorded against the Rust test whose mechanism
 it mirrors, in crates/libitofin/src/pricingengines/credit/isdacdsengine.rs.
 """
 
+# standard library
 import math
 
+# itofin library
 from itofin import Settings
 from itofin.instruments import CreditDefaultSwap, ProtectionSide
-from itofin.pricingengines import (
-    AccrualBias,
-    ForwardsInCouponPeriod,
-    IsdaCdsEngine,
-    NumericalFix,
-)
+from itofin.pricingengines import AccrualBias, ForwardsInCouponPeriod, IsdaCdsEngine, NumericalFix
 from itofin.termstructures import DiscountCurve, FlatForward, FlatHazardRate
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DayCounter,
-    Frequency,
-    Schedule,
-)
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Frequency, Schedule
 
 TODAY = Date(15, 6, 2026)
 NOTIONAL = 10000000.0

--- a/crates/itofin-py/tests/test_isda_markit.py
+++ b/crates/itofin-py/tests/test_isda_markit.py
@@ -25,27 +25,17 @@ through `QL_CHECK_CLOSE`: its 1e-6 is a *percentage*, so the bound is a relative
 operands. `pytest.approx` is neither, hence the helper below.
 """
 
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.indexes import Currency, IborIndex
 from itofin.instruments import MakeCreditDefaultSwap, PricingModel, ProtectionSide
 from itofin.pricingengines import IsdaCdsEngine
 from itofin.quotes import SimpleQuote
-from itofin.termstructures import (
-    DepositRateHelper,
-    FlatHazardRate,
-    PiecewiseLogLinearDiscount,
-    SwapRateHelper,
-)
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DayCounter,
-    Frequency,
-    Period,
-)
+from itofin.termstructures import DepositRateHelper, FlatHazardRate, PiecewiseLogLinearDiscount, SwapRateHelper
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Frequency, Period
 
 TRADE_DATE = Date(21, 5, 2009)
 NOTIONAL = 10000000.0

--- a/crates/itofin-py/tests/test_isda_reconcile.py
+++ b/crates/itofin-py/tests/test_isda_reconcile.py
@@ -26,31 +26,14 @@ The tolerance is Boost's `BOOST_CHECK_CLOSE`, a *percentage*, so the bound is a
 relative 1e-5 and it is two-sided against both operands.
 """
 
+# itofin library
 from itofin import Settings
 from itofin.indexes import Currency, IborIndex
-from itofin.instruments import (
-    CreditDefaultSwap,
-    MakeCreditDefaultSwap,
-    PricingModel,
-    ProtectionSide,
-)
+from itofin.instruments import CreditDefaultSwap, MakeCreditDefaultSwap, PricingModel, ProtectionSide
 from itofin.pricingengines import IsdaCdsEngine
 from itofin.quotes import SimpleQuote
-from itofin.termstructures import (
-    DepositRateHelper,
-    FlatHazardRate,
-    PiecewiseLogLinearDiscount,
-    SwapRateHelper,
-)
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DayCounter,
-    Frequency,
-    Period,
-    Schedule,
-)
+from itofin.termstructures import DepositRateHelper, FlatHazardRate, PiecewiseLogLinearDiscount, SwapRateHelper
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Frequency, Period, Schedule
 
 # creditdefaultswap.cpp:765 and :869: today, on both records.
 VALUE_DATE = Date(26, 7, 2021)

--- a/crates/itofin-py/tests/test_make_vanilla_swap.py
+++ b/crates/itofin-py/tests/test_make_vanilla_swap.py
@@ -23,21 +23,15 @@ apples-to-apples.
 pinned Rust-probe constants for the same fixture at a 3% fixed rate.
 """
 
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.indexes import Euribor
 from itofin.instruments import MakeVanillaSwap, SwapType, VanillaSwap
 from itofin.termstructures import FlatForward
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DayCounter,
-    Frequency,
-    Period,
-    Schedule,
-)
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Frequency, Period, Schedule
 
 PROBE_FAIR = 0.03048844643136293
 PROBE_NPV = 0.21033895380698553

--- a/crates/itofin-py/tests/test_market.py
+++ b/crates/itofin-py/tests/test_market.py
@@ -1,5 +1,7 @@
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin.processes import BlackScholesProcess
 from itofin.quotes import SimpleQuote
 from itofin.time import Date, DayCounter

--- a/crates/itofin-py/tests/test_mc_american.py
+++ b/crates/itofin-py/tests/test_mc_american.py
@@ -9,8 +9,10 @@ Actual365Fixed market, priced with withSteps(75).withAntitheticVariate(true)
 exact configuration, banded by the engine's own error estimate.
 """
 
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.instruments import OptionType, VanillaOption
 from itofin.pricingengines import MCAmericanEngine

--- a/crates/itofin-py/tests/test_mc_european.py
+++ b/crates/itofin-py/tests/test_mc_european.py
@@ -9,8 +9,10 @@ core's strengthened |mc - analytic| < 3 * error_estimate() convergence pin, not
 QuantLib's loose relative band.
 """
 
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.instruments import OptionType, VanillaOption
 from itofin.pricingengines import MCEuropeanEngine

--- a/crates/itofin-py/tests/test_mc_heston.py
+++ b/crates/itofin-py/tests/test_mc_heston.py
@@ -13,6 +13,7 @@ QuantLib's own 2.34 * error_estimate band, not a bit-exact tolerance. Pricing is
 seeded, so this facade reproduces the core's 0.0632327393488322 bitwise.
 """
 
+# itofin library
 from itofin import Settings
 from itofin.instruments import OptionType, VanillaOption
 from itofin.pricingengines import MCEuropeanHestonEngine

--- a/crates/itofin-py/tests/test_mixed_strip_bootstrap.py
+++ b/crates/itofin-py/tests/test_mixed_strip_bootstrap.py
@@ -19,6 +19,7 @@ required because `PyEuribor.six_months(curve, settings)` takes a NON-optional
 curve (hullwhite.rs:183-189), so an empty handle is unreachable through it.
 """
 
+# itofin library
 from itofin import Settings
 from itofin.indexes import Euribor
 from itofin.quotes import SimpleQuote
@@ -27,8 +28,8 @@ from itofin.termstructures import (
     FraRateHelper,
     FuturesRateHelper,
     FuturesType,
-    Pillar,
     PiecewiseLogLinearDiscount,
+    Pillar,
     SwapRateHelper,
 )
 from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Frequency

--- a/crates/itofin-py/tests/test_ois_rate_helper.py
+++ b/crates/itofin-py/tests/test_ois_rate_helper.py
@@ -15,19 +15,15 @@ OWN root (bootstraphelper.rs:317) and so re-asserted the solver residual rather
 than discriminating a mis-wire.
 """
 
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import Settings
 from itofin.indexes import Estr
 from itofin.instruments import MakeOis
 from itofin.quotes import SimpleQuote
-from itofin.termstructures import (
-    FlatForward,
-    OISRateHelper,
-    PiecewiseLogLinearDiscount,
-    Pillar,
-    RateAveraging,
-)
+from itofin.termstructures import FlatForward, OISRateHelper, PiecewiseLogLinearDiscount, Pillar, RateAveraging
 from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Frequency
 from itofin.time import Period as P
 

--- a/crates/itofin-py/tests/test_optionlet_stripping.py
+++ b/crates/itofin-py/tests/test_optionlet_stripping.py
@@ -60,8 +60,10 @@ One shared Settings drives everything: the instruments and the engines must
 agree on the evaluation date or the NPVs are silently wrong.
 """
 
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.indexes import Euribor
 from itofin.instruments import CapFloor, CapFloorType
@@ -74,7 +76,7 @@ from itofin.termstructures import (
     StrippedOptionletAdapter,
     VolatilityType,
 )
-from itofin.time import BusinessDayConvention, Calendar, DayCounter, Date, Period
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Period
 
 EVAL = Date(28, 10, 2013)
 CURVE_RATE = 0.04

--- a/crates/itofin-py/tests/test_piecewise_yield_curve.py
+++ b/crates/itofin-py/tests/test_piecewise_yield_curve.py
@@ -12,8 +12,10 @@ piecewiseyieldcurve.cpp). Tolerance 1e-9 (:322), checked with a bare
 1e-9 to ~4.5e-8.
 """
 
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.indexes import Euribor
 from itofin.quotes import SimpleQuote
@@ -26,13 +28,7 @@ from itofin.termstructures import (
     PiecewiseYieldCurve,
     SwapRateHelper,
 )
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DayCounter,
-    Frequency,
-)
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Frequency
 from itofin.time import Period as P
 
 # (n, unit, rate-in-percent), transcribed from piecewiseyieldcurve.cpp deposits.

--- a/crates/itofin-py/tests/test_primitives.py
+++ b/crates/itofin-py/tests/test_primitives.py
@@ -1,5 +1,7 @@
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.time import Calendar, Date, DayCounter
 

--- a/crates/itofin-py/tests/test_rate_helpers.py
+++ b/crates/itofin-py/tests/test_rate_helpers.py
@@ -9,26 +9,18 @@ Python's stdlib or from the documented Euribor conventions, never read back off
 the helper.
 """
 
+# standard library
 import datetime
 
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.indexes import Euribor
 from itofin.quotes import SimpleQuote
-from itofin.termstructures import (
-    DepositRateHelper,
-    FlatForward,
-    SwapRateHelper,
-)
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DayCounter,
-    Frequency,
-    Period,
-)
+from itofin.termstructures import DepositRateHelper, FlatForward, SwapRateHelper
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Frequency, Period
 
 
 def _settings_today():

--- a/crates/itofin-py/tests/test_sabr_swaption_cube.py
+++ b/crates/itofin-py/tests/test_sabr_swaption_cube.py
@@ -45,18 +45,13 @@ The cube is calibrated once for the whole module: a Levenberg-Marquardt fit per
 node plus the dense pass is the expensive part, and no arm mutates a quote.
 """
 
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.indexes import Currency, Euribor, SwapIndex
-from itofin.instruments import (
-    EuropeanExercise,
-    SettlementMethod,
-    SettlementType,
-    Swaption,
-    SwapType,
-    VanillaSwap,
-)
+from itofin.instruments import EuropeanExercise, SettlementMethod, SettlementType, Swaption, SwapType, VanillaSwap
 from itofin.pricingengines import BlackSwaptionEngine, CashAnnuityModel
 from itofin.quotes import SimpleQuote
 from itofin.termstructures import (
@@ -66,15 +61,7 @@ from itofin.termstructures import (
     SwaptionVolatilityMatrix,
     VolatilityType,
 )
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DayCounter,
-    Frequency,
-    Period,
-    Schedule,
-)
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Frequency, Period, Schedule
 
 EVAL = Date(15, 6, 2026)
 BDC = BusinessDayConvention.ModifiedFollowing

--- a/crates/itofin-py/tests/test_schedule.py
+++ b/crates/itofin-py/tests/test_schedule.py
@@ -7,16 +7,12 @@ under TARGET + ModifiedFollowing they roll forward to Monday 17-Jan. The oracle
 therefore pins 17-Jan, not the naive 15th quoted in the issue body.
 """
 
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import ItofinError
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    Frequency,
-    Schedule,
-)
+from itofin.time import BusinessDayConvention, Calendar, Date, Frequency, Schedule
 
 START = Date(15, 1, 2028)
 END = Date(15, 1, 2033)

--- a/crates/itofin-py/tests/test_shared.py
+++ b/crates/itofin-py/tests/test_shared.py
@@ -1,7 +1,10 @@
+# standard library
 import math
 
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import ItofinError
 from itofin.models import CalibrationErrorType
 from itofin.optimization import EndCriteria, LevenbergMarquardt

--- a/crates/itofin-py/tests/test_skeleton.py
+++ b/crates/itofin-py/tests/test_skeleton.py
@@ -1,3 +1,4 @@
+# itofin library
 import itofin
 
 

--- a/crates/itofin-py/tests/test_swaption.py
+++ b/crates/itofin-py/tests/test_swaption.py
@@ -22,28 +22,16 @@ fixture (``jamshidianswaptionengine.rs:344``, which never attaches a swap engine
     RECEIVER_NPV = 1.3562383202325612   (jamshidianswaptionengine.rs:517)
 """
 
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.indexes import Euribor
-from itofin.instruments import (
-    EuropeanExercise,
-    SettlementMethod,
-    SettlementType,
-    Swaption,
-    SwapType,
-    VanillaSwap,
-)
+from itofin.instruments import EuropeanExercise, SettlementMethod, SettlementType, Swaption, SwapType, VanillaSwap
 from itofin.models import HullWhite
 from itofin.termstructures import FlatForward
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DayCounter,
-    Frequency,
-    Schedule,
-)
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Frequency, Schedule
 
 PAYER_NPV = 1.5666103955750414
 RECEIVER_NPV = 1.3562383202325612

--- a/crates/itofin-py/tests/test_swaption_vol_matrix.py
+++ b/crates/itofin-py/tests/test_swaption_vol_matrix.py
@@ -41,35 +41,17 @@ C. Engine integration. The same swaption priced on the matrix and on a
    independent check of that number. Arm A and the core's 1e-16 test cover that.
 """
 
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import Settings
 from itofin.indexes import Euribor
-from itofin.instruments import (
-    EuropeanExercise,
-    SettlementMethod,
-    SettlementType,
-    Swaption,
-    SwapType,
-    VanillaSwap,
-)
+from itofin.instruments import EuropeanExercise, SettlementMethod, SettlementType, Swaption, SwapType, VanillaSwap
 from itofin.pricingengines import BlackSwaptionEngine, CashAnnuityModel
 from itofin.quotes import SimpleQuote
-from itofin.termstructures import (
-    ConstantSwaptionVolatility,
-    FlatForward,
-    SwaptionVolatilityMatrix,
-    VolatilityType,
-)
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DayCounter,
-    Frequency,
-    Period,
-    Schedule,
-)
+from itofin.termstructures import ConstantSwaptionVolatility, FlatForward, SwaptionVolatilityMatrix, VolatilityType
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Frequency, Period, Schedule
 
 EVAL = Date(15, 6, 2026)
 BDC = BusinessDayConvention.ModifiedFollowing

--- a/crates/itofin-py/tests/test_time_eq_hash.py
+++ b/crates/itofin-py/tests/test_time_eq_hash.py
@@ -23,6 +23,7 @@ delegates to the same core PartialEq either way, so the fixture is not worth its
 cost here.
 """
 
+# itofin library
 from itofin.time import DayCounter, Period
 
 

--- a/crates/itofin-py/tests/test_vanilla_swap.py
+++ b/crates/itofin-py/tests/test_vanilla_swap.py
@@ -21,20 +21,15 @@ to Monday 17-Jan under TARGET + ModifiedFollowing; the facade Schedule
 reproduces the core exactly, so the fixture stays apples-to-apples.
 """
 
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.indexes import Euribor
 from itofin.instruments import SwapType, VanillaSwap
 from itofin.termstructures import FlatForward
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DayCounter,
-    Frequency,
-    Schedule,
-)
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Frequency, Schedule
 
 PROBE_FAIR = 0.03048844643136293
 PROBE_NPV = 0.21033895380698553

--- a/crates/itofin-py/tests/test_yoy_capped_leg.py
+++ b/crates/itofin-py/tests/test_yoy_capped_leg.py
@@ -36,22 +36,15 @@ sum-identity and collar-identity the Rust oracle also carries are deliberately
 NOT ported: both are blind to a consistently mis-wired strike.
 """
 
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import Settings
 from itofin.cashflows import YoYInflationLeg, YoYInflationOptionletCouponPricer
 from itofin.indexes import CpiInterpolationType, YoYInflationIndex
 from itofin.termstructures import ConstantYoYOptionletVolatility
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DateGeneration,
-    DayCounter,
-    Frequency,
-    Period,
-    Schedule,
-)
+from itofin.time import BusinessDayConvention, Calendar, Date, DateGeneration, DayCounter, Frequency, Period, Schedule
 
 UK = Calendar.united_kingdom()
 TODAY = Date(10, 2, 2022)

--- a/crates/itofin-py/tests/test_yoy_inflation_capfloor.py
+++ b/crates/itofin-py/tests/test_yoy_inflation_capfloor.py
@@ -45,16 +45,14 @@ factory path above reaches those numbers through a builder that assembles its ow
 leg, this one through a leg Python assembles and hands over coupon by coupon.
 """
 
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.cashflows import YoYInflationCoupon, YoYInflationLeg
 from itofin.indexes import CpiInterpolationType, YoYInflationIndex, ZeroInflationIndex
-from itofin.instruments import (
-    CapFloorType,
-    MakeYoYInflationCapFloor,
-    YoYInflationCapFloor,
-)
+from itofin.instruments import CapFloorType, MakeYoYInflationCapFloor, YoYInflationCapFloor
 from itofin.pricingengines import YoYInflationCapFloorEngine
 from itofin.quotes import SimpleQuote
 from itofin.termstructures import (
@@ -63,16 +61,7 @@ from itofin.termstructures import (
     PiecewiseYoYInflationCurve,
     YearOnYearInflationSwapHelper,
 )
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DateGeneration,
-    DayCounter,
-    Frequency,
-    Period,
-    Schedule,
-)
+from itofin.time import BusinessDayConvention, Calendar, Date, DateGeneration, DayCounter, Frequency, Period, Schedule
 
 UK = Calendar.united_kingdom()
 TODAY = UK.adjust(Date(13, 8, 2007), BusinessDayConvention.Following)

--- a/crates/itofin-py/tests/test_yoy_inflation_leg.py
+++ b/crates/itofin-py/tests/test_yoy_inflation_leg.py
@@ -29,29 +29,18 @@ coupon needs a pricer carrying an optionlet volatility, and #838's cap/floor
 instrument is the supported route), and the erased `build()` leg.
 """
 
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.cashflows import YoYInflationLeg
 from itofin.indexes import CpiInterpolationType, YoYInflationIndex, ZeroInflationIndex
 from itofin.instruments import SwapType, YearOnYearInflationSwap
 from itofin.pricingengines import DiscountingSwapEngine
 from itofin.quotes import SimpleQuote
-from itofin.termstructures import (
-    FlatForward,
-    PiecewiseYoYInflationCurve,
-    YearOnYearInflationSwapHelper,
-)
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DateGeneration,
-    DayCounter,
-    Frequency,
-    Period,
-    Schedule,
-)
+from itofin.termstructures import FlatForward, PiecewiseYoYInflationCurve, YearOnYearInflationSwapHelper
+from itofin.time import BusinessDayConvention, Calendar, Date, DateGeneration, DayCounter, Frequency, Period, Schedule
 
 TODAY = Calendar.united_kingdom().adjust(
     Date(13, 8, 2007), BusinessDayConvention.Following

--- a/crates/itofin-py/tests/test_yoy_inflation_reprice.py
+++ b/crates/itofin-py/tests/test_yoy_inflation_reprice.py
@@ -27,29 +27,17 @@ Omitted visibly: seasonality on a year-on-year curve, which the zero side covers
 inherits.
 """
 
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.indexes import CpiInterpolationType, YoYInflationIndex, ZeroInflationIndex
 from itofin.instruments import SwapType, YearOnYearInflationSwap
 from itofin.pricingengines import DiscountingSwapEngine
 from itofin.quotes import SimpleQuote
-from itofin.termstructures import (
-    FlatForward,
-    PiecewiseYoYInflationCurve,
-    Pillar,
-    YearOnYearInflationSwapHelper,
-)
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DateGeneration,
-    DayCounter,
-    Frequency,
-    Period,
-    Schedule,
-)
+from itofin.termstructures import FlatForward, PiecewiseYoYInflationCurve, Pillar, YearOnYearInflationSwapHelper
+from itofin.time import BusinessDayConvention, Calendar, Date, DateGeneration, DayCounter, Frequency, Period, Schedule
 
 TODAY = Calendar.united_kingdom().adjust(
     Date(13, 8, 2007), BusinessDayConvention.Following

--- a/crates/itofin-py/tests/test_yoy_inflation_swap.py
+++ b/crates/itofin-py/tests/test_yoy_inflation_swap.py
@@ -14,21 +14,13 @@ a bootstrapped curve are the reprice oracle's job
 (test_yoy_inflation_reprice.py).
 """
 
+# itofin library
 from itofin import Settings
 from itofin.indexes import CpiInterpolationType, YoYInflationIndex
 from itofin.instruments import SwapType, YearOnYearInflationSwap
 from itofin.pricingengines import DiscountingSwapEngine
 from itofin.termstructures import FlatForward, InterpolatedYoYInflationCurve
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DateGeneration,
-    DayCounter,
-    Frequency,
-    Period,
-    Schedule,
-)
+from itofin.time import BusinessDayConvention, Calendar, Date, DateGeneration, DayCounter, Frequency, Period, Schedule
 
 TODAY = Date(13, 8, 2007)
 CURVE_BASE = Date(1, 7, 2007)

--- a/crates/itofin-py/tests/test_yoy_optionlet_vol.py
+++ b/crates/itofin-py/tests/test_yoy_optionlet_vol.py
@@ -26,13 +26,10 @@ cached value exactly as well as a live one does, so only re-pricing the same
 instrument after the quote moves tells the two apart.
 """
 
+# itofin library
 from itofin import Settings
 from itofin.indexes import CpiInterpolationType, YoYInflationIndex, ZeroInflationIndex
-from itofin.instruments import (
-    CapFloorType,
-    MakeYoYInflationCapFloor,
-    YoYInflationCapFloor,
-)
+from itofin.instruments import CapFloorType, MakeYoYInflationCapFloor, YoYInflationCapFloor
 from itofin.pricingengines import YoYInflationCapFloorEngine
 from itofin.quotes import SimpleQuote
 from itofin.termstructures import (
@@ -41,16 +38,7 @@ from itofin.termstructures import (
     PiecewiseYoYInflationCurve,
     YearOnYearInflationSwapHelper,
 )
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DateGeneration,
-    DayCounter,
-    Frequency,
-    Period,
-    Schedule,
-)
+from itofin.time import BusinessDayConvention, Calendar, Date, DateGeneration, DayCounter, Frequency, Period, Schedule
 
 UK = Calendar.united_kingdom()
 TODAY = UK.adjust(Date(13, 8, 2007), BusinessDayConvention.Following)

--- a/crates/itofin-py/tests/test_zc_inflation_reprice.py
+++ b/crates/itofin-py/tests/test_zc_inflation_reprice.py
@@ -33,8 +33,10 @@ observation reads from history, and July 2007, which the forecast compounds off
 covered by count alone.
 """
 
+# pypi/conda library
 import pytest
 
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.indexes import CpiInterpolationType, ZeroInflationIndex
 from itofin.instruments import SwapType, ZeroCouponInflationSwap
@@ -46,14 +48,7 @@ from itofin.termstructures import (
     PiecewiseZeroInflationCurve,
     ZeroCouponInflationSwapHelper,
 )
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DayCounter,
-    Frequency,
-    Period,
-)
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Frequency, Period
 
 TODAY = Date(13, 8, 2007)
 CURVE_BASE = Date(1, 7, 2007)

--- a/crates/itofin-py/tests/test_zc_inflation_swap.py
+++ b/crates/itofin-py/tests/test_zc_inflation_swap.py
@@ -23,20 +23,16 @@ strictly between the 1 Jan and 1 Jul 2008 nodes, so it reads an interpolated
 rate rather than a node outright.
 """
 
+# pypi/conda library
 import pytest
+
+# itofin library
 from itofin import ItofinError, Settings
 from itofin.indexes import CpiInterpolationType, ZeroInflationIndex
 from itofin.instruments import SwapType, ZeroCouponInflationSwap
 from itofin.pricingengines import DiscountingSwapEngine
 from itofin.termstructures import FlatForward, InterpolatedZeroInflationCurve
-from itofin.time import (
-    BusinessDayConvention,
-    Calendar,
-    Date,
-    DayCounter,
-    Frequency,
-    Period,
-)
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Frequency, Period
 
 TODAY = Date(13, 8, 2007)
 MATURITY = Date(13, 8, 2008)

--- a/example/python/.pre-commit-config.yaml
+++ b/example/python/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
     - repo: https://github.com/timothycrosley/isort
-      rev: 9.0.0b1
+      rev: 9.0.0b5
       hooks:
         - id: isort
           name: isort

--- a/example/python/credit_cds.py
+++ b/example/python/credit_cds.py
@@ -25,6 +25,7 @@ Run it with:
     python example/python/credit_cds.py
 """
 
+# plugins
 # itofin library
 from itofin import Settings
 from itofin.instruments import CreditDefaultSwap, ProtectionSide

--- a/example/python/european_option.py
+++ b/example/python/european_option.py
@@ -12,6 +12,7 @@ Run it with:
     python example/python/european_option.py
 """
 
+# plugins
 # itofin library
 from itofin import Settings
 from itofin.instruments import OptionType, VanillaOption

--- a/example/python/inflation_swap.py
+++ b/example/python/inflation_swap.py
@@ -26,6 +26,7 @@ Run it with:
     python example/python/inflation_swap.py
 """
 
+# plugins
 # itofin library
 from itofin import Settings
 from itofin.indexes import CpiInterpolationType, ZeroInflationIndex

--- a/example/python/isda_cds.py
+++ b/example/python/isda_cds.py
@@ -45,6 +45,7 @@ Run it with:
     python example/python/isda_cds.py
 """
 
+# plugins
 # itofin library
 from itofin import Settings
 from itofin.indexes import Currency, IborIndex

--- a/example/python/monte_carlo.py
+++ b/example/python/monte_carlo.py
@@ -21,6 +21,7 @@ Run it with:
     python example/python/monte_carlo.py
 """
 
+# plugins
 # itofin library
 from itofin import Settings
 from itofin.instruments import OptionType, VanillaOption

--- a/example/python/vanilla_swap.py
+++ b/example/python/vanilla_swap.py
@@ -18,6 +18,7 @@ Run it with:
     python example/python/vanilla_swap.py
 """
 
+# plugins
 # itofin library
 from itofin import Settings
 from itofin.indexes import Euribor

--- a/example/python/yield_curve.py
+++ b/example/python/yield_curve.py
@@ -14,6 +14,7 @@ Run it with:
     python example/python/yield_curve.py
 """
 
+# plugins
 # itofin library
 from itofin import Settings
 from itofin.indexes import Euribor

--- a/example/python/yoy_inflation_capfloor.py
+++ b/example/python/yoy_inflation_capfloor.py
@@ -42,6 +42,7 @@ Run it with:
     python example/python/yoy_inflation_capfloor.py
 """
 
+# plugins
 # itofin library
 from itofin import ItofinError, Settings
 from itofin.indexes import CpiInterpolationType, YoYInflationIndex, ZeroInflationIndex

--- a/example/python/yoy_inflation_swap.py
+++ b/example/python/yoy_inflation_swap.py
@@ -36,6 +36,7 @@ Run it with:
     python example/python/yoy_inflation_swap.py
 """
 
+# plugins
 # itofin library
 from itofin import Settings
 from itofin.cashflows import YoYInflationLeg

--- a/scripts/gen_sobol_tables.py
+++ b/scripts/gen_sobol_tables.py
@@ -9,6 +9,7 @@ large-file limit (1024 KB).
 Usage: python3 scripts/gen_sobol_tables.py [--quantlib DIR] [--out DIR]
 """
 
+# standard library
 import argparse
 import pathlib
 import re


### PR DESCRIPTION
- **refactor(itofin-py): use absolute imports in type stub**
- **docs(crates): expand VanillaOption type stub docstrings**
- **docs(crates): expand swap instrument type stubs with full docstrings**
- **docs(crates): expand swaption and cap/floor type stub docstrings**
- **docs(crates): expand CDS instrument type stub docstrings**
- **docs(crates): expand inflation swap type stubs with full docstrings**
- **docs(crates): expand YoY inflation cap/floor type stubs**
- **docs(results): document Results property accessors**
- **docs(termstructures): expand docstrings for yield curve type stubs**
- **docs(crates): expand Black volatility term structure stubs**
- **docs(crates): expand rate helper docstrings in termstructures stubs**
- **docs(crates): add docstrings to rate helper stubs**
- **docs(crates): expand swaption vol structure type stub docstrings**
- **docs(crates): expand SABR smile and cube type stubs**
- **docs(crates): expand optionlet volatility surface type stubs**
- **docs(crates): expand optionlet stripper type stub docstrings**
- **docs(crates): expand credit term structure type stubs with docstrings**
- **docs(crates): expand inflation term structure type stub docstrings**
- **docs(crates): expand year-on-year inflation type stub docstrings**
- **docs(crates): expand ConstantYoYOptionletVolatility type stub docstrings**
- **docs(crates): add issue references to inflation curve docstrings**
- **style(python): sort imports with isort and add categorization comments**

close #883