### PR TITLE
feat(indexes): add calendar roll rule for separate-calendar rolls

### DIFF
--- a/crates/libitofin/src/indexes/ibor/custom.rs
+++ b/crates/libitofin/src/indexes/ibor/custom.rs
@@ -19,9 +19,7 @@ use crate::currency::Currency;
 use crate::errors::QlResult;
 use crate::handle::Handle;
 use crate::indexes::iborindex::IborIndex;
-use crate::indexes::index::Index;
 use crate::indexes::interestrateindex::{InterestRateIndex, InterestRateIndexBase};
-use crate::require;
 use crate::settings::Settings;
 use crate::shared::{Shared, shared};
 use crate::termstructures::yieldtermstructure::YieldTermStructure;
@@ -30,37 +28,38 @@ use crate::time::calendar::Calendar;
 use crate::time::date::Date;
 use crate::time::daycounter::DayCounter;
 use crate::time::period::Period;
-use crate::time::timeunit::TimeUnit;
-use crate::types::{Integer, Natural, Rate};
+use crate::types::{Natural, Rate};
 
 /// An [`IborIndex`] with separate fixing, value, and maturity calendars
 /// (`ql/indexes/ibor/custom.hpp:28`).
 ///
 /// The port keeps the C++ "is-an-`IborIndex`" relation as a newtype embedding
-/// the configured [`IborIndex`] (the [`OvernightIndex`] precedent), carrying
-/// the two extra calendars alongside; the base's single calendar plays the
-/// fixing-calendar role. The three date methods C++ overrides
-/// (`custom.cpp:23-41`) are overridden here on [`InterestRateIndex`].
+/// the configured [`IborIndex`] (the [`OvernightIndex`] precedent); the base's
+/// single calendar plays the fixing-calendar role. The inner index carries the
+/// other two calendars and the separate-calendar roll rule as data
+/// ([`with_separate_calendars`](IborIndex::with_separate_calendars)), so the
+/// three date methods C++ overrides (`custom.cpp:23-41`) are pure delegations
+/// here and [`upcast`](Self::upcast) hands out an `IborIndex` that still rolls
+/// on all three calendars.
 ///
-/// [`forecast_fixing`](InterestRateIndex::forecast_fixing) cannot simply
-/// delegate to the inner index: the C++ body lives on `IborIndex` but calls
+/// [`forecast_fixing`](InterestRateIndex::forecast_fixing) delegates for the
+/// same reason. The C++ body lives on `IborIndex` but calls
 /// `valueDate`/`maturityDate` virtually, resolving to this subclass's
