### PR TITLE
feat(termstructures): port additional penalty terms for GlobalBootstrap

### DIFF
--- a/crates/libitofin/src/termstructures/globalbootstrap.rs
+++ b/crates/libitofin/src/termstructures/globalbootstrap.rs
@@ -14,16 +14,16 @@
 //!
 //! ## What is ported, and what is deferred
 //!
-//! Only the single-curve path is ported; it equals the C++ path with every
-//! `additional*` argument empty and `parentBootstrapper_` null. Deferred
+//! The single-curve path is ported, together with the `additionalPenalties`
+//! residual terms (#974); it equals the C++ path with the remaining
+//! `additional*` arguments empty and `parentBootstrapper_` null. Deferred
 //! visibly, each as its own follow-up issue referencing #949:
 //!
 //! - **Additional restrictions** (`additionalHelpers`/`additionalDates`/
-//!   `additionalPenalties`/`additionalVariables`, plus the
-//!   `SimpleQuoteVariables` helper and the `SimpleZeroYield` traits): the
-//!   machinery the three upstream oracle tests
-//!   (`piecewiseyieldcurve.cpp:1306/1388/1486`) exercise - futures convexity
-//!   adjustments, penalty terms, model variables.
+//!   `additionalVariables`, plus the `SimpleQuoteVariables` helper and the
+//!   `SimpleZeroYield` traits): the machinery the two remaining upstream
+//!   oracle tests (`piecewiseyieldcurve.cpp:1306/1486`) exercise - futures
+//!   convexity adjustments, model variables.
 //! - **Multi-curve orchestration** (`MultiCurveBootstrap`,
 //!   `MultiCurveBootstrapContributor`, `setParentBootstrapper`/`setToValid`,
 //!   the `parentBootstrapper_` branch of `calculate`).
@@ -74,6 +74,16 @@
 //! because there is no frozen prefix: every node is a variable of the one
 //! global solve.
 //!
+//! ## Where the penalty terms run
+//!
+//! C++ splits the trial write (`setCostFunctionArgument`, `:379-390`) from the
+//! residual assembly (`evaluateCostFunction`, `:392-403`), so the penalty
+//! closure runs with no mutable state alive. This port keeps that separation
+//! deliberately: the penalty is invoked only after the `borrow_mut` that
+//! rewrites the nodes has dropped. A penalty may read the curve back - the
+//! upstream one reprices an additional helper - which takes a shared borrow of
+//! the same `RefCell`, and a live `borrow_mut` would panic there.
+//!
 //! ## Traits bound
 //!
 //! The driver requires
@@ -82,7 +92,7 @@
 //! known to work with the `Discount`/`ZeroYield`/`ForwardRate` IR traits
 //! (`globalbootstrap.hpp:100-103`).
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 
 use crate::errors::{QlError, QlResult};
 use crate::math::array::Array;
@@ -98,26 +108,48 @@ use crate::shared::Shared;
 use crate::termstructures::bootstraphelper::BootstrapHelperShared;
 use crate::termstructures::bootstraptraits::{BootstrapTraits, YieldBootstrapTraits};
 use crate::termstructures::iterativebootstrap::{Bootstrap, PiecewiseCurve};
-use crate::types::{Real, Size};
+use crate::types::{Real, Size, Time};
+
+/// The additional penalty terms (`AdditionalPenalties`,
+/// `globalbootstrap.hpp:108-109`).
+///
+/// Extra least-squares residuals, appended after the alive helpers' weighted
+/// quote errors. The closure is handed the FULL node grid of the trial curve -
+/// times and values INCLUDING node 0 (`hpp:395`) - not the interior slice the
+/// optimizer varies, so a penalty over `times.len() - 1` differences indexes
+/// `data[i + 1] - data[i]` directly.
+pub type AdditionalPenalties = dyn Fn(&[Time], &[Real]) -> Vec<Real>;
 
 /// The global bootstrap (`GlobalBootstrap`, single-curve core).
 ///
