### PR TITLE
ci(release): sync Cargo.lock version on release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -71,7 +71,8 @@
       "@semantic-release/git",
       {
         "assets": [
-          "Cargo.toml"
+          "Cargo.toml",
+          "Cargo.lock"
         ],
         "message": "chore(release): update version to ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "itofin-py"
-version = "0.1.0"
+version = "0.16.0"
 dependencies = [
  "libitofin",
  "pyo3",
@@ -30,7 +30,7 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libitofin"
-version = "0.1.0"
+version = "0.16.0"
 dependencies = [
  "num-complex",
  "thiserror",

--- a/crates/itofin-py/tests/test_skeleton.py
+++ b/crates/itofin-py/tests/test_skeleton.py
@@ -1,9 +1,11 @@
 # itofin library
+from importlib.metadata import version
+
 import itofin
 
 
 def test_version_matches_workspace():
-    assert itofin.__version__ == "0.1.0"
+    assert itofin.__version__ == version("itofin")
 
 
 def test_itofin_error_is_exception_subclass():

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -1,16 +1,21 @@
 #!/usr/bin/env sh
-# Set the [package] version in Cargo.toml. Invoked by semantic-release
-# (@semantic-release/exec prepareCmd) so the crate version tracks the release.
+# Set the workspace version in Cargo.toml AND the workspace-member entries in
+# Cargo.lock. Invoked by semantic-release (@semantic-release/exec prepareCmd)
+# so the crate version tracks the release; both files are committed by
+# @semantic-release/git (both must be in its assets list).
 #
 #   sh scripts/set-version.sh 1.5.1
 #
 # Uses awk only (no cargo / GNU-sed extensions) so it runs in the minimal
-# semantic-release container image.
+# semantic-release container image, which has no cargo. The Cargo.lock pass
+# rewrites the version of every source-less [[package]] block (the local
+# workspace crates - registry deps carry a source line); the lockfile-format
+# "version = N" line sits above the first [[package]] and is left untouched.
 set -eu
 
 version="${1:?usage: set-version.sh <version>}"
-tmp="$(mktemp)"
 
+tmp="$(mktemp)"
 awk -v v="$version" '
   /^\[/            { in_pkg = ($0 == "[workspace.package]") }
   in_pkg && !done && /^version[[:space:]]*=/ {
@@ -20,6 +25,29 @@ awk -v v="$version" '
   }
   { print }
 ' Cargo.toml > "$tmp"
-
 mv "$tmp" Cargo.toml
-echo "set Cargo.toml [package] version = $version"
+
+tmp2="$(mktemp)"
+awk -v v="$version" '
+  function flush(   i) {
+      for (i = 1; i <= n; i++) {
+          if (!has_source && buf[i] ~ /^version[[:space:]]*=/)
+              buf[i] = "version = \"" v "\""
+          print buf[i]
+      }
+      n = 0; has_source = 0
+  }
+  /^\[/ { flush(); buf[++n] = $0; next }
+  {
+      if (n > 0) {
+          if ($0 ~ /^source[[:space:]]*=/) has_source = 1
+          buf[++n] = $0
+      } else {
+          print
+      }
+  }
+  END { flush() }
+' Cargo.lock > "$tmp2"
+mv "$tmp2" Cargo.lock
+
+echo "set [workspace.package] version = $version in Cargo.toml and Cargo.lock"


### PR DESCRIPTION
The `set-version.sh` script now rewrites the version of every
workspace-member entry in `Cargo.lock` in addition to updating
`[workspace.package]` in `Cargo.toml`, using awk only so it runs in
the minimal semantic-release container without cargo. Registry
dependencies (which carry a `source` line) are left untouched, as is
the lockfile-format version line.

`Cargo.lock` is added to the `@semantic-release/git` assets list so
the updated lockfile is committed alongside `Cargo.toml`.