-/// three-calendar overrides. The override here re-derives both dates through
-/// the overridden methods and delegates only the curve read
-/// ([`forecast_fixing_between`](IborIndex::forecast_fixing_between)).
+/// three-calendar overrides; folding the roll into the inner index makes its
+/// own body resolve to those same dates, closing the composition trap at the
+/// data level rather than by re-deriving both dates here.
 ///
 /// [`OvernightIndex`]: crate::indexes::iborindex::OvernightIndex
 pub struct CustomIborIndex {
     ibor: Shared<IborIndex>,
-    value_calendar: Calendar,
-    maturity_calendar: Calendar,
 }
 
 impl CustomIborIndex {
     /// Builds the index over `forwarding`, mirroring the C++ constructor
     /// (`custom.cpp:8-21`): the base [`IborIndex`] takes `fixing_calendar` as
-    /// its single calendar, and the value and maturity calendars are stored
-    /// alongside.
+    /// its single calendar, then takes the value and maturity calendars and
+    /// the separate-calendar roll rule, which together reproduce the C++
+    /// subclass's three date overrides.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         family_name: String,
@@ -77,31 +76,44 @@ impl CustomIborIndex {
         settings: Shared<Settings<Date>>,
     ) -> CustomIborIndex {
         CustomIborIndex {
-            ibor: shared(IborIndex::new(
-                family_name,
-                tenor,
-                settlement_days,
-                currency,
-                fixing_calendar,
-                convention,
-                end_of_month,
-                day_counter,
-                forwarding,
-                settings,
-            )),
-            value_calendar,
-            maturity_calendar,
+            ibor: shared(
+                IborIndex::new(
+                    family_name,
+                    tenor,
+                    settlement_days,
+                    currency,
+                    fixing_calendar,
+                    convention,
+                    end_of_month,
+                    day_counter,
+                    forwarding,
+                    settings,
+                )
+                .with_separate_calendars(value_calendar, maturity_calendar),
+            ),
         }
+    }
+
+    /// The inner [`IborIndex`] this index configures, sharing its identity (the
+    /// C++ upcast of the same `shared_ptr`).
+    ///
+    /// The upcast is safe because the roll lives on the inner index as data:
+    /// the returned index reproduces the three-calendar fixing, value, and
+    /// maturity dates rather than the base's single-calendar ones, so a
+    /// consumer taking a plain `IborIndex` (a rate helper, a coupon) prices
+    /// this index the way C++ does.
+    pub fn upcast(&self) -> Shared<IborIndex> {
+        self.ibor.clone()
     }
 
     /// The calendar value dates are advanced on (`valueCalendar`).
     pub fn value_calendar(&self) -> Calendar {
-        self.value_calendar.clone()
+        self.ibor.value_calendar()
     }
 
     /// The calendar maturity dates are advanced on (`maturityCalendar`).
     pub fn maturity_calendar(&self) -> Calendar {
-        self.maturity_calendar.clone()
+        self.ibor.maturity_calendar()
     }
 
     /// The convention applied when rolling the value date to maturity.
@@ -116,12 +128,11 @@ impl CustomIborIndex {
 
     /// Rebuilds this index onto a different forwarding curve, re-threading all
     /// three calendars along with every other configuration field (the C++
-    /// `clone` override, `custom.cpp:43-49`).
+    /// `clone` override, `custom.cpp:43-49`). The calendars and the roll rule
+    /// ride along inside [`IborIndex::clone_with`].
     pub fn clone_with(&self, forwarding: Handle<dyn YieldTermStructure>) -> CustomIborIndex {
         CustomIborIndex {
             ibor: shared(self.ibor.clone_with(forwarding)),
-            value_calendar: self.value_calendar.clone(),
-            maturity_calendar: self.maturity_calendar.clone(),
         }
     }
 }
@@ -131,66 +142,30 @@ impl InterestRateIndex for CustomIborIndex {
         self.ibor.base()
     }
 
-    /// The three-calendar fixing date (`custom.cpp:23-27`): back
-    /// `fixing_days` business days on the value calendar, then a `Preceding`
-    /// adjust on the fixing calendar - not the base's single `Following`
-    /// advance.
+    /// The three-calendar fixing date (`custom.cpp:23-27`), answered by the
+    /// inner index's separate-calendar roll: back `fixing_days` business days
+    /// on the value calendar, then a `Preceding` adjust on the fixing calendar.
     fn fixing_date(&self, value_date: Date) -> Date {
-        let fixing_date = self.value_calendar.advance(
-            value_date,
-            -(self.fixing_days() as Integer),
-            TimeUnit::Days,
-            BusinessDayConvention::Following,
-            false,
-        );
-        self.fixing_calendar()
-            .adjust(fixing_date, BusinessDayConvention::Preceding)
+        self.ibor.fixing_date(value_date)
     }
 
-    /// The three-calendar value date (`custom.cpp:29-36`): requires a valid
-    /// fixing date on the fixing calendar, advances `fixing_days` business
-    /// days on the value calendar, then adjusts `Following` on the maturity
-    /// calendar.
+    /// The three-calendar value date (`custom.cpp:29-36`), answered by the
+    /// inner index's separate-calendar roll: a valid fixing date on the fixing
+    /// calendar, `fixing_days` business days forward on the value calendar,
+    /// then a `Following` adjust on the maturity calendar.
     fn value_date(&self, fixing_date: Date) -> QlResult<Date> {
-        require!(
-            self.is_valid_fixing_date(fixing_date),
-            "{fixing_date:?} is not a valid fixing date"
-        );
-        let d = self.value_calendar.advance(
-            fixing_date,
-            self.fixing_days() as Integer,
-            TimeUnit::Days,
-            BusinessDayConvention::Following,
-            false,
-        );
-        Ok(self
-            .maturity_calendar
-            .adjust(d, BusinessDayConvention::Following))
+        self.ibor.value_date(fixing_date)
     }
 
     /// The three-calendar maturity date (`custom.cpp:38-41`): the value date
     /// advanced by the tenor on the maturity calendar under the index's stored
     /// convention and end-of-month flag.
     fn maturity_date(&self, value_date: Date) -> QlResult<Date> {
-        Ok(self.maturity_calendar.advance_by_period(
-            value_date,
-            self.tenor(),
-            self.ibor.business_day_convention(),
-            self.ibor.end_of_month(),
-        ))
+        self.ibor.maturity_date(value_date)
     }
 
     fn forecast_fixing(&self, fixing_date: Date) -> QlResult<Rate> {
-        let d1 = self.value_date(fixing_date)?;
-        let d2 = self.maturity_date(d1)?;
-        let t = self.day_counter().year_fraction(d1, d2);
-        let positive_time = t > 0.0;
-        require!(
-            positive_time,
-            "cannot calculate forward rate between {d1:?} and {d2:?}: non positive time ({t}) using {} daycounter",
-            self.day_counter().name()
-        );
-        self.ibor.forecast_fixing_between(d1, d2, t)
+        self.ibor.forecast_fixing(fixing_date)
     }
 }
 
