### PR TITLE
feat(interpolations): add ForwardFlat interpolator factory

### DIFF
--- a/crates/libitofin/src/math/interpolations/flat.rs
+++ b/crates/libitofin/src/math/interpolations/flat.rs
@@ -28,6 +28,20 @@ impl Interpolator for BackwardFlat {
     }
 }
 
+/// Factory for [`ForwardFlatInterpolation`] (QuantLib's `ForwardFlat` traits
+/// class); unlike backward-flat, two nodes are required (`requiredPoints = 2`,
+/// the trait default).
+#[derive(Clone, Copy, Default)]
+pub struct ForwardFlat;
+
+impl Interpolator for ForwardFlat {
+    type Output = ForwardFlatInterpolation;
+
+    fn interpolate(&self, x: &[Real], y: &[Real]) -> QlResult<ForwardFlatInterpolation> {
+        ForwardFlatInterpolation::new(x.to_vec(), y.to_vec())
+    }
+}
+
 /// Validate the `(x, y)` nodes: equal length of at least `min_points`, finite,
 /// strictly increasing `x`. QuantLib requires 1 point for backward-flat and 2 for
 /// forward-flat (`requiredPoints`), so the minimum is passed in.
@@ -325,6 +339,16 @@ mod tests {
         assert_eq!(f.value(0.5).unwrap(), 4.0);
         assert_eq!(BackwardFlat.required_points(), 1);
         assert!(BackwardFlat.interpolate(&[1.0], &[2.5]).is_ok());
+    }
+
+    #[test]
+    fn forward_flat_factory_takes_the_left_node_and_requires_two() {
+        let f = ForwardFlat
+            .interpolate(&[0.0, 1.0, 3.0], &[5.0, 4.0, 2.0])
+            .unwrap();
+        assert_eq!(f.value(0.5).unwrap(), 5.0);
+        assert_eq!(ForwardFlat.required_points(), 2);
+        assert!(ForwardFlat.interpolate(&[1.0], &[2.5]).is_err());
     }
 
     #[test]

--- a/crates/libitofin/src/pricingengines/credit/isdanodegrid.rs
+++ b/crates/libitofin/src/pricingengines/credit/isdanodegrid.rs
@@ -35,19 +35,19 @@
 //! (`isdacdsengine.cpp:128-129` on the yield side, `:146-147` on the credit
 //! side) - the rejection is the ported behaviour, not a missing feature.
 //!
-//! ## Deferred (#799)
+//! ## Deferred (#915)
 //!
-//! `InterpolatedForwardCurve<ForwardFlat>` (`isdacdsengine.cpp:121-124`) and
-//! `InterpolatedSurvivalProbabilityCurve<LogLinear>` (`:132-136`) are the two
-//! ISDA curve variants absent from this port: there is no `ForwardFlat`
-//! interpolator factory and no survival-probability curve yet. Their arms are
-//! simply missing, so such a curve reports the same error as any other
-//! unsupported shape.
+//! `InterpolatedSurvivalProbabilityCurve<LogLinear>` (`isdacdsengine.cpp:132-136`)
+//! is the one ISDA curve variant still absent from this port: there is no
+//! survival-probability curve yet. Its arm is simply missing, so such a curve
+//! reports the same error as any other unsupported shape.
+//! (`InterpolatedForwardCurve<ForwardFlat>`, the other variant #799 deferred,
+//! landed with the `ForwardFlat` factory.)
 
 use crate::errors::QlResult;
 use crate::fail;
 use crate::handle::Handle;
-use crate::math::interpolations::flat::BackwardFlat;
+use crate::math::interpolations::flat::{BackwardFlat, ForwardFlat};
 use crate::math::interpolations::loglinear::LogLinear;
 use crate::termstructures::bootstraptraits::{Discount, ForwardRate};
 use crate::termstructures::credit::defaulttermstructure::DefaultProbabilityTermStructure;
