### PR TITLE
ci(.github): verify Cargo.toml version sync in release workflow

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -46,6 +46,7 @@ jobs:
         run: |
           VER="${{ needs.semantic-release.outputs.new_release_tag }}"
           sed -i -E "s/^version = \"[0-9]+\.[0-9]+\.[0-9]+\"/version = \"${VER}\"/" Cargo.toml
+          grep -qF "version = \"${VER}\"" Cargo.toml || { echo "version sync failed: workspace version does not match ${VER}"; exit 1; }
           grep -E "^version" Cargo.toml
       - name: authenticate to crates.io via OIDC trusted publishing
         uses: rust-lang/crates-io-auth-action@v1


### PR DESCRIPTION
Add a grep guard after the sed replacement to ensure the workspace
version actually matches the new release tag, failing the release job
early when the version sync does not take effect.

close #512
