### PR TITLE
feat(termstructures): support additional helpers and dates in GlobalBootstrap

### DIFF
--- a/crates/libitofin/src/termstructures/bootstraphelper.rs
+++ b/crates/libitofin/src/termstructures/bootstraphelper.rs
@@ -298,6 +298,14 @@ impl<TS: ?Sized> BootstrapHelperBase<TS> {
         &self.observable
     }
 
+    /// The same observable as an owned handle, for a caller that must keep it
+    /// past the borrow - a bootstrap collecting the observables of helpers it
+    /// owns, handing them to the curve to register with
+    /// ([`Bootstrap::additional_observables`](crate::termstructures::iterativebootstrap::Bootstrap::additional_observables)).
+    pub fn observable_shared(&self) -> Shared<Observable> {
+        Shared::clone(&self.observable)
+    }
+
     /// The helper's forwarding observer, for registering with further
     /// observables.
     pub fn observer(&self) -> SharedMut<dyn Observer> {

--- a/crates/libitofin/src/termstructures/globalbootstrap.rs
+++ b/crates/libitofin/src/termstructures/globalbootstrap.rs
@@ -11,19 +11,19 @@
 //!
 //! [`IterativeBootstrap`]: crate::termstructures::iterativebootstrap::IterativeBootstrap
 //! [`Bootstrap::calculate`]: crate::termstructures::iterativebootstrap::Bootstrap::calculate
+//! [`Bootstrap::additional_observables`]: crate::termstructures::iterativebootstrap::Bootstrap::additional_observables
 //!
 //! ## What is ported, and what is deferred
 //!
 //! The single-curve path is ported, together with the `additionalPenalties`
-//! residual terms (#974); it equals the C++ path with the remaining
-//! `additional*` arguments empty and `parentBootstrapper_` null. Deferred
+//! residual terms (#974) and the `additionalHelpers`/`additionalDates`
+//! restrictions (#976); it equals the C++ path with the remaining
+//! `additional*` argument empty and `parentBootstrapper_` null. Deferred
 //! visibly, each as its own follow-up issue referencing #949:
 //!
-//! - **Additional restrictions** (`additionalHelpers`/`additionalDates`/
-//!   `additionalVariables`, plus the `SimpleQuoteVariables` helper): the
-//!   machinery the two remaining upstream
-//!   oracle tests (`piecewiseyieldcurve.cpp:1306/1486`) exercise - futures
-//!   convexity adjustments, model variables.
+//! - **Additional variables** (`additionalVariables`, plus the
+//!   `SimpleQuoteVariables` helper): the extra optimizer coordinates the
+//!   futures-convexity oracle test (`piecewiseyieldcurve.cpp:1486`) exercises.
 //! - **Multi-curve orchestration** (`MultiCurveBootstrap`,
 //!   `MultiCurveBootstrapContributor`, `setParentBootstrapper`/`setToValid`,
 //!   the `parentBootstrapper_` branch of `calculate`).
@@ -34,7 +34,7 @@
 //! [`OptimizationMethod`](crate::math::optimization::method::OptimizationMethod)
 //! `minimize` takes `&mut self`, which a stored trait object cannot offer
 //! from the `&self` [`Bootstrap::calculate`]; an override can ride with the
-//! deferred additional-restrictions slice if a use case needs it. The
+//! deferred additional-variables slice if a use case needs it. The
 //! `EndCriteria` override is carried (it is `Copy`), defaulting to
 //! `EndCriteria(1000, 10, accuracy, accuracy, accuracy)`
 //! (`globalbootstrap.hpp:228`) - deliberately different literals from
@@ -50,8 +50,11 @@
 //! - The `setup()` D1 half, registering the curve as an observer of every
 //!   instrument (`globalbootstrap.hpp:217-218`), is performed - for any
 //!   bootstrap - by the curve constructor (`PiecewiseYieldCurve::
-//!   with_bootstrap`), which registers all instruments unconditionally. Its
-//!   guards (the weights check, `:232-236`) run at the start of `calculate`.
+//!   with_bootstrap`), which registers all instruments unconditionally. The
+//!   additional helpers of `:219-220` reach the same loop through
+//!   [`Bootstrap::additional_observables`], the trait hook a bootstrap owning
+//!   helpers of its own overrides. Its guards (the weights check, `:232-236`)
+//!   run at the start of `calculate`.
 //! - `initialize()` re-runs on every calculation. C++ caches it behind
 //!   `initialized_` and repeats it only for a moving curve
 //!   (`globalbootstrap.hpp:331-332`); the Rust curve is lazily recalculated
@@ -103,11 +106,14 @@ use crate::math::optimization::endcriteria::EndCriteria;
 use crate::math::optimization::levenbergmarquardt::LevenbergMarquardt;
 use crate::math::optimization::method::OptimizationMethod;
 use crate::math::optimization::problem::Problem;
+use crate::patterns::observable::Observable;
 use crate::require;
 use crate::shared::Shared;
-use crate::termstructures::bootstraphelper::BootstrapHelperShared;
+use crate::termstructures::bootstraphelper::{BootstrapHelperShared, RateHelper};
 use crate::termstructures::bootstraptraits::{BootstrapTraits, YieldBootstrapTraits};
 use crate::termstructures::iterativebootstrap::{Bootstrap, PiecewiseCurve};
+use crate::termstructures::yieldtermstructure::YieldTermStructure;
+use crate::time::date::Date;
 use crate::types::{Real, Size, Time};
 
 /// The additional penalty terms (`AdditionalPenalties`,
@@ -119,6 +125,16 @@ use crate::types::{Real, Size, Time};
 /// optimizer varies, so a penalty over `times.len() - 1` differences indexes
 /// `data[i + 1] - data[i]` directly.
 pub type AdditionalPenalties = dyn Fn(&[Time], &[Real]) -> Vec<Real>;
+
+/// The additional node dates (`additionalDates`, `globalbootstrap.hpp:117`).
+///
+/// Extra grid dates, re-read on every calculation because the upstream functor
+/// is evaluation-date relative (`hpp:266-267`). Each surviving date is one more
+/// interior node - one more free variable of the solve - carrying no residual
+/// of its own, so a system made under-determined this way needs the
+/// [`AdditionalPenalties`] terms to stay solvable. Dates at or before the first
+/// curve date are dropped (`hpp:268-274`).
+pub type AdditionalDates = dyn Fn() -> Vec<Date>;
 
 /// The global bootstrap (`GlobalBootstrap`, single-curve core).
 ///
@@ -133,6 +149,8 @@ pub type AdditionalPenalties = dyn Fn(&[Time], &[Real]) -> Vec<Real>;
 /// [`PiecewiseYieldCurve::new`](crate::termstructures::yields::PiecewiseYieldCurve::new)
 /// still needs the empty configuration.
 pub struct GlobalBootstrap {
+    additional_helpers: Vec<Shared<dyn RateHelper>>,
+    additional_dates: Option<Box<AdditionalDates>>,
     accuracy: Option<Real>,
     end_criteria: Option<EndCriteria>,
     instrument_weights: Vec<Real>,
@@ -156,6 +174,8 @@ impl GlobalBootstrap {
         instrument_weights: Vec<Real>,
     ) -> GlobalBootstrap {
         GlobalBootstrap {
+            additional_helpers: Vec::new(),
+            additional_dates: None,
             accuracy,
             end_criteria,
             instrument_weights,
@@ -163,14 +183,19 @@ impl GlobalBootstrap {
         }
     }
 
-    /// The same configuration plus [`AdditionalPenalties`] over the trial
-    /// curve's node grid (the penalty argument of C++ constructor #2,
-    /// `globalbootstrap.hpp:116-123`, definition `:169-186`).
+    /// The additional-restrictions constructor (C++ constructor #2,
+    /// `globalbootstrap.hpp:116-123`, definition `:169-186`): the
+    /// [`AdditionalPenalties`] over the trial curve's node grid, plus the
+    /// `additionalHelpers` the penalty reprices and the [`AdditionalDates`] the
+    /// grid gains.
     ///
-    /// That constructor also carries `additionalHelpers`, `additionalDates` and
-    /// `additionalVariables`; those are still deferred, so this form takes the
-    /// penalty alone.
+    /// The additional helpers are handed the curve and registered with it, but
+    /// contribute neither a pillar date nor a residual: they exist so a penalty
+    /// can read their `implied_quote`. Its `additionalVariables` argument is
+    /// still deferred.
     pub fn with_penalties<F>(
+        additional_helpers: Vec<Shared<dyn RateHelper>>,
+        additional_dates: Option<Box<AdditionalDates>>,
         accuracy: Option<Real>,
         end_criteria: Option<EndCriteria>,
         instrument_weights: Vec<Real>,
@@ -180,6 +205,8 @@ impl GlobalBootstrap {
         F: Fn(&[Time], &[Real]) -> Vec<Real> + 'static,
     {
         GlobalBootstrap {
+            additional_helpers,
+            additional_dates,
             accuracy,
             end_criteria,
             instrument_weights,
@@ -192,6 +219,8 @@ impl GlobalBootstrap {
     /// `globalbootstrap.hpp:124-131`, definition `:196-206`, which wraps the
     /// no-argument closure into the two-argument one and delegates).
     pub fn with_grid_independent_penalties<F>(
+        additional_helpers: Vec<Shared<dyn RateHelper>>,
+        additional_dates: Option<Box<AdditionalDates>>,
         accuracy: Option<Real>,
         end_criteria: Option<EndCriteria>,
         instrument_weights: Vec<Real>,
@@ -200,9 +229,14 @@ impl GlobalBootstrap {
     where
         F: Fn() -> Vec<Real> + 'static,
     {
-        Self::with_penalties(accuracy, end_criteria, instrument_weights, move |_, _| {
-            penalties()
-        })
+        Self::with_penalties(
+            additional_helpers,
+            additional_dates,
+            accuracy,
+            end_criteria,
+            instrument_weights,
+            move |_, _| penalties(),
+        )
     }
 }
 
@@ -226,9 +260,12 @@ where
     alive: &'a [Shared<C::Helper>],
     alive_weights: &'a [Real],
     penalties: Option<&'a AdditionalPenalties>,
-    /// The number of interior nodes, `times.len() - 1`; residual count is
-    /// `alive.len()` plus the penalty terms, at least `interior` (the grid
-    /// dedup can only shrink the helper half).
+    /// The number of interior nodes, `times.len() - 1`, and the number of
+    /// variables the solve carries; the residual count is `alive.len()` plus
+    /// the penalty terms. The two are equal for a strip of distinct pillars
+    /// and no additional dates; each additional date adds one variable the
+    /// penalty terms have to answer for, and the least-squares solver rejects
+    /// a system left with fewer residuals than variables.
     interior: Size,
     /// The penalty-term count of the last evaluation, so a failed evaluation's
     /// NaN vector has the length the solver sized itself on.
@@ -291,10 +328,20 @@ where
     }
 }
 
-impl<C: PiecewiseCurve> Bootstrap<C> for GlobalBootstrap
+impl<C> Bootstrap<C> for GlobalBootstrap
 where
+    C: PiecewiseCurve<Helper = dyn RateHelper, TS = dyn YieldTermStructure>,
     C::Traits: YieldBootstrapTraits,
 {
+    /// The additional helpers, all of them: the alive filter of `calculate`
+    /// governs the solve, never observability (`globalbootstrap.hpp:219-220`).
+    fn additional_observables(&self) -> Vec<Shared<Observable>> {
+        self.additional_helpers
+            .iter()
+            .map(|helper| helper.base().observable_shared())
+            .collect()
+    }
+
     fn calculate(&self, curve: &C) -> QlResult<()> {
         let instruments = curve.instruments();
         let n = instruments.len();
@@ -324,13 +371,34 @@ where
             }
         }
 
+        // The alive additional helpers (`:256-262`), on the same threshold as
+        // the instruments; they carry no pillar and no residual.
+        let alive_additional: Vec<&Shared<dyn RateHelper>> = self
+            .additional_helpers
+            .iter()
+            .filter(|helper| helper.pillar_date() > first_date)
+            .collect();
+
+        // The additional dates (`:264-274`), re-read on every calculation
+        // because the upstream functor is evaluation-date relative, with the
+        // expired ones dropped before they can reach the grid.
+        let additional_dates: Vec<Date> = match &self.additional_dates {
+            Some(dates) => dates()
+                .into_iter()
+                .filter(|date| *date > first_date)
+                .collect(),
+            None => Vec::new(),
+        };
+
         // The pillar grid (`:280-294`): the first date plus every alive
-        // pillar, sorted with duplicates merged - the one dedup in QuantLib's
-        // bootstraps. A duplicate pillar leaves the least-squares system
-        // overdetermined rather than rejected, unlike IterativeBootstrap.
-        let mut dates = Vec::with_capacity(alive.len() + 1);
+        // pillar plus the surviving additional dates, sorted with duplicates
+        // merged - the one dedup in QuantLib's bootstraps. A duplicate pillar
+        // leaves the least-squares system overdetermined rather than rejected,
+        // unlike IterativeBootstrap.
+        let mut dates = Vec::with_capacity(alive.len() + additional_dates.len() + 1);
         dates.push(first_date);
         dates.extend(alive.iter().map(|helper| helper.pillar_date()));
+        dates.extend(additional_dates);
         dates.sort_unstable();
         dates.dedup();
 
@@ -346,9 +414,10 @@ where
             times.push(curve.time_from_reference(*date)?);
         }
 
-        // maxDate covers every alive helper (`:301-306`).
+        // maxDate covers every alive helper, additional helpers included
+        // (`:301-306`).
         let mut max_date = *dates.last().expect("the grid holds the first date");
-        for helper in &alive {
+        for helper in alive.iter().chain(alive_additional.iter().copied()) {
             max_date = max_date.max(helper.latest_relevant_date());
         }
 
@@ -378,6 +447,18 @@ where
                     "instrument (maturity: {}, pillar: {}) has an invalid quote",
                     helper.maturity_date(),
                     helper.pillar_date()
+                );
+            }
+            helper.set_term_structure(&term_structure);
+        }
+
+        // The same for the alive additional helpers, after the instruments and
+        // under their own message (`:347-352`).
+        for helper in &alive_additional {
+            if helper.quote_value().is_err() {
+                crate::fail!(
+                    "additional instrument (maturity: {}) has an invalid quote",
+                    helper.maturity_date()
                 );
             }
             helper.set_term_structure(&term_structure);
@@ -723,8 +804,8 @@ mod tests {
     }
 
     /// The re-entrancy pin of the penalty slice: a penalty that READS THE
-    /// CURVE mid-solve, the shape the deferred `additionalHelpers` penalty
-    /// takes upstream (`globalbootstrap.hpp:392-395` reprices additional
+    /// CURVE mid-solve, the shape the `additionalHelpers` penalty takes
+    /// upstream (`globalbootstrap.hpp:392-395` reprices additional
     /// helpers off the trial curve).
     ///
     /// The residual is a tiny multiple of the first helper's own quote error,
@@ -742,13 +823,20 @@ mod tests {
         let counter = Shared::clone(&fired);
         let curve = curve_with(
             &fixture,
-            GlobalBootstrap::with_penalties(Some(1.0e-12), None, Vec::new(), move |_, _| {
-                counter.set(counter.get() + 1);
-                let error = probe
-                    .quote_error()
-                    .expect("the probe helper reprices off the trial curve");
-                vec![1.0e-8 * error]
-            }),
+            GlobalBootstrap::with_penalties(
+                Vec::new(),
+                None,
+                Some(1.0e-12),
+                None,
+                Vec::new(),
+                move |_, _| {
+                    counter.set(counter.get() + 1);
+                    let error = probe
+                        .quote_error()
+                        .expect("the probe helper reprices off the trial curve");
+                    vec![1.0e-8 * error]
+                },
+            ),
         );
 
         let rates = zero_rates(&curve, &fixture);
@@ -789,6 +877,8 @@ mod tests {
         let curve = curve_with(
             &fixture,
             GlobalBootstrap::with_grid_independent_penalties(
+                Vec::new(),
+                None,
                 Some(1.0e-12),
                 None,
                 Vec::new(),
@@ -831,10 +921,17 @@ mod tests {
         let record = Shared::clone(&seen);
         let curve = curve_with(
             &fixture,
-            GlobalBootstrap::with_penalties(Some(1.0e-12), None, Vec::new(), move |times, data| {
-                record.set((times.len(), data.len(), times[0], data[0], data[1]));
-                Vec::new()
-            }),
+            GlobalBootstrap::with_penalties(
+                Vec::new(),
+                None,
+                Some(1.0e-12),
+                None,
+                Vec::new(),
+                move |times, data| {
+                    record.set((times.len(), data.len(), times[0], data[0], data[1]));
+                    Vec::new()
+                },
+            ),
         );
 
         assert!(zero_rates(&curve, &fixture).iter().all(|r| r.is_finite()));
@@ -899,11 +996,18 @@ mod tests {
         let gradient_penalty = zero_rates(
             &curve_with(
                 &fixture,
-                GlobalBootstrap::with_penalties(Some(1.0e-12), None, Vec::new(), |times, data| {
-                    (0..times.len() - 1)
-                        .map(|i| 0.01 * (data[i + 1] - data[i]) / (times[i + 1] - times[i]))
-                        .collect()
-                }),
+                GlobalBootstrap::with_penalties(
+                    Vec::new(),
+                    None,
+                    Some(1.0e-12),
+                    None,
+                    Vec::new(),
+                    |times, data| {
+                        (0..times.len() - 1)
+                            .map(|i| 0.01 * (data[i + 1] - data[i]) / (times[i + 1] - times[i]))
+                            .collect()
+                    },
+                ),
             ),
             &fixture,
         );

--- a/crates/libitofin/src/termstructures/globalbootstrap.rs
+++ b/crates/libitofin/src/termstructures/globalbootstrap.rs
@@ -22,7 +22,7 @@
 //! visibly, each as its own follow-up issue referencing #949:
 //!
 //! - **Additional variables** (`additionalVariables`, plus the
-//!   `SimpleQuoteVariables` helper): the extra optimizer coordinates the
+//!   `SimpleQuoteVariables` helper, #977): the extra optimizer coordinates the
 //!   futures-convexity oracle test (`piecewiseyieldcurve.cpp:1486`) exercises.
 //! - **Multi-curve orchestration** (`MultiCurveBootstrap`,
 //!   `MultiCurveBootstrapContributor`, `setParentBootstrapper`/`setToValid`,
@@ -139,10 +139,12 @@ pub type AdditionalDates = dyn Fn() -> Vec<Date>;
 /// The global bootstrap (`GlobalBootstrap`, single-curve core).
 ///
 /// Carries the stopping-accuracy override, the `EndCriteria` override, the
-/// per-instrument residual weights and the additional penalty terms; defaults
+/// per-instrument residual weights, the additional penalty terms, and the
+/// additional helpers and dates those penalties are built around; defaults
 /// mirror the C++ constructor (`accuracy = Null`, `endCriteria = nullptr`,
-/// `instrumentWeights = {}`, no penalties, `globalbootstrap.hpp:112-115`), with
-/// everything resolved from the curve at calculation time.
+/// `instrumentWeights = {}`, no penalties, no additional restrictions,
+/// `globalbootstrap.hpp:112-115`), with everything resolved from the curve at
+/// calculation time.
 ///
 /// The boxed penalty closure is neither `Clone` nor `Debug`, so those two
 /// derives are gone; `Default` is hand-rolled because a curve built through
@@ -551,6 +553,24 @@ mod tests {
     //! The asserts keep the C++ tolerance of 1e-6, but the port is far tighter
     //! than that: every one of the 64 rates matches the dylib to better than
     //! 1e-9, and the worst node parts company only at 1e-12.
+    //!
+    //! Second oracle: `testGlobalBootstrap` (`:1306-1386`) - the same strip
+    //! under `PiecewiseYieldCurve<SimpleZeroYield, Linear, GlobalBootstrap>`,
+    //! now with the seven additional helpers, the additional dates and the
+    //! penalty that ties the helpers' implied quotes to a line. Its 32 rates
+    //! come from the same harness and match it to 1.9e-16.
+    //!
+    //! HONEST NEGATIVES, neither faked into an arm. Both concern branches the
+    //! upstream fixture never reaches:
+    //!
+    //! - The **alive filter on additional helpers** (`hpp:256-262`): all seven
+    //!   start twelve months out, so all seven are alive and the drop branch is
+    //!   unexercised. Its instrument-side twin is the same line of code the
+    //!   32 instruments already run.
+    //! - The **invalid-quote guard on additional helpers** (`hpp:348-351`):
+    //!   every additional quote is a valid `SimpleQuote`, so the guard is
+    //!   unexercised. Reaching it needs an empty quote handle, which no
+    //!   upstream test builds here.
 
     use std::cell::Cell;
 

--- a/crates/libitofin/src/termstructures/globalbootstrap.rs
+++ b/crates/libitofin/src/termstructures/globalbootstrap.rs
@@ -564,6 +564,7 @@ mod tests {
     use crate::quotes::{Quote, SimpleQuote};
     use crate::settings::Settings;
     use crate::shared::shared;
+    use crate::termstructures::TermStructure;
     use crate::termstructures::bootstraphelper::RateHelper;
     use crate::termstructures::bootstraptraits::{ForwardRate, SimpleZeroYield};
     use crate::termstructures::yields::{
@@ -1299,5 +1300,132 @@ mod tests {
         ] {
             assert!(!dates.contains(&stale), "{stale} precedes the first date");
         }
+    }
+
+    /// ARM E: at the solution BOTH residual families vanish - the 32 helpers'
+    /// quote errors and the five penalty terms alike (the dylib reaches 6.6e-16
+    /// and 4.7e-16).
+    ///
+    /// This is what makes the enlarged system square: 37 variables answered by
+    /// 32 + 5 residuals. It also exercises the additional helpers' own
+    /// `set_term_structure` loop (`hpp:347-352`) - an additional helper that
+    /// was never handed the curve cannot imply a quote at all, and the penalty
+    /// evaluated here would fail rather than come out small.
+    #[test]
+    fn global_bootstrap_zeroes_both_residual_families() {
+        let fixture = fixture();
+        let helpers = additional_helpers(&fixture);
+        let curve = PiecewiseYieldCurve::<SimpleZeroYield, Linear, _>::with_bootstrap(
+            fixture.reference_date,
+            fixture.helpers.clone(),
+            Actual365Fixed::new(),
+            Linear,
+            GlobalBootstrap::with_grid_independent_penalties(
+                helpers.clone(),
+                Some(additional_dates(&fixture)),
+                Some(1.0e-12),
+                None,
+                Vec::new(),
+                additional_errors(helpers.clone()),
+            ),
+        )
+        .expect("the 32-helper strip builds a curve");
+        curve.dates().expect("the strip solves");
+
+        for (i, helper) in fixture.helpers.iter().enumerate() {
+            let error = helper
+                .quote_error()
+                .expect("every helper reprices off the solved curve");
+            assert!(error.abs() < 1.0e-9, "helper {i} does not reprice: {error}");
+        }
+        for (k, error) in additional_errors(helpers)().iter().enumerate() {
+            assert!(
+                error.abs() < 1.0e-9,
+                "penalty term {k} does not vanish: {error}"
+            );
+        }
+    }
+
+    /// ARM F, the under-determined pin: the same additional dates with NO
+    /// penalty leave 32 residuals against 37 variables, and the least-squares
+    /// solver refuses the system (`levenbergmarquardt.rs:167-170`; the C++ LM
+    /// raises the identical text).
+    ///
+    /// This is the arm that proves the surviving dates became free VARIABLES
+    /// rather than decoration, and it proves it without the dylib: a port that
+    /// inserted the dates into the grid but not into the optimizer's argument
+    /// vector would solve happily here. An empty penalty vector stands in for
+    /// the C++ null `additionalPenalties_`, which contributes no residual
+    /// either.
+    #[test]
+    fn global_bootstrap_additional_dates_need_penalty_terms() {
+        let fixture = fixture();
+        let curve = PiecewiseYieldCurve::<SimpleZeroYield, Linear, _>::with_bootstrap(
+            fixture.reference_date,
+            fixture.helpers.clone(),
+            Actual365Fixed::new(),
+            Linear,
+            GlobalBootstrap::with_penalties(
+                Vec::new(),
+                Some(additional_dates(&fixture)),
+                Some(1.0e-12),
+                None,
+                Vec::new(),
+                |_, _| Vec::new(),
+            ),
+        )
+        .expect("construction is lazy");
+
+        let message = curve
+            .dates()
+            .expect_err("32 residuals cannot pin 37 variables")
+            .to_string();
+        assert!(
+            message.contains("less functions (32) than available variables (37)"),
+            "unexpected failure: {message}"
+        );
+    }
+
+    /// ARM G, the maxDate extension over the additional helpers
+    /// (`globalbootstrap.hpp:305-306`).
+    ///
+    /// HONEST NEGATIVE: the oracle fixture is BLIND to this line. Its
+    /// additional FRAs all mature in 2021, far inside the 2069 last pillar, so
+    /// the dylib's MAX_DATE is the last pillar either way. The arm is therefore
+    /// built deliberately: the deposit and twelve FRAs of the fixture, whose
+    /// grid ends on 31 Mar 2021, plus one additional helper reaching 30 Sep
+    /// 2021. Without the extension the curve would stop at the last pillar and
+    /// the discount query below would fall outside its range.
+    #[test]
+    fn global_bootstrap_max_date_covers_an_additional_helper() {
+        let fixture = fixture();
+        let additional = Shared::clone(&additional_helpers(&fixture)[6]);
+        let curve = PiecewiseYieldCurve::<SimpleZeroYield, Linear, _>::with_bootstrap(
+            fixture.reference_date,
+            fixture.helpers[..13].to_vec(),
+            Actual365Fixed::new(),
+            Linear,
+            GlobalBootstrap::with_penalties(
+                vec![Shared::clone(&additional)],
+                None,
+                Some(1.0e-12),
+                None,
+                Vec::new(),
+                |_, _| Vec::new(),
+            ),
+        )
+        .expect("the front of the strip builds a curve");
+
+        let last_pillar = fixture.helpers[12].pillar_date();
+        let max_date = curve.max_date();
+        assert_ne!(
+            max_date, last_pillar,
+            "the additional helper must push the maximum past the last pillar"
+        );
+        assert_eq!(max_date, additional.latest_relevant_date());
+        assert!(
+            curve.discount_date(max_date, false).is_ok(),
+            "the extended range must be queryable without extrapolation"
+        );
     }
 }

--- a/crates/libitofin/src/termstructures/globalbootstrap.rs
+++ b/crates/libitofin/src/termstructures/globalbootstrap.rs
@@ -556,14 +556,16 @@ mod tests {
 
     use super::*;
     use crate::handle::Handle;
+    use crate::indexes::IborIndex;
     use crate::indexes::ibor::euribor::Euribor;
     use crate::interestrate::Compounding;
     use crate::math::interpolations::flat::BackwardFlat;
+    use crate::math::interpolations::linear::Linear;
     use crate::quotes::{Quote, SimpleQuote};
     use crate::settings::Settings;
     use crate::shared::shared;
     use crate::termstructures::bootstraphelper::RateHelper;
-    use crate::termstructures::bootstraptraits::ForwardRate;
+    use crate::termstructures::bootstraptraits::{ForwardRate, SimpleZeroYield};
     use crate::termstructures::yields::{
         DepositRateHelper, FraRateHelper, PiecewiseYieldCurve, Pillar, SwapRateHelper,
     };
@@ -667,6 +669,44 @@ mod tests {
         0.0006289189187075171,
     ];
 
+    /// The `testGlobalBootstrap` pillar zero rates, reproduced from the C++
+    /// dylib and written in their shortest round-tripping form; `:1337-1342`
+    /// prints the same values to 8 decimals.
+    const REF_ZERO_RATE_AD: [Real; 32] = [
+        -0.00373354067173059,
+        -0.003810050775257402,
+        -0.0038768926341334457,
+        -0.0039412379977853225,
+        -0.0040770590967655115,
+        -0.004136329462812865,
+        -0.004119347704602793,
+        -0.004163696290681206,
+        -0.004205570570898868,
+        -0.004244312604300202,
+        -0.004278238728862865,
+        -0.004309771141705333,
+        -0.00434401190355896,
+        -0.0044524306053832785,
+        -0.004485055406658101,
+        -0.0043369013657431075,
+        -0.0040740106932843105,
+        -0.0037275150355157113,
+        -0.003300502203893726,
+        -0.002791390998101797,
+        -0.0022547726443913644,
+        -0.0017342152462374019,
+        -0.0012368804047865718,
+        -0.0007723647126769745,
+        0.00038554381038254917,
+        0.0014424807165811571,
+        0.001759949836190311,
+        0.0017287285812646173,
+        0.0015078180913406802,
+        0.0012114528819535877,
+        0.000933912094611891,
+        0.0006289461592278805,
+    ];
+
     /// The gradient-penalty pillar zero rates, reproduced from the C++ dylib and
     /// written in their shortest round-tripping form; `:1417-1422` prints the
     /// same values printed to 8 decimals.
@@ -708,11 +748,18 @@ mod tests {
     /// The curve under test.
     type PenaltyCurve = PiecewiseYieldCurve<ForwardRate, BackwardFlat, GlobalBootstrap>;
 
-    /// The shared fixture: evaluation date 26 Sep 2019 (`:1390`) and the
-    /// 32 helpers of `:1428-1441`, all reading one empty-forwarding Euribor 6M.
+    /// The shared fixture: evaluation date 26 Sep 2019 (`:1390`/`:1309`) and
+    /// the 32 helpers of `:1428-1441` (`:1339-1352`), all reading one
+    /// empty-forwarding Euribor 6M.
+    ///
+    /// The settings and the index are carried too: `testGlobalBootstrap` builds
+    /// its additional helpers off the same index (`:1362`) and reads the
+    /// evaluation date from its additional-dates functor (`:1290`).
     struct Fixture {
         reference_date: Date,
         helpers: Vec<Shared<dyn RateHelper>>,
+        settings: Shared<Settings<Date>>,
+        index: IborIndex,
     }
 
     /// C++ builds the curve from `(2, TARGET())`, a moving reference two
@@ -735,7 +782,7 @@ mod tests {
             BusinessDayConvention::Following,
             false,
         );
-        let euribor6m = Euribor::six_months(Handle::empty(), settings);
+        let euribor6m = Euribor::six_months(Handle::empty(), Shared::clone(&settings));
 
         let mut helpers: Vec<Shared<dyn RateHelper>> = Vec::new();
         helpers.push(
@@ -767,6 +814,8 @@ mod tests {
         Fixture {
             reference_date,
             helpers,
+            settings,
+            index: euribor6m,
         }
     }
 
@@ -783,8 +832,10 @@ mod tests {
         .expect("the 32-helper strip builds a curve")
     }
 
-    /// The continuous Actual/360 zero rate at every pillar (`:1459`/`:1481`).
-    fn zero_rates(curve: &Shared<PenaltyCurve>, fixture: &Fixture) -> Vec<Real> {
+    /// The continuous Actual/360 zero rate at every pillar (`:1459`/`:1481`,
+    /// `:1383`). Taken through the term-structure trait so both oracle curves
+    /// share it.
+    fn zero_rates(curve: &dyn YieldTermStructure, fixture: &Fixture) -> Vec<Real> {
         fixture
             .helpers
             .iter()
@@ -839,7 +890,7 @@ mod tests {
             ),
         );
 
-        let rates = zero_rates(&curve, &fixture);
+        let rates = zero_rates(curve.as_ref(), &fixture);
         assert!(
             rates.iter().all(|rate| rate.is_finite()),
             "the solved curve must carry finite zero rates"
@@ -890,7 +941,9 @@ mod tests {
         );
 
         assert!(
-            zero_rates(&curve, &fixture).iter().all(|r| r.is_finite()),
+            zero_rates(curve.as_ref(), &fixture)
+                .iter()
+                .all(|r| r.is_finite()),
             "a zero constant penalty must leave the strip solvable"
         );
         assert!(
@@ -934,7 +987,11 @@ mod tests {
             ),
         );
 
-        assert!(zero_rates(&curve, &fixture).iter().all(|r| r.is_finite()));
+        assert!(
+            zero_rates(curve.as_ref(), &fixture)
+                .iter()
+                .all(|r| r.is_finite())
+        );
         let (times_len, data_len, first_time, node0, node1) = seen.get();
         assert_eq!(
             times_len,
@@ -987,14 +1044,15 @@ mod tests {
     fn global_bootstrap_penalty_zero_rates() {
         let fixture = fixture();
         let no_penalty = zero_rates(
-            &curve_with(
+            curve_with(
                 &fixture,
                 GlobalBootstrap::new(Some(1.0e-12), None, Vec::new()),
-            ),
+            )
+            .as_ref(),
             &fixture,
         );
         let gradient_penalty = zero_rates(
-            &curve_with(
+            curve_with(
                 &fixture,
                 GlobalBootstrap::with_penalties(
                     Vec::new(),
@@ -1008,7 +1066,8 @@ mod tests {
                             .collect()
                     },
                 ),
-            ),
+            )
+            .as_ref(),
             &fixture,
         );
 
@@ -1035,6 +1094,210 @@ mod tests {
                 "gradient-penalty zero rate {i}: {} vs {expected}",
                 gradient_penalty[i]
             );
+        }
+    }
+
+    /// The curve of `testGlobalBootstrap` (`piecewiseyieldcurve.cpp:1367-1372`):
+    /// the same 32-helper strip under the simply compounded zero-yield traits
+    /// and a linear interpolation.
+    type AdditionalCurve = PiecewiseYieldCurve<SimpleZeroYield, Linear, GlobalBootstrap>;
+
+    /// The seven additional helpers of `:1357-1364`: FRAs on the strip's own
+    /// index, at a flat -0.004, starting 12 to 18 months out. They add neither
+    /// a pillar nor a residual; the penalty below is the only thing that reads
+    /// them.
+    fn additional_helpers(fixture: &Fixture) -> Vec<Shared<dyn RateHelper>> {
+        (0..7)
+            .map(|i| {
+                let quote = Handle::new(shared(SimpleQuote::new(-0.004)) as Shared<dyn Quote>);
+                FraRateHelper::from_months(
+                    quote,
+                    12 + i,
+                    &fixture.index,
+                    true,
+                    Pillar::LastRelevantDate,
+                ) as Shared<dyn RateHelper>
+            })
+            .collect()
+    }
+
+    /// The `additionalDates` functor of `:1287-1303`: the five monthly dates
+    /// past spot, with the evaluation date minus one day pushed to the FRONT
+    /// and minus two days appended at the BACK. Both of those precede the
+    /// curve's first date and must be dropped; the vector is deliberately left
+    /// unsorted, since the grid sorts it.
+    fn additional_dates(fixture: &Fixture) -> Box<AdditionalDates> {
+        let settings = Shared::clone(&fixture.settings);
+        Box::new(move || {
+            let calendar = Target::new();
+            let today = settings
+                .evaluation_date()
+                .expect("the fixture sets an evaluation date");
+            let settlement = calendar.advance(
+                today,
+                2,
+                TimeUnit::Days,
+                BusinessDayConvention::Following,
+                false,
+            );
+            let mut dates: Vec<Date> = (1..=5)
+                .map(|i| {
+                    calendar.advance(
+                        settlement,
+                        i,
+                        TimeUnit::Months,
+                        BusinessDayConvention::Following,
+                        false,
+                    )
+                })
+                .collect();
+            dates.insert(0, today - 1);
+            dates.push(today - 2);
+            dates
+        })
+    }
+
+    /// The `additionalErrors` functor of `:1271-1285`: the seven additional
+    /// helpers' implied quotes forced onto a straight line, so the five
+    /// interior ones are pinned by the two ends. These are the residuals that
+    /// answer for the five extra variables the additional dates create.
+    fn additional_errors(helpers: Vec<Shared<dyn RateHelper>>) -> impl Fn() -> Vec<Real> {
+        move || {
+            let implied = |i: usize| {
+                helpers[i]
+                    .implied_quote()
+                    .expect("an additional helper reprices off the trial curve")
+            };
+            let a = implied(0);
+            let b = implied(6);
+            (0..5)
+                .map(|k| (5.0 - k as Real) / 6.0 * a + (1.0 + k as Real) / 6.0 * b - implied(1 + k))
+                .collect()
+        }
+    }
+
+    /// The full `testGlobalBootstrap` configuration, over the shared fixture.
+    fn additional_curve(fixture: &Fixture) -> Shared<AdditionalCurve> {
+        let helpers = additional_helpers(fixture);
+        PiecewiseYieldCurve::with_bootstrap(
+            fixture.reference_date,
+            fixture.helpers.clone(),
+            Actual365Fixed::new(),
+            Linear,
+            GlobalBootstrap::with_grid_independent_penalties(
+                helpers.clone(),
+                Some(additional_dates(fixture)),
+                Some(1.0e-12),
+                None,
+                Vec::new(),
+                additional_errors(helpers),
+            ),
+        )
+        .expect("the 32-helper strip builds a curve")
+    }
+
+    /// ARM A of `testGlobalBootstrap` (`:1376-1378`): the pillar dates, both
+    /// families. External truth that stands on its own - no reference to the
+    /// solve - so a mis-specified strip or a mis-specified additional helper
+    /// fails here rather than smearing into the rates. The seven additional
+    /// pillars are the dylib's, and they also establish that all seven are
+    /// alive (each is past the 30 Sep 2019 first date).
+    #[test]
+    fn global_bootstrap_pillar_dates() {
+        let fixture = fixture();
+        for (i, (day, month, year)) in REF_DATE.iter().enumerate() {
+            assert_eq!(
+                fixture.helpers[i].pillar_date(),
+                Date::new(*day, *month, *year),
+                "helper {i} sits on the wrong pillar"
+            );
+        }
+
+        let expected = [
+            Date::new(31, Month::March, 2021),
+            Date::new(30, Month::April, 2021),
+            Date::new(31, Month::May, 2021),
+            Date::new(30, Month::June, 2021),
+            Date::new(30, Month::July, 2021),
+            Date::new(31, Month::August, 2021),
+            Date::new(30, Month::September, 2021),
+        ];
+        for (i, helper) in additional_helpers(&fixture).iter().enumerate() {
+            assert_eq!(
+                helper.pillar_date(),
+                expected[i],
+                "additional helper {i} sits on the wrong pillar"
+            );
+            assert!(helper.pillar_date() > fixture.reference_date);
+        }
+    }
+
+    /// ARM B, the headline oracle of `testGlobalBootstrap` (`:1381-1385`): the
+    /// 32 pillar zero rates at the C++ tolerance of 1e-6 (0.01 basis points).
+    ///
+    /// The reference numbers are NOT the `.cpp` literals: they are reproduced
+    /// at full precision by a C++ harness rebuilding this fixture against a
+    /// locally built QuantLib dylib with
+    /// `IborCoupon::Settings::instance().createAtParCoupons()` set, so that the
+    /// test's own `usingAtParCoupons()` precondition holds. The literals agree
+    /// with the harness to 5.3e-9, inside their 8-decimal printing.
+    ///
+    /// VACUITY GUARD: the numbers depend on the additional dates. Dropping the
+    /// `additionalDates` functor leaves a 33-node grid whose solution moves 14
+    /// of these 32 rates past the assert tolerance (worst 7.8e-5, dylib-
+    /// measured), so this table cannot be reproduced by the #974 machinery
+    /// alone.
+    #[test]
+    fn global_bootstrap_zero_rates() {
+        let fixture = fixture();
+        let rates = zero_rates(additional_curve(&fixture).as_ref(), &fixture);
+
+        let worst = rates
+            .iter()
+            .zip(&REF_ZERO_RATE_AD)
+            .map(|(rate, expected)| (rate - expected).abs())
+            .fold(0.0, Real::max);
+        assert!(
+            worst < 1.0e-6,
+            "the strip parts company with the dylib by {worst}"
+        );
+    }
+
+    /// ARM C, the stale-date drop (`globalbootstrap.hpp:268-274`): the two
+    /// dates before the curve's first date never reach the grid.
+    ///
+    /// The count is the discriminating half - 38 nodes is the reference date
+    /// plus 32 pillars plus the FIVE surviving dates, and a port that kept the
+    /// stale pair would carry 40 and would not solve, since the two extra
+    /// variables have no residual answering for them. The membership asserts
+    /// name which five survived.
+    #[test]
+    fn global_bootstrap_drops_stale_additional_dates() {
+        let fixture = fixture();
+        let dates = additional_curve(&fixture)
+            .dates()
+            .expect("the solved curve exposes its nodes");
+
+        assert_eq!(
+            dates.len(),
+            38,
+            "reference + 32 pillars + 5 surviving dates"
+        );
+        assert_eq!(dates[0], fixture.reference_date);
+        for date in [
+            Date::new(30, Month::October, 2019),
+            Date::new(2, Month::December, 2019),
+            Date::new(30, Month::December, 2019),
+            Date::new(30, Month::January, 2020),
+            Date::new(2, Month::March, 2020),
+        ] {
+            assert!(dates.contains(&date), "{date} should be a node");
+        }
+        for stale in [
+            Date::new(25, Month::September, 2019),
+            Date::new(24, Month::September, 2019),
+        ] {
+            assert!(!dates.contains(&stale), "{stale} precedes the first date");
         }
     }
 }

--- a/crates/libitofin/src/termstructures/iterativebootstrap.rs
+++ b/crates/libitofin/src/termstructures/iterativebootstrap.rs
@@ -65,6 +65,7 @@ use crate::math::interpolations::Interpolator;
 use crate::math::solver1d::Solver1D;
 use crate::math::solvers1d::brent::Brent;
 use crate::math::solvers1d::finitedifferencenewtonsafe::FiniteDifferenceNewtonSafe;
+use crate::patterns::observable::Observable;
 use crate::shared::Shared;
 use crate::termstructures::bootstraphelper::{BootstrapHelperShared, sort_by_pillar_date};
 use crate::termstructures::bootstraptraits::{BootstrapTraits, CurveData};
@@ -157,6 +158,22 @@ pub trait PiecewiseCurve {
 pub trait Bootstrap<C: PiecewiseCurve> {
     /// Bootstraps `curve` in place (C++'s `Bootstrap::calculate`).
     fn calculate(&self, curve: &C) -> QlResult<()>;
+
+    /// Observables the curve must register with beyond its own instruments,
+    /// the second registration loop of C++'s `setup`
+    /// (`globalbootstrap.hpp:219-220`).
+    ///
+    /// A bootstrap holding helpers of its own - only
+    /// [`GlobalBootstrap`](crate::termstructures::globalbootstrap::GlobalBootstrap)
+    /// and its additional helpers - returns their observables here, and the
+    /// curve constructor registers them alongside the instruments. The default
+    /// is empty, so the bootstraps that own no helpers are untouched.
+    ///
+    /// Registration is unconditional upstream: the alive filter applies only
+    /// inside the solve, not to observability.
+    fn additional_observables(&self) -> Vec<Shared<Observable>> {
+        Vec::new()
+    }
 }
 
 /// The iterative bootstrap (`IterativeBootstrap`).

--- a/crates/libitofin/src/termstructures/yields/piecewiseyieldcurve.rs
+++ b/crates/libitofin/src/termstructures/yields/piecewiseyieldcurve.rs
@@ -353,7 +353,7 @@ mod tests {
     use crate::termstructures::credit::defaulttermstructure::DefaultProbabilityTermStructure;
     use crate::termstructures::credit::flathazardrate::FlatHazardRate;
     use crate::termstructures::yields::{
-        DepositRateHelper, InterpolatedSimpleZeroCurve, SwapRateHelper,
+        DepositRateHelper, FraRateHelper, InterpolatedSimpleZeroCurve, Pillar, SwapRateHelper,
     };
     use crate::time::businessdayconvention::BusinessDayConvention;
     use crate::time::calendars::target::Target;
@@ -759,10 +759,11 @@ mod tests {
     /// The `GlobalBootstrap` arm of the consistency harness:
     /// `<Discount, LogLinear, GlobalBootstrap>` at 1e-9 (and a
     /// `<ZeroYield, Linear>` arm below). The minimal single-curve core has no
-    /// direct C++ oracle - `testGlobalBootstrapPenalty` is ported alongside the
-    /// penalty terms in `globalbootstrap.rs`, and the two remaining upstream
-    /// tests (`piecewiseyieldcurve.cpp:1306/1486`) exercise the still-deferred
-    /// additional restrictions - so the vs-consistency round-trip stands in.
+    /// direct C++ oracle - `testGlobalBootstrapPenalty` and
+    /// `testGlobalBootstrap` are ported alongside the penalty terms and the
+    /// additional restrictions in `globalbootstrap.rs`, and the one remaining
+    /// upstream test (`piecewiseyieldcurve.cpp:1486`) exercises the
+    /// still-deferred additional variables - so the round-trip stands in.
     /// Unlike [`local_bootstrap_consistency`] this oracle is NOT vacuous: the
     /// system is exactly determined (21 helper residuals over 21 interior
     /// nodes, no free window parameter), so the zero-residual root is locally
@@ -1179,5 +1180,88 @@ mod tests {
             df2 < df1,
             "a higher deposit rate discounts more: {df2} vs {df1}"
         );
+    }
+
+    /// D1 for the helpers the BOOTSTRAP owns rather than fits
+    /// (`globalbootstrap.hpp:219-220`): a `GlobalBootstrap` additional helper
+    /// is registered with the curve through
+    /// [`Bootstrap::additional_observables`], so a change to its quote
+    /// invalidates the cache exactly as an instrument's does.
+    ///
+    /// The re-bootstrapped curve is then IDENTICAL, and deliberately so: an
+    /// additional helper contributes no residual, and the driver only
+    /// validates its quote (`hpp:348`) before handing it the curve. Its market
+    /// quote reaches the solve solely through whatever the penalty reads, and
+    /// here there is no penalty. So the pair of assertions is the whole
+    /// contract - the notification must arrive, and it must not move the
+    /// answer. The quote is moved from -0.004 to 0.05, orders of magnitude
+    /// more than the 1e-12 agreement asserted, so a port that let it into the
+    /// residual vector could not pass the second half.
+    ///
+    /// Bit-equality is not asserted: the second solve warm-restarts from the
+    /// stored solution and rewrites every node through the transform pair, so
+    /// the last digits may differ.
+    #[test]
+    fn a_global_bootstrap_additional_helper_is_observed() {
+        use crate::termstructures::globalbootstrap::GlobalBootstrap;
+
+        let calendar = Target::new();
+        let today = calendar.adjust(
+            Date::new(15, Month::June, 2026),
+            BusinessDayConvention::Following,
+        );
+        let settings = shared(Settings::<Date>::new());
+        settings.set_evaluation_date(today);
+        let settlement = calendar.advance(
+            today,
+            2,
+            TimeUnit::Days,
+            BusinessDayConvention::Following,
+            false,
+        );
+        let index = Euribor::new(Period::new(3, TimeUnit::Months), Handle::empty(), settings)
+            .expect("deposit tenor is valid");
+
+        let quote = shared(SimpleQuote::new(-0.004));
+        let additional = FraRateHelper::from_months(
+            Handle::new(Shared::clone(&quote) as Shared<dyn Quote>),
+            6,
+            &index,
+            true,
+            Pillar::LastRelevantDate,
+        ) as Shared<dyn RateHelper>;
+        let curve = PiecewiseYieldCurve::<Discount, LogLinear, _>::with_bootstrap(
+            settlement,
+            vec![DepositRateHelper::from_rate(0.04557, &index) as Shared<dyn RateHelper>],
+            Actual360::new(),
+            LogLinear,
+            GlobalBootstrap::with_penalties(
+                vec![additional],
+                None,
+                None,
+                None,
+                Vec::new(),
+                |_, _| Vec::new(),
+            ),
+        )
+        .expect("a one-deposit strip builds a curve");
+
+        let before = curve.data().expect("the strip solves");
+        assert!(curve.lazy.borrow().is_calculated());
+
+        quote.set_value(0.05);
+        assert!(
+            !curve.lazy.borrow().is_calculated(),
+            "an additional helper's quote must invalidate the curve"
+        );
+
+        let after = curve.data().expect("the strip re-solves");
+        assert_eq!(before.len(), after.len());
+        for (i, (old, new)) in before.iter().zip(&after).enumerate() {
+            assert!(
+                (old - new).abs() < 1.0e-12,
+                "node {i} moved on an additional helper's quote: {old} vs {new}"
+            );
+        }
     }
 }

--- a/crates/libitofin/src/termstructures/yields/piecewiseyieldcurve.rs
+++ b/crates/libitofin/src/termstructures/yields/piecewiseyieldcurve.rs
@@ -1201,6 +1201,11 @@ mod tests {
     /// Bit-equality is not asserted: the second solve warm-restarts from the
     /// stored solution and rewrites every node through the transform pair, so
     /// the last digits may differ.
+    ///
+    /// Two additional helpers are registered and the quote moved is the
+    /// SECOND one's: with a single helper the arm cannot tell "all of them"
+    /// from "the first of them" (gate-probed - a registration truncated to
+    /// the first helper passed the single-helper form).
     #[test]
     fn a_global_bootstrap_additional_helper_is_observed() {
         use crate::termstructures::globalbootstrap::GlobalBootstrap;
@@ -1222,8 +1227,15 @@ mod tests {
         let index = Euribor::new(Period::new(3, TimeUnit::Months), Handle::empty(), settings)
             .expect("deposit tenor is valid");
 
+        let first = FraRateHelper::from_months(
+            Handle::new(shared(SimpleQuote::new(-0.004)) as Shared<dyn Quote>),
+            3,
+            &index,
+            true,
+            Pillar::LastRelevantDate,
+        ) as Shared<dyn RateHelper>;
         let quote = shared(SimpleQuote::new(-0.004));
-        let additional = FraRateHelper::from_months(
+        let second = FraRateHelper::from_months(
             Handle::new(Shared::clone(&quote) as Shared<dyn Quote>),
             6,
             &index,
@@ -1236,7 +1248,7 @@ mod tests {
             Actual360::new(),
             LogLinear,
             GlobalBootstrap::with_penalties(
-                vec![additional],
+                vec![first, second],
                 None,
                 None,
                 None,
@@ -1252,7 +1264,7 @@ mod tests {
         quote.set_value(0.05);
         assert!(
             !curve.lazy.borrow().is_calculated(),
-            "an additional helper's quote must invalidate the curve"
+            "the second additional helper's quote must invalidate the curve"
         );
 
         let after = curve.data().expect("the strip re-solves");

--- a/crates/libitofin/src/termstructures/yields/piecewiseyieldcurve.rs
+++ b/crates/libitofin/src/termstructures/yields/piecewiseyieldcurve.rs
@@ -163,6 +163,11 @@ where
         for helper in &curve.instruments {
             helper.observable().register_observer(&observer);
         }
+        // Helpers the bootstrap owns rather than fits - GlobalBootstrap's
+        // additional helpers - register too (`globalbootstrap.hpp:219-220`).
+        for observable in curve.bootstrap.additional_observables() {
+            observable.register_observer(&observer);
+        }
         Ok(curve)
     }
 


### PR DESCRIPTION
- **feat(termstructures): support additional helpers and dates in GlobalBootstrap**
- **test(crates): cover testGlobalBootstrap additional-dates strip**
- **test(termstructures): cover global bootstrap additional restrictions**
- **docs(crates): document second oracle test for GlobalBootstrap**
- **test(crates): pin registration of every additional helper**

close #976