### PR TITLE
feat(src): add base_level to yoy optionlet volatility surface

### DIFF
--- a/crates/libitofin/src/handle.rs
+++ b/crates/libitofin/src/handle.rs
@@ -231,6 +231,18 @@ impl<T: ?Sized> RelinkableHandle<T> {
     }
 }
 
+/// Copies share the one underlying link, as C++ `RelinkableHandle` copies do:
+/// relinking any copy re-points them all and notifies their common observers.
+/// The optionlet stripper leans on this, its helpers re-pointing the same link
+/// the cap/floor engine reads (`yoyoptionlethelpers.cpp:74-89`).
+impl<T: ?Sized> Clone for RelinkableHandle<T> {
+    fn clone(&self) -> Self {
+        RelinkableHandle {
+            handle: self.handle.clone(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/libitofin/src/indexes/inflation/genericindexes.rs
+++ b/crates/libitofin/src/indexes/inflation/genericindexes.rs
@@ -1,0 +1,91 @@
+//! Generic inflation indexes.
+//!
+//! Port of `ql/experimental/inflation/genericindexes.hpp`: [`YyGenericCpi`] is
+//! the quoted year-on-year generic CPI `YYGenericCPI` (`genericindexes.hpp:57-71`),
+//! a [`YoYInflationIndex`] parameterised by frequency, revision flag,
+//! availability lag and currency over the `GenericRegion` (name `"Generic"`,
+//! code `"GENERIC"`, `region.hpp:33-40` in that header's include chain). The
+//! optionlet stripper builds one as a "fake index" whose lag and frequency
+//! match the price surface it strips (`interpolatedyoyoptionletstripper.hpp:182-189`).
+//!
+//! ## Omitted (visible)
+//!
+//! The zero-coupon sibling `GenericCPI` (`genericindexes.hpp:43-53`) has no
+//! consumer in the ported code and is omitted rather than carried unread; it
+//! lands with whatever first needs it.
+
+use crate::currency::Currency;
+use crate::indexes::inflationindex::YoYInflationIndex;
+use crate::indexes::region::Region;
+use crate::settings::Settings;
+use crate::shared::Shared;
+use crate::time::date::Date;
+use crate::time::frequency::Frequency;
+use crate::time::period::Period;
+
+/// The quoted year-on-year generic CPI (`YYGenericCPI`).
+///
+/// A zero-sized namespace for the constructor, on the pattern of
+/// [`YyUsCpi`](super::YyUsCpi).
+pub struct YyGenericCpi;
+
+impl YyGenericCpi {
+    /// Builds the quoted year-on-year generic CPI, mirroring
+    /// `YYGenericCPI::YYGenericCPI` (`genericindexes.hpp:59-70`) less the
+    /// year-on-year curve, which
+    /// [`with_term_structure`](YoYInflationIndex::with_term_structure) links.
+    ///
+    /// The family name is `"YY_CPI"` over the `GenericRegion`, so the composed
+    /// index name reads `"Generic YY_CPI"`. Quoted, not a ratio: it forecasts
+    /// off its curve and would read its own store for history.
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(
+        frequency: Frequency,
+        revised: bool,
+        availability_lag: Period,
+        currency: Currency,
+        settings: Shared<Settings<Date>>,
+    ) -> YoYInflationIndex {
+        YoYInflationIndex::new(
+            "YY_CPI".into(),
+            Region::new("Generic", "GENERIC"),
+            revised,
+            frequency,
+            availability_lag,
+            currency,
+            settings,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::indexes::index::Index;
+    use crate::indexes::inflationindex::InflationIndex;
+    use crate::shared::shared;
+    use crate::time::timeunit::TimeUnit;
+
+    /// The metadata `genericindexes.hpp:59-70` forwards, with the composed
+    /// name carrying the `GenericRegion` name rather than its code.
+    #[test]
+    fn construction_matches_the_cpp_header() {
+        let index = YyGenericCpi::new(
+            Frequency::Monthly,
+            false,
+            Period::new(3, TimeUnit::Months),
+            Currency::eur(),
+            shared(Settings::<Date>::new()),
+        );
+
+        assert_eq!(index.name(), "Generic YY_CPI");
+        assert_eq!(index.region().name(), "Generic");
+        assert_eq!(index.region().code(), "GENERIC");
+        assert_eq!(index.frequency(), Frequency::Monthly);
+        assert!(!index.revised());
+        assert!(!index.ratio());
+        assert!(index.underlying_index().is_none());
+        assert_eq!(index.availability_lag(), Period::new(3, TimeUnit::Months));
+        assert_eq!(index.currency().code(), "EUR");
+    }
+}

--- a/crates/libitofin/src/indexes/inflation/mod.rs
+++ b/crates/libitofin/src/indexes/inflation/mod.rs
@@ -26,11 +26,13 @@
 //! [`YoYInflationIndex`]: crate::indexes::inflationindex::YoYInflationIndex
 
 pub mod euhicp;
+pub mod genericindexes;
 pub mod ukhicp;
 pub mod ukrpi;
 pub mod uscpi;
 
 pub use euhicp::{EuHicp, YyEuHicp, YyEuHicpXt};
+pub use genericindexes::YyGenericCpi;
 pub use ukhicp::UkHicp;
 pub use ukrpi::{UkRpi, YyUkRpi};
 pub use uscpi::{UsCpi, YyUsCpi};

--- a/crates/libitofin/src/termstructures/volatility/inflation/interpolatedyoyoptionletvol.rs
+++ b/crates/libitofin/src/termstructures/volatility/inflation/interpolatedyoyoptionletvol.rs
@@ -1,0 +1,254 @@
+//! Interpolated year-on-year optionlet volatility curve.
+//!
+//! Port of `InterpolatedYoYOptionletVolatilityCurve`
+//! (`ql/experimental/inflation/yoyinflationoptionletvolatilitystructure2.hpp:39-186`):
+//! a flat-smile surface, interpolated in the time direction and constant in
+//! strike, which the optionlet stripper rebuilds on every solver iteration and
+//! the piecewise bootstrap produces per strike. It embeds the shared
+//! [`YoYOptionletVolatilitySurfaceBase`] holder.
+//!
+//! ## Divergences from QuantLib
+//!
+//! - The moving reference date takes the shared [`Settings`] handle explicitly
+//!   (D5), and every volatility query takes its observation lag explicitly, as
+//!   the module docs of [`super`] record for the flat surface.
+//! - The protected no-data constructor (`hpp:91-102`) exists in C++ only
+//!   because `PiecewiseYoYOptionletVolatilityCurve` derives from this class;
+//!   the port's piecewise curve is standalone (as
+//!   [`PiecewiseYoYInflationCurve`] is), so it has no counterpart here.
+//! - The `VolatilityType`/`displacement` pair is omitted unread, exactly as on
+//!   [`ConstantYoYOptionletVolatility`](super::ConstantYoYOptionletVolatility).
+//!
+//! [`PiecewiseYoYInflationCurve`]: crate::termstructures::inflation::piecewiseyoyinflationcurve::PiecewiseYoYInflationCurve
+
+use crate::errors::QlResult;
+use crate::math::interpolations::{Interpolation, Interpolator};
+use crate::patterns::observable::{AsObservable, Observable};
+use crate::require;
+use crate::settings::Settings;
+use crate::shared::Shared;
+use crate::termstructures::interpolatedcurve::InterpolatedCurve;
+use crate::termstructures::volatility::VolatilityTermStructure;
+use crate::termstructures::{TermStructure, TermStructureBase};
+use crate::time::businessdayconvention::BusinessDayConvention;
+use crate::time::calendar::Calendar;
+use crate::time::date::Date;
+use crate::time::daycounter::DayCounter;
+use crate::time::frequency::Frequency;
+use crate::time::period::Period;
+use crate::time::timeunit::TimeUnit;
+use crate::types::{Natural, Rate, Real, Time, Volatility};
+
+use super::{YoYOptionletVolatilitySurface, YoYOptionletVolatilitySurfaceBase};
+
+/// The value of `interpolation` at `t`, extended past either end on the end
+/// segment's own slope.
+///
+/// The port of C++'s `interpolation_(t, true)` reads for the wired
+/// interpolator: `Linear`'s allowed extrapolation continues the boundary
+/// segment, which is the same extension
+/// [`PiecewiseYoYInflationCurve::yoy_rate_impl`] spells out on the inflation
+/// side.
+///
+/// [`PiecewiseYoYInflationCurve::yoy_rate_impl`]: crate::termstructures::inflation::piecewiseyoyinflationcurve::PiecewiseYoYInflationCurve
+pub(crate) fn extended_value<I: Interpolation>(interpolation: &I, t: Time) -> QlResult<Real> {
+    let x_min = interpolation.x_min();
+    let x_max = interpolation.x_max();
+    if t < x_min {
+        Ok(interpolation.value(x_min)? + interpolation.derivative(x_min)? * (t - x_min))
+    } else if t > x_max {
+        Ok(interpolation.value(x_max)? + interpolation.derivative(x_max)? * (t - x_max))
+    } else {
+        interpolation.value(t)
+    }
+}
+
+/// Interpolated flat-smile year-on-year optionlet volatility curve:
+/// interpolated in the time direction, constant in strike
+/// (`yoyinflationoptionletvolatilitystructure2.hpp:39-114`).
+pub struct InterpolatedYoYOptionletVolatilityCurve<I: Interpolator> {
+    base: YoYOptionletVolatilitySurfaceBase,
+    curve: InterpolatedCurve<I>,
+    dates: Vec<Date>,
+    min_strike: Rate,
+    max_strike: Rate,
+}
+
+impl<I: Interpolator> InterpolatedYoYOptionletVolatilityCurve<I> {
+    /// Curve through the volatilities quoted at the given dates
+    /// (`hpp:118-153`). The dates are those of the volatility, with no lag on
+    /// them, but relative to a start earlier than the reference date as always
+    /// for inflation (`hpp:45-49`).
+    ///
+    /// The base level is set to the interpolation's own value at the base
+    /// date's time, extended past the first node when that time precedes it
+    /// (C++'s `interpolation_(baseTime, true)`, `hpp:149-152`).
+    ///
+    /// # Errors
+    ///
+    /// The C++ `QL_REQUIRE`s: a date/volatility count mismatch, or fewer than
+    /// two dates; plus an unresolvable reference date.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        settlement_days: Natural,
+        calendar: Calendar,
+        business_day_convention: BusinessDayConvention,
+        day_counter: DayCounter,
+        observation_lag: Period,
+        frequency: Frequency,
+        index_is_interpolated: bool,
+        dates: Vec<Date>,
+        volatilities: Vec<Volatility>,
+        min_strike: Rate,
+        max_strike: Rate,
+        interpolator: I,
+        settings: Shared<Settings<Date>>,
+    ) -> QlResult<InterpolatedYoYOptionletVolatilityCurve<I>> {
+        require!(
+            dates.len() == volatilities.len(),
+            "must have same number of dates and vols: {} vs {}",
+            dates.len(),
+            volatilities.len()
+        );
+        require!(
+            dates.len() > 1,
+            "must have at least two dates: {}",
+            dates.len()
+        );
+
+        let base = YoYOptionletVolatilitySurfaceBase::new(
+            settlement_days,
+            calendar,
+            business_day_convention,
+            day_counter.clone(),
+            observation_lag,
+            frequency,
+            index_is_interpolated,
+            settings,
+        );
+        let reference = base.term_structure_base().reference_date()?;
+        let times = InterpolatedCurve::<I>::times_from_dates(&dates, reference, &day_counter)?;
+        let mut curve = InterpolatedCurve::new(times, volatilities, interpolator);
+        curve.setup_interpolation()?;
+
+        let base_time = day_counter.year_fraction(reference, base.base_date()?);
+        base.set_base_level(extended_value(curve.interpolation()?, base_time)?);
+
+        Ok(InterpolatedYoYOptionletVolatilityCurve {
+            base,
+            curve,
+            dates,
+            min_strike,
+            max_strike,
+        })
+    }
+
+    /// The embedded shared holder.
+    pub fn surface_base(&self) -> &YoYOptionletVolatilitySurfaceBase {
+        &self.base
+    }
+
+    /// The node times (`hpp:81`), measured from the reference date.
+    pub fn times(&self) -> &[Time] {
+        self.curve.times()
+    }
+
+    /// The node dates (`hpp:82`).
+    pub fn dates(&self) -> &[Date] {
+        &self.dates
+    }
+
+    /// The node volatilities (`hpp:83`).
+    pub fn data(&self) -> &[Real] {
+        self.curve.data()
+    }
+
+    /// The (date, volatility) nodes (`hpp:84`).
+    pub fn nodes(&self) -> Vec<(Date, Real)> {
+        self.dates
+            .iter()
+            .copied()
+            .zip(self.curve.data().iter().copied())
+            .collect()
+    }
+
+    fn last_date(&self) -> Date {
+        *self
+            .dates
+            .last()
+            .expect("construction rejected fewer than two dates")
+    }
+
+    /// For the curve the strike is ignored, the smile being flat
+    /// (`volatilityImpl`, `hpp:180-186`); C++ evaluates without extrapolation,
+    /// so a time off the node range errors here too.
+    fn volatility_impl(&self, t: Time) -> QlResult<Volatility> {
+        self.curve.interpolation()?.value(t)
+    }
+}
+
+impl<I: Interpolator> AsObservable for InterpolatedYoYOptionletVolatilityCurve<I> {
+    fn observable(&self) -> &Observable {
+        self.base.term_structure_base().observable()
+    }
+}
+
+impl<I: Interpolator> TermStructure for InterpolatedYoYOptionletVolatilityCurve<I> {
+    fn base(&self) -> &TermStructureBase {
+        self.base.term_structure_base()
+    }
+
+    /// C++'s self-described approximation (`hpp:73-76`): the reference date
+    /// advanced by the last node time rounded up to whole years. Should the
+    /// tenor conversion fail, the last node date stands in.
+    fn max_date(&self) -> Date {
+        let t_max = *self
+            .curve
+            .times()
+            .last()
+            .expect("construction rejected fewer than two dates");
+        self.option_date_from_tenor(Period::new(t_max.ceil() as i32, TimeUnit::Years))
+            .unwrap_or_else(|_| self.last_date())
+    }
+}
+
+impl<I: Interpolator> VolatilityTermStructure for InterpolatedYoYOptionletVolatilityCurve<I> {
+    fn business_day_convention(&self) -> BusinessDayConvention {
+        self.base.business_day_convention()
+    }
+
+    fn min_strike(&self) -> Rate {
+        self.min_strike
+    }
+
+    fn max_strike(&self) -> Rate {
+        self.max_strike
+    }
+}
+
+impl<I: Interpolator> YoYOptionletVolatilitySurface for InterpolatedYoYOptionletVolatilityCurve<I> {
+    fn base_date(&self) -> QlResult<Date> {
+        self.base.base_date()
+    }
+
+    fn volatility(&self, date: Date, strike: Rate, obs_lag: Period) -> QlResult<Volatility> {
+        let observed = self.base.observed(date - obs_lag)?;
+        self.base.check_range(
+            observed,
+            strike,
+            self.min_strike,
+            self.max_strike,
+            TermStructure::max_date(self),
+        )?;
+        self.volatility_impl(self.time_from_reference(observed)?)
+    }
+
+    fn total_variance(&self, date: Date, strike: Rate, obs_lag: Period) -> QlResult<Real> {
+        let volatility = self.volatility(date, strike, obs_lag)?;
+        Ok(volatility * volatility * self.base.time_from_base(date, obs_lag)?)
+    }
+
+    fn base_level(&self) -> QlResult<Volatility> {
+        self.base.base_level()
+    }
+}

--- a/crates/libitofin/src/termstructures/volatility/inflation/interpolatedyoyoptionletvol.rs
+++ b/crates/libitofin/src/termstructures/volatility/inflation/interpolatedyoyoptionletvol.rs
@@ -252,3 +252,180 @@ impl<I: Interpolator> YoYOptionletVolatilitySurface for InterpolatedYoYOptionlet
         self.base.base_level()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! QuantLib builds this curve only inside the stripper, whose numeric
+    //! oracle closes with the K-interpolated surface; what is pinned here is
+    //! the curve's own arithmetic, every figure a hand-computable function of
+    //! the explicit nodes.
+
+    use super::*;
+    use crate::math::interpolations::linear::Linear;
+    use crate::shared::shared;
+    use crate::time::calendars::target::Target;
+    use crate::time::date::Month::{April, July, June, March, May};
+    use crate::time::daycounters::actual365fixed::Actual365Fixed;
+
+    fn settings() -> Shared<Settings<Date>> {
+        let settings = shared(Settings::<Date>::new());
+        settings.set_evaluation_date(Date::new(15, June, 2026));
+        settings
+    }
+
+    fn build(
+        index_is_interpolated: bool,
+        dates: Vec<Date>,
+        volatilities: Vec<Volatility>,
+    ) -> QlResult<InterpolatedYoYOptionletVolatilityCurve<Linear>> {
+        InterpolatedYoYOptionletVolatilityCurve::new(
+            0,
+            Target::new(),
+            BusinessDayConvention::ModifiedFollowing,
+            Actual365Fixed::new(),
+            Period::new(2, TimeUnit::Months),
+            Frequency::Monthly,
+            index_is_interpolated,
+            dates,
+            volatilities,
+            -1.0,
+            3.0,
+            Linear,
+            settings(),
+        )
+    }
+
+    /// Nodes starting on the non-interpolated base date itself: 15 June less
+    /// two months snaps to 1 April.
+    fn sample_dates() -> Vec<Date> {
+        vec![
+            Date::new(1, April, 2026),
+            Date::new(1, April, 2027),
+            Date::new(1, April, 2028),
+        ]
+    }
+
+    fn sample_vols() -> Vec<Volatility> {
+        vec![0.010, 0.014, 0.012]
+    }
+
+    fn sample() -> InterpolatedYoYOptionletVolatilityCurve<Linear> {
+        build(false, sample_dates(), sample_vols()).unwrap()
+    }
+
+    /// The base date runs on the shared holder's arithmetic: snapped to the
+    /// publication period unless the index interpolates (`.cpp:57-63`).
+    #[test]
+    fn the_base_date_snaps_to_the_publication_period_unless_interpolated() {
+        assert_eq!(sample().base_date().unwrap(), Date::new(1, April, 2026));
+        let interpolated = build(true, sample_dates(), sample_vols()).unwrap();
+        assert_eq!(
+            YoYOptionletVolatilitySurface::base_date(&interpolated).unwrap(),
+            Date::new(15, April, 2026)
+        );
+    }
+
+    /// The base level is the interpolation at the base time (`hpp:149-152`):
+    /// on the first node when the base date is the first date, and on the
+    /// first segment's backward extension when it precedes it - where the flat
+    /// surface, which never sets one, keeps the trait's unset error.
+    #[test]
+    fn the_base_level_reads_the_interpolation_at_the_base_time() {
+        let curve = sample();
+        assert_eq!(curve.base_level().unwrap(), 0.010);
+
+        let shifted = build(
+            false,
+            vec![
+                Date::new(1, May, 2026),
+                Date::new(1, April, 2027),
+                Date::new(1, April, 2028),
+            ],
+            sample_vols(),
+        )
+        .unwrap();
+        let times = shifted.times().to_vec();
+        let base_time = shifted
+            .time_from_reference(Date::new(1, April, 2026))
+            .unwrap();
+        let slope = (0.014 - 0.010) / (times[1] - times[0]);
+        let expected = 0.010 + slope * (base_time - times[0]);
+        let level = shifted.base_level().unwrap();
+        assert!(
+            (level - expected).abs() < 1e-15,
+            "extended base level was {level}, expected {expected}"
+        );
+    }
+
+    /// Interpolated in time, constant in strike: every node answers its own
+    /// volatility at any strike, and a mid-period query lands on the linear
+    /// interpolant of the bracketing nodes.
+    #[test]
+    fn the_curve_interpolates_in_time_and_ignores_the_strike() {
+        let curve = sample();
+        let zero_lag = Period::new(0, TimeUnit::Days);
+
+        for (date, vol) in curve.nodes() {
+            for strike in [-0.5, 0.0, 0.02] {
+                let read = curve.volatility(date, strike, zero_lag).unwrap();
+                assert!((read - vol).abs() < 1e-15, "node {date} read {read}");
+            }
+        }
+
+        let times = curve.times().to_vec();
+        let t = curve.time_from_reference(Date::new(1, July, 2027)).unwrap();
+        let expected = 0.014 + (0.012 - 0.014) * (t - times[1]) / (times[2] - times[1]);
+        let read = curve
+            .volatility(Date::new(20, July, 2027), 0.02, zero_lag)
+            .unwrap();
+        assert!(
+            (read - expected).abs() < 1e-15,
+            "mid-period read {read}, expected {expected}"
+        );
+    }
+
+    /// `totalVariance` is `vol * vol * timeFromBase` under the handed lag.
+    #[test]
+    fn the_total_variance_accrues_from_the_base_date() {
+        let curve = sample();
+        let zero_lag = Period::new(0, TimeUnit::Days);
+        let exercise = Date::new(20, July, 2027);
+
+        let vol = curve.volatility(exercise, 0.02, zero_lag).unwrap();
+        let time = Actual365Fixed::new()
+            .year_fraction(Date::new(1, April, 2026), Date::new(1, July, 2027));
+        let variance = curve.total_variance(exercise, 0.02, zero_lag).unwrap();
+        assert!(
+            (variance - vol * vol * time).abs() < 1e-18,
+            "variance was {variance}"
+        );
+    }
+
+    /// The C++ `QL_REQUIRE`s of the constructor, and `checkRange`'s date and
+    /// strike refusals on a query.
+    #[test]
+    fn construction_and_queries_reject_inconsistent_input() {
+        let err = match build(false, sample_dates(), vec![0.01, 0.014]) {
+            Ok(_) => panic!("expected a construction error"),
+            Err(err) => err,
+        };
+        assert!(err.message().contains("same number of dates and vols"));
+
+        let err = match build(false, vec![Date::new(1, April, 2026)], vec![0.01]) {
+            Ok(_) => panic!("expected a construction error"),
+            Err(err) => err,
+        };
+        assert!(err.message().contains("at least two dates"));
+
+        let curve = sample();
+        let zero_lag = Period::new(0, TimeUnit::Days);
+        let early = curve
+            .volatility(Date::new(20, March, 2026), 0.02, zero_lag)
+            .expect_err("March 2026 precedes the April base date");
+        assert!(early.message().contains("before base date"), "err: {early}");
+        let wide = curve
+            .volatility(Date::new(20, July, 2027), 5.0, zero_lag)
+            .expect_err("5.0 is past the 3.0 maximum strike");
+        assert!(wide.message().contains("outside the curve"), "err: {wide}");
+    }
+}

--- a/crates/libitofin/src/termstructures/volatility/inflation/kinterpolatedyoyoptionletvol.rs
+++ b/crates/libitofin/src/termstructures/volatility/inflation/kinterpolatedyoyoptionletvol.rs
@@ -1,0 +1,262 @@
+//! K-interpolated year-on-year optionlet volatility surface.
+//!
+//! Port of `KInterpolatedYoYOptionletVolatilitySurface`
+//! (`ql/experimental/inflation/kinterpolatedyoyoptionletvolatilitysurface.hpp:45-203`):
+//! the stripper provides curves in the T direction along each quoted strike,
+//! and this surface interpolates *across* those strikes - no model fitting -
+//! caching one K-slice per queried date.
+//!
+//! ## Divergences from QuantLib
+//!
+//! - The C++ constructor takes the engine and calls the stripper's
+//!   `initialize` with it (`hpp:57-58`, `:148-155`); the Rust engine's
+//!   volatility handle is immutable, so the constructor also takes the
+//!   *retained* [`RelinkableHandle`] the engine reads and forwards both - the
+//!   repointing contract of [`YoYOptionletStripper`]'s module docs. The
+//!   `performCalculations` the C++ constructor runs (`hpp:121`) is the
+//!   `initialize` call itself, so it runs here too and construction is
+//!   fallible.
+//! - The stored `yoyInflationCouponPricer_` and `slope_` members serve only
+//!   that constructor-run calculation, so they are not kept.
+//! - The `VolatilityType`/`displacement` pair is omitted unread, as on every
+//!   surface in this module; the moving reference date takes the shared
+//!   [`Settings`] handle (D5).
+//!
+//! [`YoYCapFloorTermPriceSurface`]: crate::termstructures::inflation::yoycapfloortermpricesurface::YoYCapFloorTermPriceSurface
+
+use std::cell::RefCell;
+
+use crate::errors::QlResult;
+use crate::handle::RelinkableHandle;
+use crate::indexes::inflationindex::InflationIndex;
+use crate::math::interpolations::linear::Linear;
+use crate::math::interpolations::{Interpolation, Interpolator};
+use crate::patterns::observable::{AsObservable, Observable};
+use crate::pricingengines::inflation::YoYInflationCapFloorEngine;
+use crate::settings::Settings;
+use crate::shared::{Shared, SharedMut};
+use crate::termstructures::inflation::yoycapfloortermpricesurface::YoYCapFloorTermPriceSurface;
+use crate::termstructures::volatility::VolatilityTermStructure;
+use crate::termstructures::{TermStructure, TermStructureBase};
+use crate::time::businessdayconvention::BusinessDayConvention;
+use crate::time::calendar::Calendar;
+use crate::time::date::Date;
+use crate::time::daycounter::DayCounter;
+use crate::time::period::Period;
+use crate::time::timeunit::TimeUnit;
+use crate::types::{Natural, Rate, Real, Time, Volatility};
+
+use super::interpolatedyoyoptionletvol::extended_value;
+use super::{
+    YoYOptionletStripper, YoYOptionletVolatilitySurface, YoYOptionletVolatilitySurfaceBase,
+};
+
+/// One cached K-slice: the (strikes, volatilities) profile at `date` and the
+/// interpolation over it (the C++ mutable members `lastDate_`, `slice_` and
+/// `tempKinterpolation_`, `hpp:83-86`).
+struct SliceCache<I: Interpolator> {
+    date: Date,
+    slice: (Vec<Rate>, Vec<Volatility>),
+    interpolation: I::Output,
+}
+
+/// K-interpolated year-on-year optionlet volatility surface
+/// (`hpp:45-89`).
+pub struct KInterpolatedYoYOptionletVolatilitySurface<I: Interpolator> {
+    vol_base: YoYOptionletVolatilitySurfaceBase,
+    cap_floor_prices: Shared<dyn YoYCapFloorTermPriceSurface>,
+    stripper: Shared<dyn YoYOptionletStripper>,
+    interpolator: I,
+    slice_cache: RefCell<Option<SliceCache<I>>>,
+}
+
+impl KInterpolatedYoYOptionletVolatilitySurface<Linear> {
+    /// Builds the surface and runs the stripping (`hpp:94-122`): the
+    /// frequency comes off the price surface's index (`hpp:114`), the index
+    /// is taken as not interpolated (`hpp:116`), and `stripper.initialize` -
+    /// C++'s constructor-run `performCalculations` - strips `cap_floor_prices`
+    /// with `pricer` at `slope`. `vol_handle` must be the link `pricer` reads
+    /// its volatility through; see the module docs.
+    ///
+    /// # Errors
+    ///
+    /// As [`YoYOptionletStripper::initialize`].
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        settlement_days: Natural,
+        calendar: Calendar,
+        business_day_convention: BusinessDayConvention,
+        day_counter: DayCounter,
+        observation_lag: Period,
+        cap_floor_prices: Shared<dyn YoYCapFloorTermPriceSurface>,
+        pricer: &SharedMut<YoYInflationCapFloorEngine>,
+        vol_handle: &RelinkableHandle<dyn YoYOptionletVolatilitySurface>,
+        stripper: Shared<dyn YoYOptionletStripper>,
+        slope: Real,
+        settings: Shared<Settings<Date>>,
+    ) -> QlResult<KInterpolatedYoYOptionletVolatilitySurface<Linear>> {
+        let frequency = cap_floor_prices.yoy_index().frequency();
+        let vol_base = YoYOptionletVolatilitySurfaceBase::new(
+            settlement_days,
+            calendar,
+            business_day_convention,
+            day_counter,
+            observation_lag,
+            frequency,
+            false,
+            settings,
+        );
+        stripper.initialize(&cap_floor_prices, pricer, vol_handle, slope)?;
+        Ok(KInterpolatedYoYOptionletVolatilitySurface {
+            vol_base,
+            cap_floor_prices,
+            stripper,
+            interpolator: Linear,
+            slice_cache: RefCell::new(None),
+        })
+    }
+}
+
+impl<I: Interpolator> KInterpolatedYoYOptionletVolatilitySurface<I> {
+    /// The (strikes, volatilities) profile at `d` (`Dslice`, `hpp:169-175`):
+    /// the stripper's slice, cached per date.
+    ///
+    /// # Errors
+    ///
+    /// As [`YoYOptionletStripper::slice`].
+    pub fn d_slice(&self, d: Date) -> QlResult<(Vec<Rate>, Vec<Volatility>)> {
+        self.update_slice(d)?;
+        Ok(self
+            .slice_cache
+            .borrow()
+            .as_ref()
+            .expect("update_slice filled the cache")
+            .slice
+            .clone())
+    }
+
+    /// Refreshes the cached slice and its strike interpolation when `d` is
+    /// not the date last asked for (`updateSlice`, `hpp:189-203`).
+    fn update_slice(&self, d: Date) -> QlResult<()> {
+        let stale = match self.slice_cache.borrow().as_ref() {
+            Some(cache) => cache.date != d,
+            None => true,
+        };
+        if stale {
+            let slice = self.stripper.slice(d)?;
+            let interpolation = self.interpolator.interpolate(&slice.0, &slice.1)?;
+            *self.slice_cache.borrow_mut() = Some(SliceCache {
+                date: d,
+                slice,
+                interpolation,
+            });
+        }
+        Ok(())
+    }
+
+    /// The date-keyed volatility hook (`volatilityImpl(Date, Rate)`,
+    /// `hpp:158-166`): the cached slice's strike interpolation, extended past
+    /// the quoted strikes when the surface extrapolates (C++'s
+    /// `enableExtrapolation` on `tempKinterpolation_`).
+    fn volatility_impl_date(&self, d: Date, strike: Rate) -> QlResult<Volatility> {
+        self.update_slice(d)?;
+        let cache = self.slice_cache.borrow();
+        let interpolation = &cache
+            .as_ref()
+            .expect("update_slice filled the cache")
+            .interpolation;
+        if self.allows_extrapolation() {
+            extended_value(interpolation, strike)
+        } else {
+            interpolation.value(strike)
+        }
+    }
+
+    /// The time-keyed hook (`volatilityImpl(Time, Rate)`, `hpp:178-187`):
+    /// C++ reconstructs a date as the reference date advanced by the whole
+    /// years and the 365ths of the remainder, then defers to the date-keyed
+    /// hook.
+    fn volatility_impl(&self, t: Time, strike: Rate) -> QlResult<Volatility> {
+        let years = t.floor();
+        let days = ((t - years) * 365.0).floor() as i32;
+        let d = self.vol_base.term_structure_base().reference_date()?
+            + Period::new(years as i32, TimeUnit::Years)
+            + Period::new(days, TimeUnit::Days);
+        self.volatility_impl_date(d, strike)
+    }
+
+    fn last_maturity(&self) -> Period {
+        *self
+            .cap_floor_prices
+            .maturities()
+            .last()
+            .expect("the price surface carries maturities")
+    }
+}
+
+impl<I: Interpolator> AsObservable for KInterpolatedYoYOptionletVolatilitySurface<I> {
+    fn observable(&self) -> &Observable {
+        self.vol_base.term_structure_base().observable()
+    }
+}
+
+impl<I: Interpolator> TermStructure for KInterpolatedYoYOptionletVolatilitySurface<I> {
+    fn base(&self) -> &TermStructureBase {
+        self.vol_base.term_structure_base()
+    }
+
+    /// The reference date advanced by the last quoted maturity
+    /// (`hpp:125-130`); the null date should the reference be unresolvable.
+    fn max_date(&self) -> Date {
+        match self.vol_base.term_structure_base().reference_date() {
+            Ok(reference) => reference + self.last_maturity(),
+            Err(_) => Date::null(),
+        }
+    }
+}
+
+impl<I: Interpolator> VolatilityTermStructure for KInterpolatedYoYOptionletVolatilitySurface<I> {
+    fn business_day_convention(&self) -> BusinessDayConvention {
+        self.vol_base.business_day_convention()
+    }
+
+    /// The lowest quoted strike (`hpp:133-137`).
+    fn min_strike(&self) -> Rate {
+        self.cap_floor_prices.strikes()[0]
+    }
+
+    /// The highest quoted strike (`hpp:140-144`).
+    fn max_strike(&self) -> Rate {
+        *self
+            .cap_floor_prices
+            .strikes()
+            .last()
+            .expect("the price surface carries strikes")
+    }
+}
+
+impl<I: Interpolator> YoYOptionletVolatilitySurface
+    for KInterpolatedYoYOptionletVolatilitySurface<I>
+{
+    fn base_date(&self) -> QlResult<Date> {
+        self.vol_base.base_date()
+    }
+
+    fn volatility(&self, date: Date, strike: Rate, obs_lag: Period) -> QlResult<Volatility> {
+        let observed = self.vol_base.observed(date - obs_lag)?;
+        self.vol_base.check_range(
+            observed,
+            strike,
+            self.min_strike(),
+            self.max_strike(),
+            TermStructure::max_date(self),
+        )?;
+        let t = TermStructure::time_from_reference(self, observed)?;
+        self.volatility_impl(t, strike)
+    }
+
+    fn total_variance(&self, date: Date, strike: Rate, obs_lag: Period) -> QlResult<Real> {
+        let volatility = self.volatility(date, strike, obs_lag)?;
+        Ok(volatility * volatility * self.vol_base.time_from_base(date, obs_lag)?)
+    }
+}

--- a/crates/libitofin/src/termstructures/volatility/inflation/kinterpolatedyoyoptionletvol.rs
+++ b/crates/libitofin/src/termstructures/volatility/inflation/kinterpolatedyoyoptionletvol.rs
@@ -260,3 +260,276 @@ impl<I: Interpolator> YoYOptionletVolatilitySurface
         Ok(volatility * volatility * self.vol_base.time_from_base(date, obs_lag)?)
     }
 }
+
+#[cfg(test)]
+mod yoy_price_surface_to_vol_oracle {
+    //! `test-suite/inflationvolatility.cpp`'s `testYoYPriceSurfaceToVol`
+    //! (`:271-352`), the numeric oracle closing the whole #874 stack: the EU
+    //! fixture of `setup()` (`:91-240`) and `setupPriceSurface()` (`:243-268`)
+    //! built into the price surface, stripped through
+    //! `InterpolatedYoYOptionletStripper<Linear>` under the unit-displaced
+    //! Black engine at slope -0.5, and the K-surface's `Dslice` pinned against
+    //! `volATyear1[]`/`volATyear3[]` to `eps = 1e-4` (`:320-335`).
+    //!
+    //! Unlike the sibling ATM oracle (`yoycapfloortermpricesurface.rs`), this
+    //! test needs `setup()`'s `yoyEU` curve (`:164-190`) linked to the ratio
+    //! index: the engine forecasts each optionlet's forward off the *index's
+    //! own* year-on-year curve, while the stripper's generic index reads the
+    //! price surface's bootstrapped one.
+    //!
+    //! The upstream headers carry a stale `\bug Tests currently fail` note;
+    //! the C++ test was built and run against this tree on 2026-08-25 and
+    //! passes clean, so the header literals are the live target.
+
+    use super::*;
+    use crate::handle::Handle;
+    use crate::indexes::inflation::EuHicp;
+    use crate::indexes::inflationindex::{
+        CpiInterpolationType, YoYInflationIndex, inflation_period,
+    };
+    use crate::math::interpolations::cubic::Cubic;
+    use crate::math::matrix::Matrix;
+    use crate::shared::{shared, shared_mut};
+    use crate::termstructures::inflation::inflationtermstructure::YoYInflationTermStructure;
+    use crate::termstructures::inflation::interpolatedyoyinflationcurve::InterpolatedYoYInflationCurve;
+    use crate::termstructures::inflation::yoycapfloortermpricesurface::InterpolatedYoYCapFloorTermPriceSurface;
+    use crate::termstructures::yields::InterpolatedZeroCurve;
+    use crate::termstructures::yieldtermstructure::YieldTermStructure;
+    use crate::time::calendars::target::Target;
+    use crate::time::date::Month::November;
+    use crate::time::daycounters::actual365fixed::Actual365Fixed;
+    use crate::time::frequency::Frequency;
+    use crate::types::Integer;
+
+    use super::super::InterpolatedYoYOptionletStripper;
+
+    /// EUR nominal zero times, in years of 365 days (`:101-105`).
+    const TIMES_EUR: [Real; 25] = [
+        0.0109589, 0.0684932, 0.263014, 0.317808, 0.567123, 0.816438, 1.06575, 1.31507, 1.56438,
+        2.0137, 3.01918, 4.01644, 5.01644, 6.01644, 7.01644, 8.01644, 9.02192, 10.0192, 12.0192,
+        15.0247, 20.0301, 25.0356, 30.0329, 40.0384, 50.0466,
+    ];
+
+    /// EUR nominal zero rates (`:106-110`).
+    const RATES_EUR: [Real; 25] = [
+        0.0415600, 0.0426840, 0.0470980, 0.0458506, 0.0449550, 0.0439784, 0.0431887, 0.0426604,
+        0.0422925, 0.0424591, 0.0421477, 0.0421853, 0.0424016, 0.0426969, 0.0430804, 0.0435011,
+        0.0439368, 0.0443825, 0.0452589, 0.0463389, 0.0472636, 0.0473401, 0.0470629, 0.0461092,
+        0.0450794,
+    ];
+
+    /// EU year-on-year rates for the index's own curve (`:164-170`); the
+    /// first sits in the base period.
+    const YOY_EU_RATES: [Real; 31] = [
+        0.0237951, 0.0238749, 0.0240334, 0.0241934, 0.0243567, 0.0245323, 0.0247213, 0.0249348,
+        0.0251768, 0.0254337, 0.0257258, 0.0260217, 0.0263006, 0.0265538, 0.0267803, 0.0269378,
+        0.0270608, 0.0271363, 0.0272, 0.0272512, 0.0272927, 0.027317, 0.0273615, 0.0273811,
+        0.0274063, 0.0274307, 0.0274625, 0.027527, 0.0275952, 0.0276734, 0.027794,
+    ];
+
+    /// EU cap strikes (`:196`) and floor strikes (`:207`).
+    const C_STRIKES_EU: [Real; 6] = [0.02, 0.025, 0.03, 0.035, 0.04, 0.05];
+    const F_STRIKES_EU: [Real; 6] = [-0.01, 0.00, 0.005, 0.01, 0.015, 0.02];
+
+    /// EU cap prices by strike (rows) and maturity (columns) (`:199-205`).
+    const C_PRICES_EU: [[Real; 7]; 6] = [
+        [116.225, 204.945, 296.285, 434.29, 654.47, 844.775, 1132.33],
+        [34.305, 71.575, 114.1, 184.33, 307.595, 421.395, 602.35],
+        [6.37, 19.085, 35.635, 66.42, 127.69, 189.685, 296.195],
+        [1.325, 5.745, 12.585, 26.945, 58.95, 94.08, 158.985],
+        [0.501, 2.37, 5.38, 13.065, 31.91, 53.95, 96.97],
+        [0.501, 0.695, 1.47, 4.415, 12.86, 23.75, 46.7],
+    ];
+
+    /// EU floor prices by strike (rows) and maturity (columns) (`:208-214`).
+    const F_PRICES_EU: [[Real; 7]; 6] = [
+        [0.501, 0.851, 2.44, 6.645, 16.23, 26.85, 46.365],
+        [0.501, 2.236, 5.555, 13.075, 28.46, 44.525, 73.08],
+        [1.025, 3.935, 9.095, 19.64, 39.93, 60.375, 96.02],
+        [2.465, 7.885, 16.155, 31.6, 59.34, 86.21, 132.045],
+        [6.9, 17.92, 32.085, 56.08, 95.95, 132.85, 194.18],
+        [23.52, 47.625, 74.085, 114.355, 175.72, 229.565, 316.285],
+    ];
+
+    /// The T = 1y and T = 3y constant-time lines (`:320-329`), one entry per
+    /// strike of the 11-strike union.
+    const VOL_AT_YEAR1: [Real; 11] = [
+        0.0129, 0.0094, 0.0083, 0.0073, 0.0064, 0.0058, 0.0042, 0.0046, 0.0053, 0.0064, 0.0098,
+    ];
+    const VOL_AT_YEAR3: [Real; 11] = [
+        0.0080, 0.0058, 0.0051, 0.0045, 0.0040, 0.0035, 0.0026, 0.0028, 0.0033, 0.0040, 0.0061,
+    ];
+
+    const EPS: Real = 1e-4;
+
+    fn eval_date() -> Date {
+        Date::new(23, November, 2007)
+    }
+
+    fn cf_maturities_eu() -> Vec<Period> {
+        [3, 5, 7, 10, 15, 20, 30]
+            .into_iter()
+            .map(|n| Period::new(n, TimeUnit::Years))
+            .collect()
+    }
+
+    fn matrix_of(rows: &[[Real; 7]; 6]) -> Matrix {
+        let mut m = Matrix::with_size(6, 7);
+        for (i, row) in rows.iter().enumerate() {
+            for (j, &value) in row.iter().enumerate() {
+                m[(i, j)] = value;
+            }
+        }
+        m
+    }
+
+    /// The EUR nominal curve (`:129-140`), the day fraction truncated as the
+    /// C++ casts do.
+    fn eur_nominal_curve() -> Handle<dyn YieldTermStructure> {
+        let dates: Vec<Date> = TIMES_EUR
+            .iter()
+            .map(|&t| {
+                let ys = t.floor() as i32;
+                let ds = ((t - Real::from(ys)) * 365.0) as i32;
+                eval_date() + Period::new(ys, TimeUnit::Years) + Period::new(ds, TimeUnit::Days)
+            })
+            .collect();
+        let curve = InterpolatedZeroCurve::<Cubic>::new(
+            dates,
+            RATES_EUR.to_vec(),
+            Actual365Fixed::new(),
+            Cubic,
+        )
+        .expect("25 well-ordered nodes");
+        Handle::new(shared(curve) as Shared<dyn YieldTermStructure>)
+    }
+
+    /// The oracle (`:271-352`). `setup()` links the index to the `yoyEU`
+    /// curve, whose base date sits one month back of the evaluation date and
+    /// whose thirty yearly nodes run off the 2-month-lagged cap start date
+    /// (`:172-190`); `setupPriceSurface()` builds the 3-month-lag price
+    /// surface over the 6x7 EU matrices; the stripper then strips it at slope
+    /// -0.5 under the unit-displaced engine, whose volatility link starts
+    /// empty ("the vol gets set in the stripper ... else no point", `:287`).
+    #[test]
+    fn d_slice_recovers_the_one_and_three_year_vol_lines() {
+        let settings = shared(Settings::<Date>::new());
+        settings.set_evaluation_date(eval_date());
+
+        let yoy_handle = crate::handle::RelinkableHandle::<dyn YoYInflationTermStructure>::empty();
+        let index = shared(
+            YoYInflationIndex::from_underlying(shared(EuHicp::new(Shared::clone(&settings))))
+                .with_term_structure(yoy_handle.handle()),
+        );
+
+        let base_date = inflation_period(
+            eval_date() - Period::new(1, TimeUnit::Months),
+            index.frequency(),
+        )
+        .unwrap()
+        .0;
+        let mut dates = vec![base_date];
+        let mut rates = vec![YOY_EU_RATES[0]];
+        let cap_start = Target::new().advance(
+            eval_date(),
+            -2 as Integer,
+            TimeUnit::Months,
+            BusinessDayConvention::ModifiedFollowing,
+            false,
+        );
+        for (i, &rate) in YOY_EU_RATES.iter().enumerate().skip(1) {
+            dates.push(Target::new().advance(
+                cap_start,
+                i as Integer,
+                TimeUnit::Years,
+                BusinessDayConvention::ModifiedFollowing,
+                false,
+            ));
+            rates.push(rate);
+        }
+        let yoy_eu = shared(
+            InterpolatedYoYInflationCurve::<Linear>::new(
+                eval_date(),
+                dates,
+                rates,
+                Frequency::Monthly,
+                Actual365Fixed::new(),
+                Linear,
+                None,
+            )
+            .expect("31 well-ordered nodes"),
+        ) as Shared<dyn YoYInflationTermStructure>;
+        yoy_handle.link_to(yoy_eu);
+
+        let price_surface = shared(
+            InterpolatedYoYCapFloorTermPriceSurface::new(
+                0,
+                Period::new(3, TimeUnit::Months),
+                Shared::clone(&index),
+                CpiInterpolationType::Linear,
+                eur_nominal_curve(),
+                Actual365Fixed::new(),
+                Target::new(),
+                BusinessDayConvention::ModifiedFollowing,
+                C_STRIKES_EU.to_vec(),
+                F_STRIKES_EU.to_vec(),
+                cf_maturities_eu(),
+                matrix_of(&C_PRICES_EU),
+                matrix_of(&F_PRICES_EU),
+                Shared::clone(&settings),
+            )
+            .expect("the EU fixture is consistent"),
+        ) as Shared<dyn YoYCapFloorTermPriceSurface>;
+        let lag = price_surface.observation_lag();
+
+        let vol_handle = RelinkableHandle::<dyn YoYOptionletVolatilitySurface>::empty();
+        let pricer = shared_mut(YoYInflationCapFloorEngine::unit_displaced(
+            Shared::clone(&index),
+            vol_handle.handle(),
+            eur_nominal_curve(),
+        ));
+        let stripper = shared(InterpolatedYoYOptionletStripper::<Linear>::new())
+            as Shared<dyn YoYOptionletStripper>;
+
+        let yoy_surf = KInterpolatedYoYOptionletVolatilitySurface::<Linear>::new(
+            0,
+            Target::new(),
+            BusinessDayConvention::ModifiedFollowing,
+            Actual365Fixed::new(),
+            lag,
+            price_surface,
+            &pricer,
+            &vol_handle,
+            stripper,
+            -0.5,
+            Shared::clone(&settings),
+        )
+        .expect("the stripping succeeds");
+
+        let base = yoy_surf.base_date().unwrap();
+
+        let year1 = yoy_surf
+            .d_slice(base + Period::new(1, TimeUnit::Years))
+            .unwrap();
+        assert_eq!(year1.0.len(), 11);
+        for (i, (vol, expected)) in year1.1.iter().zip(VOL_AT_YEAR1).enumerate() {
+            assert!(
+                (vol - expected).abs() < EPS,
+                "could not recover 1yr vol at strike {i} ({}): {vol} vs {expected}",
+                year1.0[i]
+            );
+        }
+
+        let year3 = yoy_surf
+            .d_slice(base + Period::new(3, TimeUnit::Years))
+            .unwrap();
+        assert_eq!(year3.0.len(), 11);
+        for (i, (vol, expected)) in year3.1.iter().zip(VOL_AT_YEAR3).enumerate() {
+            assert!(
+                (vol - expected).abs() < EPS,
+                "could not recover 3yr vol at strike {i} ({}): {vol} vs {expected}",
+                year3.0[i]
+            );
+        }
+    }
+}

--- a/crates/libitofin/src/termstructures/volatility/inflation/mod.rs
+++ b/crates/libitofin/src/termstructures/volatility/inflation/mod.rs
@@ -58,6 +58,7 @@ mod constantyoyoptionletvol;
 mod interpolatedyoyoptionletvol;
 mod piecewiseyoyoptionletvol;
 mod yoyoptionlethelpers;
+mod yoyoptionletstripper;
 mod yoyoptionletvolsurfacebase;
 
 pub use constantyoyoptionletvol::ConstantYoYOptionletVolatility;
@@ -68,6 +69,7 @@ pub use piecewiseyoyoptionletvol::{
 pub use yoyoptionlethelpers::{
     YoYOptionletHelper, YoYOptionletVolHelperBase, YoYOptionletVolatilityHelper,
 };
+pub use yoyoptionletstripper::YoYOptionletStripper;
 pub use yoyoptionletvolsurfacebase::YoYOptionletVolatilitySurfaceBase;
 
 use crate::errors::QlResult;

--- a/crates/libitofin/src/termstructures/volatility/inflation/mod.rs
+++ b/crates/libitofin/src/termstructures/volatility/inflation/mod.rs
@@ -62,7 +62,9 @@ mod yoyoptionletvolsurfacebase;
 
 pub use constantyoyoptionletvol::ConstantYoYOptionletVolatility;
 pub use interpolatedyoyoptionletvol::InterpolatedYoYOptionletVolatilityCurve;
-pub use piecewiseyoyoptionletvol::YoYInflationVolatilityTraits;
+pub use piecewiseyoyoptionletvol::{
+    PiecewiseYoYOptionletVolatilityCurve, YoYInflationVolatilityTraits,
+};
 pub use yoyoptionlethelpers::{
     YoYOptionletHelper, YoYOptionletVolHelperBase, YoYOptionletVolatilityHelper,
 };

--- a/crates/libitofin/src/termstructures/volatility/inflation/mod.rs
+++ b/crates/libitofin/src/termstructures/volatility/inflation/mod.rs
@@ -56,6 +56,7 @@
 
 mod constantyoyoptionletvol;
 mod interpolatedyoyoptionletvol;
+mod kinterpolatedyoyoptionletvol;
 mod piecewiseyoyoptionletvol;
 mod yoyoptionlethelpers;
 mod yoyoptionletstripper;
@@ -63,6 +64,7 @@ mod yoyoptionletvolsurfacebase;
 
 pub use constantyoyoptionletvol::ConstantYoYOptionletVolatility;
 pub use interpolatedyoyoptionletvol::InterpolatedYoYOptionletVolatilityCurve;
+pub use kinterpolatedyoyoptionletvol::KInterpolatedYoYOptionletVolatilitySurface;
 pub use piecewiseyoyoptionletvol::{
     PiecewiseYoYOptionletVolatilityCurve, YoYInflationVolatilityTraits,
 };

--- a/crates/libitofin/src/termstructures/volatility/inflation/mod.rs
+++ b/crates/libitofin/src/termstructures/volatility/inflation/mod.rs
@@ -55,9 +55,11 @@
 //! apiece on the same branch.
 
 mod constantyoyoptionletvol;
+mod interpolatedyoyoptionletvol;
 mod yoyoptionletvolsurfacebase;
 
 pub use constantyoyoptionletvol::ConstantYoYOptionletVolatility;
+pub use interpolatedyoyoptionletvol::InterpolatedYoYOptionletVolatilityCurve;
 pub use yoyoptionletvolsurfacebase::YoYOptionletVolatilitySurfaceBase;
 
 use crate::errors::QlResult;

--- a/crates/libitofin/src/termstructures/volatility/inflation/mod.rs
+++ b/crates/libitofin/src/termstructures/volatility/inflation/mod.rs
@@ -56,11 +56,13 @@
 
 mod constantyoyoptionletvol;
 mod interpolatedyoyoptionletvol;
+mod piecewiseyoyoptionletvol;
 mod yoyoptionlethelpers;
 mod yoyoptionletvolsurfacebase;
 
 pub use constantyoyoptionletvol::ConstantYoYOptionletVolatility;
 pub use interpolatedyoyoptionletvol::InterpolatedYoYOptionletVolatilityCurve;
+pub use piecewiseyoyoptionletvol::YoYInflationVolatilityTraits;
 pub use yoyoptionlethelpers::{
     YoYOptionletHelper, YoYOptionletVolHelperBase, YoYOptionletVolatilityHelper,
 };

--- a/crates/libitofin/src/termstructures/volatility/inflation/mod.rs
+++ b/crates/libitofin/src/termstructures/volatility/inflation/mod.rs
@@ -16,7 +16,9 @@
 //! ## Shape
 //!
 //! The trait carries the three members the pricer calls
-//! (`inflationcouponpricer.cpp:99`, `:114-117`) and nothing else. C++ reaches
+//! (`inflationcouponpricer.cpp:99`, `:114-117`), plus the defaulted
+//! [`base_level`](YoYOptionletVolatilitySurface::base_level) whose default *is*
+//! C++'s unset state, and nothing else. C++ reaches
 //! them through `VolatilityTermStructure`, whose `timeFromBase`, `baseLevel`,
 //! `checkRange` and tenor-keyed overloads serve the stripping hierarchy rather
 //! than the coupon; [`ConstantYoYOptionletVolatility`] implements
@@ -42,17 +44,21 @@
 //!
 //! ## Deferred (visible)
 //!
-//! Only the flat surface lands here. The stripped and interpolated hierarchy -
+//! The flat surface and, from #874, the stripped and interpolated hierarchy of
+//! `ql/experimental/inflation/` land here: the shared
+//! [`YoYOptionletVolatilitySurfaceBase`] holder first, with `baseLevel` -
+//! which exists to seed the stripping bootstraps - as the trait's
+//! [`base_level`](YoYOptionletVolatilitySurface::base_level), then
 //! `InterpolatedYoYOptionletVolatilityCurve`,
-//! `KInterpolatedYoYOptionletVolatilitySurface`, the optionlet strippers and
-//! `PiecewiseYoYOptionletVolatilityCurve`, all of `ql/experimental/inflation/` -
-//! has no port, and neither do the `YoYInflationCapFloor` engines that consume
-//! it (`#851`). `baseLevel`, which exists to seed those bootstraps, goes with
-//! them.
+//! `PiecewiseYoYOptionletVolatilityCurve` and its helpers, the optionlet
+//! strippers and `KInterpolatedYoYOptionletVolatilitySurface`, one commit
+//! apiece on the same branch.
 
 mod constantyoyoptionletvol;
+mod yoyoptionletvolsurfacebase;
 
 pub use constantyoyoptionletvol::ConstantYoYOptionletVolatility;
+pub use yoyoptionletvolsurfacebase::YoYOptionletVolatilitySurfaceBase;
 
 use crate::errors::QlResult;
 use crate::patterns::observable::AsObservable;
@@ -100,4 +106,21 @@ pub trait YoYOptionletVolatilitySurface: AsObservable {
     /// As [`volatility`](Self::volatility), plus a surface carrying no day
     /// counter to measure the elapsed time with.
     fn total_variance(&self, date: Date, strike: Rate, obs_lag: Period) -> QlResult<Real>;
+
+    /// The volatility acting as the zero-time value for a stripping bootstrap
+    /// (`baseLevel`, `hpp:123-128`).
+    ///
+    /// C++ initialises the member to the `Null<Volatility>` sentinel and throws
+    /// on an unset read; under D4/D10 the unset state is this default `Err`.
+    /// The stripped surfaces of #874 override it with the level their
+    /// constructors or interpolations set (`setBaseLevel`, `hpp:141`, which
+    /// stays on the concrete types); the flat surface, which no bootstrap
+    /// seeds from, keeps the unset answer.
+    ///
+    /// # Errors
+    ///
+    /// When no base level has been set.
+    fn base_level(&self) -> QlResult<Volatility> {
+        crate::fail!("base volatility, for base_date(), not set")
+    }
 }

--- a/crates/libitofin/src/termstructures/volatility/inflation/mod.rs
+++ b/crates/libitofin/src/termstructures/volatility/inflation/mod.rs
@@ -69,7 +69,7 @@ pub use piecewiseyoyoptionletvol::{
 pub use yoyoptionlethelpers::{
     YoYOptionletHelper, YoYOptionletVolHelperBase, YoYOptionletVolatilityHelper,
 };
-pub use yoyoptionletstripper::YoYOptionletStripper;
+pub use yoyoptionletstripper::{InterpolatedYoYOptionletStripper, YoYOptionletStripper};
 pub use yoyoptionletvolsurfacebase::YoYOptionletVolatilitySurfaceBase;
 
 use crate::errors::QlResult;

--- a/crates/libitofin/src/termstructures/volatility/inflation/mod.rs
+++ b/crates/libitofin/src/termstructures/volatility/inflation/mod.rs
@@ -42,17 +42,18 @@
 //! which under D10 refuses rather than inventing one when no evaluation date is
 //! set, and the period snapping refuses a frequency finer than monthly.
 //!
-//! ## Deferred (visible)
+//! ## The stripped hierarchy (#874)
 //!
-//! The flat surface and, from #874, the stripped and interpolated hierarchy of
-//! `ql/experimental/inflation/` land here: the shared
-//! [`YoYOptionletVolatilitySurfaceBase`] holder first, with `baseLevel` -
-//! which exists to seed the stripping bootstraps - as the trait's
-//! [`base_level`](YoYOptionletVolatilitySurface::base_level), then
-//! `InterpolatedYoYOptionletVolatilityCurve`,
-//! `PiecewiseYoYOptionletVolatilityCurve` and its helpers, the optionlet
-//! strippers and `KInterpolatedYoYOptionletVolatilitySurface`, one commit
-//! apiece on the same branch.
+//! The stripped and interpolated hierarchy of `ql/experimental/inflation/`
+//! lands here beside the flat surface: the shared
+//! [`YoYOptionletVolatilitySurfaceBase`] holder - with `baseLevel`, which
+//! exists to seed the stripping bootstraps, as the trait's defaulted
+//! [`base_level`](YoYOptionletVolatilitySurface::base_level) -
+//! [`InterpolatedYoYOptionletVolatilityCurve`],
+//! [`PiecewiseYoYOptionletVolatilityCurve`] and its [`YoYOptionletHelper`]s,
+//! the [`YoYOptionletStripper`]s and
+//! [`KInterpolatedYoYOptionletVolatilitySurface`], whose `Dslice` oracle
+//! (`test-suite/inflationvolatility.cpp:271-352`) closes the stack.
 
 mod constantyoyoptionletvol;
 mod interpolatedyoyoptionletvol;

--- a/crates/libitofin/src/termstructures/volatility/inflation/mod.rs
+++ b/crates/libitofin/src/termstructures/volatility/inflation/mod.rs
@@ -56,10 +56,14 @@
 
 mod constantyoyoptionletvol;
 mod interpolatedyoyoptionletvol;
+mod yoyoptionlethelpers;
 mod yoyoptionletvolsurfacebase;
 
 pub use constantyoyoptionletvol::ConstantYoYOptionletVolatility;
 pub use interpolatedyoyoptionletvol::InterpolatedYoYOptionletVolatilityCurve;
+pub use yoyoptionlethelpers::{
+    YoYOptionletHelper, YoYOptionletVolHelperBase, YoYOptionletVolatilityHelper,
+};
 pub use yoyoptionletvolsurfacebase::YoYOptionletVolatilitySurfaceBase;
 
 use crate::errors::QlResult;

--- a/crates/libitofin/src/termstructures/volatility/inflation/piecewiseyoyoptionletvol.rs
+++ b/crates/libitofin/src/termstructures/volatility/inflation/piecewiseyoyoptionletvol.rs
@@ -38,8 +38,32 @@
 //! [`PiecewiseCurve::initial_date`]: crate::termstructures::iterativebootstrap::PiecewiseCurve::initial_date
 //! [`PiecewiseCurve::initial_value`]: crate::termstructures::iterativebootstrap::PiecewiseCurve::initial_value
 
-use crate::termstructures::bootstraptraits::BootstrapTraits;
-use crate::types::{Real, Size, Time};
+use std::cell::RefCell;
+use std::rc::Weak;
+
+use crate::errors::QlResult;
+use crate::math::interpolations::linear::Linear;
+use crate::math::interpolations::{Interpolation, Interpolator};
+use crate::patterns::lazyobject::LazyObject;
+use crate::patterns::observable::{AsObservable, Observable, Observer};
+use crate::require;
+use crate::settings::Settings;
+use crate::shared::{Shared, SharedMut, shared_mut};
+use crate::termstructures::bootstraptraits::{BootstrapTraits, CurveData};
+use crate::termstructures::iterativebootstrap::{IterativeBootstrap, PiecewiseCurve};
+use crate::termstructures::volatility::VolatilityTermStructure;
+use crate::termstructures::{TermStructure, TermStructureBase};
+use crate::time::businessdayconvention::BusinessDayConvention;
+use crate::time::calendar::Calendar;
+use crate::time::date::Date;
+use crate::time::daycounter::DayCounter;
+use crate::time::frequency::Frequency;
+use crate::time::period::Period;
+use crate::time::timeunit::TimeUnit;
+use crate::types::{Natural, Rate, Real, Size, Time, Volatility};
+
+use super::yoyoptionlethelpers::YoYOptionletVolatilityHelper;
+use super::{YoYOptionletVolatilitySurface, YoYOptionletVolatilitySurfaceBase};
 
 /// Traits for the inflation-volatility bootstrap
 /// (`YoYInflationVolatilityTraits`, `hpp:36-96`).
@@ -87,5 +111,317 @@ impl BootstrapTraits for YoYInflationVolatilityTraits {
     /// The convergence-loop cap (`hpp:95`).
     fn max_iterations() -> Size {
         25
+    }
+}
+
+/// Feeds a helper-quote or evaluation-date notification into the curve's lazy
+/// core: it invalidates the bootstrap cache and re-broadcasts to the curve's
+/// own observers (the port of `update()`, `hpp:226-230`).
+struct CurveUpdater {
+    lazy: SharedMut<LazyObject>,
+}
+
+impl Observer for CurveUpdater {
+    fn update(&mut self) {
+        if let Some(update) = LazyObject::deferred_update(&self.lazy) {
+            update.notify_observers();
+        }
+    }
+}
+
+/// Piecewise year-on-year optionlet volatility curve
+/// (`PiecewiseYoYOptionletVolatilityCurve`, `hpp:105-175`).
+///
+/// `I` is the interpolation factory ([`Linear`]); the shape traits are always
+/// [`YoYInflationVolatilityTraits`], the nodes being the optionlet
+/// volatilities themselves.
+pub struct PiecewiseYoYOptionletVolatilityCurve<I: Interpolator> {
+    vol_base: YoYOptionletVolatilitySurfaceBase,
+    min_strike: Rate,
+    max_strike: Rate,
+    instruments: Vec<Shared<dyn YoYOptionletVolatilityHelper>>,
+    interpolator: I,
+    data: RefCell<CurveData<I>>,
+    lazy: SharedMut<LazyObject>,
+    observable: Shared<Observable>,
+    updater: SharedMut<CurveUpdater>,
+    bootstrap: IterativeBootstrap,
+    accuracy: Real,
+    self_weak: Weak<dyn YoYOptionletVolatilitySurface>,
+}
+
+impl PiecewiseYoYOptionletVolatilityCurve<Linear> {
+    /// Builds a linearly interpolated curve over `instruments`
+    /// (`hpp:121-148`). Construction is cheap; the bootstrap runs on first
+    /// use. `base_yoy_volatility` is the artificial volatility at the base
+    /// date - the C++ constructor forwards it into the protected
+    /// interpolated-curve constructor, whose whole job is `setBaseLevel`
+    /// (`yoyinflationoptionletvolatilitystructure2.hpp:156-176`) - and it is
+    /// what node zero is seeded with and keeps.
+    ///
+    /// # Errors
+    ///
+    /// Rejects an empty helper set.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        settlement_days: Natural,
+        calendar: Calendar,
+        business_day_convention: BusinessDayConvention,
+        day_counter: DayCounter,
+        observation_lag: Period,
+        frequency: Frequency,
+        index_is_interpolated: bool,
+        min_strike: Rate,
+        max_strike: Rate,
+        base_yoy_volatility: Volatility,
+        instruments: Vec<Shared<dyn YoYOptionletVolatilityHelper>>,
+        settings: Shared<Settings<Date>>,
+    ) -> QlResult<Shared<PiecewiseYoYOptionletVolatilityCurve<Linear>>> {
+        require!(!instruments.is_empty(), "no bootstrap helpers given");
+
+        let curve = Shared::new_cyclic(
+            |weak: &Weak<PiecewiseYoYOptionletVolatilityCurve<Linear>>| {
+                let self_weak: Weak<dyn YoYOptionletVolatilitySurface> = weak.clone();
+                let lazy = shared_mut(LazyObject::new(true));
+                let observable = lazy.borrow().observable_handle();
+                let updater = shared_mut(CurveUpdater {
+                    lazy: SharedMut::clone(&lazy),
+                });
+                let vol_base = YoYOptionletVolatilitySurfaceBase::new(
+                    settlement_days,
+                    calendar,
+                    business_day_convention,
+                    day_counter,
+                    observation_lag,
+                    frequency,
+                    index_is_interpolated,
+                    settings,
+                );
+                vol_base.set_base_level(base_yoy_volatility);
+                PiecewiseYoYOptionletVolatilityCurve {
+                    vol_base,
+                    min_strike,
+                    max_strike,
+                    instruments,
+                    interpolator: Linear,
+                    data: RefCell::new(CurveData::new()),
+                    lazy,
+                    observable,
+                    updater,
+                    bootstrap: IterativeBootstrap::new(),
+                    accuracy: 1.0e-12,
+                    self_weak,
+                }
+            },
+        );
+
+        let observer = SharedMut::clone(&curve.updater) as SharedMut<dyn Observer>;
+        for helper in &curve.instruments {
+            helper.observable().register_observer(&observer);
+        }
+        // The reference date moves with the evaluation date, whose change must
+        // invalidate the bootstrap; the term base broadcasts it and the lazy
+        // core turns it into a re-solve on the next read.
+        curve
+            .vol_base
+            .term_structure_base()
+            .observable()
+            .register_observer(&observer);
+        Ok(curve)
+    }
+}
+
+impl<I: Interpolator + 'static> PiecewiseYoYOptionletVolatilityCurve<I> {
+    /// Runs the bootstrap if the cache is stale, caching the result
+    /// (`performCalculations`, `hpp:220-224`; the stripper calls C++'s
+    /// `recalculate()` on a fresh curve, which this equals). Re-entrant: a
+    /// helper repricing mid-bootstrap - every one does, through the engine
+    /// reading this same surface - returns on the pre-set flag and answers off
+    /// the solved prefix.
+    pub fn calculate(&self) -> QlResult<()> {
+        if self.lazy.borrow().is_calculated() {
+            return Ok(());
+        }
+        if !self.lazy.borrow_mut().start_calculation() {
+            return Ok(());
+        }
+        let result = self.bootstrap.calculate(self);
+        self.lazy.borrow_mut().finish_calculation(&result);
+        result
+    }
+
+    /// The node times, after bootstrapping (`hpp:192-197`). The first is
+    /// negative, the base date preceding the reference date.
+    pub fn times(&self) -> QlResult<Vec<Time>> {
+        self.calculate()?;
+        Ok(self.data.borrow().times().to_vec())
+    }
+
+    /// The node dates, after bootstrapping (`hpp:199-204`). The first is the
+    /// base date.
+    pub fn dates(&self) -> QlResult<Vec<Date>> {
+        self.calculate()?;
+        Ok(self.data.borrow().dates().to_vec())
+    }
+
+    /// The node volatilities, after bootstrapping (`hpp:206-211`). The first
+    /// is the base level the curve was built with.
+    pub fn data(&self) -> QlResult<Vec<Real>> {
+        self.calculate()?;
+        Ok(self.data.borrow().data().to_vec())
+    }
+
+    /// The (date, volatility) nodes, after bootstrapping (`hpp:213-218`).
+    pub fn nodes(&self) -> QlResult<Vec<(Date, Real)>> {
+        self.calculate()?;
+        Ok(self.data.borrow().nodes())
+    }
+
+    /// Registers a downstream observer of the curve's notifications.
+    pub fn register_observer(&self, observer: &SharedMut<dyn Observer>) -> bool {
+        self.observable.register_observer(observer)
+    }
+
+    /// For the curve the strike is ignored, the smile being flat; C++
+    /// evaluates without extrapolation
+    /// (`yoyinflationoptionletvolatilitystructure2.hpp:180-186`), and every
+    /// read of the bootstrap - the last coupon of pillar `i`'s helper fixes
+    /// *on* node `i` - lands inside the solved prefix.
+    fn volatility_impl(&self, t: Time) -> QlResult<Volatility> {
+        self.calculate()?;
+        let data = self.data.borrow();
+        data.interpolation()?.value(t)
+    }
+}
+
+impl<I: Interpolator> AsObservable for PiecewiseYoYOptionletVolatilityCurve<I> {
+    fn observable(&self) -> &Observable {
+        &self.observable
+    }
+}
+
+impl<I: Interpolator + 'static> TermStructure for PiecewiseYoYOptionletVolatilityCurve<I> {
+    fn base(&self) -> &TermStructureBase {
+        self.vol_base.term_structure_base()
+    }
+
+    /// `maxDate` triggers the bootstrap (`hpp:186-190`) and then runs the base
+    /// curve's approximation: the reference date advanced by the last node
+    /// time rounded up to whole years
+    /// (`yoyinflationoptionletvolatilitystructure2.hpp:73-76`). Fallbacks
+    /// follow the sibling piecewise curves: the reference date, then the null
+    /// date.
+    fn max_date(&self) -> Date {
+        let _ = self.calculate();
+        let t_max = self.data.borrow().times().last().copied();
+        match t_max {
+            Some(t_max) => self
+                .option_date_from_tenor(Period::new(t_max.ceil() as i32, TimeUnit::Years))
+                .unwrap_or_else(|_| Date::null()),
+            None => self
+                .vol_base
+                .term_structure_base()
+                .reference_date()
+                .unwrap_or_else(|_| Date::null()),
+        }
+    }
+}
+
+impl<I: Interpolator + 'static> VolatilityTermStructure
+    for PiecewiseYoYOptionletVolatilityCurve<I>
+{
+    fn business_day_convention(&self) -> BusinessDayConvention {
+        self.vol_base.business_day_convention()
+    }
+
+    fn min_strike(&self) -> Rate {
+        self.min_strike
+    }
+
+    fn max_strike(&self) -> Rate {
+        self.max_strike
+    }
+}
+
+impl<I: Interpolator + 'static> YoYOptionletVolatilitySurface
+    for PiecewiseYoYOptionletVolatilityCurve<I>
+{
+    /// `baseDate` triggers the bootstrap first (`hpp:180-184`), then runs the
+    /// shared date arithmetic.
+    fn base_date(&self) -> QlResult<Date> {
+        self.calculate()?;
+        self.vol_base.base_date()
+    }
+
+    fn volatility(&self, date: Date, strike: Rate, obs_lag: Period) -> QlResult<Volatility> {
+        let observed = self.vol_base.observed(date - obs_lag)?;
+        self.vol_base.check_range(
+            observed,
+            strike,
+            self.min_strike,
+            self.max_strike,
+            TermStructure::max_date(self),
+        )?;
+        self.volatility_impl(TermStructure::time_from_reference(self, observed)?)
+    }
+
+    fn total_variance(&self, date: Date, strike: Rate, obs_lag: Period) -> QlResult<Real> {
+        let volatility = self.volatility(date, strike, obs_lag)?;
+        Ok(volatility * volatility * self.vol_base.time_from_base(date, obs_lag)?)
+    }
+
+    fn base_level(&self) -> QlResult<Volatility> {
+        self.vol_base.base_level()
+    }
+}
+
+impl<I: Interpolator + 'static> PiecewiseCurve for PiecewiseYoYOptionletVolatilityCurve<I> {
+    type Traits = YoYInflationVolatilityTraits;
+    type Interp = I;
+    type TS = dyn YoYOptionletVolatilitySurface;
+    type Helper = dyn YoYOptionletVolatilityHelper;
+
+    fn instruments(&self) -> &[Shared<dyn YoYOptionletVolatilityHelper>] {
+        &self.instruments
+    }
+
+    fn interpolator(&self) -> &I {
+        &self.interpolator
+    }
+
+    fn curve_data(&self) -> &RefCell<CurveData<I>> {
+        &self.data
+    }
+
+    fn accuracy(&self) -> Real {
+        self.accuracy
+    }
+
+    fn reference_date(&self) -> QlResult<Date> {
+        self.vol_base.term_structure_base().reference_date()
+    }
+
+    /// The curve's own base date (`Traits::initialDate`, `hpp:41-43`), which
+    /// precedes the reference date, so node zero sits at a negative time.
+    fn initial_date(&self) -> QlResult<Date> {
+        self.vol_base.base_date()
+    }
+
+    /// The curve's own base level (`Traits::initialValue`, `hpp:45-51`),
+    /// where the yield conventions take a traits constant; an `Err` if it was
+    /// never set, though the public constructor always sets it.
+    fn initial_value(&self) -> QlResult<Real> {
+        self.vol_base.base_level()
+    }
+
+    fn time_from_reference(&self, date: Date) -> QlResult<Time> {
+        TermStructure::time_from_reference(self, date)
+    }
+
+    fn term_structure_shared(&self) -> QlResult<Shared<dyn YoYOptionletVolatilitySurface>> {
+        match self.self_weak.upgrade() {
+            Some(curve) => Ok(curve),
+            None => crate::fail!("curve dropped before bootstrap"),
+        }
     }
 }

