### PR TITLE
feat(itofin-py): expose EurLibor + CustomIborIndex, passable into swap/FRA (#964)

### DIFF
--- a/crates/itofin-py/python/itofin/indexes.pyi
+++ b/crates/itofin-py/python/itofin/indexes.pyi
@@ -488,6 +488,79 @@ class EurLibor(IborIndex):
         """
         ...
 
+class CustomIborIndex(IborIndex):
+    """An Ibor index with three separate calendars.
+
+    The general form of what EurLibor configures: fixing dates roll back on the
+    value calendar and adjust Preceding on the fixing calendar, value dates
+    advance on the value calendar, and maturity dates advance on the maturity
+    calendar. Passing the same calendar three times reproduces a plain
+    IborIndex, so this is the escape hatch for a Libor-like index outside the
+    named families. A subclass of IborIndex, so it is accepted wherever the
+    general index is, and the base half carries the three-calendar roll.
+    """
+
+    def __init__(
+        self,
+        family_name: str,
+        tenor: Period,
+        settlement_days: int,
+        currency: Currency,
+        fixing_calendar: Calendar,
+        value_calendar: Calendar,
+        maturity_calendar: Calendar,
+        convention: BusinessDayConvention,
+        end_of_month: bool,
+        day_counter: DayCounter,
+        forwarding: YieldTermStructure | None,
+        settings: Settings,
+    ) -> None:
+        """Build a three-calendar Ibor index.
+
+        Args:
+            family_name (str): The family name the composed index name is built
+                from.
+            tenor (Period): The index tenor.
+            settlement_days (int): The business days between a fixing and its
+                value date.
+            currency (Currency): The currency the index is quoted in.
+            fixing_calendar (Calendar): The calendar fixing dates are adjusted
+                Preceding on.
+            value_calendar (Calendar): The calendar value dates are advanced on.
+            maturity_calendar (Calendar): The calendar maturity dates are
+                advanced on.
+            convention (BusinessDayConvention): The convention the roll to
+                maturity applies.
+            end_of_month (bool): Whether the maturity roll keeps to month ends.
+            day_counter (DayCounter): The day counter the index accrues on.
+            forwarding (YieldTermStructure | None): The forwarding curve; None
+                builds the index over an empty handle, the form the bootstrap
+                rate helpers need.
+            settings (Settings): The explicit settings supplying the evaluation
+                date and the stored fixings.
+        """
+        ...
+    def fixing(self, fixing_date: Date, forecast_todays_fixing: bool) -> float:
+        """Return the index fixing for fixing_date.
+
+        Forecast off the forwarding curve for a future date, or read from the
+        stored fixings for a past one.
+
+        Args:
+            fixing_date (Date): The date the fixing is read or forecast for.
+            forecast_todays_fixing (bool): Whether a fixing dated today is
+                forecast rather than looked up.
+
+        Returns:
+            float: The fixing rate.
+
+        Raises:
+            ItofinError: If the fixing date is not a valid one, the evaluation
+                date is unset, a past fixing is missing from the store, or the
+                forwarding handle is empty on a forecast.
+        """
+        ...
+
 class OvernightIndex:
     """The base of the overnight index families.
 

--- a/crates/itofin-py/python/itofin/indexes.pyi
+++ b/crates/itofin-py/python/itofin/indexes.pyi
@@ -439,6 +439,55 @@ class GbpLibor(IborIndex):
         """
         ...
 
+class EurLibor(IborIndex):
+    """The EUR Libor index family, the Euro ICE Libor fixed in London.
+
+    Three calendars, not one: fixing dates roll on the joint UK-Exchange plus
+    TARGET calendar while value and maturity dates roll on TARGET alone. A
+    subclass of IborIndex, so a EUR Libor is accepted wherever the general index
+    is, and the base half carries the three-calendar roll rather than a
+    single-calendar approximation of it. It retains its own clone of the index
+    the base holds - the same object, not a rebuild - so its own fixing reads
+    exactly what the base reads.
+    """
+
+    def __init__(self, tenor: Period, curve: YieldTermStructure | None, settings: Settings) -> None:
+        """Build a EUR Libor index of the given tenor.
+
+        Args:
+            tenor (Period): The index tenor.
+            curve (YieldTermStructure | None): The forwarding curve; None builds
+                the index over an empty handle, the form the bootstrap rate
+                helpers need.
+            settings (Settings): The explicit settings supplying the evaluation
+                date and the stored fixings.
+
+        Raises:
+            ItofinError: If tenor is a daily tenor, which needs a dedicated
+                daily-tenor constructor the core has not ported.
+        """
+        ...
+    def fixing(self, fixing_date: Date, forecast_todays_fixing: bool) -> float:
+        """Return the index fixing for fixing_date.
+
+        Forecast off the forwarding curve for a future date, or read from the
+        stored fixings for a past one.
+
+        Args:
+            fixing_date (Date): The date the fixing is read or forecast for.
+            forecast_todays_fixing (bool): Whether a fixing dated today is
+                forecast rather than looked up.
+
+        Returns:
+            float: The fixing rate.
+
+        Raises:
+            ItofinError: If the fixing date is not a valid one, the evaluation
+                date is unset, a past fixing is missing from the store, or the
+                forwarding handle is empty on a forecast.
+        """
+        ...
+
 class OvernightIndex:
     """The base of the overnight index families.
 

--- a/crates/itofin-py/src/hullwhite.rs
+++ b/crates/itofin-py/src/hullwhite.rs
@@ -1,6 +1,7 @@
 //! Facades for the Hull-White short-rate stack: [`PyHullWhite`] and the
 //! [`PyIborIndex`] index base with its [`PyEuribor`], [`PyUsdLibor`],
-//! [`PyJpyLibor`], [`PyGbpLibor`] and [`PyEurLibor`] subclasses.
+//! [`PyJpyLibor`], [`PyGbpLibor`], [`PyEurLibor`] and [`PyCustomIborIndex`]
+//! subclasses.
 
 use crate::PyQlError;
 use crate::calibration::{PyCalibrationErrorType, PyEndCriteria, PyLevenbergMarquardt};
@@ -11,7 +12,7 @@ use crate::settings::PySettings;
 use crate::time::{PyBusinessDayConvention, PyCalendar, PyDate, PyDayCounter, PyPeriod};
 use libitofin::cashflows::RateAveraging;
 use libitofin::handle::Handle;
-use libitofin::indexes::ibor::{EurLibor, GbpLibor, JpyLibor};
+use libitofin::indexes::ibor::{CustomIborIndex, EurLibor, GbpLibor, JpyLibor};
 use libitofin::indexes::{Euribor, IborIndex, Index, InterestRateIndex, UsdLibor};
 use libitofin::models::calibrationhelper::{BlackCalibrationHelper, CalibrationHelper};
 use libitofin::models::shortrate::SwaptionHelper;
@@ -294,6 +295,94 @@ impl PyIborIndex {
     /// `&IborIndex` and are generic over the family.
     pub(crate) fn inner(&self) -> Shared<IborIndex> {
         Shared::clone(&self.inner)
+    }
+}
+
+/// Python `CustomIborIndex`: an Ibor index with three separate calendars
+/// (`indexes::ibor::CustomIborIndex`).
+///
+/// The general form of what [`PyEurLibor`] configures: fixing dates roll back
+/// on the value calendar and adjust `Preceding` on the fixing calendar, value
+/// dates advance on the value calendar, and maturity dates advance on the
+/// maturity calendar (`custom.rs:5-13`). Passing the same calendar three times
+/// reproduces a plain [`PyIborIndex`], so this is the escape hatch for a
+/// LIBOR-like index outside the named families.
+///
+/// `CustomIborIndex::new` returns the newtype; `upcast()` (`custom.rs:105`)
+/// hands out the inner `IborIndex` carrying the three-calendar roll as data, so
+/// a consumer taking the base half rolls all three dates the way C++ does.
+#[pyclass(name = "CustomIborIndex", extends = PyIborIndex, unsendable)]
+pub struct PyCustomIborIndex {
+    inner: Shared<IborIndex>,
+}
+
+#[pymethods]
+impl PyCustomIborIndex {
+    /// An index of `tenor` fixing `settlement_days` before its value date,
+    /// with each of the three date calculations rolling on its own calendar,
+    /// accruing on `day_counter` and forecasting off `forwarding` (or off an
+    /// empty handle when `None`).
+    #[new]
+    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (
+        family_name,
+        tenor,
+        settlement_days,
+        currency,
+        fixing_calendar,
+        value_calendar,
+        maturity_calendar,
+        convention,
+        end_of_month,
+        day_counter,
+        forwarding,
+        settings,
+    ))]
+    fn new(
+        family_name: String,
+        tenor: &PyPeriod,
+        settlement_days: Natural,
+        currency: &PyCurrency,
+        fixing_calendar: &PyCalendar,
+        value_calendar: &PyCalendar,
+        maturity_calendar: &PyCalendar,
+        convention: &PyBusinessDayConvention,
+        end_of_month: bool,
+        day_counter: &PyDayCounter,
+        forwarding: Option<&PyYieldTermStructure>,
+        settings: &PySettings,
+    ) -> PyClassInitializer<Self> {
+        let index = CustomIborIndex::new(
+            family_name,
+            tenor.inner(),
+            settlement_days,
+            currency.inner(),
+            fixing_calendar.inner(),
+            value_calendar.inner(),
+            maturity_calendar.inner(),
+            convention.inner(),
+            end_of_month,
+            day_counter.inner(),
+            forwarding
+                .map(|curve| curve.handle())
+                .unwrap_or_else(Handle::empty),
+            settings.inner(),
+        )
+        .upcast();
+        let base = PyIborIndex {
+            inner: Shared::clone(&index),
+        };
+        PyClassInitializer::from(base).add_subclass(PyCustomIborIndex { inner: index })
+    }
+
+    /// The index's fixing for `fixing_date`, forecast off the forwarding curve
+    /// for a future date or read from stored fixings for a past one. Fallible:
+    /// an empty forwarding handle or an unset evaluation date is an error.
+    fn fixing(&self, fixing_date: &PyDate, forecast_todays_fixing: bool) -> PyResult<f64> {
+        Ok(self
+            .inner
+            .fixing(fixing_date.inner(), forecast_todays_fixing)
+            .map_err(PyQlError::from)?)
     }
 }
 

