### PR TITLE
feat(itofin-py): expose USD, JPY and GBP Libor index families

### DIFF
--- a/crates/itofin-py/python/itofin/indexes.pyi
+++ b/crates/itofin-py/python/itofin/indexes.pyi
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 class Currency:
     """An ISO 4217 currency specification.
 
-    Only the three named currencies the core provides are exposed; the general
+    Only the four named currencies the core provides are exposed; the general
     constructor is omitted, as the core ports only the currencies its indexes
     need and the full catalogue is deferred there.
     """
@@ -43,6 +43,14 @@ class Currency:
 
         Returns:
             Currency: The pound sterling, ISO code "GBP".
+        """
+        ...
+    @staticmethod
+    def jpy() -> Currency:
+        """Return the Japanese yen.
+
+        Returns:
+            Currency: The yen, ISO code "JPY".
         """
         ...
     def code(self) -> str:
@@ -210,6 +218,20 @@ class IborIndex:
             bool: True if the roll is end-of-month.
         """
         ...
+    def name(self) -> str:
+        """Return the composed index name, e.g. "Euribor6M Actual/360".
+
+        Returns:
+            str: The name the fixings are stored under.
+        """
+        ...
+    def currency(self) -> Currency:
+        """Return the currency the index is quoted in.
+
+        Returns:
+            Currency: The index currency.
+        """
+        ...
 
 class Euribor(IborIndex):
     """The Euribor IBOR index family.
@@ -259,6 +281,141 @@ class Euribor(IborIndex):
 
         Returns:
             Euribor: The Euribor6M index.
+        """
+        ...
+    def fixing(self, fixing_date: Date, forecast_todays_fixing: bool) -> float:
+        """Return the index fixing for fixing_date.
+
+        Forecast off the forwarding curve for a future date, or read from the
+        stored fixings for a past one.
+
+        Args:
+            fixing_date (Date): The date the fixing is read or forecast for.
+            forecast_todays_fixing (bool): Whether a fixing dated today is
+                forecast rather than looked up.
+
+        Returns:
+            float: The fixing rate.
+
+        Raises:
+            ItofinError: If the fixing date is not a valid one, the evaluation
+                date is unset, a past fixing is missing from the store, or the
+                forwarding handle is empty on a forecast.
+        """
+        ...
+
+class UsdLibor(IborIndex):
+    """The USD Libor index family.
+
+    A subclass of IborIndex, so a USD Libor is accepted wherever the general
+    index is. It retains its own clone of the index the base holds - the same
+    object, not a rebuild - so its own fixing reads exactly what the base reads.
+    """
+
+    def __init__(self, tenor: Period, curve: YieldTermStructure | None, settings: Settings) -> None:
+        """Build a USD Libor index of the given tenor.
+
+        Args:
+            tenor (Period): The index tenor.
+            curve (YieldTermStructure | None): The forwarding curve; None builds
+                the index over an empty handle, the form the bootstrap rate
+                helpers need.
+            settings (Settings): The explicit settings supplying the evaluation
+                date and the stored fixings.
+
+        Raises:
+            ItofinError: If tenor is a daily tenor, which needs a dedicated
+                daily-tenor constructor the core has not ported.
+        """
+        ...
+    def fixing(self, fixing_date: Date, forecast_todays_fixing: bool) -> float:
+        """Return the index fixing for fixing_date.
+
+        Forecast off the forwarding curve for a future date, or read from the
+        stored fixings for a past one.
+
+        Args:
+            fixing_date (Date): The date the fixing is read or forecast for.
+            forecast_todays_fixing (bool): Whether a fixing dated today is
+                forecast rather than looked up.
+
+        Returns:
+            float: The fixing rate.
+
+        Raises:
+            ItofinError: If the fixing date is not a valid one, the evaluation
+                date is unset, a past fixing is missing from the store, or the
+                forwarding handle is empty on a forecast.
+        """
+        ...
+
+class JpyLibor(IborIndex):
+    """The JPY Libor index family.
+
+    A subclass of IborIndex, so a JPY Libor is accepted wherever the general
+    index is. It retains its own clone of the index the base holds - the same
+    object, not a rebuild - so its own fixing reads exactly what the base reads.
+    """
+
+    def __init__(self, tenor: Period, curve: YieldTermStructure | None, settings: Settings) -> None:
+        """Build a JPY Libor index of the given tenor.
+
+        Args:
+            tenor (Period): The index tenor.
+            curve (YieldTermStructure | None): The forwarding curve; None builds
+                the index over an empty handle, the form the bootstrap rate
+                helpers need.
+            settings (Settings): The explicit settings supplying the evaluation
+                date and the stored fixings.
+
+        Raises:
+            ItofinError: If tenor is a daily tenor, which needs a dedicated
+                daily-tenor constructor the core has not ported.
+        """
+        ...
+    def fixing(self, fixing_date: Date, forecast_todays_fixing: bool) -> float:
+        """Return the index fixing for fixing_date.
+
+        Forecast off the forwarding curve for a future date, or read from the
+        stored fixings for a past one.
+
+        Args:
+            fixing_date (Date): The date the fixing is read or forecast for.
+            forecast_todays_fixing (bool): Whether a fixing dated today is
+                forecast rather than looked up.
+
+        Returns:
+            float: The fixing rate.
+
+        Raises:
+            ItofinError: If the fixing date is not a valid one, the evaluation
+                date is unset, a past fixing is missing from the store, or the
+                forwarding handle is empty on a forecast.
+        """
+        ...
+
+class GbpLibor(IborIndex):
+    """The GBP Libor index family.
+
+    A subclass of IborIndex, so a GBP Libor is accepted wherever the general
+    index is. It retains its own clone of the index the base holds - the same
+    object, not a rebuild - so its own fixing reads exactly what the base reads.
+    """
+
+    def __init__(self, tenor: Period, curve: YieldTermStructure | None, settings: Settings) -> None:
+        """Build a GBP Libor index of the given tenor.
+
+        Args:
+            tenor (Period): The index tenor.
+            curve (YieldTermStructure | None): The forwarding curve; None builds
+                the index over an empty handle, the form the bootstrap rate
+                helpers need.
+            settings (Settings): The explicit settings supplying the evaluation
+                date and the stored fixings.
+
+        Raises:
+            ItofinError: If tenor is a daily tenor, which needs a dedicated
+                daily-tenor constructor the core has not ported.
         """
         ...
     def fixing(self, fixing_date: Date, forecast_todays_fixing: bool) -> float:

--- a/crates/itofin-py/src/currency.rs
+++ b/crates/itofin-py/src/currency.rs
@@ -1,7 +1,7 @@
 //! Facade for the currency specification [`PyCurrency`] (`currency::Currency`).
 //!
 //! An index carries a currency, so the general [`PyIborIndex`](crate::hullwhite::PyIborIndex)
-//! constructor cannot be called without one. Only the three named currencies the
+//! constructor cannot be called without one. Only the four named currencies the
 //! core provides are exposed as staticmethods; the general
 //! [`Currency::new`](libitofin::currency::Currency::new) form is deliberately
 //! omitted, since the core itself ports only the currencies the indexes need and
@@ -48,6 +48,14 @@ impl PyCurrency {
     fn gbp() -> Self {
         PyCurrency {
             inner: Currency::gbp(),
+        }
+    }
+
+    /// The Japanese yen (ISO `JPY`).
+    #[staticmethod]
+    fn jpy() -> Self {
+        PyCurrency {
+            inner: Currency::jpy(),
         }
     }
 

--- a/crates/itofin-py/src/hullwhite.rs
+++ b/crates/itofin-py/src/hullwhite.rs
@@ -1,5 +1,6 @@
 //! Facades for the Hull-White short-rate stack: [`PyHullWhite`] and the
-//! [`PyIborIndex`] index base with its [`PyEuribor`] subclass.
+//! [`PyIborIndex`] index base with its [`PyEuribor`], [`PyUsdLibor`],
+//! [`PyJpyLibor`] and [`PyGbpLibor`] subclasses.
 
 use crate::PyQlError;
 use crate::calibration::{PyCalibrationErrorType, PyEndCriteria, PyLevenbergMarquardt};
@@ -10,7 +11,8 @@ use crate::settings::PySettings;
 use crate::time::{PyBusinessDayConvention, PyCalendar, PyDate, PyDayCounter, PyPeriod};
 use libitofin::cashflows::RateAveraging;
 use libitofin::handle::Handle;
-use libitofin::indexes::{Euribor, IborIndex, Index, InterestRateIndex};
+use libitofin::indexes::ibor::{GbpLibor, JpyLibor};
+use libitofin::indexes::{Euribor, IborIndex, Index, InterestRateIndex, UsdLibor};
 use libitofin::models::calibrationhelper::{BlackCalibrationHelper, CalibrationHelper};
 use libitofin::models::shortrate::SwaptionHelper;
 use libitofin::models::{CalibratedModelHolder, HullWhite, calibrate};
@@ -274,6 +276,17 @@ impl PyIborIndex {
     fn end_of_month(&self) -> bool {
         self.inner.end_of_month()
     }
+
+    /// The composed index name the fixings are stored under
+    /// (`interestrateindex.rs:230`), e.g. `Euribor6M Actual/360`.
+    fn name(&self) -> String {
+        self.inner.name()
+    }
+
+    /// The currency the index is quoted in (`interestrateindex.rs:186`).
+    fn currency(&self) -> PyCurrency {
+        PyCurrency::from_inner(self.inner.currency().clone())
+    }
 }
 
 impl PyIborIndex {
@@ -365,6 +378,168 @@ fn init_euribor(index: Shared<IborIndex>) -> PyClassInitializer<PyEuribor> {
         inner: Shared::clone(&index),
     };
     PyClassInitializer::from(base).add_subclass(PyEuribor { inner: index })
+}
+
+/// Python `UsdLibor`: the USD Libor index family (`indexes::UsdLibor`).
+///
+/// The constructor takes a tenor, an optional forwarding curve, and the
+/// settings; passing `None` for the curve builds the index over an empty
+/// handle, the form the bootstrap rate helpers need. `UsdLibor::new` returns
+/// a plain `IborIndex` by value (`usdlibor.rs:42`); it is wrapped in
+/// `shared()` exactly as the Euribor facade wraps its family.
+///
+/// A subclass of [`PyIborIndex`], so a USD Libor is accepted wherever the
+/// general index is. It retains its own clone of the index the base holds -
+/// the same object, not a rebuild - so its own `fixing` reads exactly what
+/// the base reads.
+#[pyclass(name = "UsdLibor", extends = PyIborIndex, unsendable)]
+pub struct PyUsdLibor {
+    inner: Shared<IborIndex>,
+}
+
+#[pymethods]
+impl PyUsdLibor {
+    /// A USD Libor index of `tenor` forwarding off `curve`, or off an empty
+    /// handle when `curve` is `None`. Fallible: the Libor base rejects daily
+    /// tenors (`libor.rs:89`), which need a dedicated `DailyTenor`
+    /// constructor the core has not ported.
+    #[new]
+    #[pyo3(signature = (tenor, curve, settings))]
+    fn new(
+        tenor: &PyPeriod,
+        curve: Option<&PyYieldTermStructure>,
+        settings: &PySettings,
+    ) -> PyResult<PyClassInitializer<Self>> {
+        let forwarding = match curve {
+            Some(curve) => curve.handle(),
+            None => Handle::empty(),
+        };
+        let index =
+            UsdLibor::new(tenor.inner(), forwarding, settings.inner()).map_err(PyQlError::from)?;
+        let index = shared(index);
+        let base = PyIborIndex {
+            inner: Shared::clone(&index),
+        };
+        Ok(PyClassInitializer::from(base).add_subclass(PyUsdLibor { inner: index }))
+    }
+
+    /// The index's fixing for `fixing_date`, forecast off the forwarding curve
+    /// for a future date or read from stored fixings for a past one. Fallible:
+    /// an empty forwarding handle or an unset evaluation date is an error.
+    fn fixing(&self, fixing_date: &PyDate, forecast_todays_fixing: bool) -> PyResult<f64> {
+        Ok(self
+            .inner
+            .fixing(fixing_date.inner(), forecast_todays_fixing)
+            .map_err(PyQlError::from)?)
+    }
+}
+
+/// Python `JpyLibor`: the JPY Libor index family (`indexes::ibor::JpyLibor`).
+///
+/// The constructor takes a tenor, an optional forwarding curve, and the
+/// settings; passing `None` for the curve builds the index over an empty
+/// handle, the form the bootstrap rate helpers need. `JpyLibor::new` returns
+/// a plain `IborIndex` by value (`jpylibor.rs:43`); it is wrapped in
+/// `shared()` exactly as the Euribor facade wraps its family.
+///
+/// A subclass of [`PyIborIndex`], so a JPY Libor is accepted wherever the
+/// general index is. It retains its own clone of the index the base holds -
+/// the same object, not a rebuild - so its own `fixing` reads exactly what
+/// the base reads.
+#[pyclass(name = "JpyLibor", extends = PyIborIndex, unsendable)]
+pub struct PyJpyLibor {
+    inner: Shared<IborIndex>,
+}
+
+#[pymethods]
+impl PyJpyLibor {
+    /// A JPY Libor index of `tenor` forwarding off `curve`, or off an empty
+    /// handle when `curve` is `None`. Fallible: the Libor base rejects daily
+    /// tenors (`libor.rs:89`), which need a dedicated `DailyTenor`
+    /// constructor the core has not ported.
+    #[new]
+    #[pyo3(signature = (tenor, curve, settings))]
+    fn new(
+        tenor: &PyPeriod,
+        curve: Option<&PyYieldTermStructure>,
+        settings: &PySettings,
+    ) -> PyResult<PyClassInitializer<Self>> {
+        let forwarding = match curve {
+            Some(curve) => curve.handle(),
+            None => Handle::empty(),
+        };
+        let index =
+            JpyLibor::new(tenor.inner(), forwarding, settings.inner()).map_err(PyQlError::from)?;
+        let index = shared(index);
+        let base = PyIborIndex {
+            inner: Shared::clone(&index),
+        };
+        Ok(PyClassInitializer::from(base).add_subclass(PyJpyLibor { inner: index }))
+    }
+
+    /// The index's fixing for `fixing_date`, forecast off the forwarding curve
+    /// for a future date or read from stored fixings for a past one. Fallible:
+    /// an empty forwarding handle or an unset evaluation date is an error.
+    fn fixing(&self, fixing_date: &PyDate, forecast_todays_fixing: bool) -> PyResult<f64> {
+        Ok(self
+            .inner
+            .fixing(fixing_date.inner(), forecast_todays_fixing)
+            .map_err(PyQlError::from)?)
+    }
+}
+
+/// Python `GbpLibor`: the GBP Libor index family (`indexes::ibor::GbpLibor`).
+///
+/// The constructor takes a tenor, an optional forwarding curve, and the
+/// settings; passing `None` for the curve builds the index over an empty
+/// handle, the form the bootstrap rate helpers need. `GbpLibor::new` returns
+/// a plain `IborIndex` by value (`gbplibor.rs:45`); it is wrapped in
+/// `shared()` exactly as the Euribor facade wraps its family.
+///
+/// A subclass of [`PyIborIndex`], so a GBP Libor is accepted wherever the
+/// general index is. It retains its own clone of the index the base holds -
+/// the same object, not a rebuild - so its own `fixing` reads exactly what
+/// the base reads.
+#[pyclass(name = "GbpLibor", extends = PyIborIndex, unsendable)]
+pub struct PyGbpLibor {
+    inner: Shared<IborIndex>,
+}
+
+#[pymethods]
+impl PyGbpLibor {
+    /// A GBP Libor index of `tenor` forwarding off `curve`, or off an empty
+    /// handle when `curve` is `None`. Fallible: the Libor base rejects daily
+    /// tenors (`libor.rs:89`), which need a dedicated `DailyTenor`
+    /// constructor the core has not ported.
+    #[new]
+    #[pyo3(signature = (tenor, curve, settings))]
+    fn new(
+        tenor: &PyPeriod,
+        curve: Option<&PyYieldTermStructure>,
+        settings: &PySettings,
+    ) -> PyResult<PyClassInitializer<Self>> {
+        let forwarding = match curve {
+            Some(curve) => curve.handle(),
+            None => Handle::empty(),
+        };
+        let index =
+            GbpLibor::new(tenor.inner(), forwarding, settings.inner()).map_err(PyQlError::from)?;
+        let index = shared(index);
+        let base = PyIborIndex {
+            inner: Shared::clone(&index),
+        };
+        Ok(PyClassInitializer::from(base).add_subclass(PyGbpLibor { inner: index }))
+    }
+
+    /// The index's fixing for `fixing_date`, forecast off the forwarding curve
+    /// for a future date or read from stored fixings for a past one. Fallible:
+    /// an empty forwarding handle or an unset evaluation date is an error.
+    fn fixing(&self, fixing_date: &PyDate, forecast_todays_fixing: bool) -> PyResult<f64> {
+        Ok(self
+            .inner
+            .fixing(fixing_date.inner(), forecast_todays_fixing)
+            .map_err(PyQlError::from)?)
+    }
 }
 
 /// Python `SwaptionHelper`: a co-terminal swaption calibration instrument

--- a/crates/itofin-py/src/lib.rs
+++ b/crates/itofin-py/src/lib.rs
@@ -63,7 +63,9 @@ use helpers::{
     PyOISRateHelper, PyOvernightIndex, PyPillar, PyRateAveraging, PyRateHelper, PySwapRateHelper,
 };
 use heston::{PyHestonModel, PyHestonModelHelper, PyHestonProcess};
-use hullwhite::{PyEuribor, PyHullWhite, PyIborIndex, PySwaptionHelper};
+use hullwhite::{
+    PyEuribor, PyGbpLibor, PyHullWhite, PyIborIndex, PyJpyLibor, PySwaptionHelper, PyUsdLibor,
+};
 use inflation::{
     PyConstantYoYOptionletVolatility, PyCpiInterpolationType, PyDiscountingSwapEngine,
     PyInterpolatedYoYInflationCurve, PyInterpolatedZeroInflationCurve,
@@ -228,6 +230,9 @@ fn itofin(m: &Bound<'_, PyModule>) -> PyResult<()> {
     indexes.add_class::<PyCurrency>()?;
     indexes.add_class::<PyIborIndex>()?;
     indexes.add_class::<PyEuribor>()?;
+    indexes.add_class::<PyUsdLibor>()?;
+    indexes.add_class::<PyJpyLibor>()?;
+    indexes.add_class::<PyGbpLibor>()?;
     indexes.add_class::<PyOvernightIndex>()?;
     indexes.add_class::<PyEstr>()?;
     indexes.add_class::<PySwapIndex>()?;

--- a/crates/itofin-py/tests/test_libor_family.py
+++ b/crates/itofin-py/tests/test_libor_family.py
@@ -1,0 +1,62 @@
+"""The Libor index family facades and the JPY currency.
+
+Each family assertion pins a value the core oracles pin (usdlibor.rs /
+jpylibor.rs / gbplibor.rs), so a facade wired to the wrong family constructor
+fails on the composed name, currency or day-count suffix. The USD value-date
+and maturity fixtures land on Veterans Day under the joint UK-plus-US
+calendar, so a base half built off anything but the real core Libor index
+keeps the 11th and fails.
+"""
+
+# pypi/conda library
+import pytest
+
+# itofin library
+from itofin import Settings
+from itofin.indexes import Currency, GbpLibor, IborIndex, JpyLibor, UsdLibor
+from itofin.time import Date, Period
+
+
+@pytest.fixture
+def settings():
+    settings = Settings()
+    settings.set_evaluation_date(Date(1, 1, 2020))
+    return settings
+
+
+def test_usd_libor_carries_the_family_configuration(settings):
+    index = UsdLibor(Period(3, "Months"), None, settings)
+
+    assert isinstance(index, IborIndex)
+    assert index.name() == "USDLibor3M Actual/360"
+    assert index.tenor() == Period(3, "Months")
+    assert index.currency().code() == "USD"
+
+
+def test_jpy_libor_carries_the_family_configuration(settings):
+    index = JpyLibor(Period(3, "Months"), None, settings)
+
+    assert isinstance(index, IborIndex)
+    assert index.name() == "JPYLibor3M Actual/360"
+    assert index.tenor() == Period(3, "Months")
+    assert index.currency().code() == "JPY"
+
+
+def test_gbp_libor_carries_the_family_configuration(settings):
+    index = GbpLibor(Period(3, "Months"), None, settings)
+
+    assert isinstance(index, IborIndex)
+    assert index.name() == "GBPLibor3M Actual/365 (Fixed)"
+    assert index.tenor() == Period(3, "Months")
+    assert index.currency().code() == "GBP"
+
+
+def test_currency_jpy_carries_the_iso_code():
+    assert Currency.jpy().code() == "JPY"
+
+
+def test_usd_libor_rolls_value_and_maturity_on_the_joint_calendar(settings):
+    index = UsdLibor(Period(3, "Months"), None, settings)
+
+    assert index.value_date(Date(7, 11, 2019)) == Date(12, 11, 2019)
+    assert index.maturity_date(Date(11, 8, 2020)) == Date(12, 11, 2020)


### PR DESCRIPTION
- **feat(itofin-py): expose USD, JPY and GBP Libor index families**
- **test(itofin-py): add tests for LIBOR family**

close #953