--- a/crates/libitofin/src/termstructures/volatility/inflation/piecewiseyoyoptionletvol.rs
+++ b/crates/libitofin/src/termstructures/volatility/inflation/piecewiseyoyoptionletvol.rs
@@ -1,0 +1,91 @@
+//! Piecewise-bootstrapped year-on-year optionlet volatility curve.
+//!
+//! Port of `ql/experimental/inflation/piecewiseyoyoptionletvolatility.hpp`:
+//! [`YoYInflationVolatilityTraits`] (`hpp:36-96`) drives the bootstrap's seed,
+//! guesses and brackets, and [`PiecewiseYoYOptionletVolatilityCurve`]
+//! (`hpp:105-175`) is the curve, one per strike of the stripper, fitted to
+//! [`YoYOptionletVolatilityHelper`]s by the same [`IterativeBootstrap`] every
+//! other piecewise curve runs. "We use a flat smile for bootstrapping at
+//! constant K" (`hpp:100-103`): the smile is flat, the strike bounds a thin
+//! band around the quoted K.
+//!
+//! It mirrors [`PiecewiseYoYInflationCurve`] field for field; C++ derives from
+//! `InterpolatedYoYOptionletVolatilityCurve<Interpolator>` *and* `LazyObject`
+//! (`hpp:108-110`), and Rust has no inheritance, so the node storage lives
+//! here and the volatility lookup reads it directly.
+//!
+//! ## Node zero carries the base level
+//!
+//! `YoYInflationVolatilityTraits::initialDate` is the curve's own base date
+//! and `initialValue` its own base level (`hpp:41-51` - "REALLLYYYY important
+//! because generally don't have a clue what this should be"), both read off
+//! the curve being bootstrapped. They land here as the
+//! [`PiecewiseCurve::initial_date`]/[`PiecewiseCurve::initial_value`] hook
+//! overrides, the same seam [`PiecewiseYoYInflationCurve`] uses for its base
+//! rate; `updateGuess` writes only node `i` (`hpp:89-93`), so the seeded level
+//! survives the whole solve.
+//!
+//! ## Divergences from QuantLib
+//!
+//! - The moving reference date takes the shared [`Settings`] handle (D5).
+//! - The `accuracy` constructor argument (`hpp:133`) is not exposed, matching
+//!   the sibling curves; the field carries the C++ default `1.0e-12`.
+//! - Only [`Linear`] is constructible, the impls staying generic, exactly as
+//!   on [`PiecewiseYoYInflationCurve`].
+//!
+//! [`PiecewiseYoYInflationCurve`]: crate::termstructures::inflation::piecewiseyoyinflationcurve::PiecewiseYoYInflationCurve
+//! [`IterativeBootstrap`]: crate::termstructures::iterativebootstrap::IterativeBootstrap
+//! [`PiecewiseCurve::initial_date`]: crate::termstructures::iterativebootstrap::PiecewiseCurve::initial_date
+//! [`PiecewiseCurve::initial_value`]: crate::termstructures::iterativebootstrap::PiecewiseCurve::initial_value
+
+use crate::termstructures::bootstraptraits::BootstrapTraits;
+use crate::types::{Real, Size, Time};
+
+/// Traits for the inflation-volatility bootstrap
+/// (`YoYInflationVolatilityTraits`, `hpp:36-96`).
+pub struct YoYInflationVolatilityTraits;
+
+impl BootstrapTraits for YoYInflationVolatilityTraits {
+    /// C++ has no constant here: `initialValue` reads the bootstrapped curve's
+    /// own `baseLevel()` (`hpp:45-51`), which lands as
+    /// [`PiecewiseYoYOptionletVolatilityCurve`]'s `initial_value` hook
+    /// override, so this static is never the seeding path. A zero volatility
+    /// stands in for the total function the trait requires.
+    fn initial_value() -> Real {
+        0.0
+    }
+
+    /// The per-node guess (`hpp:54-68`): the stored node on a seeded pass,
+    /// `0.005` at the first pillar, `0.002` after it.
+    fn guess(i: Size, _times: &[Time], data: &[Real], valid_data: bool) -> Real {
+        if valid_data {
+            return data[i];
+        }
+        if i == 1 {
+            return 0.005;
+        }
+        0.002
+    }
+
+    /// The lower bracket (`hpp:71-78`): two vol points under the previous
+    /// node, floored at zero - "vol cannot be negative".
+    fn min_value_after(i: Size, _times: &[Time], data: &[Real], _valid_data: bool) -> Real {
+        (data[i - 1] - 0.02).max(0.0)
+    }
+
+    /// The upper bracket (`hpp:79-86`): two vol points over the previous node.
+    fn max_value_after(i: Size, _times: &[Time], data: &[Real], _valid_data: bool) -> Real {
+        data[i - 1] + 0.02
+    }
+
+    /// Writes a solved level back (`hpp:89-93`): node `i` takes it and nothing
+    /// else moves, so the seeded base level is never overwritten.
+    fn update_guess(data: &mut [Real], value: Real, i: Size) {
+        data[i] = value;
+    }
+
+    /// The convergence-loop cap (`hpp:95`).
+    fn max_iterations() -> Size {
+        25
+    }
+}