@@ -203,9 +178,11 @@ mod tests {
     //! three-calendar logic from a single-calendar mis-port.
 
     use super::*;
+    use crate::indexes::index::Index;
     use crate::time::calendars::bespokecalendar::BespokeCalendar;
     use crate::time::date::Month;
     use crate::time::daycounters::actual360::Actual360;
+    use crate::time::timeunit::TimeUnit;
 
     /// The `testCustomIborIndex` fixture (indexes.cpp:155-170): three bespoke
     /// calendars with hand-placed holidays and the "Custom Ibor" index over
@@ -316,6 +293,32 @@ mod tests {
                 Date::new(7, Month::January, 2025)
             );
         }
+    }
+
+    /// The safe-upcast pin (no C++ oracle: C++ upcasts a `shared_ptr` for
+    /// free). The plain `IborIndex` [`upcast`](CustomIborIndex::upcast) hands
+    /// out must reproduce all three date tables above, since a consumer taking
+    /// a concrete `IborIndex` gets exactly this index and nothing re-routes
+    /// the calls back through the newtype.
+    #[test]
+    fn the_upcast_ibor_index_reproduces_the_three_calendar_dates() {
+        let (index, _, _, _) = custom_ibor();
+        let ibor = index.upcast();
+
+        assert_eq!(
+            ibor.value_date(Date::new(20, Month::January, 2025))
+                .unwrap(),
+            Date::new(23, Month::January, 2025)
+        );
+        assert_eq!(
+            ibor.fixing_date(Date::new(23, Month::January, 2025)),
+            Date::new(20, Month::January, 2025)
+        );
+        assert_eq!(
+            ibor.maturity_date(Date::new(23, Month::January, 2025))
+                .unwrap(),
+            Date::new(24, Month::April, 2025)
+        );
     }
 
     /// The maturity-date table (indexes.cpp:197-202): advance by the tenor on

