### PR TITLE
feat(itofin-py): add bootstrap selector to convex monotone curve

### DIFF
--- a/crates/itofin-py/python/itofin/termstructures.pyi
+++ b/crates/itofin-py/python/itofin/termstructures.pyi
@@ -612,6 +612,7 @@ class PiecewiseConvexMonotoneForward(YieldTermStructure):
         reference_date: Date,
         helpers: list[RateHelper],
         day_counter: DayCounter,
+        bootstrap: str = "iterative",
     ) -> None:
         """Build the curve over helpers with a fixed reference date.
 
@@ -619,9 +620,15 @@ class PiecewiseConvexMonotoneForward(YieldTermStructure):
             reference_date (Date): The curve's reference date.
             helpers (list[RateHelper]): The bootstrap instruments.
             day_counter (DayCounter): The day count turning dates into times.
+            bootstrap (str): "iterative", the shipped behaviour, solving one
+                node at a time, or "local", least-squares-fitting a trailing
+                window of nodes at each step so the non-local interpolation
+                keeps a localised risk profile. The two agree at every pillar
+                and diverge between them.
 
         Raises:
-            ItofinError: On an empty helper list.
+            ItofinError: On an empty helper list, and on an unknown bootstrap
+                name.
         """
         ...
     def dates(self) -> list[Date]:

--- a/crates/itofin-py/python/itofin/termstructures.pyi
+++ b/crates/itofin-py/python/itofin/termstructures.pyi
@@ -623,8 +623,9 @@ class PiecewiseConvexMonotoneForward(YieldTermStructure):
             bootstrap (str): "iterative", the shipped behaviour, solving one
                 node at a time, or "local", least-squares-fitting a trailing
                 window of nodes at each step so the non-local interpolation
-                keeps a localised risk profile. The two agree at every pillar
-                and diverge between them.
+                keeps a localised risk profile. The two reprice every pillar
+                (the local solve to its own tolerance, about 1e-7 on the
+                oracle strip) and diverge between them.
 
         Raises:
             ItofinError: On an empty helper list, and on an unknown bootstrap

--- a/crates/itofin-py/src/curve.rs
+++ b/crates/itofin-py/src/curve.rs
@@ -14,6 +14,7 @@ use libitofin::math::interpolations::loglinear::LogLinear;
 use libitofin::shared::{Shared, shared};
 use libitofin::termstructures::RateHelper;
 use libitofin::termstructures::bootstraptraits::{Discount, ForwardRate, ZeroYield};
+use libitofin::termstructures::localbootstrap::LocalBootstrap;
 use libitofin::termstructures::yields::{
     DiscountCurve, FlatForward, ForwardCurve, InterpolatedDiscountCurve, InterpolatedZeroCurve,
     PiecewiseYieldCurve, ZeroCurve,
@@ -622,6 +623,11 @@ impl PyPiecewiseLinearForward {
     }
 }
 
+enum ConvexMonotoneCurve {
+    Iterative(Shared<PiecewiseYieldCurve<ForwardRate, ConvexMonotone>>),
+    Local(Shared<PiecewiseYieldCurve<ForwardRate, ConvexMonotone, LocalBootstrap>>),
+}
+
 /// Python `PiecewiseConvexMonotoneForward`: a curve bootstrapped in
 /// instantaneous forward-rate space with convex-monotone interpolation
 /// (`PiecewiseYieldCurve<ForwardRate, ConvexMonotone>`).