--- a/crates/libitofin/src/termstructures/volatility/inflation/piecewiseyoyoptionletvol.rs
+++ b/crates/libitofin/src/termstructures/volatility/inflation/piecewiseyoyoptionletvol.rs
@@ -425,3 +425,247 @@ impl<I: Interpolator + 'static> PiecewiseCurve for PiecewiseYoYOptionletVolatili
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! The C++ suite reaches this curve only through the stripper, whose
+    //! numeric oracle closes with the K-interpolated surface; what is checked
+    //! here is what the curve decides on its own, against a helper written to
+    //! make those decisions visible. The mock reprices off *two* points of the
+    //! surface, its pillar and the base date, so its solved node is
+    //! `2 * quote - base_level`: a curve seeded from anything but its own base
+    //! level lands every node somewhere else while still repricing perfectly.
+
+    use super::super::yoyoptionlethelpers::YoYOptionletVolHelperBase;
+    use super::*;
+    use crate::handle::Handle;
+    use crate::quotes::{Quote, SimpleQuote};
+    use crate::shared::shared;
+    use crate::time::calendars::target::Target;
+    use crate::time::date::Month::{April, June};
+    use crate::time::daycounters::actual365fixed::Actual365Fixed;
+
+    /// Distinct from every solved pillar and from the traits' guesses.
+    const BASE_LEVEL: Volatility = 0.01;
+    const QUOTES: [Real; 3] = [0.012, 0.013, 0.011];
+    const MATURITY_YEARS: [i32; 3] = [1, 2, 3];
+
+    fn zero_lag() -> Period {
+        Period::new(0, TimeUnit::Days)
+    }
+
+    /// A helper whose implied quote is the mean of the surface's volatility at
+    /// its pillar and at the base date, both read at the quoted strike with no
+    /// further lag; the fixture's index interpolates, so the observed date is
+    /// the query date itself and the reads land on nodes.
+    struct MeanVolHelper {
+        base: YoYOptionletVolHelperBase,
+    }
+
+    impl MeanVolHelper {
+        fn new(quote: &Shared<SimpleQuote>, pillar: Date) -> Shared<MeanVolHelper> {
+            let base = YoYOptionletVolHelperBase::new(Handle::new(
+                Shared::clone(quote) as Shared<dyn Quote>
+            ));
+            base.set_pillar_date(pillar);
+            base.set_latest_relevant_date(pillar);
+            base.set_maturity_date(pillar);
+            shared(MeanVolHelper { base })
+        }
+    }
+
+    impl AsObservable for MeanVolHelper {
+        fn observable(&self) -> &Observable {
+            self.base.observable()
+        }
+    }
+
+    impl YoYOptionletVolatilityHelper for MeanVolHelper {
+        fn base(&self) -> &YoYOptionletVolHelperBase {
+            &self.base
+        }
+
+        fn implied_quote(&self) -> QlResult<Real> {
+            let surface = self.base.term_structure()?;
+            let at_pillar = surface.volatility(self.base.pillar_date(), 0.02, zero_lag())?;
+            let at_base = surface.volatility(surface.base_date()?, 0.02, zero_lag())?;
+            Ok(0.5 * (at_pillar + at_base))
+        }
+    }
+
+    struct Fixture {
+        helpers: Vec<Shared<dyn YoYOptionletVolatilityHelper>>,
+        curve: Shared<PiecewiseYoYOptionletVolatilityCurve<Linear>>,
+        quotes: Vec<Shared<SimpleQuote>>,
+    }
+
+    /// Settlement days 0 and a 2-month lag on an interpolated monthly index:
+    /// the base date is 15 April 2026, two months before the reference, at a
+    /// negative time.
+    fn a_curve() -> Fixture {
+        let settings = shared(Settings::<Date>::new());
+        settings.set_evaluation_date(Date::new(15, June, 2026));
+        let quotes: Vec<Shared<SimpleQuote>> = QUOTES
+            .iter()
+            .map(|quote| shared(SimpleQuote::new(Some(*quote))))
+            .collect();
+        let helpers: Vec<Shared<dyn YoYOptionletVolatilityHelper>> = quotes
+            .iter()
+            .zip(MATURITY_YEARS)
+            .map(|(quote, years)| {
+                MeanVolHelper::new(
+                    quote,
+                    Date::new(15, June, 2026) + Period::new(years, TimeUnit::Years),
+                ) as Shared<dyn YoYOptionletVolatilityHelper>
+            })
+            .collect();
+        let curve = PiecewiseYoYOptionletVolatilityCurve::new(
+            0,
+            Target::new(),
+            BusinessDayConvention::ModifiedFollowing,
+            Actual365Fixed::new(),
+            Period::new(2, TimeUnit::Months),
+            Frequency::Monthly,
+            true,
+            0.018,
+            0.022,
+            BASE_LEVEL,
+            helpers.clone(),
+            settings,
+        )
+        .unwrap();
+        Fixture {
+            helpers,
+            curve,
+            quotes,
+        }
+    }
+
+    /// Every helper reprices its quote off the bootstrapped curve, the pillars
+    /// land where the helpers put them, and node zero sits at the base date's
+    /// negative time.
+    #[test]
+    fn the_bootstrapped_curve_reproduces_every_helpers_quote() {
+        let fixture = a_curve();
+        fixture.curve.calculate().unwrap();
+
+        for (helper, quote) in fixture.helpers.iter().zip(QUOTES) {
+            let error = helper.quote_error().unwrap();
+            assert!(
+                error.abs() < 1.0e-10,
+                "quote error {error} on the {quote} helper"
+            );
+        }
+
+        let dates = fixture.curve.dates().unwrap();
+        assert_eq!(dates.len(), 4);
+        assert_eq!(dates[0], Date::new(15, April, 2026));
+        for (i, helper) in fixture.helpers.iter().enumerate() {
+            assert_eq!(dates[i + 1], helper.pillar_date());
+        }
+        assert!(fixture.curve.times().unwrap()[0] < 0.0);
+    }
+
+    /// The two halves of the traits transcription: node zero is seeded from
+    /// the curve's own base level through the `initial_value` hook, and
+    /// `update_guess` never writes to it, so it holds that level bit for bit
+    /// once every pillar is solved to `2 * quote - base_level`.
+    #[test]
+    fn the_base_node_keeps_the_curves_own_base_level_through_the_bootstrap() {
+        let fixture = a_curve();
+        let data = fixture.curve.data().unwrap();
+
+        assert_eq!(data[0], BASE_LEVEL);
+        for (i, quote) in QUOTES.iter().enumerate() {
+            let expected = 2.0 * quote - BASE_LEVEL;
+            assert!(
+                (data[i + 1] - expected).abs() < 1.0e-10,
+                "node {} solved to {} against {expected}",
+                i + 1,
+                data[i + 1]
+            );
+        }
+        assert_eq!(
+            fixture.curve.base_level().unwrap(),
+            BASE_LEVEL,
+            "the surface reports the level it was seeded with"
+        );
+    }
+
+    /// The traits' statics against `hpp:54-95`: the two fresh-pass guesses,
+    /// the vol-cannot-be-negative floor on the lower bracket, and the
+    /// one-node-only write.
+    #[test]
+    fn the_traits_statics_match_the_cpp_header() {
+        let times = [0.0, 1.0, 2.0];
+        let data = [0.01, 0.005, 0.0];
+        assert_eq!(
+            YoYInflationVolatilityTraits::guess(1, &times, &data, false),
+            0.005
+        );
+        assert_eq!(
+            YoYInflationVolatilityTraits::guess(2, &times, &data, false),
+            0.002
+        );
+        assert_eq!(
+            YoYInflationVolatilityTraits::guess(2, &times, &data, true),
+            0.0
+        );
+        assert_eq!(
+            YoYInflationVolatilityTraits::min_value_after(1, &times, &data, false),
+            0.0,
+            "0.01 - 0.02 floors at zero"
+        );
+        assert_eq!(
+            YoYInflationVolatilityTraits::max_value_after(1, &times, &data, false),
+            0.03
+        );
+        let mut nodes = [0.01, 0.0, 0.0];
+        YoYInflationVolatilityTraits::update_guess(&mut nodes, 0.007, 1);
+        assert_eq!(nodes, [0.01, 0.007, 0.0]);
+        assert_eq!(YoYInflationVolatilityTraits::max_iterations(), 25);
+    }
+
+    /// Construction lays down no nodes; the first read bootstraps; a quote
+    /// move invalidates the cache and the next read re-solves.
+    #[test]
+    fn the_bootstrap_is_lazy_and_reruns_on_a_quote_change() {
+        let fixture = a_curve();
+        assert!(!fixture.curve.lazy.borrow().is_calculated());
+
+        let first = fixture.curve.data().unwrap()[1];
+        assert!(fixture.curve.lazy.borrow().is_calculated());
+
+        fixture.quotes[0].set_value(Some(0.015));
+        assert!(!fixture.curve.lazy.borrow().is_calculated());
+        assert!(
+            fixture.curve.data().unwrap()[1] > first,
+            "a higher quoted price must lift the curve"
+        );
+    }
+
+    #[test]
+    fn an_empty_helper_set_is_rejected() {
+        let settings = shared(Settings::<Date>::new());
+        settings.set_evaluation_date(Date::new(15, June, 2026));
+        let built = PiecewiseYoYOptionletVolatilityCurve::new(
+            0,
+            Target::new(),
+            BusinessDayConvention::ModifiedFollowing,
+            Actual365Fixed::new(),
+            Period::new(2, TimeUnit::Months),
+            Frequency::Monthly,
+            true,
+            0.018,
+            0.022,
+            BASE_LEVEL,
+            Vec::new(),
+            settings,
+        );
+        let err = match built {
+            Ok(_) => panic!("expected a construction error"),
+            Err(err) => err,
+        };
+        assert!(err.message().contains("no bootstrap helpers"));
+    }
+}

