### PR TITLE
docs(example): refresh MC examples for the antithetic variate and version pin

### DIFF
--- a/example/python/monte_carlo.py
+++ b/example/python/monte_carlo.py
@@ -43,11 +43,11 @@ def mc_european() -> None:
     analytic.set_engine(process)
 
     # MC: single time step is enough for a path-independent European payoff.
-    # NB: MCEuropeanEngine does not accept the antithetic variate.
+    # MCEuropeanEngine now accepts the antithetic variate (#772).
     mc = VanillaOption(OptionType.Call, 100.0, expiry, settings)
-    mc.set_mc_engine(MCEuropeanEngine(process, steps=1, samples=40000, seed=42))
+    mc.set_mc_engine(MCEuropeanEngine(process, steps=1, samples=40000, antithetic=True, seed=42))
 
-    print("MC European call (K=100, 1y, 40000 paths, seed 42):")
+    print("MC European call (K=100, 1y, 40000 paths, antithetic, seed 42):")
     print(f"  analytic NPV = {analytic.npv():.6f}")
     print(f"  MC NPV       = {mc.npv():.6f}  +/- {mc.error_estimate():.6f} (std err)")
 

--- a/example/rust/monte_carlo.rs
+++ b/example/rust/monte_carlo.rs
@@ -10,7 +10,7 @@
 //!     testAmericanOption, i=j=0), so the numbers reproduce ~2.0544 +/- ~0.0178.
 //!
 //! Run as a binary in a crate that depends on `libitofin` (e.g. add
-//! `libitofin = "0.2"` to Cargo.toml).
+//! `libitofin = "0.16"` to Cargo.toml).
 
 use libitofin::exercise::{AmericanExercise, EuropeanExercise, Exercise};
 use libitofin::handle::Handle;


### PR DESCRIPTION
* monte_carlo.py: correct the stale 'MCEuropeanEngine does not accept
  antithetic' note (#772 added it) and demonstrate antithetic=True.
* monte_carlo.rs: bump the copy-paste dependency pin libitofin 0.2 -> 0.16.

Both example sets were otherwise already current against 0.16.0 (all 9
python + 9 rust ran clean). No em dashes.