--- a/crates/libitofin/src/indexes/ibor/custom.rs
+++ b/crates/libitofin/src/indexes/ibor/custom.rs
@@ -353,9 +353,11 @@ mod tests {
     /// no curve): `forecastFixing` lives on `IborIndex` but calls
     /// `valueDate`/`maturityDate` virtually, so the forecast must read the
     /// curve between this subclass's three-calendar dates (23 Jan / 24 Apr for
-    /// a 20 Jan fixing), not the inner index's single-calendar ones
-    /// (22 Jan / 22 Apr). Over a steep zero curve the two pairs give visibly
-    /// different simple forwards, so a plain delegation cannot pass.
+    /// a 20 Jan fixing), never single-calendar ones (22 Jan / 22 Apr). Over a
+    /// steep zero curve the two pairs give visibly different simple forwards,
+    /// so an inner index left on the single-calendar roll cannot pass; the
+    /// #963 fold puts the separate-calendar roll on the inner index itself,
+    /// which is what lets the plain delegation satisfy this pin.
     #[test]
     fn forecast_fixing_reads_the_curve_between_the_overridden_dates() {
         use crate::math::interpolations::linear::Linear;

--- a/crates/libitofin/src/indexes/ibor/usdlibor.rs
+++ b/crates/libitofin/src/indexes/ibor/usdlibor.rs
@@ -191,4 +191,21 @@ mod tests {
         let clone = index.clone_with(Handle::empty());
         assert_eq!(clone.maturity_date(v).unwrap(), maturity);
     }
+
+    /// The single-calendar regression pin for the #963 roll-rule fold: a
+    /// `Libor` keeps `valueCalendar == fixingCalendar == UK Exchange`
+    /// (`libor.cpp:98`), so now that `IborIndex` overrides `fixing_date` its
+    /// answer must still be the plain UK roll-back.
+    ///
+    /// Off Friday 13 November 2020 that is Wednesday the 11th - Veterans Day,
+    /// a US LiborImpact holiday and a UK business day, so a roll-back on the
+    /// joint maturity calendar would give Tuesday the 10th instead.
+    #[test]
+    fn fixing_date_rolls_back_on_the_uk_calendar_alone() {
+        let index = usd_libor_3m(shared(Settings::<Date>::new()));
+        assert_eq!(
+            index.fixing_date(Date::new(13, Month::November, 2020)),
+            Date::new(11, Month::November, 2020)
+        );
+    }
 }

--- a/crates/libitofin/src/indexes/iborindex.rs
+++ b/crates/libitofin/src/indexes/iborindex.rs
@@ -34,6 +34,23 @@ use crate::time::timeunit::TimeUnit;
 use crate::types::{Integer, Natural, Rate, Time};
 use crate::{currency::Currency, require};
 
+/// Which calendar the fixing and value rolls advance on.
+///
+/// C++ splits the two shapes across subclasses: `Libor::valueDate` advances on
+/// the fixing calendar (`libor.cpp:98`), while `CustomIborIndex` advances on a
+/// separate value calendar and pulls the fixing date `Preceding` back onto the
+/// fixing calendar (`custom.cpp:23-36`). Carrying the choice as data keeps the
+/// roll dispatching through every site holding a concrete [`IborIndex`], where
+/// a newtype override would be bypassed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CalendarRollRule {
+    /// Advance on the fixing calendar: plain [`IborIndex`] and `Libor`.
+    SingleCalendar,
+    /// Advance on the value calendar, then adjust the fixing date `Preceding`
+    /// on the fixing calendar: `CustomIborIndex` and `EURLibor`.
+    SeparateCalendars,
+}
+
 /// A concrete Inter-Bank-Offered-Rate index (e.g. Libor, Euribor).
 ///
 /// Wraps an [`InterestRateIndexBase`] with the forwarding curve and the
@@ -49,6 +66,13 @@ use crate::{currency::Currency, require};
 /// calendars in keeps the roll dispatching through every site holding a
 /// concrete `IborIndex` (`makevanillaswap.rs:440`), where a newtype override
 /// would be bypassed.