--- a/crates/libitofin/src/termstructures/volatility/inflation/yoyoptionlethelpers.rs
+++ b/crates/libitofin/src/termstructures/volatility/inflation/yoyoptionlethelpers.rs
@@ -1,0 +1,368 @@
+//! Bootstrap helpers for the year-on-year optionlet volatility bootstrap.
+//!
+//! Port of `ql/experimental/inflation/yoyoptionlethelpers.{hpp,cpp}`:
+//! [`YoYOptionletHelper`] is `BootstrapHelper<YoYOptionletVolatilitySurface>`
+//! over a quoted cap/floor *price* (`hpp:35-67`), repricing one
+//! [`YoYInflationCapFloor`] per pillar. [`YoYOptionletVolatilityHelper`] is
+//! the family trait, split off the C++ template exactly as
+//! [`YoYInflationHelper`] is on the inflation-curve side.
+//!
+//! ## The engine repointing divergence
+//!
+//! C++ `setTermStructure` wraps the curve being bootstrapped in a non-owning
+//! handle and calls `pricer_->setVolatility(volSurf)` (`cpp:74-89`), mutating
+//! the shared engine's member. The Rust engine holds its volatility
+//! [`Handle`] immutably, so the repointing is expressed through the *retained
+//! shared link*: the helper is handed the [`RelinkableHandle`] the engine was
+//! built over and re-points it - weakly, the `null_deleter` analogue - at each
+//! curve it is handed. The relink also notifies the engine, which C++'s
+//! member overwrite never did; the C++ side compensates with the `deepUpdate`
+//! in `impliedQuote` (`cpp:68-71`), which is ported too, because a bootstrap
+//! moving a curve *node* (rather than the handle) notifies nobody.
+//!
+//! [`YoYInflationHelper`]: crate::termstructures::inflation::inflationhelpers::YoYInflationHelper
+
+use std::cell::RefCell;
+
+use crate::errors::QlResult;
+use crate::handle::{Handle, RelinkableHandle};
+use crate::indexes::inflationindex::{CpiInterpolationType, YoYInflationIndex};
+use crate::instrument::Instrument;
+use crate::instruments::{CapFloorType, MakeYoYInflationCapFloor, YoYInflationCapFloor};
+use crate::patterns::observable::AsObservable;
+use crate::pricingengine::PricingEngine;
+use crate::pricingengines::inflation::YoYInflationCapFloorEngine;
+use crate::quotes::Quote;
+use crate::settings::Settings;
+use crate::shared::{Shared, SharedMut};
+use crate::termstructures::bootstraphelper::{BootstrapHelperBase, BootstrapHelperShared};
+use crate::termstructures::volatility::YoYOptionletVolatilitySurface;
+use crate::time::calendar::Calendar;
+use crate::time::date::Date;
+use crate::time::daycounter::DayCounter;
+use crate::time::period::Period;
+use crate::types::{Natural, Rate, Real, Size};
+
+/// The shared state of a year-on-year optionlet volatility bootstrap helper: a
+/// [`BootstrapHelperBase`] whose back-pointer is a volatility surface.
+pub type YoYOptionletVolHelperBase = BootstrapHelperBase<dyn YoYOptionletVolatilitySurface>;
+
+/// Bootstrap helper family for the year-on-year optionlet volatility bootstrap
+/// (`BootstrapHelper<YoYOptionletVolatilitySurface>`).
+pub trait YoYOptionletVolatilityHelper: AsObservable {
+    /// The embedded shared state.
+    fn base(&self) -> &YoYOptionletVolHelperBase;
+
+    /// The price implied by the current surface, computed by the concrete
+    /// helper.
+    fn implied_quote(&self) -> QlResult<Real>;
+
+    /// The market price the helper fits the surface to.
+    fn quote(&self) -> &Handle<dyn Quote> {
+        self.base().quote()
+    }
+
+    /// The bootstrap's root: market price minus implied price.
+    fn quote_error(&self) -> QlResult<Real> {
+        Ok(self.base().quote_value()? - self.implied_quote()?)
+    }
+
+    /// Sets the surface being bootstrapped (non-owning, unobserved).
+    fn set_term_structure(&self, term_structure: &Shared<dyn YoYOptionletVolatilitySurface>) {
+        self.base().set_term_structure(term_structure);
+    }
+
+    /// The earliest date data are needed at.
+    fn earliest_date(&self) -> Date {
+        self.base().earliest_date()
+    }
+
+    /// The instrument's maturity date.
+    fn maturity_date(&self) -> Date {
+        self.base().maturity_date()
+    }
+
+    /// The latest date data are needed at.
+    fn latest_relevant_date(&self) -> Date {
+        self.base().latest_relevant_date()
+    }
+
+    /// The pillar date, at which the surface node this helper sets sits.
+    fn pillar_date(&self) -> Date {
+        self.base().pillar_date()
+    }
+
+    /// The latest date, equal to the pillar date.
+    fn latest_date(&self) -> Date {
+        self.base().latest_date()
+    }
+}
+
+/// The volatility half of the driver bound, routing through
+/// [`YoYOptionletVolatilityHelper`] so a concrete helper's
+/// `set_term_structure` override still runs.
+impl BootstrapHelperShared for dyn YoYOptionletVolatilityHelper {
+    type TS = dyn YoYOptionletVolatilitySurface;
+
+    fn set_term_structure(&self, term_structure: &Shared<dyn YoYOptionletVolatilitySurface>) {
+        YoYOptionletVolatilityHelper::set_term_structure(self, term_structure);
+    }
+
+    fn quote_value(&self) -> QlResult<Real> {
+        self.base().quote_value()
+    }
+
+    fn quote_error(&self) -> QlResult<Real> {
+        YoYOptionletVolatilityHelper::quote_error(self)
+    }
+
+    fn pillar_date(&self) -> Date {
+        YoYOptionletVolatilityHelper::pillar_date(self)
+    }
+
+    fn latest_relevant_date(&self) -> Date {
+        YoYOptionletVolatilityHelper::latest_relevant_date(self)
+    }
+
+    fn maturity_date(&self) -> Date {
+        YoYOptionletVolatilityHelper::maturity_date(self)
+    }
+}
+
+/// Year-on-year inflation-volatility bootstrap helper (`YoYOptionletHelper`,
+/// `hpp:35-67`): reprices one cap/floor, built once at construction
+/// (`cpp:44-51`), against the surface being bootstrapped.
+///
+/// C++'s stored configuration members (`hpp:55-64`) exist only to build that
+/// instrument, so here they reduce to it; what survives is the contract and
+/// the retained volatility link of the module docs.
+pub struct YoYOptionletHelper {
+    base: YoYOptionletVolHelperBase,
+    vol_handle: RelinkableHandle<dyn YoYOptionletVolatilitySurface>,
+    capfloor: RefCell<YoYInflationCapFloor>,
+}
+
+impl YoYOptionletHelper {
+    /// Builds the helper and its cap/floor (`cpp:27-65`): `n` annual payments
+    /// on `index` observed `lag` back, struck at `strike` on a notional of
+    /// `notional` ("get the price level right, e.g., bps = 10,000", `hpp:39`),
+    /// with `pricer` installed on it. The helper's earliest and latest dates
+    /// are the fixing dates of the leg's first and last coupons (`cpp:53-59`);
+    /// the pillar falls back to the latest, C++'s default.
+    ///
+    /// `vol_handle` must be the link `pricer` reads its volatility through;
+    /// see the module docs. `settings` carries the evaluation date the leg
+    /// starts at (D5).
+    ///
+    /// # Errors
+    ///
+    /// As `MakeYoYInflationCapFloor::build`: no evaluation date, or an
+    /// unbuildable leg.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        price: Handle<dyn Quote>,
+        notional: Real,
+        cap_floor_type: CapFloorType,
+        lag: Period,
+        yoy_day_counter: DayCounter,
+        payment_calendar: Calendar,
+        fixing_days: Natural,
+        index: &Shared<YoYInflationIndex>,
+        interpolation: CpiInterpolationType,
+        strike: Rate,
+        n: Size,
+        pricer: SharedMut<YoYInflationCapFloorEngine>,
+        vol_handle: RelinkableHandle<dyn YoYOptionletVolatilitySurface>,
+        settings: Shared<Settings<Date>>,
+    ) -> QlResult<Shared<YoYOptionletHelper>> {
+        let capfloor = MakeYoYInflationCapFloor::new(
+            cap_floor_type,
+            Shared::clone(index),
+            n,
+            payment_calendar,
+            lag,
+            interpolation,
+            settings,
+        )
+        .with_nominal(notional)
+        .with_fixing_days(fixing_days)
+        .with_payment_day_counter(yoy_day_counter)
+        .with_strike(strike)
+        .with_pricing_engine(pricer as SharedMut<dyn PricingEngine>)
+        .build()?;
+
+        let base = YoYOptionletVolHelperBase::new(price);
+        let leg = capfloor.yoy_leg();
+        base.set_earliest_date(leg.first().expect("the leg is non-empty").fixing_date());
+        base.set_latest_date(leg.last().expect("the leg is non-empty").fixing_date());
+
+        Ok(crate::shared::shared(YoYOptionletHelper {
+            base,
+            vol_handle,
+            capfloor: RefCell::new(capfloor),
+        }))
+    }
+
+    /// The cap/floor the helper reprices.
+    pub fn capfloor(&self) -> &RefCell<YoYInflationCapFloor> {
+        &self.capfloor
+    }
+}
+
+impl AsObservable for YoYOptionletHelper {
+    fn observable(&self) -> &crate::patterns::observable::Observable {
+        self.base.observable()
+    }
+}
+
+impl YoYOptionletVolatilityHelper for YoYOptionletHelper {
+    fn base(&self) -> &YoYOptionletVolHelperBase {
+        &self.base
+    }
+
+    /// The cap/floor's NPV after a forced refresh (`impliedQuote`,
+    /// `cpp:68-71`). The `deepUpdate` is load-bearing: the bootstrap moves the
+    /// surface's nodes directly, which notifies nobody, so the cached NPV
+    /// would otherwise stand.
+    fn implied_quote(&self) -> QlResult<Real> {
+        let mut capfloor = self.capfloor.borrow_mut();
+        capfloor.base().observer().borrow_mut().update();
+        capfloor.npv()
+    }
+
+    /// Re-points the retained volatility link at the surface under
+    /// construction - weakly, so the surface is neither owned nor observed -
+    /// then records it (`setTermStructure`, `cpp:74-89`).
+    fn set_term_structure(&self, term_structure: &Shared<dyn YoYOptionletVolatilitySurface>) {
+        self.base.set_term_structure(term_structure);
+        self.vol_handle
+            .link_to_weak(Shared::downgrade(term_structure));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! The helper's numeric proof closes with the stripper's oracle; pinned
+    //! here are the decisions it makes on its own: which dates it derives from
+    //! the leg it builds, and how `set_term_structure` re-points the retained
+    //! volatility link.
+
+    use super::*;
+    use crate::currency::Currency;
+    use crate::indexes::inflation::YyGenericCpi;
+    use crate::quotes::SimpleQuote;
+    use crate::shared::{shared, shared_mut};
+    use crate::termstructures::volatility::ConstantYoYOptionletVolatility;
+    use crate::time::businessdayconvention::BusinessDayConvention;
+    use crate::time::calendars::target::Target;
+    use crate::time::date::Month::{June, March};
+    use crate::time::daycounters::actual365fixed::Actual365Fixed;
+    use crate::time::frequency::Frequency;
+    use crate::time::timeunit::TimeUnit;
+
+    fn lag() -> Period {
+        Period::new(3, TimeUnit::Months)
+    }
+
+    struct Fixture {
+        settings: Shared<Settings<Date>>,
+        vol_handle: RelinkableHandle<dyn YoYOptionletVolatilitySurface>,
+        helper: Shared<YoYOptionletHelper>,
+    }
+
+    /// A three-payment cap helper on a generic index, its engine reading the
+    /// retained link, which starts empty as the stripper's does.
+    fn a_helper() -> Fixture {
+        let settings = shared(Settings::<Date>::new());
+        settings.set_evaluation_date(Date::new(15, June, 2026));
+        let index = shared(YyGenericCpi::new(
+            Frequency::Monthly,
+            false,
+            lag(),
+            Currency::eur(),
+            Shared::clone(&settings),
+        ));
+        let vol_handle = RelinkableHandle::<dyn YoYOptionletVolatilitySurface>::empty();
+        let pricer = shared_mut(YoYInflationCapFloorEngine::unit_displaced(
+            Shared::clone(&index),
+            vol_handle.handle(),
+            crate::handle::Handle::empty(),
+        ));
+        let helper = YoYOptionletHelper::new(
+            Handle::new(shared(SimpleQuote::new(Some(25.0)))),
+            10_000.0,
+            CapFloorType::Cap,
+            lag(),
+            Actual365Fixed::new(),
+            Target::new(),
+            0,
+            &index,
+            CpiInterpolationType::Flat,
+            0.03,
+            3,
+            pricer,
+            vol_handle.clone(),
+            Shared::clone(&settings),
+        )
+        .expect("a well-formed helper");
+        Fixture {
+            settings,
+            vol_handle,
+            helper,
+        }
+    }
+
+    /// The dates come from the leg (`cpp:53-59`): the first and last coupons'
+    /// fixing dates, each the reference-period end less the 3-month lag, and
+    /// the pillar falls back to the latest.
+    #[test]
+    fn the_dates_are_the_first_and_last_coupon_fixings() {
+        let fixture = a_helper();
+        let helper = &fixture.helper;
+
+        assert_eq!(helper.earliest_date(), Date::new(15, March, 2027));
+        assert_eq!(helper.latest_date(), Date::new(15, March, 2029));
+        assert_eq!(helper.pillar_date(), Date::new(15, March, 2029));
+        assert_eq!(helper.capfloor().borrow().yoy_leg().len(), 3);
+        let _ = fixture.settings;
+    }
+
+    /// `set_term_structure` re-points the retained link at the surface under
+    /// construction, weakly: every copy of the link sees it, and dropping the
+    /// surface empties the link rather than leaking a kept-alive curve.
+    #[test]
+    fn set_term_structure_repoints_the_retained_link_weakly() {
+        let fixture = a_helper();
+        assert!(fixture.vol_handle.handle().current_link().is_err());
+
+        let surface = shared(ConstantYoYOptionletVolatility::new(
+            0.01,
+            0,
+            Target::new(),
+            BusinessDayConvention::ModifiedFollowing,
+            Actual365Fixed::new(),
+            lag(),
+            Frequency::Monthly,
+            false,
+            -1.0,
+            3.0,
+            Shared::clone(&fixture.settings),
+        )) as Shared<dyn YoYOptionletVolatilitySurface>;
+
+        YoYOptionletVolatilityHelper::set_term_structure(fixture.helper.as_ref(), &surface);
+        assert!(
+            Shared::ptr_eq(
+                &fixture.vol_handle.handle().current_link().unwrap(),
+                &surface
+            ),
+            "the link must point at the surface just set"
+        );
+        assert!(fixture.helper.base().term_structure().is_ok());
+
+        drop(surface);
+        assert!(
+            fixture.vol_handle.handle().current_link().is_err(),
+            "the link must not keep the surface alive"
+        );
+    }
+}

--- a/crates/libitofin/src/termstructures/volatility/inflation/yoyoptionletstripper.rs
+++ b/crates/libitofin/src/termstructures/volatility/inflation/yoyoptionletstripper.rs
@@ -425,3 +425,158 @@ impl YoYOptionletStripper for InterpolatedYoYOptionletStripper<Linear> {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! The stripper's numeric oracle (`testYoYPriceSurfaceToVol`) closes with
+    //! the K-interpolated surface in the next commit; this module pins the
+    //! mechanism everything rests on - the retained-link repointing - and the
+    //! uninitialised refusals.
+
+    use super::*;
+    use crate::handle::Handle;
+    use crate::instrument::Instrument;
+    use crate::interestrate::Compounding;
+    use crate::math::interpolations::linear::Linear;
+    use crate::settings::Settings;
+    use crate::shared::shared_mut;
+    use crate::termstructures::inflation::inflationtermstructure::YoYInflationTermStructure;
+    use crate::termstructures::inflation::interpolatedyoyinflationcurve::InterpolatedYoYInflationCurve;
+    use crate::termstructures::yields::FlatForward;
+    use crate::termstructures::yieldtermstructure::YieldTermStructure;
+    use crate::time::businessdayconvention::BusinessDayConvention;
+    use crate::time::date::Month::{April, June};
+    use crate::time::frequency::Frequency;
+    use crate::types::Natural;
+
+    /// The pin behind the whole stripping design, demanded by the #874 gate:
+    /// pricing an instrument, re-pointing the engine's retained volatility
+    /// link at a *different* surface, and pricing again must move the NPV -
+    /// relink, engine notification, instrument invalidation, recompute. The
+    /// precedent it guards against is #387, where a term-structure relink did
+    /// *not* auto-fire recalculation in another hierarchy: with a cached NPV
+    /// the Brent objective would be constant, the solver would converge on
+    /// anything, and the numeric oracle could pass green on wrong volatilities.
+    #[test]
+    fn relinking_the_engines_volatility_handle_moves_the_npv() {
+        let settings = shared(Settings::<Date>::new());
+        let eval = Date::new(15, June, 2026);
+        settings.set_evaluation_date(eval);
+
+        let yoy_curve = shared(
+            InterpolatedYoYInflationCurve::<Linear>::new(
+                eval,
+                vec![Date::new(1, April, 2026), Date::new(1, June, 2032)],
+                vec![0.02, 0.02],
+                Frequency::Monthly,
+                Actual365Fixed::new(),
+                Linear,
+                None,
+            )
+            .expect("two well-ordered nodes"),
+        ) as Shared<dyn YoYInflationTermStructure>;
+        let index = shared(
+            YyGenericCpi::new(
+                Frequency::Monthly,
+                false,
+                Period::new(2, TimeUnit::Months),
+                Currency::eur(),
+                Shared::clone(&settings),
+            )
+            .with_term_structure(Handle::new(yoy_curve)),
+        );
+        let nominal_curve = Handle::new(shared(FlatForward::with_rate(
+            eval,
+            0.05,
+            Actual365Fixed::new(),
+            Compounding::Continuous,
+            Frequency::Annual,
+        )) as Shared<dyn YieldTermStructure>);
+
+        let flat_at = |vol: Volatility| -> Shared<dyn YoYOptionletVolatilitySurface> {
+            shared(ConstantYoYOptionletVolatility::new(
+                vol,
+                0 as Natural,
+                Target::new(),
+                BusinessDayConvention::ModifiedFollowing,
+                Actual365Fixed::new(),
+                Period::new(0, TimeUnit::Days),
+                Frequency::Monthly,
+                false,
+                -1.0,
+                3.0,
+                Shared::clone(&settings),
+            ))
+        };
+
+        let vol_handle = RelinkableHandle::<dyn YoYOptionletVolatilitySurface>::empty();
+        vol_handle.link_to(flat_at(0.01));
+        let pricer = shared_mut(YoYInflationCapFloorEngine::unit_displaced(
+            Shared::clone(&index),
+            vol_handle.handle(),
+            nominal_curve,
+        ));
+
+        let mut capfloor = MakeYoYInflationCapFloor::new(
+            CapFloorType::Cap,
+            Shared::clone(&index),
+            3,
+            Target::new(),
+            Period::new(0, TimeUnit::Days),
+            CpiInterpolationType::Flat,
+            Shared::clone(&settings),
+        )
+        .with_nominal(10_000.0)
+        .with_strike(0.02)
+        .with_pricing_engine(SharedMut::clone(&pricer) as SharedMut<dyn PricingEngine>)
+        .build()
+        .expect("a well-formed cap");
+
+        let quiet = capfloor.npv().expect("the 1 % surface prices it");
+        assert!(capfloor.base().is_calculated());
+
+        vol_handle.link_to(flat_at(0.10));
+        let noisy = capfloor.npv().expect("the 10 % surface prices it");
+
+        assert!(
+            (noisy - quiet).abs() > 1e-4,
+            "the relink did not move the NPV ({quiet} vs {noisy}): a cached value \
+             would let the stripper's Brent solve converge on a constant"
+        );
+        assert!(
+            noisy > quiet,
+            "an at-the-money cap must gain value with volatility ({quiet} -> {noisy})"
+        );
+    }
+
+    /// Every accessor refuses before `initialize` (`hpp:52-56` dereference a
+    /// null surface there).
+    #[test]
+    fn the_accessors_refuse_before_initialize() {
+        let stripper = InterpolatedYoYOptionletStripper::<Linear>::new();
+        for message in [
+            stripper
+                .min_strike()
+                .expect_err("no surface yet")
+                .message()
+                .to_string(),
+            stripper
+                .max_strike()
+                .expect_err("no surface yet")
+                .message()
+                .to_string(),
+            stripper
+                .strikes()
+                .expect_err("no surface yet")
+                .message()
+                .to_string(),
+            stripper
+                .slice(Date::new(15, June, 2027))
+                .expect_err("no surface yet")
+                .message()
+                .to_string(),
+        ] {
+            assert!(message.contains("stripper not initialized"), "{message}");
+        }
+    }
+}

--- a/crates/libitofin/src/termstructures/volatility/inflation/yoyoptionletstripper.rs
+++ b/crates/libitofin/src/termstructures/volatility/inflation/yoyoptionletstripper.rs
@@ -1,0 +1,109 @@
+//! Year-on-year inflation optionlet stripping.
+//!
+//! Port of `ql/experimental/inflation/yoyoptionletstripper.hpp` (the
+//! [`YoYOptionletStripper`] interface, `hpp:37-60`) and
+//! `interpolatedyoyoptionletstripper.hpp` (the interpolated implementation,
+//! `hpp:43-298`): from a [`YoYCapFloorTermPriceSurface`] of quoted cap/floor
+//! prices, strip one [`PiecewiseYoYOptionletVolatilityCurve`] per strike, so
+//! that [`slice`](YoYOptionletStripper::slice) can answer the K-profile of
+//! optionlet volatilities at any date.
+//!
+//! ## The engine repointing divergence
+//!
+//! C++ `initialize` takes the shared `YoYInflationCapFloorEngine` and the
+//! solver's objective calls `p_->setVolatility(hCurve)` on *every* evaluation
+//! (`interpolatedyoyoptionletstripper.hpp:154-155`), overwriting the engine's
+//! handle member. The Rust engine's handle is immutable, so the caller hands
+//! `initialize` the *retained* [`RelinkableHandle`] the engine was built over,
+//! and the objective re-links it to each freshly built
+//! [`InterpolatedYoYOptionletVolatilityCurve`] instead - which notifies the
+//! engine and, through it, invalidates the cap/floor being repriced. The
+//! bootstrap phase then shares the same link through each
+//! [`YoYOptionletHelper`], whose `set_term_structure` re-points it at the
+//! curve under construction.
+//!
+//! ## Fidelity pins (ported faithfully, not fixed)
+//!
+//! - The objective's volatility curves are built with
+//!   `indexIsInterpolated = false`: the C++ `ObjectiveFunction` declares the
+//!   member with that default and no constructor ever assigns it (`hpp:81`,
+//!   `:97-136`), even though the surface's own flag feeds everything else.
+//! - The `fixingDays` the C++ `ObjectiveFunction` takes (`hpp:71`, `:102`) is
+//!   never stored or read; the port's objective simply takes none. The
+//!   *helpers* do read the surface's fixing days (`hpp:239`), and so do they
+//!   here.
+//! - Two lags travel separately: the `lag` parameter goes to
+//!   `MakeYoYInflationCapFloor` (`hpp:116`) while the member `lag_` is
+//!   overwritten from `surf_->observationLag()` (`hpp:112`) and feeds the vol
+//!   curves. `initialize` passes its own `lag_` - also the surface's
+//!   observation lag - so the two coincide in every reachable call, and the
+//!   port keeps both locals.
+//! - The objective's curve hardcodes `TARGET`, `ModifiedFollowing` and
+//!   `Actual/365 (Fixed)` (`hpp:149-150`), not the surface's conventions; and
+//!   each helper is handed a throwaway flat surface at the solved volatility
+//!   (`hpp:243-254`) that the bootstrap immediately replaces.
+//!
+//! [`YoYCapFloorTermPriceSurface`]: crate::termstructures::inflation::yoycapfloortermpricesurface::YoYCapFloorTermPriceSurface
+
+use crate::errors::QlResult;
+use crate::handle::RelinkableHandle;
+use crate::pricingengines::inflation::YoYInflationCapFloorEngine;
+use crate::shared::{Shared, SharedMut};
+use crate::termstructures::inflation::yoycapfloortermpricesurface::YoYCapFloorTermPriceSurface;
+use crate::time::date::Date;
+use crate::types::{Rate, Real, Volatility};
+
+use super::YoYOptionletVolatilitySurface;
+
+/// Interface for inflation cap stripping from price surfaces
+/// (`YoYOptionletStripper`, `yoyoptionletstripper.hpp:37-60`). Strippers
+/// return K slices of the volatility surface at a given T; `initialize` does
+/// the actual stripping along each K.
+pub trait YoYOptionletStripper {
+    /// Strips `surface` with `pricer`, whose volatility must be read through
+    /// the retained `vol_handle` (see the module docs); `slope` is the assumed
+    /// proportional change of the unobserved initial caplet volatility.
+    ///
+    /// # Errors
+    ///
+    /// A strike whose initial-point solve fails (C++'s `QL_FAIL` wrap,
+    /// `interpolatedyoyoptionletstripper.hpp:214-216`), an unbuildable
+    /// instrument or helper, or a failed per-strike bootstrap.
+    fn initialize(
+        &self,
+        surface: &Shared<dyn YoYCapFloorTermPriceSurface>,
+        pricer: &SharedMut<YoYInflationCapFloorEngine>,
+        vol_handle: &RelinkableHandle<dyn YoYOptionletVolatilitySurface>,
+        slope: Real,
+    ) -> QlResult<()>;
+
+    /// The lowest quoted strike (`minStrike`).
+    ///
+    /// # Errors
+    ///
+    /// Before `initialize` has run, where C++ dereferences null.
+    fn min_strike(&self) -> QlResult<Rate>;
+
+    /// The highest quoted strike (`maxStrike`).
+    ///
+    /// # Errors
+    ///
+    /// As [`min_strike`](Self::min_strike).
+    fn max_strike(&self) -> QlResult<Rate>;
+
+    /// The quoted strike union (`strikes`).
+    ///
+    /// # Errors
+    ///
+    /// As [`min_strike`](Self::min_strike).
+    fn strikes(&self) -> QlResult<Vec<Rate>>;
+
+    /// The (strikes, volatilities) profile at `d` (`slice`), one entry per
+    /// quoted strike, each read off that strike's stripped curve.
+    ///
+    /// # Errors
+    ///
+    /// As [`min_strike`](Self::min_strike), plus a date the stripped curves
+    /// refuse.
+    fn slice(&self, d: Date) -> QlResult<(Vec<Rate>, Vec<Volatility>)>;
+}

--- a/crates/libitofin/src/termstructures/volatility/inflation/yoyoptionletstripper.rs
+++ b/crates/libitofin/src/termstructures/volatility/inflation/yoyoptionletstripper.rs
@@ -45,15 +45,38 @@
 //!
 //! [`YoYCapFloorTermPriceSurface`]: crate::termstructures::inflation::yoycapfloortermpricesurface::YoYCapFloorTermPriceSurface
 
-use crate::errors::QlResult;
-use crate::handle::RelinkableHandle;
-use crate::pricingengines::inflation::YoYInflationCapFloorEngine;
-use crate::shared::{Shared, SharedMut};
-use crate::termstructures::inflation::yoycapfloortermpricesurface::YoYCapFloorTermPriceSurface;
-use crate::time::date::Date;
-use crate::types::{Rate, Real, Volatility};
+use std::cell::RefCell;
+use std::marker::PhantomData;
 
-use super::YoYOptionletVolatilitySurface;
+use crate::currency::Currency;
+use crate::errors::{QlError, QlResult};
+use crate::handle::{Handle, RelinkableHandle};
+use crate::indexes::inflation::YyGenericCpi;
+use crate::indexes::inflationindex::CpiInterpolationType;
+use crate::instrument::Instrument;
+use crate::instruments::{CapFloorType, MakeYoYInflationCapFloor};
+use crate::math::interpolations::Interpolator;
+use crate::math::interpolations::linear::Linear;
+use crate::math::solver1d::Solver1D;
+use crate::math::solvers1d::brent::Brent;
+use crate::pricingengine::PricingEngine;
+use crate::pricingengines::inflation::YoYInflationCapFloorEngine;
+use crate::quotes::{Quote, SimpleQuote};
+use crate::shared::{Shared, SharedMut, shared};
+use crate::termstructures::inflation::yoycapfloortermpricesurface::YoYCapFloorTermPriceSurface;
+use crate::time::calendars::target::Target;
+use crate::time::date::Date;
+use crate::time::daycounters::actual365fixed::Actual365Fixed;
+use crate::time::period::Period;
+use crate::time::timeunit::TimeUnit;
+use crate::types::{Rate, Real, Size, Volatility};
+use crate::{fail, require};
+
+use super::yoyoptionlethelpers::{YoYOptionletHelper, YoYOptionletVolatilityHelper};
+use super::{
+    ConstantYoYOptionletVolatility, InterpolatedYoYOptionletVolatilityCurve,
+    PiecewiseYoYOptionletVolatilityCurve, YoYOptionletVolatilitySurface,
+};
 
 /// Interface for inflation cap stripping from price surfaces
 /// (`YoYOptionletStripper`, `yoyoptionletstripper.hpp:37-60`). Strippers
@@ -106,4 +129,299 @@ pub trait YoYOptionletStripper {
     /// As [`min_strike`](Self::min_strike), plus a date the stripped curves
     /// refuse.
     fn slice(&self, d: Date) -> QlResult<(Vec<Rate>, Vec<Volatility>)>;
+}
+
+/// What `initialize` stores (the C++ mutable members,
+/// `yoyoptionletstripper.hpp:53-59` and
+/// `interpolatedyoyoptionletstripper.hpp:61`).
+struct StripperState {
+    surface: Shared<dyn YoYCapFloorTermPriceSurface>,
+    lag: Period,
+    vol_curves: Vec<Shared<dyn YoYOptionletVolatilitySurface>>,
+}
+
+/// The interpolated stripper (`InterpolatedYoYOptionletStripper`,
+/// `interpolatedyoyoptionletstripper.hpp:43-91`): interpolates along each K,
+/// as opposed to fitting a model.
+pub struct InterpolatedYoYOptionletStripper<I: Interpolator> {
+    state: RefCell<Option<StripperState>>,
+    _interpolator: PhantomData<I>,
+}
+
+impl InterpolatedYoYOptionletStripper<Linear> {
+    /// An uninitialised stripper; the work happens in
+    /// [`initialize`](YoYOptionletStripper::initialize).
+    pub fn new() -> InterpolatedYoYOptionletStripper<Linear> {
+        InterpolatedYoYOptionletStripper {
+            state: RefCell::new(None),
+            _interpolator: PhantomData,
+        }
+    }
+}
+
+impl Default for InterpolatedYoYOptionletStripper<Linear> {
+    fn default() -> Self {
+        InterpolatedYoYOptionletStripper::new()
+    }
+}
+
+impl<I: Interpolator> InterpolatedYoYOptionletStripper<I> {
+    fn with_state<R>(&self, f: impl FnOnce(&StripperState) -> QlResult<R>) -> QlResult<R> {
+        match self.state.borrow().as_ref() {
+            Some(state) => f(state),
+            None => fail!("stripper not initialized: no price surface set"),
+        }
+    }
+}
+
+impl YoYOptionletStripper for InterpolatedYoYOptionletStripper<Linear> {
+    /// The stripping (`interpolatedyoyoptionletstripper.hpp:161-275`): per
+    /// quoted strike, Brent-solve the initial caplet volatility so the
+    /// shortest quoted cap/floor reprices, then bootstrap a
+    /// [`PiecewiseYoYOptionletVolatilityCurve`] through that strike's whole
+    /// maturity column.
+    fn initialize(
+        &self,
+        surface: &Shared<dyn YoYCapFloorTermPriceSurface>,
+        pricer: &SharedMut<YoYInflationCapFloorEngine>,
+        vol_handle: &RelinkableHandle<dyn YoYOptionletVolatilitySurface>,
+        slope: Real,
+    ) -> QlResult<()> {
+        let lag = surface.observation_lag();
+        let frequency = surface.frequency();
+        let index_is_interpolated = surface.index_is_interpolated();
+        let fixing_days = surface.fixing_days();
+        let settlement_days = 0;
+        let Some(calendar) = surface.calendar() else {
+            fail!("the price surface holds a calendar by construction");
+        };
+        let bdc = surface.business_day_convention();
+        let day_counter = surface.require_day_counter()?;
+        let settings = Shared::clone(surface.surface_base().settings());
+        let reference = surface.reference_date()?;
+
+        // Switch from floors to caps when out of floors (`hpp:178-180`).
+        let max_floor = *surface
+            .floor_strikes()
+            .last()
+            .expect("the surface carries floor strikes");
+        let mut use_type = CapFloorType::Floor;
+        let tp_min = surface.maturities()[0];
+
+        // The "fake index" over the surface's own year-on-year curve
+        // (`hpp:182-189`); C++ hands it a default-constructed `Currency()`.
+        let h_yoy = Handle::new(surface.yoy_ts()?);
+        let an_index = shared(
+            YyGenericCpi::new(
+                frequency,
+                false,
+                lag,
+                Currency::new("", "", 0, "", "", 0),
+                Shared::clone(&settings),
+            )
+            .with_term_structure(h_yoy),
+        );
+
+        // The shortest quoted maturity in whole years, shared by the
+        // objective's instrument (`hpp:115`) and its sanity gate (`hpp:129-132`).
+        let n = (surface.time_from_reference(surface.min_maturity()?)? + 0.5).floor() as Size;
+        require!(n > 0, "first maturity in price surface not > 0: {n}");
+
+        // The two seed nodes of every objective curve (`hpp:120-127`): the
+        // surface's base date and one week past its shortest maturity.
+        let objective_lag = surface.observation_lag();
+        let d0 = surface.base_date()?;
+        let d1 = surface.min_maturity()? + Period::new(7, TimeUnit::Days);
+        let t0 = day_counter.year_fraction(reference, d0);
+        let t1 = day_counter.year_fraction(reference, d1);
+
+        let mut vol_curves: Vec<Shared<dyn YoYOptionletVolatilitySurface>> = Vec::new();
+        for &k in surface.strikes() {
+            if k > max_floor {
+                use_type = CapFloorType::Cap;
+            }
+
+            let solver_tolerance = 1e-7;
+            let (lo, hi) = (0.00001, 0.08);
+            let guess = (hi + lo) / 2.0;
+            let price_to_match = match use_type {
+                CapFloorType::Cap => surface.cap_price_by_tenor(tp_min, k)?,
+                _ => surface.floor_price_by_tenor(tp_min, k)?,
+            };
+
+            // The objective's cap/floor, built once per strike (`hpp:113-118`,
+            // `:134`): flat interpolation, a 10,000 nominal, the shared pricer.
+            let mut capfloor = MakeYoYInflationCapFloor::new(
+                use_type,
+                Shared::clone(&an_index),
+                n,
+                calendar.clone(),
+                lag,
+                CpiInterpolationType::Flat,
+                Shared::clone(&settings),
+            )
+            .with_nominal(10_000.0)
+            .with_strike(k)
+            .build()?;
+            capfloor
+                .base_mut()
+                .set_pricing_engine(SharedMut::clone(pricer) as SharedMut<dyn PricingEngine>);
+
+            // The objective (`hpp:139-158`): seed a two-node curve from the
+            // guess and the slope, re-point the engine's link at it, reprice.
+            let error_slot: RefCell<Option<QlError>> = RefCell::new(None);
+            let mut evaluate = |guess: Volatility| -> QlResult<Real> {
+                let v1 = guess;
+                let v0 = guess - slope * (t1 - t0) * guess;
+                let curve = InterpolatedYoYOptionletVolatilityCurve::new(
+                    0,
+                    Target::new(),
+                    crate::time::businessdayconvention::BusinessDayConvention::ModifiedFollowing,
+                    Actual365Fixed::new(),
+                    objective_lag,
+                    frequency,
+                    false,
+                    vec![d0, d1],
+                    vec![v0, v1],
+                    -1.0,
+                    3.0,
+                    Linear,
+                    Shared::clone(&settings),
+                )?;
+                vol_handle.link_to(shared(curve) as Shared<dyn YoYOptionletVolatilitySurface>);
+                Ok(price_to_match - capfloor.npv()?)
+            };
+            let objective = |guess: Volatility| -> Real {
+                match evaluate(guess) {
+                    Ok(value) => value,
+                    Err(error) => {
+                        *error_slot.borrow_mut() = Some(error);
+                        Real::NAN
+                    }
+                }
+            };
+            let found =
+                match Brent::new().solve_bracketed(objective, solver_tolerance, guess, lo, hi) {
+                    Ok(found) => found,
+                    Err(solver_error) => {
+                        let message = match error_slot.into_inner() {
+                            Some(inner) => inner.message().to_string(),
+                            None => solver_error.message().to_string(),
+                        };
+                        fail!("failed to find solution here because: {message}");
+                    }
+                };
+
+            // One helper per quoted maturity, working in bps (`hpp:218-256`),
+            // each handed a throwaway flat surface at the solved volatility.
+            let notional = 10_000.0;
+            let mut helper_instruments: Vec<Shared<dyn YoYOptionletVolatilityHelper>> = Vec::new();
+            for &tp in surface.maturities() {
+                let next_price = match use_type {
+                    CapFloorType::Cap => surface.cap_price_by_tenor(tp, k)?,
+                    _ => surface.floor_price_by_tenor(tp, k)?,
+                };
+                let quote =
+                    Handle::new(shared(SimpleQuote::new(Some(next_price))) as Shared<dyn Quote>);
+                // An integer number of periods away, enforced by rounding
+                // (`hpp:232-234`).
+                let n_t = (surface.time_from_reference(surface.yoy_option_date_from_tenor(tp)?)?
+                    + 0.5)
+                    .floor() as Size;
+                let helper = YoYOptionletHelper::new(
+                    quote,
+                    notional,
+                    use_type,
+                    lag,
+                    day_counter.clone(),
+                    calendar.clone(),
+                    fixing_days,
+                    &an_index,
+                    CpiInterpolationType::Flat,
+                    k,
+                    n_t,
+                    SharedMut::clone(pricer),
+                    vol_handle.clone(),
+                    Shared::clone(&settings),
+                )?;
+                let yoy_vol_black = shared(ConstantYoYOptionletVolatility::new(
+                    found,
+                    settlement_days,
+                    calendar.clone(),
+                    bdc,
+                    day_counter.clone(),
+                    lag,
+                    frequency,
+                    false,
+                    -1.0,
+                    3.0,
+                    Shared::clone(&settings),
+                )) as Shared<dyn YoYOptionletVolatilitySurface>;
+                YoYOptionletVolatilityHelper::set_term_structure(helper.as_ref(), &yoy_vol_black);
+                helper_instruments.push(helper as Shared<dyn YoYOptionletVolatilityHelper>);
+            }
+
+            // The artificial vol at zero so the first section works
+            // (`hpp:257-273`), and a strike band of `max(K, 0.02) / 1000`
+            // around the quoted strike.
+            let t_min = surface.time_from_reference(surface.yoy_option_date_from_tenor(tp_min)?)?;
+            let base_yoy_volatility = found - slope * t_min * found;
+            let eps = k.max(0.02) / 1000.0;
+            let curve = PiecewiseYoYOptionletVolatilityCurve::new(
+                settlement_days,
+                calendar.clone(),
+                bdc,
+                day_counter.clone(),
+                lag,
+                frequency,
+                index_is_interpolated,
+                k - eps,
+                k + eps,
+                base_yoy_volatility,
+                helper_instruments,
+                Shared::clone(&settings),
+            )?;
+            curve.calculate()?;
+            vol_curves.push(curve as Shared<dyn YoYOptionletVolatilitySurface>);
+        }
+
+        *self.state.borrow_mut() = Some(StripperState {
+            surface: Shared::clone(surface),
+            lag,
+            vol_curves,
+        });
+        Ok(())
+    }
+
+    fn min_strike(&self) -> QlResult<Rate> {
+        self.with_state(|state| Ok(state.surface.strikes()[0]))
+    }
+
+    fn max_strike(&self) -> QlResult<Rate> {
+        self.with_state(|state| {
+            Ok(*state
+                .surface
+                .strikes()
+                .last()
+                .expect("the surface carries strikes"))
+        })
+    }
+
+    fn strikes(&self) -> QlResult<Vec<Rate>> {
+        self.with_state(|state| Ok(state.surface.strikes().to_vec()))
+    }
+
+    /// `hpp:278-298`. C++ reads each curve with its defaulted observation
+    /// lag, which the curve substitutes with its own - the surface's - so the
+    /// port passes that lag explicitly.
+    fn slice(&self, d: Date) -> QlResult<(Vec<Rate>, Vec<Volatility>)> {
+        self.with_state(|state| {
+            let strikes = state.surface.strikes();
+            let mut volatilities = Vec::with_capacity(strikes.len());
+            for (curve, &k) in state.vol_curves.iter().zip(strikes) {
+                volatilities.push(curve.volatility(d, k, state.lag)?);
+            }
+            Ok((strikes.to_vec(), volatilities))
+        })
+    }
 }

--- a/crates/libitofin/src/termstructures/volatility/inflation/yoyoptionletvolsurfacebase.rs
+++ b/crates/libitofin/src/termstructures/volatility/inflation/yoyoptionletvolsurfacebase.rs
@@ -1,0 +1,183 @@
+//! Shared holder for year-on-year optionlet volatility surfaces.
+//!
+//! Port of the C++ abstract base `YoYOptionletVolatilitySurface`'s members
+//! (`ql/termstructures/volatility/inflation/yoyinflationoptionletvolatilitystructure.hpp:141-149`)
+//! and date arithmetic (`.cpp:51-154`), including the `baseLevel` slot the
+//! stripping bootstrap seeds from. On the pattern of
+//! [`YoYCapFloorTermPriceSurfaceBase`]: the stripping hierarchy's concrete
+//! surfaces (#874) embed one where [`ConstantYoYOptionletVolatility`] - which
+//! predates it and stays untouched - carries the same arithmetic itself.
+//!
+//! The moving reference date takes the shared [`Settings`] handle explicitly
+//! (D5), and the lag-substituting sentinel default is not carried, per the
+//! module docs of [`super`].
+//!
+//! [`YoYCapFloorTermPriceSurfaceBase`]: crate::termstructures::inflation::yoycapfloortermpricesurface::YoYCapFloorTermPriceSurfaceBase
+//! [`ConstantYoYOptionletVolatility`]: super::ConstantYoYOptionletVolatility
+
+use std::cell::Cell;
+
+use crate::errors::QlResult;
+use crate::indexes::inflationindex::inflation_period;
+use crate::require;
+use crate::settings::Settings;
+use crate::shared::Shared;
+use crate::termstructures::TermStructureBase;
+use crate::time::businessdayconvention::BusinessDayConvention;
+use crate::time::calendar::Calendar;
+use crate::time::date::Date;
+use crate::time::daycounter::DayCounter;
+use crate::time::frequency::Frequency;
+use crate::time::period::Period;
+use crate::types::{Natural, Rate, Time, Volatility};
+
+/// Shared holder for year-on-year optionlet volatility surfaces: the C++
+/// abstract base's members (`yoyinflationoptionletvolatilitystructure.hpp:141-149`)
+/// and its date arithmetic (`.cpp:51-154`), including the `baseLevel` slot the
+/// stripping bootstrap seeds from.
+pub struct YoYOptionletVolatilitySurfaceBase {
+    term: TermStructureBase,
+    business_day_convention: BusinessDayConvention,
+    observation_lag: Period,
+    frequency: Frequency,
+    index_is_interpolated: bool,
+    base_level: Cell<Option<Volatility>>,
+}
+
+impl YoYOptionletVolatilitySurfaceBase {
+    /// The abstract-base constructor (`.cpp:31-48`): a moving term structure
+    /// whose reference date follows the evaluation date `settings` carries,
+    /// with the base level starting unset (C++'s `Null<Volatility>`).
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        settlement_days: Natural,
+        calendar: Calendar,
+        business_day_convention: BusinessDayConvention,
+        day_counter: DayCounter,
+        observation_lag: Period,
+        frequency: Frequency,
+        index_is_interpolated: bool,
+        settings: Shared<Settings<Date>>,
+    ) -> YoYOptionletVolatilitySurfaceBase {
+        YoYOptionletVolatilitySurfaceBase {
+            term: TermStructureBase::moving(settlement_days, calendar, Some(day_counter), settings),
+            business_day_convention,
+            observation_lag,
+            frequency,
+            index_is_interpolated,
+            base_level: Cell::new(None),
+        }
+    }
+
+    /// The wrapped term-structure holder.
+    pub fn term_structure_base(&self) -> &TermStructureBase {
+        &self.term
+    }
+
+    /// The convention tenors are converted to dates with (`hpp` via
+    /// `VolatilityTermStructure`).
+    pub fn business_day_convention(&self) -> BusinessDayConvention {
+        self.business_day_convention
+    }
+
+    /// The lag the surface observes inflation with (`observationLag`).
+    pub fn observation_lag(&self) -> Period {
+        self.observation_lag
+    }
+
+    /// How often the observed index publishes (`frequency`).
+    pub fn frequency(&self) -> Frequency {
+        self.frequency
+    }
+
+    /// Whether the observed index interpolates between publications
+    /// (`indexIsInterpolated`).
+    pub fn index_is_interpolated(&self) -> bool {
+        self.index_is_interpolated
+    }
+
+    /// The volatility acting as the zero-time value for bootstrapping
+    /// (`baseLevel`, `hpp:124-128`); an `Err` while unset, C++'s throw on the
+    /// `Null<Volatility>` sentinel.
+    pub fn base_level(&self) -> QlResult<Volatility> {
+        match self.base_level.get() {
+            Some(level) => Ok(level),
+            None => crate::fail!("base volatility, for base_date(), not set"),
+        }
+    }
+
+    /// Sets the base level (`setBaseLevel`, `hpp:141`).
+    pub fn set_base_level(&self, level: Volatility) {
+        self.base_level.set(Some(level));
+    }
+
+    /// `date` as the surface observes it: itself for an interpolated index,
+    /// the start of its publication period otherwise (`.cpp:57-63`).
+    ///
+    /// # Errors
+    ///
+    /// When the frequency admits no publication period.
+    pub fn observed(&self, date: Date) -> QlResult<Date> {
+        if self.index_is_interpolated {
+            Ok(date)
+        } else {
+            Ok(inflation_period(date, self.frequency)?.0)
+        }
+    }
+
+    /// The reference date pulled back by the surface's own lag and observed
+    /// (`baseDate`, `.cpp:51-64`).
+    ///
+    /// # Errors
+    ///
+    /// When the reference date cannot be resolved, or the frequency admits no
+    /// publication period.
+    pub fn base_date(&self) -> QlResult<Date> {
+        self.observed(self.term.reference_date()? - self.observation_lag)
+    }
+
+    /// The time from [`base_date`](Self::base_date) to the date observed for
+    /// an exercise on `date` under the handed lag (`timeFromBase`,
+    /// `.cpp:133-154`).
+    ///
+    /// # Errors
+    ///
+    /// As [`base_date`](Self::base_date), plus a surface built without a day
+    /// counter.
+    pub fn time_from_base(&self, date: Date, obs_lag: Period) -> QlResult<Time> {
+        let observed = self.observed(date - obs_lag)?;
+        let Some(day_counter) = self.term.day_counter() else {
+            crate::fail!("day counter not provided for this volatility surface");
+        };
+        Ok(day_counter.year_fraction(self.base_date()?, observed))
+    }
+
+    /// The checks C++ runs before every volatility query (`checkRange(Date...)`,
+    /// `.cpp:67-78`), on an already observed date: not before the base date,
+    /// and - unless extrapolation is enabled - not past `max_date` nor struck
+    /// outside `[min_strike, max_strike]`.
+    pub fn check_range(
+        &self,
+        date: Date,
+        strike: Rate,
+        min_strike: Rate,
+        max_strike: Rate,
+        max_date: Date,
+    ) -> QlResult<()> {
+        let base_date = self.base_date()?;
+        require!(
+            date >= base_date,
+            "date ({date}) is before base date ({base_date})"
+        );
+        require!(
+            self.term.allows_extrapolation() || date <= max_date,
+            "date ({date}) is past max curve date ({max_date})"
+        );
+        require!(
+            self.term.allows_extrapolation() || (strike >= min_strike && strike <= max_strike),
+            "strike ({strike}) is outside the curve domain [{min_strike},{max_strike}] at date = \
+             {date}"
+        );
+        Ok(())
+    }
+}

