### PR TITLE
ci(docs): deploy via mkdocs gh-deploy instead of actions/deploy-pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,14 +16,14 @@ on:
       - ".github/workflows/docs.yml"
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: docs-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  build:
+  docs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -33,21 +33,7 @@ jobs:
       - name: Build site (strict)
         working-directory: docs
         run: uv run --frozen mkdocs build --strict
-      - uses: actions/upload-pages-artifact@v3
+      - name: Deploy to gh-pages
         if: github.ref == 'refs/heads/main'
-        with:
-          path: docs/site
-
-  deploy:
-    if: github.ref == 'refs/heads/main'
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - uses: actions/deploy-pages@v4
-        id: deployment
+        working-directory: docs
+        run: uv run --frozen mkdocs gh-deploy --force


### PR DESCRIPTION
## Why
Pages is now served from the `gh-pages` branch (legacy source), not the "GitHub Actions" build type. The old `actions/deploy-pages` job hard-404s on every push to main ("Ensure GitHub Pages has been enabled") even though the site builds fine.

## What
Replace the two-job artifact/deploy pipeline with a single job:
- `mkdocs build --strict` (the gate) on every PR and push.
- `mkdocs gh-deploy --force` on main only - builds and force-pushes the site to `gh-pages` (the branch Pages already serves).
- `permissions: contents: write` so the token can push the branch; dropped `pages`/`id-token`.

Site is already live at https://benbenbang.github.io/libitofin/ (deployed manually once); this makes future pushes keep it current without the red X.