--- a/crates/itofin-py/src/hullwhite.rs
+++ b/crates/itofin-py/src/hullwhite.rs
@@ -1,6 +1,6 @@
 //! Facades for the Hull-White short-rate stack: [`PyHullWhite`] and the
 //! [`PyIborIndex`] index base with its [`PyEuribor`], [`PyUsdLibor`],
-//! [`PyJpyLibor`] and [`PyGbpLibor`] subclasses.
+//! [`PyJpyLibor`], [`PyGbpLibor`] and [`PyEurLibor`] subclasses.
 
 use crate::PyQlError;
 use crate::calibration::{PyCalibrationErrorType, PyEndCriteria, PyLevenbergMarquardt};
@@ -11,7 +11,7 @@ use crate::settings::PySettings;
 use crate::time::{PyBusinessDayConvention, PyCalendar, PyDate, PyDayCounter, PyPeriod};
 use libitofin::cashflows::RateAveraging;
 use libitofin::handle::Handle;
-use libitofin::indexes::ibor::{GbpLibor, JpyLibor};
+use libitofin::indexes::ibor::{EurLibor, GbpLibor, JpyLibor};
 use libitofin::indexes::{Euribor, IborIndex, Index, InterestRateIndex, UsdLibor};
 use libitofin::models::calibrationhelper::{BlackCalibrationHelper, CalibrationHelper};
 use libitofin::models::shortrate::SwaptionHelper;