--- a/crates/libitofin/src/termstructures/volatility/mod.rs
+++ b/crates/libitofin/src/termstructures/volatility/mod.rs
@@ -51,10 +51,10 @@ pub use capfloor::{CapFloorTermVolSurface, CapFloorTermVolatilityStructure};
 pub use flatsmilesection::FlatSmileSection;
 pub use inflation::{
     ConstantYoYOptionletVolatility, InterpolatedYoYOptionletStripper,
-    InterpolatedYoYOptionletVolatilityCurve, PiecewiseYoYOptionletVolatilityCurve,
-    YoYInflationVolatilityTraits, YoYOptionletHelper, YoYOptionletStripper,
-    YoYOptionletVolHelperBase, YoYOptionletVolatilityHelper, YoYOptionletVolatilitySurface,
-    YoYOptionletVolatilitySurfaceBase,
+    InterpolatedYoYOptionletVolatilityCurve, KInterpolatedYoYOptionletVolatilitySurface,
+    PiecewiseYoYOptionletVolatilityCurve, YoYInflationVolatilityTraits, YoYOptionletHelper,
+    YoYOptionletStripper, YoYOptionletVolHelperBase, YoYOptionletVolatilityHelper,
+    YoYOptionletVolatilitySurface, YoYOptionletVolatilitySurfaceBase,
 };
 pub use interpolatedsmilesection::InterpolatedSmileSection;
 pub use localconstantvol::LocalConstantVol;