+///
+/// The internal `CalendarRollRule` extends that fold to the
+/// `CustomIborIndex` three-calendar roll (`custom.cpp:23-41`): it selects
+/// which of the two calendars the fixing and value advances run on, and
+/// [`with_separate_calendars`](Self::with_separate_calendars) is the only way
+/// to leave the single-calendar default, so a Libor-style calendar assignment
+/// cannot flip it by accident.
 pub struct IborIndex {
     base: InterestRateIndexBase,
     convention: BusinessDayConvention,
@@ -56,6 +80,7 @@ pub struct IborIndex {
     term_structure: Handle<dyn YieldTermStructure>,
     value_calendar: Calendar,
     maturity_calendar: Calendar,
+    roll_rule: CalendarRollRule,
 }
 
 impl IborIndex {
@@ -97,7 +122,30 @@ impl IborIndex {
             term_structure: forwarding,
             value_calendar,
             maturity_calendar,
+            roll_rule: CalendarRollRule::SingleCalendar,
         }
+    }
+
+    /// Points the value and maturity rolls at their own calendars and switches
+    /// the index to the `CustomIborIndex` three-calendar roll
+    /// (`custom.cpp:23-41`).
+    ///
+    /// The fixing calendar stays the one the constructor took, so the result
+    /// carries the C++ subclass's whole configuration as data. The
+    /// `Libor` constructor deliberately does not use this: `Libor::valueDate`
+    /// advances on the fixing calendar (`libor.cpp:98`), so it points the two
+    /// calendars with the crate-internal `set_value_calendar` /
+    /// `set_maturity_calendar` and keeps the single-calendar rule.
+    #[must_use]
+    pub fn with_separate_calendars(
+        mut self,
+        value_calendar: Calendar,
+        maturity_calendar: Calendar,
+    ) -> IborIndex {
+        self.value_calendar = value_calendar;
+        self.maturity_calendar = maturity_calendar;
+        self.roll_rule = CalendarRollRule::SeparateCalendars;
+        self
     }
 
     /// The convention applied when rolling the value date to maturity.
@@ -161,6 +209,7 @@ impl IborIndex {
         );
         clone.value_calendar = self.value_calendar.clone();
         clone.maturity_calendar = self.maturity_calendar.clone();
+        clone.roll_rule = self.roll_rule;
         clone
     }
 
@@ -191,8 +240,42 @@ impl InterestRateIndex for IborIndex {
         &self.base
     }
 
