### PR TITLE
feat(itofin-py): expose Cubic and ConvexMonotone piecewise curves

### DIFF
--- a/crates/itofin-py/python/itofin/termstructures.pyi
+++ b/crates/itofin-py/python/itofin/termstructures.pyi
@@ -399,13 +399,12 @@ class PiecewiseYieldCurve(YieldTermStructure):
             helpers (list[RateHelper]): The bootstrap instruments; any
                 RateHelper subclass is accepted.
             day_counter (DayCounter): The day count turning dates into times.
-            interpolation (str): "LogLinear" or "Linear". "Cubic" is refused: a
-                global interpolator cannot converge under the single-pass
-                bootstrap, and it is available on ZeroCurve and DiscountCurve
-                instead.
+            interpolation (str): "LogLinear", "Linear" or "Cubic". Cubic is a
+                global interpolator, so its bootstrap runs the multi-pass
+                convergence loop instead of a single pass.
 
         Raises:
-            ItofinError: On an empty helper list and on an unknown or refused
+            ItofinError: On an empty helper list and on an unknown
                 interpolation name.
         """
         ...
@@ -505,11 +504,107 @@ class PiecewiseLinearZero(YieldTermStructure):
         """
         ...
 
+class PiecewiseCubicZero(YieldTermStructure):
+    """A curve bootstrapped in zero-rate space with Kruger cubic interpolation.
+
+    The QuantLib-SWIG name for the (ZeroYield, Cubic) combination. Cubic is a
+    global interpolator, so the bootstrap runs the multi-pass convergence loop
+    instead of a single pass. data() are continuously-compounded zero rates, so
+    data()[0] mirrors the first solved pillar's rate rather than a 1.0 discount.
+    """
+
+    def __init__(
+        self,
+        reference_date: Date,
+        helpers: list[RateHelper],
+        day_counter: DayCounter,
+    ) -> None:
+        """Build the curve over helpers with a fixed reference date.
+
+        Args:
+            reference_date (Date): The curve's reference date.
+            helpers (list[RateHelper]): The bootstrap instruments.
+            day_counter (DayCounter): The day count turning dates into times.
+
+        Raises:
+            ItofinError: On an empty helper list.
+        """
+        ...
+    def dates(self) -> list[Date]:
+        """Return the bootstrapped node dates, triggering the lazy bootstrap.
+
+        Returns:
+            list[Date]: One date per helper maturity, plus the reference node.
+
+        Raises:
+            ItofinError: On a bootstrap failure.
+        """
+        ...
+    def data(self) -> list[float]:
+        """Return the bootstrapped node values, triggering the lazy bootstrap.
+
+        Returns:
+            list[float]: The zero rates at the nodes.
+
+        Raises:
+            ItofinError: On a bootstrap failure.
+        """
+        ...
+
 class PiecewiseLinearForward(YieldTermStructure):
     """A curve bootstrapped in instantaneous forward-rate space, interpolating linearly.
 
     The verbatim QuantLib-SWIG name for the blessed (ForwardRate, Linear)
     combination. data() are instantaneous forward rates.
+    """
+
+    def __init__(
+        self,
+        reference_date: Date,
+        helpers: list[RateHelper],
+        day_counter: DayCounter,
+    ) -> None:
+        """Build the curve over helpers with a fixed reference date.
+
+        Args:
+            reference_date (Date): The curve's reference date.
+            helpers (list[RateHelper]): The bootstrap instruments.
+            day_counter (DayCounter): The day count turning dates into times.
+
+        Raises:
+            ItofinError: On an empty helper list.
+        """
+        ...
+    def dates(self) -> list[Date]:
+        """Return the bootstrapped node dates, triggering the lazy bootstrap.
+
+        Returns:
+            list[Date]: One date per helper maturity, plus the reference node.
+
+        Raises:
+            ItofinError: On a bootstrap failure.
+        """
+        ...
+    def data(self) -> list[float]:
+        """Return the bootstrapped node values, triggering the lazy bootstrap.
+
+        Returns:
+            list[float]: The instantaneous forward rates at the nodes.
+
+        Raises:
+            ItofinError: On a bootstrap failure.
+        """
+        ...
+
+class PiecewiseConvexMonotoneForward(YieldTermStructure):
+    """A curve bootstrapped in forward-rate space with convex-monotone interpolation.
+
+    The QuantLib-SWIG name for the (ForwardRate, ConvexMonotone) combination,
+    built with QuantLib's defaults (quadraticity 0.3, monotonicity 0.7, forced
+    positive). ConvexMonotone is a global interpolator that reads the solved
+    nodes as discrete forwards, so the bootstrap runs the multi-pass
+    convergence loop. data() are instantaneous forward rates; the interpolation
+    ignores node [0], which only mirrors the first solved pillar.
     """
 
     def __init__(

--- a/crates/itofin-py/src/curve.rs
+++ b/crates/itofin-py/src/curve.rs
@@ -6,6 +6,7 @@ use crate::time::{PyCalendar, PyDate, PyDayCounter};
 use crate::{ItofinError, PyQlError};
 use libitofin::handle::Handle;
 use libitofin::interestrate::Compounding;
+use libitofin::math::interpolations::convexmonotone::ConvexMonotone;
 use libitofin::math::interpolations::cubic::Cubic;
 use libitofin::math::interpolations::flat::BackwardFlat;
 use libitofin::math::interpolations::linear::Linear;
@@ -318,14 +319,21 @@ impl PyForwardCurve {
 ///
 /// Extends [`PyYieldTermStructure`]; every helper is solved so it reprices its
 /// own market quote off the curve. This ergonomic string-dispatch alias covers
-/// the `Discount` convention over the `LogLinear` (default) or `Linear`
-/// interpolator selected by the `interpolation` string; both erase to the same
-/// `Handle<dyn YieldTermStructure>`, so no discriminant is stored. The other
-/// bootstrap conventions (`ZeroYield`, `ForwardRate`) are reached through the
-/// named [`PyPiecewiseLinearZero`], [`PyPiecewiseLinearForward`] and
+/// the `Discount` convention over the `LogLinear` (default), `Linear` or
+/// `Cubic` interpolator selected by the `interpolation` string; all erase to
+/// the same `Handle<dyn YieldTermStructure>`, so no discriminant is stored.
+/// `Cubic` is a global interpolator, so its bootstrap runs the multi-pass
+/// convergence loop (#543) instead of a single pass. The other bootstrap
+/// conventions (`ZeroYield`, `ForwardRate`) are reached through the named
+/// [`PyPiecewiseLinearZero`], [`PyPiecewiseCubicZero`],
+/// [`PyPiecewiseLinearForward`], [`PyPiecewiseConvexMonotoneForward`] and
 /// [`PyPiecewiseFlatForward`] classes, which also expose node introspection.
 /// `(Discount, Linear)` deliberately gets no named class - QuantLib-SWIG has no
 /// equivalent - so it stays reachable only through this alias's `"Linear"` arm.
+/// `(ForwardRate, Cubic)` is deliberately not reachable at all: a piecewise
+/// cubic on instantaneous forwards settles into a period-2 cycle and never
+/// converges (the configuration upstream itself disables as unstable), so no
+/// named class offers it.
 ///
 /// The bootstrap is lazy: construction only rejects an empty helper list, and
 /// the solver runs on the first query (a `discount`/`zero_rate`), re-running
@@ -340,8 +348,8 @@ impl PyPiecewiseYieldCurve {
     /// A curve over `helpers` with a fixed `reference_date` (typically the
     /// settlement date the caller computed via `Calendar.advance`). `helpers`
     /// accepts any [`RateHelper`](PyRateHelper) subclass; `interpolation` is
-    /// `"LogLinear"` or `"Linear"`. Fallible: an empty helper list is rejected
-    /// here, an unknown interpolation name too.
+    /// `"LogLinear"`, `"Linear"` or `"Cubic"`. Fallible: an empty helper list
+    /// is rejected here, an unknown interpolation name too.
     #[new]
     #[pyo3(signature = (reference_date, helpers, day_counter, interpolation = "LogLinear"))]
     fn new(
@@ -367,18 +375,16 @@ impl PyPiecewiseYieldCurve {
                 Linear,
             )
             .map_err(PyQlError::from)?,
-            "Cubic" => {
-                return Err(ItofinError::new_err(
-                    "Cubic is a global interpolator (every node depends on all others), \
-                     which the single-pass IterativeBootstrap cannot converge; the global \
-                     convergence loop is unported (#543) and the core-side guard that would \
-                     reject it is tracked separately (#552). Cubic is available on the \
-                     standalone ZeroCurve and DiscountCurve instead.",
-                ));
-            }
+            "Cubic" => PiecewiseYieldCurve::<Discount, Cubic>::new(
+                reference_date.inner(),
+                instruments,
+                day_counter.inner(),
+                Cubic,
+            )
+            .map_err(PyQlError::from)?,
             other => {
                 return Err(ItofinError::new_err(format!(
-                    "unknown interpolation {other:?}, expected LogLinear or Linear"
+                    "unknown interpolation {other:?}, expected LogLinear, Linear or Cubic"
                 )));
             }
         };
@@ -504,6 +510,63 @@ impl PyPiecewiseLinearZero {
     }
 }
 
+/// Python `PiecewiseCubicZero`: a curve bootstrapped in zero-rate space with
+/// Kruger cubic interpolation (`PiecewiseYieldCurve<ZeroYield, Cubic>`).
+///
+/// The QuantLib-SWIG name for the `(ZeroYield, Cubic)` combination. `Cubic` is
+/// a global interpolator (every node depends on all others), so the bootstrap
+/// runs the multi-pass convergence loop (#543) instead of a single pass. Its
+/// stored `data()` are continuously-compounded zero rates, so `data()[0]`
+/// mirrors the first solved pillar's rate rather than a `1.0` discount.
+#[pyclass(name = "PiecewiseCubicZero", extends = PyYieldTermStructure, unsendable)]
+pub struct PyPiecewiseCubicZero {
+    concrete: Shared<PiecewiseYieldCurve<ZeroYield, Cubic>>,
+}
+
+#[pymethods]
+impl PyPiecewiseCubicZero {
+    /// A curve over `helpers` with a fixed `reference_date`. Fallible: an empty
+    /// helper list is rejected here.
+    #[new]
+    fn new(
+        reference_date: &PyDate,
+        helpers: Vec<PyRef<PyRateHelper>>,
+        day_counter: &PyDayCounter,
+    ) -> PyResult<PyClassInitializer<Self>> {
+        let instruments: Vec<Shared<dyn RateHelper>> =
+            helpers.iter().map(|helper| helper.inner()).collect();
+        let concrete = PiecewiseYieldCurve::<ZeroYield, Cubic>::new(
+            reference_date.inner(),
+            instruments,
+            day_counter.inner(),
+            Cubic,
+        )
+        .map_err(PyQlError::from)?;
+        let erased = Shared::clone(&concrete) as Shared<dyn YieldTermStructure>;
+        Ok(PyClassInitializer::from(PyYieldTermStructure {
+            inner: Handle::new(erased),
+        })
+        .add_subclass(PyPiecewiseCubicZero { concrete }))
+    }
+
+    /// The bootstrapped node dates (triggers the lazy bootstrap).
+    fn dates(&self) -> PyResult<Vec<PyDate>> {
+        Ok(self
+            .concrete
+            .dates()
+            .map_err(PyQlError::from)?
+            .into_iter()
+            .map(PyDate::from_inner)
+            .collect())
+    }
+
+    /// The bootstrapped node values, zero rates here (triggers the lazy
+    /// bootstrap).
+    fn data(&self) -> PyResult<Vec<f64>> {
+        Ok(self.concrete.data().map_err(PyQlError::from)?)
+    }
+}
+
 /// Python `PiecewiseLinearForward`: a curve bootstrapped in instantaneous
 /// forward-rate space with linear interpolation
 /// (`PiecewiseYieldCurve<ForwardRate, Linear>`).
@@ -539,6 +602,66 @@ impl PyPiecewiseLinearForward {
             inner: Handle::new(erased),
         })
         .add_subclass(PyPiecewiseLinearForward { concrete }))