--- a/crates/libitofin/src/termstructures/volatility/mod.rs
+++ b/crates/libitofin/src/termstructures/volatility/mod.rs
@@ -50,10 +50,11 @@ pub use blackvariancesurface::{BlackVarianceSurface, Extrapolation};
 pub use capfloor::{CapFloorTermVolSurface, CapFloorTermVolatilityStructure};
 pub use flatsmilesection::FlatSmileSection;
 pub use inflation::{
-    ConstantYoYOptionletVolatility, InterpolatedYoYOptionletVolatilityCurve,
-    PiecewiseYoYOptionletVolatilityCurve, YoYInflationVolatilityTraits, YoYOptionletHelper,
-    YoYOptionletStripper, YoYOptionletVolHelperBase, YoYOptionletVolatilityHelper,
-    YoYOptionletVolatilitySurface, YoYOptionletVolatilitySurfaceBase,
+    ConstantYoYOptionletVolatility, InterpolatedYoYOptionletStripper,
+    InterpolatedYoYOptionletVolatilityCurve, PiecewiseYoYOptionletVolatilityCurve,
+    YoYInflationVolatilityTraits, YoYOptionletHelper, YoYOptionletStripper,
+    YoYOptionletVolHelperBase, YoYOptionletVolatilityHelper, YoYOptionletVolatilitySurface,
+    YoYOptionletVolatilitySurfaceBase,
 };
 pub use interpolatedsmilesection::InterpolatedSmileSection;
 pub use localconstantvol::LocalConstantVol;