@@ -118,6 +118,9 @@ fn yield_curve_dates(curve: &dyn YieldTermStructure) -> QlResult<Vec<Date>> {
     }
     if let Some(curve) = any.downcast_ref::<PiecewiseYieldCurve<ForwardRate, BackwardFlat>>() {
         return curve.dates();
+    }
+    if let Some(curve) = any.downcast_ref::<InterpolatedForwardCurve<ForwardFlat>>() {
+        return Ok(curve.dates().to_vec());
     }
     if any.is::<FlatForward>() {
         return Ok(Vec::new());
@@ -281,6 +284,38 @@ mod tests {
             maturity(),
         )
         .expect("a backward-flat forward curve is supported");
+        assert_eq!(
+            grid, dates,
+            "the arm is reached through the grid, not only directly"
+        );
+    }
+
+    /// `isdacdsengine.cpp:121-124` (arm `castY3`): the forward-flat sibling of
+    /// the backward-flat arm above.
+    #[test]
+    fn forward_flat_curve_is_downcastable_to_its_pillar_dates() {
+        let dates = dates_at(&YIELD_OFFSETS);
+        let curve = shared(
+            InterpolatedForwardCurve::new(
+                dates.clone(),
+                vec![0.02, 0.021, 0.022, 0.023],
+                day_counter(),
+                ForwardFlat,
+            )
+            .expect("the forward nodes are well formed"),
+        );
+        let any = YieldTermStructure::as_any(&*curve).expect("the curve opts into the seam");
+        let recovered = any
+            .downcast_ref::<InterpolatedForwardCurve<ForwardFlat>>()
+            .expect("the curve is forward-flat interpolated");
+        assert_eq!(recovered.dates(), dates);
+
+        let grid = isda_node_grid(
+            &yield_handle(curve),
+            &credit_handle(flat_hazard_rate()),
+            maturity(),
+        )
+        .expect("a forward-flat forward curve is supported");
         assert_eq!(
             grid, dates,
             "the arm is reached through the grid, not only directly"

--- a/crates/libitofin/src/termstructures/yields/forwardcurve.rs
+++ b/crates/libitofin/src/termstructures/yields/forwardcurve.rs
@@ -205,6 +205,7 @@ where
 mod tests {
     use super::*;
     use crate::interestrate::Compounding;
+    use crate::math::interpolations::flat::ForwardFlat;
     use crate::math::interpolations::linear::Linear;
     use crate::time::date::Month;
     use crate::time::daycounters::actual360::Actual360;
@@ -359,6 +360,29 @@ mod tests {
 
         let df = curve.discount(2.0, false).unwrap();
         assert!((df - (-0.10_f64).exp()).abs() < 1.0e-15);
+    }
+
+    // The forward-flat twin of the test above, on the same nodes: a segment
+    // takes the LEFT node (`forward_flat_matches_oracle`, flat.rs), so a
+    // backward-flat mis-wire of the `ForwardFlat` factory shifts every zero.
+    #[test]
+    fn forward_flat_forwards_average_into_zeros() {
+        let curve = InterpolatedForwardCurve::new(
+            vec![reference(), reference() + 360, reference() + 720],
+            vec![0.03, 0.04, 0.06],
+            Actual360::new(),
+            ForwardFlat,
+        )
+        .unwrap();
+        // Segment forwards are the left nodes: 0.03 on [0,1), 0.04 on [1,2)
+        // (backward-flat would give 0.04 and 0.06).
+        assert!((curve.zero_yield_impl(1.0).unwrap() - 0.03).abs() < 1.0e-15);
+        assert!((curve.zero_yield_impl(2.0).unwrap() - 0.035).abs() < 1.0e-15);
+        assert!((curve.zero_yield_impl(0.5).unwrap() - 0.03).abs() < 1.0e-15);
+        assert_eq!(curve.zero_yield_impl(0.0).unwrap(), 0.03);
+
+        let df = curve.discount(2.0, false).unwrap();
+        assert!((df - (-0.07_f64).exp()).abs() < 1.0e-15);
     }
 
     #[test]


### PR DESCRIPTION
Add a `ForwardFlat` interpolator factory alongside the existing
`BackwardFlat`, requiring two nodes and taking the left node of each
segment. Wire it into the ISDA node grid so that
`InterpolatedForwardCurve<ForwardFlat>` yield curves are downcastable
and supported, one of the two previously deferred ISDA curve variants.

* Add `ForwardFlat` factory implementing `Interpolator` in flat.rs.
* Support forward-flat forward curves in the ISDA node grid, updating
  the deferred docs to leave only the survival-probability curve.
* Cover the factory and curve behaviour with tests confirming segments
  take the left node, unlike backward-flat.

close #799