+    }
+
+    /// The bootstrapped node dates (triggers the lazy bootstrap).
+    fn dates(&self) -> PyResult<Vec<PyDate>> {
+        Ok(self
+            .concrete
+            .dates()
+            .map_err(PyQlError::from)?
+            .into_iter()
+            .map(PyDate::from_inner)
+            .collect())
+    }
+
+    /// The bootstrapped node values, forward rates here (triggers the lazy
+    /// bootstrap).
+    fn data(&self) -> PyResult<Vec<f64>> {
+        Ok(self.concrete.data().map_err(PyQlError::from)?)
+    }
+}
+
+/// Python `PiecewiseConvexMonotoneForward`: a curve bootstrapped in
+/// instantaneous forward-rate space with convex-monotone interpolation
+/// (`PiecewiseYieldCurve<ForwardRate, ConvexMonotone>`).
+///
+/// The QuantLib-SWIG name for the `(ForwardRate, ConvexMonotone)` combination,
+/// built with QuantLib's defaults (quadraticity 0.3, monotonicity 0.7, forced
+/// positive). `ConvexMonotone` is a global interpolator that reads the solved
+/// nodes as discrete forwards, so the bootstrap runs the multi-pass
+/// convergence loop (#543). Its stored `data()` are instantaneous forward
+/// rates; the interpolation itself ignores node `[0]`, which only mirrors the
+/// first solved pillar.
+#[pyclass(name = "PiecewiseConvexMonotoneForward", extends = PyYieldTermStructure, unsendable)]
+pub struct PyPiecewiseConvexMonotoneForward {
+    concrete: Shared<PiecewiseYieldCurve<ForwardRate, ConvexMonotone>>,
+}
+
+#[pymethods]
+impl PyPiecewiseConvexMonotoneForward {
+    /// A curve over `helpers` with a fixed `reference_date`. Fallible: an empty
+    /// helper list is rejected here.
+    #[new]
+    fn new(
+        reference_date: &PyDate,
+        helpers: Vec<PyRef<PyRateHelper>>,
+        day_counter: &PyDayCounter,
+    ) -> PyResult<PyClassInitializer<Self>> {
+        let instruments: Vec<Shared<dyn RateHelper>> =
+            helpers.iter().map(|helper| helper.inner()).collect();
+        let concrete = PiecewiseYieldCurve::<ForwardRate, ConvexMonotone>::new(
+            reference_date.inner(),
+            instruments,
+            day_counter.inner(),
+            ConvexMonotone::default(),
+        )
+        .map_err(PyQlError::from)?;
+        let erased = Shared::clone(&concrete) as Shared<dyn YieldTermStructure>;
+        Ok(PyClassInitializer::from(PyYieldTermStructure {
+            inner: Handle::new(erased),
+        })
+        .add_subclass(PyPiecewiseConvexMonotoneForward { concrete }))
     }
 
     /// The bootstrapped node dates (triggers the lazy bootstrap).

--- a/crates/itofin-py/src/lib.rs
+++ b/crates/itofin-py/src/lib.rs
@@ -55,9 +55,9 @@ use creditengine::{
 use credithelpers::{PyDefaultProbabilityHelper, PySpreadCdsHelper};
 use currency::PyCurrency;
 use curve::{
-    PyDiscountCurve, PyFlatForward, PyForwardCurve, PyPiecewiseFlatForward,
-    PyPiecewiseLinearForward, PyPiecewiseLinearZero, PyPiecewiseLogLinearDiscount,
-    PyPiecewiseYieldCurve, PyYieldTermStructure, PyZeroCurve,
+    PyDiscountCurve, PyFlatForward, PyForwardCurve, PyPiecewiseConvexMonotoneForward,
+    PyPiecewiseCubicZero, PyPiecewiseFlatForward, PyPiecewiseLinearForward, PyPiecewiseLinearZero,
+    PyPiecewiseLogLinearDiscount, PyPiecewiseYieldCurve, PyYieldTermStructure, PyZeroCurve,
 };
 use fra::{PyForwardRateAgreement, PyPosition};
 use helpers::{
@@ -189,7 +189,9 @@ fn itofin(m: &Bound<'_, PyModule>) -> PyResult<()> {
     termstructures.add_class::<PyPiecewiseYieldCurve>()?;
     termstructures.add_class::<PyPiecewiseLogLinearDiscount>()?;
     termstructures.add_class::<PyPiecewiseLinearZero>()?;
+    termstructures.add_class::<PyPiecewiseCubicZero>()?;
     termstructures.add_class::<PyPiecewiseLinearForward>()?;
+    termstructures.add_class::<PyPiecewiseConvexMonotoneForward>()?;
     termstructures.add_class::<PyPiecewiseFlatForward>()?;
     termstructures.add_class::<PySwaptionVolatilityStructure>()?;
     termstructures.add_class::<PyVolatilityType>()?;

--- a/crates/itofin-py/tests/test_piecewise_yield_curve.py
+++ b/crates/itofin-py/tests/test_piecewise_yield_curve.py
@@ -16,11 +16,13 @@ piecewiseyieldcurve.cpp). Tolerance 1e-9 (:322), checked with a bare
 import pytest
 
 # itofin library
-from itofin import ItofinError, Settings
+from itofin import ItofinError, Settings, termstructures
 from itofin.indexes import Euribor
 from itofin.quotes import SimpleQuote
 from itofin.termstructures import (
     DepositRateHelper,
+    PiecewiseConvexMonotoneForward,
+    PiecewiseCubicZero,
     PiecewiseFlatForward,
     PiecewiseLinearForward,
     PiecewiseLinearZero,
@@ -100,11 +102,13 @@ def _fixture():
     return settings, calendar, today, settlement, deposits, swaps
 
 
-@pytest.mark.parametrize("interpolation", ["LogLinear", "Linear"])
+@pytest.mark.parametrize("interpolation", ["LogLinear", "Linear", "Cubic"])
 def test_bootstrapped_curve_reprices_its_strip(interpolation):
     """The port of `testCurveConsistency<Discount, I, IterativeBootstrap>`,
-    deposits + swaps, parametrized over both exposed interpolators
-    (log_linear_discount_consistency :441, linear_discount_consistency :449).
+    deposits + swaps, parametrized over all three exposed interpolators
+    (log_linear_discount_consistency :441, linear_discount_consistency :449,
+    global_interpolator_bootstraps_through_the_convergence_loop :905). The
+    Cubic arm bootstraps through the multi-pass convergence loop (#543).
     """
     settings, _, today, settlement, deposits, swaps = _fixture()
     instruments = deposits + swaps
@@ -210,22 +214,26 @@ def test_unknown_interpolation_raises():
         PiecewiseYieldCurve(settlement, deposits, DayCounter.actual360(), "Spline")
 
 
-def test_cubic_is_rejected_by_piecewise_with_reason():
-    """Scope C guard (#547): PiecewiseYieldCurve<_, Cubic> COMPILES AND RUNS AND
-    IS SILENTLY WRONG (Cubic is a global interpolator, but IterativeBootstrap is
-    single-pass; on the merged mixed strip <ForwardRate, Cubic> mis-reprices by
-    130bp while raising nothing). The named classes never offer Cubic and the
-    string-dispatch arm rejects it with a reason that cites the unported
-    convergence loop (#543) and the core-side guard (#552). A deposits-only strip
-    would pass green even with Cubic (deposits read the curve only at their own
-    pillar), so the rejection itself is the assertion here."""
+def test_cubic_alias_no_longer_rejected():
+    """The #547 scope-C guard is retired (#955): the stale rejection cited the
+    convergence loop as unported (#543), but #543 is merged (Cubic::GLOBAL, the
+    multi-pass IterativeBootstrap loop), so the "Cubic" arm now constructs the
+    real <Discount, Cubic> curve. Construction and an in-range query must both
+    succeed where the old guard raised at construction; the full repricing
+    oracle is the "Cubic" arm of test_bootstrapped_curve_reprices_its_strip."""
     _, _, _, settlement, deposits, _ = _fixture()
-    with pytest.raises(ItofinError) as excinfo:
-        PiecewiseYieldCurve(settlement, deposits, DayCounter.actual360(), "Cubic")
-    message = str(excinfo.value)
-    assert "Cubic" in message
-    assert "#543" in message
-    assert "#552" in message
+    curve = PiecewiseYieldCurve(settlement, deposits, DayCounter.actual360(), "Cubic")
+    assert 0.0 < curve.discount(0.5) < 1.0
+
+
+def test_forward_cubic_stays_unreachable():
+    """<ForwardRate, Cubic> stays rejected (#955): the core reproduces the
+    upstream `//Unstable` period-2 cycle (piecewiseyieldcurve.rs:943, the
+    bootstrap exhausts its iteration cap), so no facade offers the combination.
+    The alias is Discount-only and no named class exists under any plausible
+    SWIG-style name - the visible omission IS the guard."""
+    for name in ("PiecewiseCubicForward", "PiecewiseKrugerForward"):
+        assert not hasattr(termstructures, name), name
 
 
 def test_bootstrap_failure_surfaces_at_query_not_construction():
@@ -390,3 +398,104 @@ def test_named_classes_expose_node_dates_and_data():
     for name, curve in curves.items():
         assert len(curve.dates()) == expected, name
         assert len(curve.data()) == expected, name
+
+
+# --- Cubic / ConvexMonotone named classes (#955) ------------------------------
+#
+# The two global-interpolator conventions with green core oracles, bootstrapped
+# through the multi-pass convergence loop (#543).
+
+
+def _reprice_strip(curve, settings, today, swaps):
+    """The alias test's two arms at 1e-9: deposits repriced by a FRESH index on
+    the curve (the independent oracle) and swaps via implied_quote (the wiring
+    smoke-test; see test_bootstrapped_curve_reprices_its_strip)."""
+    curve.discount(0.5)
+    for n, unit, rate in DEPOSIT_DATA:
+        index = Euribor(P(n, unit), curve, settings)
+        estimated = index.fixing(today, False)
+        expected = rate / 100.0
+        assert abs(estimated - expected) <= TOLERANCE, (
+            f"{n} {unit} deposit: {estimated} vs {expected}"
+        )
+    for (n, rate), helper in zip(SWAP_DATA, swaps):
+        estimated = helper.implied_quote()
+        expected = rate / 100.0
+        assert abs(estimated - expected) <= TOLERANCE, (
+            f"{n}Y swap: {estimated} vs {expected}"
+        )
+
+
+def test_cubic_zero_reprices_its_strip():
+    """The pytest mirror of spline_zero_consistency
+    (piecewiseyieldcurve.rs:583): <ZeroYield, Cubic> over the mixed strip
+    reprices every quote to 1e-9, and data[0] mirrors the first solved pillar
+    (the update_guess mirror the core pins at :585)."""
+    settings, _, today, settlement, deposits, swaps = _fixture()
+    instruments = deposits + swaps
+    curve = PiecewiseCubicZero(settlement, instruments, DayCounter.actual360())
+    _reprice_strip(curve, settings, today, swaps)
+    data = curve.data()
+    assert data[0] == data[1], "the reference zero rate must mirror the first pillar"
+    assert len(curve.dates()) == len(instruments) + 1
+
+
+def test_convex_monotone_forward_reprices_its_strip():
+    """The pytest mirror of convex_monotone_forward_consistency
+    (piecewiseyieldcurve.rs:633): <ForwardRate, ConvexMonotone> over the mixed
+    strip reprices every quote to 1e-9, and data[0] mirrors the first solved
+    pillar (the interpolation itself ignores that node)."""
+    settings, _, today, settlement, deposits, swaps = _fixture()
+    instruments = deposits + swaps
+    curve = PiecewiseConvexMonotoneForward(
+        settlement, instruments, DayCounter.actual360()
+    )
+    _reprice_strip(curve, settings, today, swaps)
+    data = curve.data()
+    assert data[0] == data[1], "the reference forward must mirror the first pillar"
+    assert len(curve.dates()) == len(instruments) + 1
+
+
+def test_new_named_classes_differ_from_their_linear_siblings():
+    """Anti-miswiring arm: a copy-paste that wired either new class to Linear
+    would produce a curve BIT-IDENTICAL to its linear sibling (same solve), and
+    the reprice arms above would stay green. The interpolator genuinely reshapes
+    the curve between pillars, so the off-pillar discounts must separate."""
+    _, _, _, settlement, deposits, swaps = _fixture()
+    instruments = deposits + swaps
+    dc = DayCounter.actual360()
+    pairs = [
+        (
+            "cubic_zero",
+            PiecewiseCubicZero(settlement, instruments, dc),
+            PiecewiseLinearZero(settlement, instruments, dc),
+        ),
+        (
+            "convex_monotone_forward",
+            PiecewiseConvexMonotoneForward(settlement, instruments, dc),
+            PiecewiseLinearForward(settlement, instruments, dc),
+        ),
+    ]
+    times = [0.6, 0.9, 1.5, 3.5, 7.5]
+    for name, new, linear in pairs:
+        separation = max(abs(new.discount(t) - linear.discount(t)) for t in times)
+        assert separation > 1.0e-12, f"{name}: identical to its linear sibling"
+
+
+def test_cubic_alias_differs_from_its_linear_siblings():
+    """Anti-miswiring arm for the ALIAS's "Cubic" match arm: mis-wired to
+    <Discount, Linear> (or LogLinear) it would produce a curve BIT-IDENTICAL to
+    that sibling arm, and the parametrized reprice test would stay green (it is
+    self-consistent). The interpolator genuinely reshapes the curve between
+    pillars, so the off-pillar discounts must separate from BOTH other arms."""
+    _, _, _, settlement, deposits, swaps = _fixture()
+    instruments = deposits + swaps
+    dc = DayCounter.actual360()
+    cubic = PiecewiseYieldCurve(settlement, instruments, dc, "Cubic")
+    linear = PiecewiseYieldCurve(settlement, instruments, dc, "Linear")
+    log_linear = PiecewiseYieldCurve(settlement, instruments, dc, "LogLinear")
+
+    times = [0.6, 0.9, 1.5, 3.5, 7.5]
+    for name, sibling in [("Linear", linear), ("LogLinear", log_linear)]:
+        separation = max(abs(cubic.discount(t) - sibling.discount(t)) for t in times)
+        assert separation > 1.0e-12, f"Cubic identical to the {name} arm"


### PR DESCRIPTION
This pull request retires the stale Cubic rejection and surfaces the two
global-interpolator bootstrap conventions to Python, now that the
multi-pass convergence loop (#543) is merged.

**New named curve classes:**
* Added `PiecewiseCubicZero` for the `(ZeroYield, Cubic)` combination,
  bootstrapped through the convergence loop; its `data()[0]` mirrors the
  first solved pillar's zero rate.
* Added `PiecewiseConvexMonotoneForward` for the
  `(ForwardRate, ConvexMonotone)` combination, built with QuantLib's
  defaults (quadraticity 0.3, monotonicity 0.7, forced positive).
* Both classes expose `dates()` and `data()` node introspection and are
  registered in the `termstructures` module.

**Alias behaviour change:**
* The `PiecewiseYieldCurve` string dispatch now accepts `"Cubic"` on the
  `Discount` convention, constructing the real `(Discount, Cubic)` curve
  instead of raising; `(ForwardRate, Cubic)` stays deliberately
  unreachable due to its unstable period-2 cycle.

**Testing:**
* Parametrized the strip-repricing test over the new `Cubic` arm and
  added repricing oracles for both named classes at 1e-9.
* Replaced the old rejection test with checks that the alias no longer
  raises and that `(ForwardRate, Cubic)` remains unexposed.
* Added an anti-miswiring test that separates each new curve from its
  linear sibling off-pillar.

Closes #955