-/// Carries the stopping-accuracy override, the `EndCriteria` override and the
-/// per-instrument residual weights; defaults mirror the C++ constructor
-/// (`accuracy = Null`, `endCriteria = nullptr`, `instrumentWeights = {}`,
-/// `globalbootstrap.hpp:112-115`), with everything resolved from the curve at
-/// calculation time.
-#[derive(Clone, Debug, Default)]
+/// Carries the stopping-accuracy override, the `EndCriteria` override, the
+/// per-instrument residual weights and the additional penalty terms; defaults
+/// mirror the C++ constructor (`accuracy = Null`, `endCriteria = nullptr`,
+/// `instrumentWeights = {}`, no penalties, `globalbootstrap.hpp:112-115`), with
+/// everything resolved from the curve at calculation time.
+///
+/// The boxed penalty closure is neither `Clone` nor `Debug`, so those two
+/// derives are gone; `Default` is hand-rolled because a curve built through
+/// [`PiecewiseYieldCurve::new`](crate::termstructures::yields::PiecewiseYieldCurve::new)
+/// still needs the empty configuration.
 pub struct GlobalBootstrap {
     accuracy: Option<Real>,
     end_criteria: Option<EndCriteria>,
     instrument_weights: Vec<Real>,
+    penalties: Option<Box<AdditionalPenalties>>,
+}
+
+impl Default for GlobalBootstrap {
+    fn default() -> GlobalBootstrap {
+        GlobalBootstrap::new(None, None, Vec::new())
+    }
 }
 
 impl GlobalBootstrap {
     /// A global bootstrap with an optional accuracy override, an optional
     /// stopping-criteria override and optional per-instrument weights (empty
-    /// weights resolve to 1.0 for every instrument).
+    /// weights resolve to 1.0 for every instrument), and no penalty terms
+    /// (C++ constructor #1, `globalbootstrap.hpp:112-115`).
     pub fn new(
         accuracy: Option<Real>,
         end_criteria: Option<EndCriteria>,
@@ -127,15 +159,59 @@ impl GlobalBootstrap {
             accuracy,
             end_criteria,
             instrument_weights,
+            penalties: None,
         }
+    }
+
+    /// The same configuration plus [`AdditionalPenalties`] over the trial
+    /// curve's node grid (the penalty argument of C++ constructor #2,
+    /// `globalbootstrap.hpp:116-123`, definition `:169-186`).
+    ///
+    /// That constructor also carries `additionalHelpers`, `additionalDates` and
+    /// `additionalVariables`; those are still deferred, so this form takes the
+    /// penalty alone.
+    pub fn with_penalties<F>(
+        accuracy: Option<Real>,
+        end_criteria: Option<EndCriteria>,
+        instrument_weights: Vec<Real>,
+        penalties: F,
+    ) -> GlobalBootstrap
+    where
+        F: Fn(&[Time], &[Real]) -> Vec<Real> + 'static,
+    {
+        GlobalBootstrap {
+            accuracy,
+            end_criteria,
+            instrument_weights,
+            penalties: Some(Box::new(penalties)),
+        }
+    }
+
+    /// The same, for a penalty that does not read the node grid (C++
+    /// constructor #3's `std::function<Array()>` form,
+    /// `globalbootstrap.hpp:124-131`, definition `:196-206`, which wraps the
+    /// no-argument closure into the two-argument one and delegates).
+    pub fn with_grid_independent_penalties<F>(
+        accuracy: Option<Real>,
+        end_criteria: Option<EndCriteria>,
+        instrument_weights: Vec<Real>,
+        penalties: F,
+    ) -> GlobalBootstrap
+    where
+        F: Fn() -> Vec<Real> + 'static,
+    {
+        Self::with_penalties(accuracy, end_criteria, instrument_weights, move |_, _| {
+            penalties()
+        })
     }
 }
 
 /// The global cost (`setCostFunctionArgument` + `evaluateCostFunction`,
 /// `globalbootstrap.hpp:379-403`): writes every interior trial node into the
 /// node vector through `transform_direct`, rebuilds the full-grid
-/// interpolation, and returns the alive helpers' weighted quote errors as the
-/// residual vector.
+/// interpolation, and returns the alive helpers' weighted quote errors -
+/// followed by the [`AdditionalPenalties`] terms, if any - as the residual
+/// vector.
 ///
 /// The [`CostFunction`] trait is infallible, so a failed rebuild or reprice
 /// parks its error in `error` and returns NaN residuals, which the solver
@@ -149,9 +225,14 @@ where
     curve: &'a C,
     alive: &'a [Shared<C::Helper>],
     alive_weights: &'a [Real],
+    penalties: Option<&'a AdditionalPenalties>,
     /// The number of interior nodes, `times.len() - 1`; residual count is
-    /// `alive.len()`, at least `interior` (the grid dedup can only shrink it).
+    /// `alive.len()` plus the penalty terms, at least `interior` (the grid
+    /// dedup can only shrink the helper half).
     interior: Size,
+    /// The penalty-term count of the last evaluation, so a failed evaluation's
+    /// NaN vector has the length the solver sized itself on.
+    penalty_len: Cell<Size>,
     error: RefCell<Option<QlError>>,
 }
 
@@ -168,9 +249,23 @@ where
             }
             cd.rebuild(self.curve.interpolator(), self.interior)?;
         }
-        let mut residuals = Array::with_size(self.alive.len());
+        // Only now that the `borrow_mut` above has dropped, so a penalty that
+        // reads the curve back can take its own shared borrow (`:392-395`).
+        let penalty_errors = match self.penalties {
+            Some(penalties) => {
+                let cd = self.curve.curve_data().borrow();
+                penalties(cd.times(), cd.data())
+            }
+            None => Vec::new(),
+        };
+        self.penalty_len.set(penalty_errors.len());
+
+        let mut residuals = Array::with_size(self.alive.len() + penalty_errors.len());
         for (i, helper) in self.alive.iter().enumerate() {
             residuals[i] = helper.quote_error()? * self.alive_weights[i];
+        }
+        for (i, penalty_error) in penalty_errors.into_iter().enumerate() {
+            residuals[self.alive.len() + i] = penalty_error;
         }
         Ok(residuals)
     }
