### PR TITLE
style(itofin-py): apply isort import grouping and ruff formatting

### DIFF
--- a/crates/itofin-py/.isort.cfg
+++ b/crates/itofin-py/.isort.cfg
@@ -1,0 +1,13 @@
+[settings]
+py_version=3
+line_length=120
+sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+ensure_newline_before_comments=True
+known_first_party=itofin
+import_heading_stdlib=standard library
+import_heading_firstparty=itofin library
+import_heading_thirdparty=pypi/conda library

--- a/crates/itofin-py/.pre-commit-config.yaml
+++ b/crates/itofin-py/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+    - repo: https://github.com/timothycrosley/isort
+      rev: 9.0.0b5
+      hooks:
+        - id: isort
+          name: isort
+          args:
+            - --settings-path=.isort.cfg
+    - repo: https://github.com/astral-sh/ruff-pre-commit
+      rev: v0.15.12
+      hooks:
+        - id: ruff
+          args:
+            - --fix
+          exclude: "tests/|scripts/"
+        - id: ruff-format
+          exclude: "tests/|scripts/"

--- a/crates/itofin-py/pyproject.toml
+++ b/crates/itofin-py/pyproject.toml
@@ -30,3 +30,52 @@ Issues = "https://github.com/benbenbang/libitofin/issues"
 module-name = "itofin"
 python-source = "python"
 features = ["itofin-py/extension-module"]
