### PR TITLE
ci(itofin-py): add submodule shim generation pre-commit hook

### DIFF
--- a/crates/itofin-py/.pre-commit-config.yaml
+++ b/crates/itofin-py/.pre-commit-config.yaml
@@ -1,4 +1,12 @@
 repos:
+    - repo: local
+      hooks:
+        - id: gen-submodule-shims
+          name: generate itofin submodule shims
+          entry: python scripts/gen_submodule_shims.py
+          language: system
+          files: ^python/itofin/.*\.pyi$
+          pass_filenames: false
     - repo: https://github.com/timothycrosley/isort
       rev: 9.0.0b5
       hooks:
@@ -6,12 +14,13 @@ repos:
           name: isort
           args:
             - --settings-path=.isort.cfg
+          exclude: "tests/|scripts/|python/itofin/(?!__init__\\.py$)[^/]*\\.py$"
     - repo: https://github.com/astral-sh/ruff-pre-commit
       rev: v0.15.12
       hooks:
         - id: ruff
           args:
             - --fix
-          exclude: "tests/|scripts/"
+          exclude: "tests/|scripts/|python/itofin/(?!__init__\\.py$)[^/]*\\.py$"
         - id: ruff-format
-          exclude: "tests/|scripts/"
+          exclude: "tests/|scripts/|python/itofin/(?!__init__\\.py$)[^/]*\\.py$"


### PR DESCRIPTION
Add a local pre-commit hook that regenerates itofin submodule shims from `.pyi` files, and exclude generated submodule modules from isort, ruff, and ruff-format to prevent conflicts with the generated output.