### PR TITLE
ci(release): automate version bump in Cargo.toml on release

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -16,7 +16,7 @@ jobs:
   semantic-release:
     name: semantic-release
     if: ${{ inputs.prompt == 'true' }}
-    uses: benbenbang/reusable-workflows/.github/workflows/semantic-release.yml@1.0.1
+    uses: benbenbang/reusable-workflows/.github/workflows/semantic-release.yml@1.3.2
     permissions:
       contents: read
       pull-requests: write

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -62,6 +62,21 @@
     ],
     "@semantic-release/release-notes-generator",
     [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "sh scripts/set-version.sh ${nextRelease.version}"
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": [
+          "Cargo.toml"
+        ],
+        "message": "chore(release): update version to ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ],
+    [
       "@semantic-release/github",
       {
         "failComment": false,


### PR DESCRIPTION
Update semantic-release reusable workflow to 1.3.2 and configure the
release pipeline to sync the crate version. The `@semantic-release/exec`
plugin runs `scripts/set-version.sh` to set the next version, and
`@semantic-release/git` commits the updated `Cargo.toml` back to the
repository, keeping the manifest version in step with each release.