@@ -529,6 +529,63 @@ impl PyGbpLibor {
             inner: Shared::clone(&index),
         };
         Ok(PyClassInitializer::from(base).add_subclass(PyGbpLibor { inner: index }))
+    }
+
+    /// The index's fixing for `fixing_date`, forecast off the forwarding curve
+    /// for a future date or read from stored fixings for a past one. Fallible:
+    /// an empty forwarding handle or an unset evaluation date is an error.
+    fn fixing(&self, fixing_date: &PyDate, forecast_todays_fixing: bool) -> PyResult<f64> {
+        Ok(self
+            .inner
+            .fixing(fixing_date.inner(), forecast_todays_fixing)
+            .map_err(PyQlError::from)?)
+    }
+}
+
+/// Python `EurLibor`: the EUR Libor index family (`indexes::ibor::EurLibor`).
+///
+/// The constructor takes a tenor, an optional forwarding curve, and the
+/// settings; passing `None` for the curve builds the index over an empty
+/// handle, the form the bootstrap rate helpers need. `EurLibor::new` returns a
+/// `CustomIborIndex` (`eurlibor.rs:64`), the three-calendar index whose fixing
+/// dates roll on the joint UK-Exchange-plus-TARGET calendar and whose value and
+/// maturity dates roll on TARGET alone; `upcast()` (`custom.rs:105`) hands out
+/// the inner `IborIndex` carrying that roll as data, so the facade holds one
+/// shared index like the other families.
+///
+/// A subclass of [`PyIborIndex`], so a EUR Libor is accepted wherever the
+/// general index is. It retains its own clone of the index the base holds -
+/// the same object, not a rebuild - so its own `fixing` reads exactly what
+/// the base reads.
+#[pyclass(name = "EurLibor", extends = PyIborIndex, unsendable)]
+pub struct PyEurLibor {
+    inner: Shared<IborIndex>,
+}
+
+#[pymethods]
+impl PyEurLibor {
+    /// A EUR Libor index of `tenor` forwarding off `curve`, or off an empty
+    /// handle when `curve` is `None`. Fallible: the core rejects daily tenors
+    /// (`eurlibor.rs:87`), which need the dedicated `DailyTenorEURLibor`
+    /// constructor the core has not ported.
+    #[new]
+    #[pyo3(signature = (tenor, curve, settings))]
+    fn new(
+        tenor: &PyPeriod,
+        curve: Option<&PyYieldTermStructure>,
+        settings: &PySettings,
+    ) -> PyResult<PyClassInitializer<Self>> {
+        let forwarding = match curve {
+            Some(curve) => curve.handle(),
+            None => Handle::empty(),
+        };
+        let index =
+            EurLibor::new(tenor.inner(), forwarding, settings.inner()).map_err(PyQlError::from)?;
+        let index = index.upcast();
+        let base = PyIborIndex {
+            inner: Shared::clone(&index),
+        };
+        Ok(PyClassInitializer::from(base).add_subclass(PyEurLibor { inner: index }))
     }
 
     /// The index's fixing for `fixing_date`, forecast off the forwarding curve

--- a/crates/itofin-py/src/lib.rs
+++ b/crates/itofin-py/src/lib.rs
@@ -66,8 +66,8 @@ use helpers::{
 };
 use heston::{PyHestonModel, PyHestonModelHelper, PyHestonProcess};
 use hullwhite::{
-    PyEurLibor, PyEuribor, PyGbpLibor, PyHullWhite, PyIborIndex, PyJpyLibor, PySwaptionHelper,
-    PyUsdLibor,
+    PyCustomIborIndex, PyEurLibor, PyEuribor, PyGbpLibor, PyHullWhite, PyIborIndex, PyJpyLibor,
+    PySwaptionHelper, PyUsdLibor,
 };
 use inflation::{
     PyConstantYoYOptionletVolatility, PyCpiInterpolationType, PyDiscountingSwapEngine,
@@ -239,6 +239,7 @@ fn itofin(m: &Bound<'_, PyModule>) -> PyResult<()> {
     indexes.add_class::<PyJpyLibor>()?;
     indexes.add_class::<PyGbpLibor>()?;
     indexes.add_class::<PyEurLibor>()?;
+    indexes.add_class::<PyCustomIborIndex>()?;
     indexes.add_class::<PyOvernightIndex>()?;
     indexes.add_class::<PyEstr>()?;
     indexes.add_class::<PySwapIndex>()?;

--- a/crates/itofin-py/src/lib.rs
+++ b/crates/itofin-py/src/lib.rs
@@ -66,7 +66,8 @@ use helpers::{
 };
 use heston::{PyHestonModel, PyHestonModelHelper, PyHestonProcess};
 use hullwhite::{
-    PyEuribor, PyGbpLibor, PyHullWhite, PyIborIndex, PyJpyLibor, PySwaptionHelper, PyUsdLibor,
+    PyEurLibor, PyEuribor, PyGbpLibor, PyHullWhite, PyIborIndex, PyJpyLibor, PySwaptionHelper,
+    PyUsdLibor,
 };
 use inflation::{
     PyConstantYoYOptionletVolatility, PyCpiInterpolationType, PyDiscountingSwapEngine,
@@ -237,6 +238,7 @@ fn itofin(m: &Bound<'_, PyModule>) -> PyResult<()> {
     indexes.add_class::<PyUsdLibor>()?;
     indexes.add_class::<PyJpyLibor>()?;
     indexes.add_class::<PyGbpLibor>()?;
+    indexes.add_class::<PyEurLibor>()?;
     indexes.add_class::<PyOvernightIndex>()?;
     indexes.add_class::<PyEstr>()?;
     indexes.add_class::<PySwapIndex>()?;

--- a/crates/itofin-py/tests/test_custom_ibor_index.py
+++ b/crates/itofin-py/tests/test_custom_ibor_index.py
@@ -1,0 +1,105 @@
+"""The general three-calendar CustomIborIndex facade (#964).
+
+The date table of custom.rs:5-13 has one pin per calendar role, and the fixture
+assigns three deliberately DIVERGING calendars so each pin moves under exactly
+one role: fixing on the UK, value on TARGET, maturity on WeekendsOnly. A
+fixture that reused one calendar in two roles would leave a role-collapse
+mutant invisible, the vacuity #963 was rewritten to avoid.
+
+Each expected date below is stated with the answer the role-collapse mutant
+gives, and the mutants were run: collapsing any one role changes exactly the
+pin named for it.
+"""
+
+# itofin library
+from itofin import Settings
+from itofin.indexes import Currency, CustomIborIndex, IborIndex
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Period
+
+TODAY = Date(15, 6, 2021)
+
+# Wednesday 1 September 2021 back two TARGET business days is Monday the 30th,
+# the UK Summer Bank Holiday; the Preceding adjust on the UK fixing calendar
+# then falls to Friday the 27th. A fixing calendar collapsed to TARGET stops at
+# the 30th.
+FIXING_ROLL_VALUE_DATE = Date(1, 9, 2021)
+EXPECTED_FIXING_DATE = Date(27, 8, 2021)
+
+# Thursday 26 August 2021 plus two TARGET business days is Monday the 30th,
+# which WeekendsOnly leaves alone. A value calendar collapsed to the UK one
+# skips the Summer Bank Holiday and answers Tuesday the 31st.
+VALUE_ROLL_FIXING_DATE = Date(26, 8, 2021)
+EXPECTED_VALUE_DATE = Date(30, 8, 2021)
+
+# Monday 4 January 2021 plus 3M is Easter Sunday, 4 April; WeekendsOnly rolls
+# it to Monday the 5th. A maturity calendar collapsed to either the UK or
+# TARGET calendar hits Easter Monday and answers Tuesday the 6th.
+MATURITY_ROLL_VALUE_DATE = Date(4, 1, 2021)
+EXPECTED_MATURITY_DATE = Date(5, 4, 2021)
+
+
+def _three_calendar_index(fixing, value, maturity):
+    settings = Settings()
+    settings.set_evaluation_date(TODAY)
+    return CustomIborIndex(
+        "Custom",
+        Period(3, "Months"),
+        2,
+        Currency.eur(),
+        fixing,
+        value,
+        maturity,
+        BusinessDayConvention.ModifiedFollowing,
+        False,
+        DayCounter.actual360(),
+        None,
+        settings,
+    )
+
+
+def test_each_date_role_rolls_on_its_own_calendar():
+    """The custom.rs:5-13 date table over three diverging calendars: one pin per
+    role, each stated against the date its role-collapse mutant returns."""
+    index = _three_calendar_index(
+        Calendar.united_kingdom(), Calendar.target(), Calendar.weekends_only()
+    )
+
+    assert isinstance(index, IborIndex)
+    assert index.name() == "Custom3M Actual/360"
+    assert index.fixing_date(FIXING_ROLL_VALUE_DATE) == EXPECTED_FIXING_DATE
+    assert index.value_date(VALUE_ROLL_FIXING_DATE) == EXPECTED_VALUE_DATE
+    assert index.maturity_date(MATURITY_ROLL_VALUE_DATE) == EXPECTED_MATURITY_DATE
+
+
+def test_one_calendar_in_all_three_roles_matches_a_plain_index():
+    """The degenerate assignment is the plain single-calendar index: passing the
+    UK calendar three times reproduces IborIndex on that calendar, so the three
+    pins above are the divergence and not an artefact of the facade."""
+    index = _three_calendar_index(
+        Calendar.united_kingdom(), Calendar.united_kingdom(), Calendar.united_kingdom()
+    )
+    settings = Settings()
+    settings.set_evaluation_date(TODAY)
+    plain = IborIndex(
+        "Custom",
+        Period(3, "Months"),
+        2,
+        Currency.eur(),
+        Calendar.united_kingdom(),
+        BusinessDayConvention.ModifiedFollowing,
+        False,
+        DayCounter.actual360(),
+        None,
+        settings,
+    )
+
+    assert index.fixing_date(FIXING_ROLL_VALUE_DATE) == plain.fixing_date(
+        FIXING_ROLL_VALUE_DATE
+    )
+    assert index.value_date(VALUE_ROLL_FIXING_DATE) == plain.value_date(
+        VALUE_ROLL_FIXING_DATE
+    )
+    assert index.maturity_date(MATURITY_ROLL_VALUE_DATE) == plain.maturity_date(
+        MATURITY_ROLL_VALUE_DATE
+    )
+    assert index.value_date(VALUE_ROLL_FIXING_DATE) != EXPECTED_VALUE_DATE

--- a/crates/itofin-py/tests/test_eur_libor.py
+++ b/crates/itofin-py/tests/test_eur_libor.py
@@ -1,0 +1,215 @@
+"""The EurLibor facade: a three-calendar index passed into a FRA (#964).
+
+EurLibor is the only Py index family whose core constructor returns a
+CustomIborIndex rather than a plain IborIndex, so the facade reaches the base
+half through upcast() (custom.rs:105). What that has to carry is the
+three-calendar roll: fixing dates on the joint UK-Exchange-plus-TARGET
+calendar, value and maturity dates on TARGET alone (eurlibor.rs:64).
+
+The mutant every date pin here is aimed at is a facade that quietly built a
+single-calendar IborIndex on the joint fixing calendar - the shape the other
+four families legitimately use. That mutant is not hypothetical prose: it is
+constructed in-test as `_single_calendar_twin`, off the EurLibor's own
+inspectors so the fixing calendar is structurally the same one, and every
+literal below is stated alongside the twin's differing answer.
+
+The date fixtures are the merged #939 core oracles (eurlibor.rs:216, :232),
+which sit on UK bank holidays TARGET stays open for. The FRA numbers are
+rebuilt from math.exp and Actual360 day counts over DISTINCT 4%/6% curves, the
+same independent oracle test_fra.py uses.
+"""
+
+# standard library
+import datetime
+import math
+
+# pypi/conda library
+import pytest
+
+# itofin library
+from itofin import Settings
+from itofin.indexes import EurLibor, IborIndex
+from itofin.instruments import ForwardRateAgreement, Position
+from itofin.termstructures import FlatForward
+from itofin.time import BusinessDayConvention, Calendar, Date, DayCounter, Period
+
+TODAY = Date(15, 6, 2021)
+FORWARD_FLAT = 0.04
+DISCOUNT_FLAT = 0.06
+STRIKE = 0.02
+NOTIONAL = 100.0
+
+# Thursday 26 August 2021 is a business day on every calendar in play. Two
+# TARGET business days on is Monday the 30th, the UK Summer Bank Holiday that
+# TARGET stays open for; the joint calendar skips it to Tuesday the 31st.
+FIXING_DATE = Date(26, 8, 2021)
+TARGET_VALUE_DATE = Date(30, 8, 2021)
+JOINT_VALUE_DATE = Date(31, 8, 2021)
+FRA_MATURITY_DATE = Date(30, 11, 2021)
+
+# Monday 1 February 2021 plus 3M is Saturday 1 May; ModifiedFollowing rolls to
+# Monday the 3rd on TARGET (whose May holiday is the 1st) but on to Tuesday the
+# 4th on the joint calendar, where the 3rd is the UK Early May Bank Holiday.
+MATURITY_ROLL_START = Date(1, 2, 2021)
+TARGET_MATURITY_DATE = Date(3, 5, 2021)
+JOINT_MATURITY_DATE = Date(4, 5, 2021)
+
+
+def _actual360(start: Date, end: Date) -> float:
+    days = (
+        datetime.date(end.year, end.month, end.day)
+        - datetime.date(start.year, start.month, start.day)
+    ).days
+    return days / 360.0
+
+
+def _discount(rate: float, date: Date) -> float:
+    return math.exp(-rate * _actual360(TODAY, date))
+
+
+def _expected_forward(value_date: Date, maturity_date: Date) -> float:
+    return (
+        _discount(FORWARD_FLAT, value_date) / _discount(FORWARD_FLAT, maturity_date)
+        - 1.0
+    ) / _actual360(value_date, maturity_date)
+
+
+@pytest.fixture
+def settings():
+    settings = Settings()
+    settings.set_evaluation_date(TODAY)
+    return settings
+
+
+@pytest.fixture
+def forwarding():
+    return FlatForward(TODAY, FORWARD_FLAT, DayCounter.actual360())
+
+
+@pytest.fixture
+def discounting():
+    return FlatForward(TODAY, DISCOUNT_FLAT, DayCounter.actual360())
+
+
+@pytest.fixture
+def eur_libor(settings, forwarding):
+    return EurLibor(Period(3, "Months"), forwarding, settings)
+
+
+def _single_calendar_twin(eur_libor, settings, forwarding):
+    """The mutant the date pins exist to kill: the same conventions on the same
+    fixing calendar, but that one calendar in all three date roles."""
+    return IborIndex(
+        "EURLibor",
+        eur_libor.tenor(),
+        2,
+        eur_libor.currency(),
+        eur_libor.fixing_calendar(),
+        eur_libor.business_day_convention(),
+        eur_libor.end_of_month(),
+        eur_libor.day_counter(),
+        forwarding,
+        settings,
+    )
+
+
+def test_eur_libor_carries_the_ice_configuration(eur_libor):
+    """The eurlibor.cpp:60-78 configuration. The name pin kills a facade wired
+    to Euribor (the other EUR family) and the calendar pin kills one whose
+    fixing calendar is bare TARGET: Monday 30 August 2021 is a TARGET business
+    day, so only the joint calendar moves it on to the 31st."""
+    assert isinstance(eur_libor, IborIndex)
+    assert eur_libor.name() == "EURLibor3M Actual/360"
+    assert eur_libor.tenor() == Period(3, "Months")
+    assert eur_libor.currency().code() == "EUR"
+    assert eur_libor.business_day_convention() == BusinessDayConvention.ModifiedFollowing
+    assert eur_libor.end_of_month()
+
+    joint = eur_libor.fixing_calendar()
+    assert joint.adjust(TARGET_VALUE_DATE, BusinessDayConvention.Following) == (
+        JOINT_VALUE_DATE
+    )
+    assert Calendar.target().adjust(
+        TARGET_VALUE_DATE, BusinessDayConvention.Following
+    ) == TARGET_VALUE_DATE
+
+
+def test_base_half_rolls_value_and_maturity_on_target(eur_libor, settings, forwarding):
+    """The upcast proof, read through the base IborIndex half every consumer
+    holds: both dates roll on TARGET, not on the joint fixing calendar. The
+    single-calendar twin answers 31 August and 4 May on the same two inputs, so
+    each literal is one calendar role's discrimination."""
+    twin = _single_calendar_twin(eur_libor, settings, forwarding)
+
+    assert eur_libor.value_date(FIXING_DATE) == TARGET_VALUE_DATE
+    assert twin.value_date(FIXING_DATE) == JOINT_VALUE_DATE
+
+    assert eur_libor.maturity_date(MATURITY_ROLL_START) == TARGET_MATURITY_DATE
+    assert twin.maturity_date(MATURITY_ROLL_START) == JOINT_MATURITY_DATE
+
+
+def test_daily_tenor_is_rejected(settings, forwarding):
+    """The daily-tenor guard (eurlibor.rs:87) surfaces as an ItofinError; the
+    dedicated DailyTenorEURLibor constructor is not ported."""
+    with pytest.raises(Exception, match="DailyTenor"):
+        EurLibor(Period(3, "Days"), forwarding, settings)
+
+
+def test_fra_over_eur_libor_prices_off_the_target_window(eur_libor, discounting):
+    """Pass-into-instrument: a Python EurLibor drives a ForwardRateAgreement.
+    The window opens on the index's own value date, so it is the TARGET one -
+    30 August, the day the single-calendar twin skips. The rate, amount and NPV
+    are the hand-built par formulas over that window off the 4% forwarding
+    curve, discounted on the 6% curve."""
+    value_date = eur_libor.value_date(FIXING_DATE)
+    fra = ForwardRateAgreement(
+        eur_libor, value_date, Position.Long, STRIKE, NOTIONAL, discounting
+    )
+
+    assert fra.value_date() == TARGET_VALUE_DATE
+    assert fra.maturity_date() == FRA_MATURITY_DATE
+
+    expected_forward = _expected_forward(TARGET_VALUE_DATE, FRA_MATURITY_DATE)
+    assert abs(expected_forward - STRIKE) > 0.01, (
+        "degenerate fixture: K == F would leave the amount pin vacuous"
+    )
+    assert abs(fra.forward_rate() - expected_forward) < 1.0e-12
+
+    accrual = _actual360(TARGET_VALUE_DATE, FRA_MATURITY_DATE)
+    expected_amount = (
+        NOTIONAL * (expected_forward - STRIKE) * accrual / (1.0 + expected_forward * accrual)
+    )
+    assert abs(fra.amount() - expected_amount) < 1.0e-12
+
+    expected_npv = expected_amount * _discount(DISCOUNT_FLAT, TARGET_VALUE_DATE)
+    assert abs(fra.npv() - expected_npv) < 1.0e-12
+
+    assert abs(eur_libor.fixing(FIXING_DATE, False) - expected_forward) < 1.0e-12
+
+
+def test_fra_window_differs_from_a_single_calendar_index(
+    eur_libor, settings, forwarding, discounting
+):
+    """The discrimination arm for the instrument leg. Both FRAs start from the
+    same fixing date and let the index set the window; the EurLibor one opens
+    on 30 August and the single-calendar twin on the 31st, and the day of
+    accrual that separates them is worth ~5.6e-3 of NPV on a notional of 100 -
+    a facade that had lost the three-calendar roll would price the twin's
+    number here."""
+    twin = _single_calendar_twin(eur_libor, settings, forwarding)
+
+    fra = ForwardRateAgreement(
+        eur_libor,
+        eur_libor.value_date(FIXING_DATE),
+        Position.Long,
+        STRIKE,
+        NOTIONAL,
+        discounting,
+    )
+    twin_fra = ForwardRateAgreement(
+        twin, twin.value_date(FIXING_DATE), Position.Long, STRIKE, NOTIONAL, discounting
+    )
+
+    assert fra.value_date() == TARGET_VALUE_DATE
+    assert twin_fra.value_date() == JOINT_VALUE_DATE
+    assert abs(fra.npv() - twin_fra.npv()) > 1.0e-6


### PR DESCRIPTION
Closes #964.

Exposes `EurLibor` and the general 3-calendar `CustomIborIndex` to Python as standard `PyIborIndex` subclasses (via the core roll-rule `upcast()` from #963), so a Python-built EurLibor flows into `ForwardRateAgreement`/swaps/helpers correctly.

- fd64b577 PyEurLibor (extends PyIborIndex; EurLibor::new -> upcast)
- c9aa6610 PyCustomIborIndex (general 12-arg 3-calendar ctor; R4 split)

Gated: pytest 473 (+7); FRA discrimination arm is value-date-based (non-vacuous); independent end-to-end probe (core value_date roll -> upcast -> PyEurLibor -> FRA) confirmed load-bearing.