+
+[tool.ruff]
+line-length = 120
+target-version = "py313"
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+[tool.ruff.lint]
+fixable = ["ALL"]
+unfixable = []
+ignore = ["E731"]
+# exclude = ["ALL"]
+select = ["D1"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+
+[tool.pyright]
+venvPath = "."
+venv = ".venv"

--- a/crates/itofin-py/python/itofin/__init__.py
+++ b/crates/itofin-py/python/itofin/__init__.py
@@ -1,5 +1,13 @@
+"""Python bindings for libitofin, a Rust port of QuantLib.
+
+Re-exports the compiled ``itofin`` extension module so ``import itofin``
+resolves to the native bindings (classes, functions and submodules).
+"""
+
 from .itofin import *
 
-__doc__ = itofin.__doc__
 if hasattr(itofin, "__all__"):
     __all__ = itofin.__all__
+
+if hasattr(itofin, "__doc__"):
+    __doc__ = itofin.__doc__

--- a/crates/itofin-py/python/itofin/cashflows.pyi
+++ b/crates/itofin-py/python/itofin/cashflows.pyi
@@ -426,9 +426,7 @@ class IborLeg:
             IborLeg: A new leg carrying the day counter.
         """
         ...
-    def with_payment_adjustment(
-        self, convention: BusinessDayConvention
-    ) -> IborLeg:
+    def with_payment_adjustment(self, convention: BusinessDayConvention) -> IborLeg:
         """Return the leg rolling its payment dates with convention.
 
         Args:

--- a/crates/itofin-py/python/itofin/indexes.pyi
+++ b/crates/itofin-py/python/itofin/indexes.pyi
@@ -1,10 +1,17 @@
 # Hand-written stubs for itofin.indexes; sync manually with src/hullwhite.rs, src/helpers.rs,
 # src/swapindex.rs, src/currency.rs and src/inflation.rs (#517).
 
+# standard library
+from typing import TYPE_CHECKING
+
 # itofin library
 from itofin import Settings
 from itofin.termstructures import YieldTermStructure, YoYInflationTermStructure, ZeroInflationTermStructure
 from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Period
+
+if TYPE_CHECKING:
+    # itofin library
+    from itofin.time import Frequency
 
 class Currency:
     """An ISO 4217 currency specification.
@@ -212,9 +219,7 @@ class Euribor(IborIndex):
     not a rebuild - so its own fixing reads exactly what the base reads.
     """
 
-    def __init__(
-        self, tenor: Period, curve: YieldTermStructure | None, settings: Settings
-    ) -> None:
+    def __init__(self, tenor: Period, curve: YieldTermStructure | None, settings: Settings) -> None:
         """Build a Euribor index of the given tenor.
 
         Args:

--- a/crates/itofin-py/python/itofin/instruments.pyi
+++ b/crates/itofin-py/python/itofin/instruments.pyi
@@ -42,9 +42,7 @@ class VanillaOption:
     registered with - has notified it.
     """
 
-    def __init__(
-        self, option_type: OptionType, strike: float, expiry: Date, settings: Settings
-    ) -> None:
+    def __init__(self, option_type: OptionType, strike: float, expiry: Date, settings: Settings) -> None:
         """Build the European-exercise option, exercisable only at expiry.
 
         Args:
@@ -872,9 +870,7 @@ class CapFloor:
         """
         ...
     @staticmethod
-    def floor(
-        leg: IborLeg, floor_rates: list[float], settings: Settings
-    ) -> CapFloor:
+    def floor(leg: IborLeg, floor_rates: list[float], settings: Settings) -> CapFloor:
         """Build a floor over the coupons leg builds, struck at floor_rates.
 
         Args:

--- a/crates/itofin-py/python/itofin/models.pyi
+++ b/crates/itofin-py/python/itofin/models.pyi
@@ -147,7 +147,11 @@ class HullWhite:
         ...
 
     def discount_bond_option(
-        self, option_type: OptionType, strike: float, maturity: float, bond_maturity: float
+        self,
+        option_type: OptionType,
+        strike: float,
+        maturity: float,
+        bond_maturity: float,
     ) -> float:
         """Price a European option on a zero-coupon bond.
 

--- a/crates/itofin-py/python/itofin/termstructures.pyi
+++ b/crates/itofin-py/python/itofin/termstructures.pyi
@@ -1188,9 +1188,7 @@ class SwaptionVolatilityStructure:
                 is not allowed.
         """
         ...
-    def shift(
-        self, option_date: Date, swap_length: float, extrapolate: bool = False
-    ) -> float:
+    def shift(self, option_date: Date, swap_length: float, extrapolate: bool = False) -> float:
         """Return the lognormal shift, in the date form.
 
         Taken in the date form because the core trait has no tenor overload for
@@ -1685,9 +1683,7 @@ class OptionletVolatilityStructure:
     A single option axis, unlike the swaption surfaces: a query takes one option
     tenor (or date) and a strike."""
 
-    def volatility(
-        self, option_tenor: Period, strike: float, extrapolate: bool = False
-    ) -> float:
+    def volatility(self, option_tenor: Period, strike: float, extrapolate: bool = False) -> float:
         """Return the caplet volatility for an option tenor and strike.
 
         Args:
@@ -1704,9 +1700,7 @@ class OptionletVolatilityStructure:
                 is not allowed.
         """
         ...
-    def volatility_date(
-        self, option_date: Date, strike: float, extrapolate: bool = False
-    ) -> float:
+    def volatility_date(self, option_date: Date, strike: float, extrapolate: bool = False) -> float:
         """Return the caplet volatility for an option date and strike.
 
         The date form the optionlet stripper and the cap/floor engine use, both
@@ -1725,9 +1719,7 @@ class OptionletVolatilityStructure:
                 is not allowed.
         """
         ...
-    def black_variance(
-        self, option_tenor: Period, strike: float, extrapolate: bool = False
-    ) -> float:
+    def black_variance(self, option_tenor: Period, strike: float, extrapolate: bool = False) -> float:
         """Return the Black variance, the squared volatility times option time.
 
         Args:
@@ -2003,9 +1995,7 @@ class CapFloorTermVolSurface:
             ItofinError: On the same conditions __init__ reports.
         """
         ...
-    def volatility(
-        self, option_tenor: Period, strike: float, extrapolate: bool = False
-    ) -> float:
+    def volatility(self, option_tenor: Period, strike: float, extrapolate: bool = False) -> float:
         """Return the flat cap volatility for a cap tenor and strike.
 
         The tenor form resolves against the surface's own calendar and
@@ -2025,9 +2015,7 @@ class CapFloorTermVolSurface:
                 is not allowed.
         """
         ...
-    def volatility_date(
-        self, end_date: Date, strike: float, extrapolate: bool = False
-    ) -> float:
+    def volatility_date(self, end_date: Date, strike: float, extrapolate: bool = False) -> float:
         """Return the flat cap volatility for a cap end date and strike.
 
         Args:
@@ -2043,9 +2031,7 @@ class CapFloorTermVolSurface:
                 is not allowed.
         """
         ...
-    def volatility_time(
-        self, length: float, strike: float, extrapolate: bool = False
-    ) -> float:
+    def volatility_time(self, length: float, strike: float, extrapolate: bool = False) -> float:
         """Return the flat cap volatility for a cap end time and strike.
 
         Args:
@@ -2307,9 +2293,7 @@ class FlatHazardRate(DefaultProbabilityTermStructure):
     quote. The moving forms fix the reference date settlement_days business days
     past the evaluation date carried by settings."""
 
-    def __init__(
-        self, reference_date: Date, hazard_rate: SimpleQuote, day_counter: DayCounter
-    ) -> None:
+    def __init__(self, reference_date: Date, hazard_rate: SimpleQuote, day_counter: DayCounter) -> None:
         """Build a curve reading its hazard rate live, on a pinned reference date.
 
         Args:
@@ -2320,9 +2304,7 @@ class FlatHazardRate(DefaultProbabilityTermStructure):
         """
         ...
     @staticmethod
-    def with_rate(
-        reference_date: Date, rate: float, day_counter: DayCounter
-    ) -> FlatHazardRate:
+    def with_rate(reference_date: Date, rate: float, day_counter: DayCounter) -> FlatHazardRate:
         """Build a curve at a fixed rate, on a pinned reference date.
 
         Args:
@@ -2739,9 +2721,7 @@ class ZeroInflationTermStructure:
             Frequency: The fixing frequency.
         """
         ...
-    def set_seasonality(
-        self, seasonality: MultiplicativePriceSeasonality | None
-    ) -> None:
+    def set_seasonality(self, seasonality: MultiplicativePriceSeasonality | None) -> None:
         """Install seasonality on the curve, replacing whatever it carried.
 
         A curve that caches anything derived from the correction - every
@@ -3080,9 +3060,7 @@ class YoYInflationTermStructure:
             Frequency: The fixing frequency.
         """
         ...
-    def set_seasonality(
-        self, seasonality: MultiplicativePriceSeasonality | None
-    ) -> None:
+    def set_seasonality(self, seasonality: MultiplicativePriceSeasonality | None) -> None:
         """Install seasonality on the curve, replacing whatever it carried.
 
         Args:

--- a/example/python/pyproject.toml
+++ b/example/python/pyproject.toml
@@ -4,18 +4,10 @@ version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
-dependencies = []
-
-[tool.uv]
-package = true
-
-# optional - choose between tool.uv or build-version
-# [build-system]
-# requires = ["uv_build>=0.8.9,<0.9.0"]
-# build-backend = "uv_build"
-
-[project.scripts]
-# command-name = "project-name.module-name:function-name"
+dependencies = [
+    "ipython>=9.16.1",
+    "itofin>=0.15.0",
+]
 
 [tool.ruff]
 line-length = 120
@@ -54,7 +46,7 @@ fixable = ["ALL"]
 unfixable = []
 ignore = ["E731"]
 # exclude = ["ALL"]
-# select = ["PL"]
+select = ["D1"]
 
 [tool.ruff.format]
 quote-style = "double"
@@ -62,112 +54,6 @@ indent-style = "space"
 skip-magic-trailing-comma = false
 line-ending = "auto"
 
-[tool.pylint.messages_control]
-disable = ["all"]
-enable = [
-    "consider-using-f-string",
-    "cyclic-import",
-    "deprecated-module",
-    "f-string-without-interpolation",
-    "import-error",
-    "import-self",
-    "undefined-variable",
-    "undefined-all-variable",
-    "unused-format-string-argument",
-    "unused-format-string-key",
-    "unused-import",
-    #   This might be unused but a mandatory signature in airflow runtime
-    #   "unused-argument",
-    "unused-wildcard-import",
-    "unused-variable",
-    "used-before-assignment",
-    "use-list-literal",
-    "raise-missing-from",
-    "simplifiable-condition",
-    "simplify-boolean-expression",
-    "super-with-arguments",
-    "wrong-spelling-in-comment",
-    "wrong-spelling-in-docstring",
-]
-
 [tool.pyright]
 venvPath = "."
 venv = ".venv"
-
-[tool.pytest.ini_options]
-addopts = '--basetemp=/tmp/pytest'
-# switch on `-s` for deep debuging
-# addopts = '-s --basetemp=/tmp/pytest'
-
-filterwarnings = [
-    "ignore:distutils Version classes:DeprecationWarning",
-    "ignore:'contextfilter' is renamed:DeprecationWarning",
-    "ignore:Unbuilt egg for pytest-airflow-utils:UserWarning",
-    "ignore:The 'missing' argument:DeprecationWarning",
-    "ignore:The 'default' argument:DeprecationWarning",
-    "ignore:The field metadata as keyword:DeprecationWarning",
-    "ignore:Passing field metadata:DeprecationWarning",
-    "ignore:.*__new__.*:pytest.PytestCollectionWarning",
-    "ignore:'_request_ctx_stack':DeprecationWarning",
-    "ignore:'_app_ctx_stack':DeprecationWarning",
-    "ignore:'urllib3.contrib.pyopenssl':DeprecationWarning",
-    "ignore:::.*pkg_resources.*:2350",
-    "ignore:::.*pkg_resources.*:2871",
-    "ignore:::.*gunicorn.*",
-    "ignore:::.*grpc_gcp*",
-]
-
-# testpaths = ["tests/project-name"]
-
-markers = [
-    "unittests: run unittests",
-    "integrationtests: run integrationtests",
-]
-
-[tool.mypy]
-ignore_missing_imports = true
-warn_unreachable = true
-
-[tool.black]
-line-length = 120
-exclude = '''
-/(
-  | {{ cookiecutter.* }}
-  | hooks
-  | .venv
-  | .cache
-)/
-'''
-
-[tool.coverage.run]
-omit = [
-    "tests/*",
-    "**/__init__.py",
-    "datamodel/*",
-    "*/sql/*",
-    "*__SQL.py",
-    "*__DAG.py",
-    "*/__init__.py",
-    "*/setup.py",
-    "provider/*",
-]
-source = ["."]
-parallel = true
-
-[tool.coverage.report]
-exclude_lines = ["if TYPE_CHECKING:", '\.\.\.', '...']
-exclude_also = [
-    "# pragma: no cover",
-    "def __repr__",
-    "if self.debug:",
-    "if settings.DEBUG",
-    "raise AssertionError",
-    "raise NotImplementedError",
-    "if 0:",
-    "if __name__ == .__main__.:",
-    "if TYPE_CHECKING:",
-    "class .*\\bProtocol\\):",
-    "@(abc\\.)?abstractmethod",
-    '\.\.\.',
-    '...',
-]

--- a/example/python/uv.lock
+++ b/example/python/uv.lock
@@ -1,0 +1,233 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"
+
+[[package]]
+name = "asttokens"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/1e/faf0f247f6f881b98fc4d6d07e14085cb89d13665084e6d6ac1dc2c03d0b/asttokens-3.0.2.tar.gz", hash = "sha256:3ecdbd8f2cc195f53ccada3a613538bb5f9ef6f6869129f13e03c30a677b8fe2", size = 63136, upload-time = "2026-07-12T03:31:49.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/2b/04b8a15f3a1c77bc79ddf5c73875327f34b4fa75982df2b76e45e402d364/asttokens-3.0.2-py3-none-any.whl", hash = "sha256:9da13157f5b28becde0bd374fc677dcd3c290614264eff096f167c469cd9f933", size = 28702, upload-time = "2026-07-12T03:31:47.542Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "executing"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
+name = "ipython"
+version = "9.16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "psutil", marker = "sys_platform != 'cygwin' and sys_platform != 'emscripten'" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/96/b150fe7e25a5a29ae9ac1374e71488639605d39a1ea4abb74c9ce33af235/ipython-9.16.1.tar.gz", hash = "sha256:5a3d1f9a47ff216d6cf9cf863124f6a2c1a198d1354c546a4d24a370a283b64c", size = 4515302, upload-time = "2026-08-03T08:36:15.571Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/8e/1239df488393d61076653bfb29f759d0f60cab8e030abdf7c17c31539b51/ipython-9.16.1-py3-none-any.whl", hash = "sha256:4acae635506f6d352d94c4899a19d5f85f8bc4d230932342dca556fdab1c69b4", size = 625974, upload-time = "2026-08-03T08:36:13.654Z" },
+]
+
+[[package]]
+name = "ipython-pygments-lexers"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c", size = 8074, upload-time = "2025-01-17T11:24:33.271Z" },
+]
+
+[[package]]
+name = "ito-fin"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "ipython" },
+    { name = "itofin" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "ipython", specifier = ">=9.16.1" },
+    { name = "itofin", specifier = ">=0.15.0" },
+]
+
+[[package]]
+name = "itofin"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/04/3717938dbaf9c5fb598e4f818165eba302bffa22f695bc5a95c55fcedee6/itofin-0.15.0.tar.gz", hash = "sha256:ac589f5b17d9b093b6302f880559b4a2b1acdb961cdf9a3645ed72bcd88a605a", size = 2780665, upload-time = "2026-08-20T00:31:16.363Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/4f/a5e68864758d0bc51895267d8a5a7126ea14b9d09dd1bf8de520edf7cc16/itofin-0.15.0-cp313-abi3-macosx_11_0_arm64.whl", hash = "sha256:947d3e6257ec40a60f3305966e31ecca1e98cd9815678e99b74b6f4b1f5a00f5", size = 1601311, upload-time = "2026-08-20T00:31:12.106Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b4/98a1dd852d3d88aadd925bf3af2c29aa91a4241cae3f206703e4641d644b/itofin-0.15.0-cp313-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d6bd10a1926969d75d17a6457611d5acd6802deaf70ea6a4f70bc078994fc0e9", size = 1727469, upload-time = "2026-08-20T00:31:13.584Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/71/2498aed6442c278cfe0ffd9c6655606986b9f7722fb2eead343ad32bf6a8/itofin-0.15.0-cp313-abi3-win_amd64.whl", hash = "sha256:8ba484b160974e273669d5585419f229ccfb9376d535485f1168afdfa5507acd", size = 1398502, upload-time = "2026-08-20T00:31:15.077Z" },
+]
+
+[[package]]
+name = "jedi"
+version = "0.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "parso" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/b7/a3635f6a2d7cf5b5dd98064fc1d5fbbafcb25477bcea204a3a92145d158b/jedi-0.20.0.tar.gz", hash = "sha256:c3f4ccbd276696f4b19c54618d4fb18f9fc24b0aef02acf704b23f487daa1011", size = 3119416, upload-time = "2026-05-01T23:38:47.814Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/93/242e2eab5fe682ffcb8b0084bde703a41d51e17ee0f3a31ff0d9d813620a/jedi-0.20.0-py2.py3-none-any.whl", hash = "sha256:7bdd9c2634f56713299976f4cbd59cb3fa92165cc5e05ea811fb253480728b67", size = 4884812, upload-time = "2026-05-01T23:38:43.919Z" },
+]
+
+[[package]]
+name = "matplotlib-inline"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/c0/9f7c9a46090390368a4d7bcb76bb87a4a36c421e4c0792cdb53486ffac7a/matplotlib_inline-0.2.2.tar.gz", hash = "sha256:72f3fe8fce36b70d4a5b612f899090cd0401deddc4ea90e1572b9f4bfb058c79", size = 8150, upload-time = "2026-05-08T17:33:33.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/09/5b161152e2d90f7b87f781c2e1267494aef9c32498df793f73ad0a0a494a/matplotlib_inline-0.2.2-py3-none-any.whl", hash = "sha256:3c821cf1c209f59fb2d2d64abbf5b23b67bcb2210d663f9918dd851c6da1fcf6", size = 9534, upload-time = "2026-05-08T17:33:32.055Z" },
+]
+
+[[package]]
+name = "parso"
+version = "0.8.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/4b/90c937815137d43ce71ba043cd3566221e9df6b9c805f24b5d138c9d40a7/parso-0.8.7.tar.gz", hash = "sha256:eaaac4c9fdd5e9e8852dc778d2d7405897ec510f2a298071453e5e3a07914bb1", size = 401824, upload-time = "2026-05-01T23:13:02.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/5d/8268b644392ee874ee82a635cd0df1773de230bde356c38de28e298392cc/parso-0.8.7-py2.py3-none-any.whl", hash = "sha256:a8926eb2a1b915486941fdbd31e86a4baf88fe8c210f25f2f35ecec5b574ca1c", size = 107025, upload-time = "2026-05-01T23:12:58.867Z" },
+]
+
+[[package]]
+name = "pexpect"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ptyprocess" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.53"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ea/39b988c938f75cb75d7045b5c69f8bfed47ee2152c8837fb403de29d6fb8/prompt_toolkit-3.0.53.tar.gz", hash = "sha256:9ec8a0ad96d5c56148b3f914aa79c1564c3fde5d2e6b876e7bc327e353cf8fa6", size = 435492, upload-time = "2026-07-26T20:56:14.758Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/6f/84908cad2d6aa5144abcf7b42709fe4fdb459bc640ec7ac5786e7693dabc/prompt_toolkit-3.0.53-py3-none-any.whl", hash = "sha256:01c0891d7f9237d5e339f7d3e42cdae80b7534abb1c7c0e3352efba6231492f2", size = 392288, upload-time = "2026-07-26T20:56:12.512Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "ptyprocess"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
+]
+
+[[package]]
+name = "pure-eval"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
+]
+
+[[package]]
+name = "stack-data"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asttokens" },
+    { name = "executing" },
+    { name = "pure-eval" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
+name = "traitlets"
+version = "5.16.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/2e/a7fbfe268c8a3b32546930c0297c101d65a4a14c304ad5790a9f478f0e4e/traitlets-5.16.1.tar.gz", hash = "sha256:ed900c2b631aa3a112811139fa97b8d2c3bad5e989656bba4b7e52c7852c18c1", size = 166137, upload-time = "2026-08-03T08:32:36.848Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/66/0d785f0bc5e4315a96c989bb476d0fc07ea4f85132550c7b156ca2035d52/traitlets-5.16.1-py3-none-any.whl", hash = "sha256:f775618166caa0396c8e337099240f2bd3e5e917d203b2e6fbe21a58d3cb1f6b", size = 86211, upload-time = "2026-08-03T08:32:34.48Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/74/c6428f875774288bec1396f5bfcbc2d925700a4dad61727fd5f2b12f249d/wcwidth-0.8.2.tar.gz", hash = "sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda", size = 1466253, upload-time = "2026-06-29T18:11:11.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl", hash = "sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85", size = 323166, upload-time = "2026-06-29T18:11:09.888Z" },
+]


### PR DESCRIPTION
Add isort/ruff/pre-commit configuration and reformat Python sources
across the itofin-py bindings, tests, examples, and stubs.

**Tooling configuration:**
* Added `.isort.cfg` and `.pre-commit-config.yaml` to enforce import
  grouping with section comments (standard library, pypi/conda, itofin).
* Added `[tool.ruff]`, `[tool.ruff.lint]`, `[tool.ruff.format]` and
  `[tool.pyright]` sections to `crates/itofin-py/pyproject.toml`.
* Bumped the isort pre-commit hook in the example config to `9.0.0b5`.

**Import and formatting cleanup:**
* Annotated imports with section comments and collapsed multi-line
  imports onto single lines across tests, stubs, and example scripts.
* Condensed multi-line function signatures in the `.pyi` stubs.
* Guarded `Frequency` behind `TYPE_CHECKING` in `indexes.pyi`.

**Example project maintenance:**
* Pruned the boilerplate cookiecutter tooling config from
  `example/python/pyproject.toml` and declared real dependencies
  (`ipython`, `itofin`).

**Package init:**
* Rewrote `itofin/__init__.py` to re-export the compiled extension with
  a module docstring and guarded `__all__`/`__doc__` propagation.