@@ -633,31 +639,65 @@ impl PyPiecewiseLinearForward {
 /// convergence loop (#543). Its stored `data()` are instantaneous forward
 /// rates; the interpolation itself ignores node `[0]`, which only mirrors the
 /// first solved pillar.
+///
+/// `bootstrap` selects the bootstrap algorithm: `"iterative"` (default, the
+/// shipped behaviour) solves one node at a time, while `"local"`
+/// least-squares-fits a trailing window of nodes at each step so the
+/// non-local interpolation keeps a localised risk profile. The two agree at
+/// every pillar and diverge between them.
 #[pyclass(name = "PiecewiseConvexMonotoneForward", extends = PyYieldTermStructure, unsendable)]
 pub struct PyPiecewiseConvexMonotoneForward {
-    concrete: Shared<PiecewiseYieldCurve<ForwardRate, ConvexMonotone>>,
+    concrete: ConvexMonotoneCurve,
 }
 
 #[pymethods]
 impl PyPiecewiseConvexMonotoneForward {
-    /// A curve over `helpers` with a fixed `reference_date`. Fallible: an empty
-    /// helper list is rejected here.
+    /// A curve over `helpers` with a fixed `reference_date`, bootstrapped by
+    /// the algorithm `bootstrap` names. Fallible: an empty helper list and an
+    /// unknown bootstrap name are both rejected here.
     #[new]
+    #[pyo3(signature = (reference_date, helpers, day_counter, bootstrap = "iterative"))]
     fn new(
         reference_date: &PyDate,
         helpers: Vec<PyRef<PyRateHelper>>,
         day_counter: &PyDayCounter,
+        bootstrap: &str,
     ) -> PyResult<PyClassInitializer<Self>> {
         let instruments: Vec<Shared<dyn RateHelper>> =
             helpers.iter().map(|helper| helper.inner()).collect();
-        let concrete = PiecewiseYieldCurve::<ForwardRate, ConvexMonotone>::new(
-            reference_date.inner(),
-            instruments,
-            day_counter.inner(),
-            ConvexMonotone::default(),
-        )
-        .map_err(PyQlError::from)?;
-        let erased = Shared::clone(&concrete) as Shared<dyn YieldTermStructure>;
+        let concrete = match bootstrap {
+            "iterative" => ConvexMonotoneCurve::Iterative(
+                PiecewiseYieldCurve::<ForwardRate, ConvexMonotone>::new(
+                    reference_date.inner(),
+                    instruments,
+                    day_counter.inner(),
+                    ConvexMonotone::default(),
+                )
+                .map_err(PyQlError::from)?,
+            ),
+            "local" => ConvexMonotoneCurve::Local(
+                PiecewiseYieldCurve::<ForwardRate, ConvexMonotone, LocalBootstrap>::new(
+                    reference_date.inner(),
+                    instruments,
+                    day_counter.inner(),
+                    ConvexMonotone::default(),
+                )
+                .map_err(PyQlError::from)?,
+            ),
+            other => {
+                return Err(ItofinError::new_err(format!(
+                    "unknown bootstrap {other:?}, expected iterative or local"
+                )));
+            }
+        };
+        let erased: Shared<dyn YieldTermStructure> = match &concrete {
+            ConvexMonotoneCurve::Iterative(curve) => {
+                Shared::clone(curve) as Shared<dyn YieldTermStructure>
+            }
+            ConvexMonotoneCurve::Local(curve) => {
+                Shared::clone(curve) as Shared<dyn YieldTermStructure>
+            }
+        };
         Ok(PyClassInitializer::from(PyYieldTermStructure {
             inner: Handle::new(erased),
         })
@@ -666,9 +706,11 @@ impl PyPiecewiseConvexMonotoneForward {
 
     /// The bootstrapped node dates (triggers the lazy bootstrap).
     fn dates(&self) -> PyResult<Vec<PyDate>> {
-        Ok(self
-            .concrete
-            .dates()
+        let dates = match &self.concrete {
+            ConvexMonotoneCurve::Iterative(curve) => curve.dates(),
+            ConvexMonotoneCurve::Local(curve) => curve.dates(),
+        };
+        Ok(dates
             .map_err(PyQlError::from)?
             .into_iter()
             .map(PyDate::from_inner)
@@ -678,7 +720,11 @@ impl PyPiecewiseConvexMonotoneForward {
     /// The bootstrapped node values, forward rates here (triggers the lazy
     /// bootstrap).
     fn data(&self) -> PyResult<Vec<f64>> {
-        Ok(self.concrete.data().map_err(PyQlError::from)?)
+        let data = match &self.concrete {
+            ConvexMonotoneCurve::Iterative(curve) => curve.data(),
+            ConvexMonotoneCurve::Local(curve) => curve.data(),
+        };
+        Ok(data.map_err(PyQlError::from)?)
     }
 }
 

--- a/crates/itofin-py/src/curve.rs
+++ b/crates/itofin-py/src/curve.rs
@@ -643,8 +643,9 @@ enum ConvexMonotoneCurve {
 /// `bootstrap` selects the bootstrap algorithm: `"iterative"` (default, the
 /// shipped behaviour) solves one node at a time, while `"local"`
 /// least-squares-fits a trailing window of nodes at each step so the
-/// non-local interpolation keeps a localised risk profile. The two agree at
-/// every pillar and diverge between them.
+/// non-local interpolation keeps a localised risk profile. The two reprice
+/// every pillar (the local solve to its own tolerance, about 1e-7 on the
+/// oracle strip) and diverge between them.
 #[pyclass(name = "PiecewiseConvexMonotoneForward", extends = PyYieldTermStructure, unsendable)]
 pub struct PyPiecewiseConvexMonotoneForward {
     concrete: ConvexMonotoneCurve,

--- a/crates/itofin-py/tests/test_piecewise_yield_curve.py
+++ b/crates/itofin-py/tests/test_piecewise_yield_curve.py
@@ -499,3 +499,80 @@ def test_cubic_alias_differs_from_its_linear_siblings():
     for name, sibling in [("Linear", linear), ("LogLinear", log_linear)]:
         separation = max(abs(cubic.discount(t) - sibling.discount(t)) for t in times)
         assert separation > 1.0e-12, f"Cubic identical to the {name} arm"
+
+
+def test_local_bootstrap_differs_from_iterative_off_pillar():
+    """DISCRIMINATION ARM for the bootstrap= selector (#967): the SAME helper
+    strip bootstrapped iteratively and locally reprices every pillar to the
+    same quote, so a reprice-only oracle is vacuous. The two algorithms only
+    separate BETWEEN pillars: at settlement + 9000 days (6-Feb-2051, between
+    the 20Y and 25Y swap pillars) the discount factors differ by a measured
+    3.146438e-07, seven orders above the machine noise floor arm 2 pins. A
+    "local" arm silently wired to the iterative curve would give 0.0 here."""
+    _, _, _, settlement, deposits, swaps = _fixture()
+    instruments = deposits + swaps
+    dc = DayCounter.actual360()
+    iterative = PiecewiseConvexMonotoneForward(
+        settlement, instruments, dc, bootstrap="iterative"
+    )
+    local = PiecewiseConvexMonotoneForward(settlement, instruments, dc, bootstrap="local")
+
+    off_pillar = settlement + 9000
+    gap = abs(iterative.discount_date(off_pillar) - local.discount_date(off_pillar))
+    assert gap > 1.0e-8, f"bootstrap= did not switch the algorithm: gap {gap}"
+
+
+def test_local_bootstrap_is_deterministic():
+    """NON-VACUITY GUARD for the arm above: "local" built twice off freshly
+    built helpers agrees with itself to well under 1e-12 (measured exactly
+    0.0), so the 3.1e-7 separation is the algorithm, not run-to-run noise."""
+    _, _, _, settlement, deposits, swaps = _fixture()
+    _, _, _, settlement_again, deposits_again, swaps_again = _fixture()
+    dc = DayCounter.actual360()
+    first = PiecewiseConvexMonotoneForward(settlement, deposits + swaps, dc, "local")
+    second = PiecewiseConvexMonotoneForward(
+        settlement_again, deposits_again + swaps_again, dc, "local"
+    )
+
+    off_pillar = settlement + 9000
+    gap = abs(first.discount_date(off_pillar) - second.discount_date(off_pillar))
+    assert gap < 1.0e-12, f"LocalBootstrap is not deterministic: gap {gap}"
+
+
+def test_unknown_bootstrap_name_is_rejected():
+    """The unknown-string arm, mirroring the interpolation selectors: an
+    unrecognised bootstrap name is an ItofinError, not a silently accepted
+    no-op (the accept-and-ignore class)."""
+    _, _, _, settlement, deposits, swaps = _fixture()
+    with pytest.raises(ItofinError, match="unknown bootstrap"):
+        PiecewiseConvexMonotoneForward(
+            settlement, deposits + swaps, DayCounter.actual360(), "nope"
+        )
+
+
+def test_default_bootstrap_is_iterative():
+    """DEFAULT-PIN ARM: the omitted argument must build the iterative curve.
+    Every other arm here and the reprice test above are blind to which
+    algorithm the default names, so this pins it EXACTLY (both curves are the
+    same deterministic solve) at the off-pillar date where the two algorithms
+    provably separate."""
+    _, _, _, settlement, deposits, swaps = _fixture()
+    instruments = deposits + swaps
+    dc = DayCounter.actual360()
+    omitted = PiecewiseConvexMonotoneForward(settlement, instruments, dc)
+    explicit = PiecewiseConvexMonotoneForward(settlement, instruments, dc, "iterative")
+
+    off_pillar = settlement + 9000
+    assert omitted.discount_date(off_pillar) == explicit.discount_date(off_pillar)
+
+
+def test_local_bootstrap_exposes_its_nodes():
+    """dates()/data() dispatch across the new enum's Local variant, returning
+    one node per helper plus the reference node."""
+    _, _, _, settlement, deposits, swaps = _fixture()
+    instruments = deposits + swaps
+    local = PiecewiseConvexMonotoneForward(
+        settlement, instruments, DayCounter.actual360(), "local"
+    )
+    assert len(local.dates()) == len(instruments) + 1
+    assert len(local.data()) == len(instruments) + 1

--- a/crates/itofin-py/tests/test_piecewise_yield_curve.py
+++ b/crates/itofin-py/tests/test_piecewise_yield_curve.py
@@ -576,3 +576,22 @@ def test_local_bootstrap_exposes_its_nodes():
     )
     assert len(local.dates()) == len(instruments) + 1
     assert len(local.data()) == len(instruments) + 1
+
+
+def test_local_bootstrap_nodes_come_from_the_local_solve():
+    """The class holds the curve twice, once typed (behind dates()/data()) and
+    once erased (behind discount()), each wired by its own match. The
+    discrimination arm only reads the erased side, so a Local variant whose
+    typed side was built iteratively would pass it. The solved node forwards
+    separate the two algorithms as well (measured max 3.461058e-07 at node
+    20), which pins data() to the local solve."""
+    _, _, _, settlement, deposits, swaps = _fixture()
+    _, _, _, settlement_again, deposits_again, swaps_again = _fixture()
+    dc = DayCounter.actual360()
+    iterative = PiecewiseConvexMonotoneForward(settlement, deposits + swaps, dc)
+    local = PiecewiseConvexMonotoneForward(
+        settlement_again, deposits_again + swaps_again, dc, "local"
+    )
+
+    separation = max(abs(a - b) for a, b in zip(iterative.data(), local.data()))
+    assert separation > 1.0e-8, f"local data() identical to iterative: {separation}"


### PR DESCRIPTION
- **feat(itofin-py): add bootstrap selector to convex monotone curve**
- **test(itofin-py): pin local bootstrap data to its own solve**

close #967