@@ -188,7 +283,8 @@ where
                 if slot.is_none() {
                     *slot = Some(err);
                 }
-                std::iter::repeat_n(Real::NAN, self.alive.len()).collect()
+                let residuals = self.alive.len() + self.penalty_len.get();
+                std::iter::repeat_n(Real::NAN, residuals).collect()
             }
         }
     }
@@ -314,7 +410,9 @@ where
             curve,
             alive: &alive,
             alive_weights: &alive_weights,
+            penalties: self.penalties.as_deref(),
             interior,
+            penalty_len: Cell::new(0),
             error: RefCell::new(None),
         };
         let no_constraint = NoConstraint;
@@ -347,5 +445,248 @@ where
             cd.set_valid(true);
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Oracle: `piecewiseyieldcurve.cpp` `testGlobalBootstrapPenalty`
+    //! (`:1388-1483`) - a 32-instrument EUR strip (one 6M deposit, twelve
+    //! FRAs, nineteen swaps) bootstrapped as `PiecewiseYieldCurve<ForwardRate,
+    //! BackwardFlat, GlobalBootstrap>` once with no penalty and once under the
+    //! upstream gradient penalty.
+    //!
+    //! The reference numbers are NOT the literals printed in the `.cpp`: they
+    //! are reproduced to 17 digits by a C++ harness that rebuilds this fixture
+    //! against a locally built QuantLib 1.43-dev dylib, with
+    //! `IborCoupon::Settings::instance().createAtParCoupons()` set so that
+    //! `usingAtParCoupons()` - the test's own precondition - holds. The `.cpp`
+    //! literals agree with the harness to within 8.9e-9, which is the
+    //! truncation of their own 8-decimal printing, so they are not stale.
+
+    use std::cell::Cell;
+
+    use super::*;
+    use crate::handle::Handle;
+    use crate::indexes::ibor::euribor::Euribor;
+    use crate::interestrate::Compounding;
+    use crate::math::interpolations::flat::BackwardFlat;
+    use crate::quotes::{Quote, SimpleQuote};
+    use crate::settings::Settings;
+    use crate::shared::shared;
+    use crate::termstructures::bootstraphelper::RateHelper;
+    use crate::termstructures::bootstraptraits::ForwardRate;
+    use crate::termstructures::yields::{
+        DepositRateHelper, FraRateHelper, PiecewiseYieldCurve, Pillar, SwapRateHelper,
+    };
+    use crate::termstructures::yieldtermstructure::YieldTermStructure;
+    use crate::time::businessdayconvention::BusinessDayConvention;
+    use crate::time::calendars::target::Target;
+    use crate::time::date::{Date, Month};
+    use crate::time::daycounters::actual360::Actual360;
+    use crate::time::daycounters::actual365fixed::Actual365Fixed;
+    use crate::time::daycounters::thirty360::{Convention, Thirty360};
+    use crate::time::frequency::Frequency;
+    use crate::time::period::Period;
+    use crate::time::timeunit::TimeUnit;
+    use crate::types::Natural;
+
+    /// The market quotes in percent (`piecewiseyieldcurve.cpp:1392-1398`):
+    /// the 6M deposit, then the twelve FRAs, then the nineteen swaps.
+    const REF_MKT_RATE: [Real; 32] = [
+        -0.373, -0.388, -0.402, -0.418, -0.431, -0.441, -0.45, -0.457, -0.463, -0.469, -0.461,
+        -0.463, -0.479, -0.4511, -0.45418, -0.439, -0.4124, -0.37703, -0.3335, -0.28168, -0.22725,
+        -0.1745, -0.12425, -0.07746, 0.0385, 0.1435, 0.17525, 0.17275, 0.1515, 0.1225, 0.095,
+        0.0644,
+    ];
+
+    /// The swap tenors in years (`:1435`).
+    const SWAP_TENORS: [i32; 19] = [
+        2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 15, 20, 25, 30, 35, 40, 45, 50,
+    ];
+
+    /// The curve under test.
+    type PenaltyCurve = PiecewiseYieldCurve<ForwardRate, BackwardFlat, GlobalBootstrap>;
+
+    /// The shared fixture: evaluation date 26 Sep 2019 (`:1390`) and the
+    /// 32 helpers of `:1425-1441`, all reading one empty-forwarding Euribor 6M.
+    struct Fixture {
+        reference_date: Date,
+        helpers: Vec<Shared<dyn RateHelper>>,
+    }
+
+    /// C++ builds the curve from `(2, TARGET())`, a moving reference two
+    /// business days after the evaluation date; nothing in this test moves that
+    /// date, so the equivalent fixed reference (30 Sep 2019) is computed here
+    /// and handed to the reference-date constructor.
+    ///
+    /// The deposit takes its schedule from the index rather than from the
+    /// explicit `(6M, 2, TARGET(), ModifiedFollowing, true, Actual360())` of
+    /// `:1425-1426`: Euribor 6M carries exactly those six conventions.
+    fn fixture() -> Fixture {
+        let calendar = Target::new();
+        let today = Date::new(26, Month::September, 2019);
+        let settings = shared(Settings::<Date>::new());
+        settings.set_evaluation_date(today);
+        let reference_date = calendar.advance(
+            today,
+            2,
+            TimeUnit::Days,
+            BusinessDayConvention::Following,
+            false,
+        );
+        let euribor6m = Euribor::six_months(Handle::empty(), settings);
+
+        let mut helpers: Vec<Shared<dyn RateHelper>> = Vec::new();
+        helpers.push(
+            DepositRateHelper::from_rate(REF_MKT_RATE[0] / 100.0, &euribor6m)
+                as Shared<dyn RateHelper>,
+        );
+        for (i, rate) in REF_MKT_RATE[1..=12].iter().enumerate() {
+            let quote = Handle::new(shared(SimpleQuote::new(rate / 100.0)) as Shared<dyn Quote>);
+            helpers.push(FraRateHelper::from_months(
+                quote,
+                i as Natural + 1,
+                &euribor6m,
+                true,
+                Pillar::LastRelevantDate,
+            ) as Shared<dyn RateHelper>);
+        }
+        for (i, tenor) in SWAP_TENORS.iter().enumerate() {
+            helpers.push(SwapRateHelper::from_rate(
+                REF_MKT_RATE[13 + i] / 100.0,
+                Period::new(*tenor, TimeUnit::Years),
+                calendar.clone(),
+                Frequency::Annual,
+                BusinessDayConvention::ModifiedFollowing,
+                Thirty360::with_convention(Convention::BondBasis),
+                &euribor6m,
+            ) as Shared<dyn RateHelper>);
+        }
+
+        Fixture {
+            reference_date,
+            helpers,
+        }
+    }
+
+    /// The curve of `:1444-1448`, with the explicit 1.0e-12 accuracy both arms
+    /// pass.
+    fn curve_with(fixture: &Fixture, bootstrap: GlobalBootstrap) -> Shared<PenaltyCurve> {
+        PiecewiseYieldCurve::with_bootstrap(
+            fixture.reference_date,
+            fixture.helpers.clone(),
+            Actual365Fixed::new(),
+            BackwardFlat,
+            bootstrap,
+        )
+        .expect("the 32-helper strip builds a curve")
+    }
+
+    /// The continuous Actual/360 zero rate at every pillar (`:1478-1482`).
+    fn zero_rates(curve: &Shared<PenaltyCurve>, fixture: &Fixture) -> Vec<Real> {
+        fixture
+            .helpers
+            .iter()
+            .map(|helper| {
+                curve
+                    .zero_rate_date(
+                        helper.pillar_date(),
+                        Actual360::new(),
+                        Compounding::Continuous,
+                        Frequency::Annual,
+                        false,
+                    )
+                    .expect("the bootstrapped curve prices every pillar")
+                    .rate()
+            })
+            .collect()
+    }
+
+    /// The re-entrancy pin of the penalty slice: a penalty that READS THE
+    /// CURVE mid-solve, the shape the deferred `additionalHelpers` penalty
+    /// takes upstream (`globalbootstrap.hpp:392-395` reprices additional
+    /// helpers off the trial curve).
+    ///
+    /// The residual is a tiny multiple of the first helper's own quote error,
+    /// which is driven to zero by the helper residual anyway, so the argmin is
+    /// unmoved and the strip still reprices; what the arm pins is that the
+    /// shared borrow inside `implied_quote` is reachable at all. Invoking the
+    /// penalty while the node-rewriting `borrow_mut` is still live panics with
+    /// "already mutably borrowed", and neither the upstream gradient penalty
+    /// nor the no-argument one would notice: they never touch the `RefCell`.
+    #[test]
+    fn a_penalty_that_reprices_a_helper_solves() {
+        let fixture = fixture();
+        let probe = Shared::clone(&fixture.helpers[0]);
+        let fired = shared(Cell::new(0_usize));
+        let counter = Shared::clone(&fired);
+        let curve = curve_with(
+            &fixture,
+            GlobalBootstrap::with_penalties(Some(1.0e-12), None, Vec::new(), move |_, _| {
+                counter.set(counter.get() + 1);
+                let error = probe
+                    .quote_error()
+                    .expect("the probe helper reprices off the trial curve");
+                vec![1.0e-8 * error]
+            }),
+        );
+
+        let rates = zero_rates(&curve, &fixture);
+        assert!(
+            rates.iter().all(|rate| rate.is_finite()),
+            "the solved curve must carry finite zero rates"
+        );
+        assert!(
+            fired.get() > 0,
+            "the curve-reading penalty was never invoked"
+        );
+        for (i, helper) in fixture.helpers.iter().enumerate() {
+            let error = helper
+                .quote_error()
+                .expect("every helper reprices off the solved curve");
+            assert!(
+                error.abs() < 1.0e-9,
+                "helper {i} does not reprice under a curve-reading penalty: {error}"
+            );
+        }
+    }
+
+    /// The no-argument penalty adapter (C++ constructor #3,
+    /// `globalbootstrap.hpp:196-206`), pinned by its call count.
+    ///
+    /// HONEST NEGATIVE: this ctor cannot be pinned through the curve. A penalty
+    /// that ignores the node grid returns the same residual at every trial
+    /// point, so it cannot move the argmin; and a ZERO one cannot move the
+    /// stopping point either, since it adds nothing to the cost. The count is
+    /// therefore the only evidence the adapter reaches the residual vector -
+    /// which it must, since the residual length the solver sizes itself on
+    /// grows from 32 to 33.
+    #[test]
+    fn the_no_argument_penalty_adapter_is_invoked() {
+        let fixture = fixture();
+        let fired = shared(Cell::new(0_usize));
+        let counter = Shared::clone(&fired);
+        let curve = curve_with(
+            &fixture,
+            GlobalBootstrap::with_grid_independent_penalties(
+                Some(1.0e-12),
+                None,
+                Vec::new(),
+                move || {
+                    counter.set(counter.get() + 1);
+                    vec![0.0]
+                },
+            ),
+        );
+
+        assert!(
+            zero_rates(&curve, &fixture).iter().all(|r| r.is_finite()),
+            "a zero constant penalty must leave the strip solvable"
+        );
+        assert!(
+            fired.get() > 0,
+            "the no-argument penalty never reached the residual vector"
+        );
     }
 }