--- a/crates/libitofin/src/termstructures/volatility/mod.rs
+++ b/crates/libitofin/src/termstructures/volatility/mod.rs
@@ -49,7 +49,10 @@ pub use blackvariancecurve::{BlackVarianceCurve, BlackVolTimeExtrapolation};
 pub use blackvariancesurface::{BlackVarianceSurface, Extrapolation};
 pub use capfloor::{CapFloorTermVolSurface, CapFloorTermVolatilityStructure};
 pub use flatsmilesection::FlatSmileSection;
-pub use inflation::{ConstantYoYOptionletVolatility, YoYOptionletVolatilitySurface};
+pub use inflation::{
+    ConstantYoYOptionletVolatility, YoYOptionletVolatilitySurface,
+    YoYOptionletVolatilitySurfaceBase,
+};
 pub use interpolatedsmilesection::InterpolatedSmileSection;
 pub use localconstantvol::LocalConstantVol;
 pub use localvolcurve::LocalVolCurve;

--- a/crates/libitofin/src/termstructures/volatility/mod.rs
+++ b/crates/libitofin/src/termstructures/volatility/mod.rs
@@ -50,8 +50,9 @@ pub use blackvariancesurface::{BlackVarianceSurface, Extrapolation};
 pub use capfloor::{CapFloorTermVolSurface, CapFloorTermVolatilityStructure};
 pub use flatsmilesection::FlatSmileSection;
 pub use inflation::{
-    ConstantYoYOptionletVolatility, InterpolatedYoYOptionletVolatilityCurve,
-    YoYOptionletVolatilitySurface, YoYOptionletVolatilitySurfaceBase,
+    ConstantYoYOptionletVolatility, InterpolatedYoYOptionletVolatilityCurve, YoYOptionletHelper,
+    YoYOptionletVolHelperBase, YoYOptionletVolatilityHelper, YoYOptionletVolatilitySurface,
+    YoYOptionletVolatilitySurfaceBase,
 };
 pub use interpolatedsmilesection::InterpolatedSmileSection;
 pub use localconstantvol::LocalConstantVol;