-    /// The value date rolled as `Libor::valueDate` (`libor.cpp:86-100`): the
-    /// fixing-calendar advance of the trait default, then an adjust on the
+    /// The fixing date for `value_date`, rolled by the index's calendar rule.
+    ///
+    /// The single-calendar rule reproduces the trait default: back
+    /// `fixing_days` business days on the fixing calendar. The
+    /// separate-calendar rule is `CustomIborIndex::fixingDate`
+    /// (`custom.cpp:23-27`): back on the value calendar, then a `Preceding`
+    /// adjust onto the fixing calendar.
+    fn fixing_date(&self, value_date: Date) -> Date {
+        let days = -(self.fixing_days() as Integer);
+        match self.roll_rule {
+            CalendarRollRule::SingleCalendar => self.fixing_calendar().advance(
+                value_date,
+                days,
+                TimeUnit::Days,
+                BusinessDayConvention::Following,
+                false,
+            ),
+            CalendarRollRule::SeparateCalendars => {
+                let d = self.value_calendar.advance(
+                    value_date,
+                    days,
+                    TimeUnit::Days,
+                    BusinessDayConvention::Following,
+                    false,
+                );
+                self.fixing_calendar()
+                    .adjust(d, BusinessDayConvention::Preceding)
+            }
+        }
+    }
+
+    /// The value date rolled as `Libor::valueDate` (`libor.cpp:86-100`) or, on
+    /// the separate-calendar rule, as `CustomIborIndex::valueDate`
+    /// (`custom.cpp:29-36`): the advance runs on
+    /// the fixing calendar under the single-calendar rule and on the value
+    /// calendar under the separate-calendar one, and both then adjust on the
     /// maturity calendar. With the default calendars the adjust lands on the
     /// business day the advance produced, reducing to the trait default.
     fn value_date(&self, fixing_date: Date) -> QlResult<Date> {
@@ -200,7 +283,11 @@ impl InterestRateIndex for IborIndex {
             self.is_valid_fixing_date(fixing_date),
             "{fixing_date:?} is not a valid fixing date"
         );
-        let d = self.fixing_calendar().advance(
+        let advance_calendar = match self.roll_rule {
+            CalendarRollRule::SingleCalendar => self.fixing_calendar(),
+            CalendarRollRule::SeparateCalendars => self.value_calendar.clone(),
+        };
+        let d = advance_calendar.advance(
             fixing_date,
             self.fixing_days() as Integer,
             TimeUnit::Days,
@@ -355,6 +442,7 @@ mod tests {
     use crate::patterns::observable::Observer;
     use crate::shared::{SharedMut, shared, shared_mut};
     use crate::termstructures::yields::FlatForward;
+    use crate::time::calendars::bespokecalendar::BespokeCalendar;
     use crate::time::calendars::target::Target;
     use crate::time::calendars::unitedstates::{Market, UnitedStates};
     use crate::time::date::Month;
@@ -387,6 +475,67 @@ mod tests {
             forwarding,
             settings,
         )
+    }
+
+    /// A three-month index on `fixing_calendar`, the shape the roll-rule teeth
+    /// point at three bespoke calendars.
+    fn bespoke_ibor(fixing_calendar: Calendar) -> IborIndex {
+        IborIndex::new(
+            "bespoke".into(),
+            Period::new(3, TimeUnit::Months),
+            2,
+            Currency::new("", "", 0, "", "", 0),
+            fixing_calendar,
+            BusinessDayConvention::ModifiedFollowing,
+            true,
+            Actual360::new(),
+            Handle::empty(),
+            shared(Settings::<Date>::new()),
+        )
+    }
+
+    /// The roll-rule teeth: no single C++ test discriminates the two subclass
+    /// bodies against each other, so this pits them on one fixture. Two
+    /// [`BespokeCalendar`]s (no weekends, so the placed holiday is the only
+    /// variable) differ on Saturday 11 January 2025 alone, which sits inside
+    /// the two-day settlement window off the 10th and the 13th.
+    ///
+    /// The single-calendar index points its value calendar at that holiday
+    /// calendar too, so only the rule - not the stored calendars - can move
+    /// the dates: it must roll 10 -> 12 January and 13 -> 11 January, ignoring
+    /// the value calendar entirely, where the separate-calendar rule rolls
+    /// through the holiday to 13 and 10 January.
+    #[test]
+    fn the_roll_rule_selects_the_calendar_the_advances_run_on() {
+        let fix_cal = BespokeCalendar::new("Fixings").calendar();
+        let val_cal = BespokeCalendar::new("Value").calendar();
+        val_cal.add_holiday(Date::new(11, Month::January, 2025));
+        let mat_cal = BespokeCalendar::new("Maturity").calendar();
+
+        let mut single = bespoke_ibor(fix_cal.clone());
+        single.set_value_calendar(val_cal.clone());
+        single.set_maturity_calendar(mat_cal.clone());
+        let separate = bespoke_ibor(fix_cal).with_separate_calendars(val_cal, mat_cal);
+
+        let fixing = Date::new(10, Month::January, 2025);
+        assert_eq!(
+            single.value_date(fixing).unwrap(),
+            Date::new(12, Month::January, 2025)
+        );
+        assert_eq!(
+            separate.value_date(fixing).unwrap(),
+            Date::new(13, Month::January, 2025)
+        );
+
+        let value = Date::new(13, Month::January, 2025);
+        assert_eq!(
+            single.fixing_date(value),
+            Date::new(11, Month::January, 2025)
+        );
+        assert_eq!(
+            separate.fixing_date(value),
+            Date::new(10, Month::January, 2025)
+        );
     }
 
     fn flat_curve(reference: Date, rate: Rate) -> Handle<dyn YieldTermStructure> {


### PR DESCRIPTION
- **feat(indexes): add calendar roll rule for separate-calendar rolls**
- **refactor(crates): fold custom ibor roll into inner index**
- **docs(crates): clarify forecast fixing test pin rationale**

close #963