--- a/crates/libitofin/src/termstructures/globalbootstrap.rs
+++ b/crates/libitofin/src/termstructures/globalbootstrap.rs
@@ -457,12 +457,16 @@ mod tests {
     //! upstream gradient penalty.
     //!
     //! The reference numbers are NOT the literals printed in the `.cpp`: they
-    //! are reproduced to 17 digits by a C++ harness that rebuilds this fixture
-    //! against a locally built QuantLib 1.43-dev dylib, with
+    //! are reproduced at full precision by a C++ harness that rebuilds this
+    //! fixture against a locally built QuantLib 1.43-dev dylib, with
     //! `IborCoupon::Settings::instance().createAtParCoupons()` set so that
     //! `usingAtParCoupons()` - the test's own precondition - holds. The `.cpp`
     //! literals agree with the harness to within 8.9e-9, which is the
     //! truncation of their own 8-decimal printing, so they are not stale.
+    //!
+    //! The asserts keep the C++ tolerance of 1e-6, but the port is far tighter
+    //! than that: every one of the 64 rates matches the dylib to better than
+    //! 1e-9, and the worst node parts company only at 1e-12.
 
     use std::cell::Cell;
 
@@ -482,7 +486,7 @@ mod tests {
     use crate::termstructures::yieldtermstructure::YieldTermStructure;
     use crate::time::businessdayconvention::BusinessDayConvention;
     use crate::time::calendars::target::Target;
-    use crate::time::date::{Date, Month};
+    use crate::time::date::{Date, Day, Month, Year};
     use crate::time::daycounters::actual360::Actual360;
     use crate::time::daycounters::actual365fixed::Actual365Fixed;
     use crate::time::daycounters::thirty360::{Convention, Thirty360};
@@ -491,7 +495,7 @@ mod tests {
     use crate::time::timeunit::TimeUnit;
     use crate::types::Natural;
 
-    /// The market quotes in percent (`piecewiseyieldcurve.cpp:1392-1398`):
+    /// The market quotes in percent (`piecewiseyieldcurve.cpp:1393-1397`):
     /// the 6M deposit, then the twelve FRAs, then the nineteen swaps.
     const REF_MKT_RATE: [Real; 32] = [
         -0.373, -0.388, -0.402, -0.418, -0.431, -0.441, -0.45, -0.457, -0.463, -0.469, -0.461,
@@ -500,16 +504,128 @@ mod tests {
         0.0644,
     ];
 
-    /// The swap tenors in years (`:1435`).
+    /// The swap tenors in years (`:1436`).
     const SWAP_TENORS: [i32; 19] = [
         2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 15, 20, 25, 30, 35, 40, 45, 50,
+    ];
+
+    /// The 32 pillar dates (`piecewiseyieldcurve.cpp:1401-1409`).
+    const REF_DATE: [(Day, Month, Year); 32] = [
+        (31, Month::March, 2020),
+        (30, Month::April, 2020),
+        (29, Month::May, 2020),
+        (30, Month::June, 2020),
+        (31, Month::July, 2020),
+        (31, Month::August, 2020),
+        (30, Month::September, 2020),
+        (30, Month::October, 2020),
+        (30, Month::November, 2020),
+        (31, Month::December, 2020),
+        (29, Month::January, 2021),
+        (26, Month::February, 2021),
+        (31, Month::March, 2021),
+        (30, Month::September, 2021),
+        (30, Month::September, 2022),
+        (29, Month::September, 2023),
+        (30, Month::September, 2024),
+        (30, Month::September, 2025),
+        (30, Month::September, 2026),
+        (30, Month::September, 2027),
+        (29, Month::September, 2028),
+        (28, Month::September, 2029),
+        (30, Month::September, 2030),
+        (30, Month::September, 2031),
+        (29, Month::September, 2034),
+        (30, Month::September, 2039),
+        (30, Month::September, 2044),
+        (30, Month::September, 2049),
+        (30, Month::September, 2054),
+        (30, Month::September, 2059),
+        (30, Month::September, 2064),
+        (30, Month::September, 2069),
+    ];
+
+    /// The no-penalty pillar zero rates, reproduced from the C++ dylib and
+    /// written in their shortest round-tripping form; `:1410-1415` prints the
+    /// same values truncated to 8 decimals.
+    const REF_ZERO_RATE_NP: [Real; 32] = [
+        -0.00373354067173059,
+        -0.0038619401591129116,
+        -0.003952053377431906,
+        -0.004033031764634922,
+        -0.004080332294683344,
+        -0.00410875148971975,
+        -0.004119347704602793,
+        -0.004191606489573042,
+        -0.0042481675261172285,
+        -0.004299228525952772,
+        -0.004280288678277469,
+        -0.0042917785223669895,
+        -0.00434401190355896,
+        -0.0044524306053832785,
+        -0.004485055406658176,
+        -0.004336901365743163,
+        -0.004074010693284356,
+        -0.0037275150355157486,
+        -0.0033005022038937737,
+        -0.002791390998101853,
+        -0.0022547726443914143,
+        -0.0017342152462374019,
+        -0.001236880404786612,
+        -0.0007723647126770113,
+        0.0003855052397250581,
+        0.0014420799596420013,
+        0.001759470920941431,
+        0.00172834231444819,
+        0.0015075667291268061,
+        0.0012113127300807914,
+        0.0009338400348746001,
+        0.0006289189187075171,
+    ];
+
+    /// The gradient-penalty pillar zero rates, reproduced from the C++ dylib and
+    /// written in their shortest round-tripping form; `:1417-1422` prints the
+    /// same values truncated to 8 decimals.
+    const REF_ZERO_RATE_GP: [Real; 32] = [
+        -0.0037789204343363957,
+        -0.003861265918257509,
+        -0.003947374024601186,
+        -0.0040291352443265075,
+        -0.004095413491332919,
+        -0.0041325177094445505,
+        -0.00415463322202404,
+        -0.004194838278258465,
+        -0.004242382682770642,
+        -0.004278749680844317,
+        -0.0042971214597928705,
+        -0.00431898196411309,
+        -0.004360271377797676,
+        -0.00445296974357845,
+        -0.004485023476300989,
+        -0.004336935907495182,
+        -0.0040740612083099365,
+        -0.0037275506595484164,
+        -0.003300180655052014,
+        -0.0027913299732067252,
+        -0.002254907688857512,
+        -0.0017342855088808304,
+        -0.0012364330378685168,
+        -0.0007729806599035981,
+        0.0003854725793177982,
+        0.001442061640980936,
+        0.001759475820307776,
+        0.0017283380850002651,
+        0.0015075606415153413,
+        0.0012113489415541431,
+        0.0009337950842231714,
+        0.0006289530535829015,
     ];
 
     /// The curve under test.
     type PenaltyCurve = PiecewiseYieldCurve<ForwardRate, BackwardFlat, GlobalBootstrap>;
 
     /// The shared fixture: evaluation date 26 Sep 2019 (`:1390`) and the
-    /// 32 helpers of `:1425-1441`, all reading one empty-forwarding Euribor 6M.
+    /// 32 helpers of `:1428-1441`, all reading one empty-forwarding Euribor 6M.
     struct Fixture {
         reference_date: Date,
         helpers: Vec<Shared<dyn RateHelper>>,
@@ -522,7 +638,7 @@ mod tests {
     ///
     /// The deposit takes its schedule from the index rather than from the
     /// explicit `(6M, 2, TARGET(), ModifiedFollowing, true, Actual360())` of
-    /// `:1425-1426`: Euribor 6M carries exactly those six conventions.
+    /// `:1428-1429`: Euribor 6M carries exactly those six conventions.
     fn fixture() -> Fixture {
         let calendar = Target::new();
         let today = Date::new(26, Month::September, 2019);
@@ -570,7 +686,7 @@ mod tests {
         }
     }
 
-    /// The curve of `:1444-1448`, with the explicit 1.0e-12 accuracy both arms
+    /// The curve of `:1445-1448`, with the explicit 1.0e-12 accuracy both arms
     /// pass.
     fn curve_with(fixture: &Fixture, bootstrap: GlobalBootstrap) -> Shared<PenaltyCurve> {
         PiecewiseYieldCurve::with_bootstrap(
@@ -583,7 +699,7 @@ mod tests {
         .expect("the 32-helper strip builds a curve")
     }
 
-    /// The continuous Actual/360 zero rate at every pillar (`:1478-1482`).
+    /// The continuous Actual/360 zero rate at every pillar (`:1459`/`:1481`).
     fn zero_rates(curve: &Shared<PenaltyCurve>, fixture: &Fixture) -> Vec<Real> {
         fixture
             .helpers
@@ -688,5 +804,89 @@ mod tests {
             fired.get() > 0,
             "the no-argument penalty never reached the residual vector"
         );
+    }
+    /// ARM 0 of `testGlobalBootstrapPenalty` (`:1450-1453`): the 32 pillar
+    /// dates. External truth that stands on its own - it fixes the helper
+    /// construction (index conventions, FRA start offsets, swap tenors and the
+    /// `Pillar::LastRelevantDate` choice) without any reference to the solve,
+    /// so a mis-specified strip fails here rather than smearing into the rates.
+    #[test]
+    fn global_bootstrap_penalty_pillar_dates() {
+        let fixture = fixture();
+        assert_eq!(
+            fixture.reference_date,
+            Date::new(30, Month::September, 2019)
+        );
+        for (i, (day, month, year)) in REF_DATE.iter().enumerate() {
+            assert_eq!(
+                fixture.helpers[i].pillar_date(),
+                Date::new(*day, *month, *year),
+                "helper {i} sits on the wrong pillar"
+            );
+        }
+    }
+
+    /// The two rate arms of `testGlobalBootstrapPenalty` at the C++ tolerance
+    /// of 1e-6 (0.01 basis points): the no-penalty curve of `:1445-1448` and
+    /// the gradient-penalty curve of `:1472-1475`, whose penalty
+    /// `0.01 * (data[i + 1] - data[i]) / (times[i + 1] - times[i])` over
+    /// `times.len() - 1` terms (`:1464-1470`) reads the FULL node grid,
+    /// node 0 included.
+    ///
+    /// The C++ no-penalty arm passes an EMPTY `std::function<Array()>`, which
+    /// constructor #3 turns into no penalty at all rather than into a
+    /// zero-length one, so it is [`GlobalBootstrap::new`] here.
+    ///
+    /// VACUITY GUARD: a port that accepted the penalty and then ignored it
+    /// would solve ONE curve and hand it to both arms, and both tables would
+    /// still pass at 1e-6 for the 20 pillars where they agree. The two tables
+    /// are therefore asserted to DIFFER first: the gradient penalty moves the
+    /// short end by 4.5e-5, forty-five times the assert tolerance.
+    #[test]
+    fn global_bootstrap_penalty_zero_rates() {
+        let fixture = fixture();
+        let no_penalty = zero_rates(
+            &curve_with(
+                &fixture,
+                GlobalBootstrap::new(Some(1.0e-12), None, Vec::new()),
+            ),
+            &fixture,
+        );
+        let gradient_penalty = zero_rates(
+            &curve_with(
+                &fixture,
+                GlobalBootstrap::with_penalties(Some(1.0e-12), None, Vec::new(), |times, data| {
+                    (0..times.len() - 1)
+                        .map(|i| 0.01 * (data[i + 1] - data[i]) / (times[i + 1] - times[i]))
+                        .collect()
+                }),
+            ),
+            &fixture,
+        );
+
+        let separation = no_penalty
+            .iter()
+            .zip(&gradient_penalty)
+            .map(|(np, gp)| (np - gp).abs())
+            .fold(0.0, Real::max);
+        assert!(
+            separation > 1.0e-5,
+            "the penalty did not move the solve: the two arms agree to {separation}"
+        );
+
+        for (i, expected) in REF_ZERO_RATE_NP.iter().enumerate() {
+            assert!(
+                (no_penalty[i] - expected).abs() < 1.0e-6,
+                "no-penalty zero rate {i}: {} vs {expected}",
+                no_penalty[i]
+            );
+        }
+        for (i, expected) in REF_ZERO_RATE_GP.iter().enumerate() {
+            assert!(
+                (gradient_penalty[i] - expected).abs() < 1.0e-6,
+                "gradient-penalty zero rate {i}: {} vs {expected}",
+                gradient_penalty[i]
+            );
+        }
     }
 }

--- a/crates/libitofin/src/termstructures/globalbootstrap.rs
+++ b/crates/libitofin/src/termstructures/globalbootstrap.rs
@@ -461,8 +461,9 @@ mod tests {
     //! fixture against a locally built QuantLib 1.43-dev dylib, with
     //! `IborCoupon::Settings::instance().createAtParCoupons()` set so that
     //! `usingAtParCoupons()` - the test's own precondition - holds. The `.cpp`
-    //! literals agree with the harness to within 8.9e-9, which is the
-    //! truncation of their own 8-decimal printing, so they are not stale.
+    //! literals agree with the harness to within 8.9e-9, inside their own
+    //! 8-decimal printing (61 of the 64 are the dylib value rounded to 8
+    //! decimals, the rest truncated), so they are not stale.
     //!
     //! The asserts keep the C++ tolerance of 1e-6, but the port is far tighter
     //! than that: every one of the 64 rates matches the dylib to better than
@@ -547,7 +548,7 @@ mod tests {
 
     /// The no-penalty pillar zero rates, reproduced from the C++ dylib and
     /// written in their shortest round-tripping form; `:1410-1415` prints the
-    /// same values truncated to 8 decimals.
+    /// same values printed to 8 decimals.
     const REF_ZERO_RATE_NP: [Real; 32] = [
         -0.00373354067173059,
         -0.0038619401591129116,
@@ -585,7 +586,7 @@ mod tests {
 
     /// The gradient-penalty pillar zero rates, reproduced from the C++ dylib and
     /// written in their shortest round-tripping form; `:1417-1422` prints the
-    /// same values truncated to 8 decimals.
+    /// same values printed to 8 decimals.
     const REF_ZERO_RATE_GP: [Real; 32] = [
         -0.0037789204343363957,
         -0.003861265918257509,
@@ -805,6 +806,47 @@ mod tests {
             "the no-argument penalty never reached the residual vector"
         );
     }
+    /// The penalty-argument contract (`globalbootstrap.hpp:395`): the closure
+    /// is handed the FULL node grid, node 0 included, not the interior slice
+    /// the optimizer varies.
+    ///
+    /// HONEST NEGATIVE: `testGlobalBootstrapPenalty` cannot pin this. The
+    /// `ForwardRate` traits mirror node 0 onto node 1, so the gradient
+    /// penalty's first term is identically zero and an interior-only slice
+    /// solves to the same curve (probe-confirmed at gate). The contract is
+    /// therefore pinned directly: 33 nodes for 32 helpers, a zero time at the
+    /// front, and the mirrored node the oracle's blindness rests on.
+    #[test]
+    fn the_penalty_sees_the_full_node_grid() {
+        let fixture = fixture();
+        let seen = shared(Cell::new((
+            0_usize,
+            0_usize,
+            Real::NAN,
+            Real::NAN,
+            Real::NAN,
+        )));
+        let record = Shared::clone(&seen);
+        let curve = curve_with(
+            &fixture,
+            GlobalBootstrap::with_penalties(Some(1.0e-12), None, Vec::new(), move |times, data| {
+                record.set((times.len(), data.len(), times[0], data[0], data[1]));
+                Vec::new()
+            }),
+        );
+
+        assert!(zero_rates(&curve, &fixture).iter().all(|r| r.is_finite()));
+        let (times_len, data_len, first_time, node0, node1) = seen.get();
+        assert_eq!(
+            times_len,
+            fixture.helpers.len() + 1,
+            "the closure must see every node"
+        );
+        assert_eq!(data_len, times_len);
+        assert_eq!(first_time, 0.0, "node 0 is the reference-date node");
+        assert_eq!(node0, node1, "ForwardRate mirrors node 0 onto node 1");
+    }
+
     /// ARM 0 of `testGlobalBootstrapPenalty` (`:1450-1453`): the 32 pillar
     /// dates. External truth that stands on its own - it fixes the helper
     /// construction (index conventions, FRA start offsets, swap tenors and the

--- a/crates/libitofin/src/termstructures/yields/piecewiseyieldcurve.rs
+++ b/crates/libitofin/src/termstructures/yields/piecewiseyieldcurve.rs
@@ -666,8 +666,9 @@ mod tests {
     /// The `GlobalBootstrap` arm of the consistency harness:
     /// `<Discount, LogLinear, GlobalBootstrap>` at 1e-9 (and a
     /// `<ZeroYield, Linear>` arm below). The minimal single-curve core has no
-    /// direct C++ oracle - the three upstream tests
-    /// (`piecewiseyieldcurve.cpp:1306/1388/1486`) all exercise the deferred
+    /// direct C++ oracle - `testGlobalBootstrapPenalty` is ported alongside the
+    /// penalty terms in `globalbootstrap.rs`, and the two remaining upstream
+    /// tests (`piecewiseyieldcurve.cpp:1306/1486`) exercise the still-deferred
     /// additional restrictions - so the vs-consistency round-trip stands in.
     /// Unlike [`local_bootstrap_consistency`] this oracle is NOT vacuous: the
     /// system is exactly determined (21 helper residuals over 21 interior


### PR DESCRIPTION
- **feat(termstructures): port additional penalty terms for GlobalBootstrap**
- **test(globalbootstrap): add pillar date and zero rate assertions**
- **test(globalbootstrap): pin penalty closure to full node grid**

close #974