--- a/crates/libitofin/src/termstructures/volatility/mod.rs
+++ b/crates/libitofin/src/termstructures/volatility/mod.rs
@@ -50,9 +50,9 @@ pub use blackvariancesurface::{BlackVarianceSurface, Extrapolation};
 pub use capfloor::{CapFloorTermVolSurface, CapFloorTermVolatilityStructure};
 pub use flatsmilesection::FlatSmileSection;
 pub use inflation::{
-    ConstantYoYOptionletVolatility, InterpolatedYoYOptionletVolatilityCurve, YoYOptionletHelper,
-    YoYOptionletVolHelperBase, YoYOptionletVolatilityHelper, YoYOptionletVolatilitySurface,
-    YoYOptionletVolatilitySurfaceBase,
+    ConstantYoYOptionletVolatility, InterpolatedYoYOptionletVolatilityCurve,
+    YoYInflationVolatilityTraits, YoYOptionletHelper, YoYOptionletVolHelperBase,
+    YoYOptionletVolatilityHelper, YoYOptionletVolatilitySurface, YoYOptionletVolatilitySurfaceBase,
 };
 pub use interpolatedsmilesection::InterpolatedSmileSection;
 pub use localconstantvol::LocalConstantVol;

--- a/crates/libitofin/src/termstructures/volatility/mod.rs
+++ b/crates/libitofin/src/termstructures/volatility/mod.rs
@@ -51,8 +51,9 @@ pub use capfloor::{CapFloorTermVolSurface, CapFloorTermVolatilityStructure};
 pub use flatsmilesection::FlatSmileSection;
 pub use inflation::{
     ConstantYoYOptionletVolatility, InterpolatedYoYOptionletVolatilityCurve,
-    YoYInflationVolatilityTraits, YoYOptionletHelper, YoYOptionletVolHelperBase,
-    YoYOptionletVolatilityHelper, YoYOptionletVolatilitySurface, YoYOptionletVolatilitySurfaceBase,
+    PiecewiseYoYOptionletVolatilityCurve, YoYInflationVolatilityTraits, YoYOptionletHelper,
+    YoYOptionletVolHelperBase, YoYOptionletVolatilityHelper, YoYOptionletVolatilitySurface,
+    YoYOptionletVolatilitySurfaceBase,
 };
 pub use interpolatedsmilesection::InterpolatedSmileSection;
 pub use localconstantvol::LocalConstantVol;

--- a/crates/libitofin/src/termstructures/volatility/mod.rs
+++ b/crates/libitofin/src/termstructures/volatility/mod.rs
@@ -50,8 +50,8 @@ pub use blackvariancesurface::{BlackVarianceSurface, Extrapolation};
 pub use capfloor::{CapFloorTermVolSurface, CapFloorTermVolatilityStructure};
 pub use flatsmilesection::FlatSmileSection;
 pub use inflation::{
-    ConstantYoYOptionletVolatility, YoYOptionletVolatilitySurface,
-    YoYOptionletVolatilitySurfaceBase,
+    ConstantYoYOptionletVolatility, InterpolatedYoYOptionletVolatilityCurve,
+    YoYOptionletVolatilitySurface, YoYOptionletVolatilitySurfaceBase,
 };
 pub use interpolatedsmilesection::InterpolatedSmileSection;
 pub use localconstantvol::LocalConstantVol;

--- a/crates/libitofin/src/termstructures/volatility/mod.rs
+++ b/crates/libitofin/src/termstructures/volatility/mod.rs
@@ -52,8 +52,8 @@ pub use flatsmilesection::FlatSmileSection;
 pub use inflation::{
     ConstantYoYOptionletVolatility, InterpolatedYoYOptionletVolatilityCurve,
     PiecewiseYoYOptionletVolatilityCurve, YoYInflationVolatilityTraits, YoYOptionletHelper,
-    YoYOptionletVolHelperBase, YoYOptionletVolatilityHelper, YoYOptionletVolatilitySurface,
-    YoYOptionletVolatilitySurfaceBase,
+    YoYOptionletStripper, YoYOptionletVolHelperBase, YoYOptionletVolatilityHelper,
+    YoYOptionletVolatilitySurface, YoYOptionletVolatilitySurfaceBase,
 };
 pub use interpolatedsmilesection::InterpolatedSmileSection;
 pub use localconstantvol::LocalConstantVol;


### PR DESCRIPTION
- **feat(src): add base_level to yoy optionlet volatility surface**
- **feat(volatility): add InterpolatedYoYOptionletVolatilityCurve**
- **test(crates): add unit tests for interpolated YoY optionlet vol curve**
- **feat(src): add YoYOptionletHelper for optionlet stripping**
- **feat(volatility): add piecewise YoY optionlet volatility module**
- **feat(volatility): add piecewise YoY optionlet volatility curve**
- **test(crates): add tests for piecewise YoY optionlet vol curve**
- **feat(volatility): add YoYOptionletStripper**
- **feat(volatility): add InterpolatedYoYOptionletStripper**
- **test(yoyoptionletstripper): pin relink-driven repricing and guards**
- **feat(volatility): add KInterpolated YoY optionlet vol surface**
- **test(inflation): add YoY price surface to vol oracle for #874**

close #874