### PR TITLE
fix(itofin-py): hash PyDate by its calendar day

### DIFF
--- a/crates/itofin-py/python/itofin/time.pyi
+++ b/crates/itofin-py/python/itofin/time.pyi
@@ -122,6 +122,14 @@ class Date:
         """
         ...
 
+    def __hash__(self) -> int:
+        """Hashes the calendar day, the field equality compares.
+
+        Returns:
+            int: The hash of the date, so equal dates hash equal.
+        """
+        ...
+
     def __repr__(self) -> str:
         """Return the constructor form of the date.
 

--- a/crates/itofin-py/src/time.rs
+++ b/crates/itofin-py/src/time.rs
@@ -127,6 +127,12 @@ impl PyDate {
         self.inner == other.inner
     }
 
+    /// Hashes the core date, the one field [`__eq__`](Self::__eq__) compares,
+    /// so a date can key a dict or join a set.
+    fn __hash__(&self) -> u64 {
+        hash_of(&self.inner)
+    }
+
     fn __repr__(&self) -> String {
         format!(
             "Date({}, {}, {})",

--- a/crates/itofin-py/tests/test_time_eq_hash.py
+++ b/crates/itofin-py/tests/test_time_eq_hash.py
@@ -1,4 +1,4 @@
-"""Value equality and hashing for Period and DayCounter (#864).
+"""Value equality and hashing for Period, DayCounter (#864) and Date (#879).
 
 Both facades wrap a core type that defines equality, but neither exposed it, so
 Python compared them by identity and neither could key a dict or join a set.
@@ -24,7 +24,7 @@ cost here.
 """
 
 # itofin library
-from itofin.time import DayCounter, Period
+from itofin.time import Date, DayCounter, Period
 
 
 def test_days_and_weeks_compare_and_hash_across_units():
@@ -96,3 +96,18 @@ def test_a_day_counter_keys_a_dict_by_value():
 
 def test_a_day_counter_is_not_equal_to_a_non_day_counter():
     assert DayCounter.actual360() != "Actual/360"
+
+
+def test_equal_dates_collapse_in_a_set_and_unequal_ones_do_not():
+    """Date had __eq__ without __hash__ (#879), so equal dates hashed by
+    identity and missed each other as set members. The unequal pair guards
+    hash-routing separately from equality, per the #864 lesson."""
+    assert len({Date(15, 6, 2026), Date(15, 6, 2026)}) == 1
+    assert Date(15, 6, 2026) != Date(16, 6, 2026)
+    assert len({Date(15, 6, 2026), Date(16, 6, 2026)}) == 2
+
+
+def test_a_date_keys_a_dict_by_value():
+    fixings = {Date(15, 6, 2026): 0.0421}
+    assert fixings[Date(15, 6, 2026)] == 0.0421
+    assert Date(16, 6, 2026) not in fixings


### PR DESCRIPTION
Date defined __eq__ without __hash__, so equal dates hashed by identity
and missed each other as dict keys and set members. Hash the wrapped
core date, the field __eq__ compares, mirroring the Period and
DayCounter facades.

close #879
