### PR TITLE
docs(links): fix repo URLs (ito-fin -> libitofin)

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -42,11 +42,11 @@ Every example ships in both languages with a matching filename. Browse the full 
 
 | Topic | Python | Rust |
 |-------|--------|------|
-| European option | [`european_option.py`](https://github.com/benbenbang/ito-fin/blob/main/example/python/european_option.py) | [`european_option.rs`](https://github.com/benbenbang/ito-fin/blob/main/example/rust/european_option.rs) |
-| Monte Carlo | [`monte_carlo.py`](https://github.com/benbenbang/ito-fin/blob/main/example/python/monte_carlo.py) | [`monte_carlo.rs`](https://github.com/benbenbang/ito-fin/blob/main/example/rust/monte_carlo.rs) |
-| Vanilla swap | [`vanilla_swap.py`](https://github.com/benbenbang/ito-fin/blob/main/example/python/vanilla_swap.py) | [`vanilla_swap.rs`](https://github.com/benbenbang/ito-fin/blob/main/example/rust/vanilla_swap.rs) |
-| Yield curve | [`yield_curve.py`](https://github.com/benbenbang/ito-fin/blob/main/example/python/yield_curve.py) | [`yield_curve.rs`](https://github.com/benbenbang/ito-fin/blob/main/example/rust/yield_curve.rs) |
-| Credit CDS | [`credit_cds.py`](https://github.com/benbenbang/ito-fin/blob/main/example/python/credit_cds.py) | [`credit_cds.rs`](https://github.com/benbenbang/ito-fin/blob/main/example/rust/credit_cds.rs) |
-| ISDA CDS | [`isda_cds.py`](https://github.com/benbenbang/ito-fin/blob/main/example/python/isda_cds.py) | [`isda_cds.rs`](https://github.com/benbenbang/ito-fin/blob/main/example/rust/isda_cds.rs) |
-| Inflation swap | [`inflation_swap.py`](https://github.com/benbenbang/ito-fin/blob/main/example/python/inflation_swap.py) | [`inflation_swap.rs`](https://github.com/benbenbang/ito-fin/blob/main/example/rust/inflation_swap.rs) |
-| YoY inflation cap/floor | [`yoy_inflation_capfloor.py`](https://github.com/benbenbang/ito-fin/blob/main/example/python/yoy_inflation_capfloor.py) | [`yoy_inflation_capfloor.rs`](https://github.com/benbenbang/ito-fin/blob/main/example/rust/yoy_inflation_capfloor.rs) |
+| European option | [`european_option.py`](https://github.com/benbenbang/libitofin/blob/main/example/python/european_option.py) | [`european_option.rs`](https://github.com/benbenbang/libitofin/blob/main/example/rust/european_option.rs) |
+| Monte Carlo | [`monte_carlo.py`](https://github.com/benbenbang/libitofin/blob/main/example/python/monte_carlo.py) | [`monte_carlo.rs`](https://github.com/benbenbang/libitofin/blob/main/example/rust/monte_carlo.rs) |
+| Vanilla swap | [`vanilla_swap.py`](https://github.com/benbenbang/libitofin/blob/main/example/python/vanilla_swap.py) | [`vanilla_swap.rs`](https://github.com/benbenbang/libitofin/blob/main/example/rust/vanilla_swap.rs) |
+| Yield curve | [`yield_curve.py`](https://github.com/benbenbang/libitofin/blob/main/example/python/yield_curve.py) | [`yield_curve.rs`](https://github.com/benbenbang/libitofin/blob/main/example/rust/yield_curve.rs) |
+| Credit CDS | [`credit_cds.py`](https://github.com/benbenbang/libitofin/blob/main/example/python/credit_cds.py) | [`credit_cds.rs`](https://github.com/benbenbang/libitofin/blob/main/example/rust/credit_cds.rs) |
+| ISDA CDS | [`isda_cds.py`](https://github.com/benbenbang/libitofin/blob/main/example/python/isda_cds.py) | [`isda_cds.rs`](https://github.com/benbenbang/libitofin/blob/main/example/rust/isda_cds.rs) |
+| Inflation swap | [`inflation_swap.py`](https://github.com/benbenbang/libitofin/blob/main/example/python/inflation_swap.py) | [`inflation_swap.rs`](https://github.com/benbenbang/libitofin/blob/main/example/rust/inflation_swap.rs) |
+| YoY inflation cap/floor | [`yoy_inflation_capfloor.py`](https://github.com/benbenbang/libitofin/blob/main/example/python/yoy_inflation_capfloor.py) | [`yoy_inflation_capfloor.rs`](https://github.com/benbenbang/libitofin/blob/main/example/rust/yoy_inflation_capfloor.rs) |

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -45,4 +45,4 @@ The full walk-through, in both languages, is on the [Getting started](getting-st
 |---------|-------|
 | Python API reference | This site (see the **Python API** section) |
 | Rust API reference | [docs.rs/libitofin](https://docs.rs/libitofin) - see [Rust API](rust.md) |
-| Worked examples | [`example/python`](https://github.com/benbenbang/ito-fin/tree/main/example/python) and [`example/rust`](https://github.com/benbenbang/ito-fin/tree/main/example/rust) |
+| Worked examples | [`example/python`](https://github.com/benbenbang/libitofin/tree/main/example/python) and [`example/rust`](https://github.com/benbenbang/libitofin/tree/main/example/rust) |

--- a/docs/docs/rust.md
+++ b/docs/docs/rust.md
@@ -31,5 +31,5 @@ use libitofin::settings::Settings;
 // analytic option engines, curves and CDS pricing are available today - see docs.rs.
 ```
 
-Runnable Rust examples live in [`example/rust`](https://github.com/benbenbang/ito-fin/tree/main/example/rust);
+Runnable Rust examples live in [`example/rust`](https://github.com/benbenbang/libitofin/tree/main/example/rust);
 their Python counterparts are on the [Getting started](getting-started.md) page.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,8 +1,8 @@
 site_name: itofin
 site_description: Python API reference for itofin, the Rust QuantLib port (libitofin).
-site_url: https://benbenbang.github.io/ito-fin/
-repo_url: https://github.com/benbenbang/ito-fin
-repo_name: benbenbang/ito-fin
+site_url: https://benbenbang.github.io/libitofin/
+repo_url: https://github.com/benbenbang/libitofin
+repo_name: benbenbang/libitofin
 edit_uri: ""
 
 theme:


### PR DESCRIPTION
## What
The docs site shipped in #898 pointed every GitHub/Pages URL at `benbenbang/ito-fin` (the local checkout dir name), but the repo is `benbenbang/libitofin`. Every example link 404s and `site_url` was wrong.

## Fix
- `mkdocs.yml`: `site_url`, `repo_url`, `repo_name` -> `libitofin`
- `index.md`, `getting-started.md`, `rust.md`: all `github.com/benbenbang/ito-fin/...` example links -> `libitofin`

`mkdocs build --strict` stays clean; a fixed link now resolves to the real repo path.

## Still needed (repo setting, not code)
The #898 deploy job failed with 404 "Ensure GitHub Pages has been enabled". Set **Settings -> Pages -> Source: GitHub Actions** so the deploy publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)