### PR TITLE
feat(quotes): add FuturesConvAdjustmentQuote for convexity pricing

### DIFF
--- a/crates/libitofin/src/handle.rs
+++ b/crates/libitofin/src/handle.rs
@@ -466,6 +466,23 @@ mod tests {
         );
     }
 
+    /// The OWNING half of the contract: the handle is the pointee's only
+    /// holder here, so a non-owning (weak) implementation would leave it
+    /// empty. Pinned directly because the futures helper reads an empty
+    /// convexity handle as a ZERO adjustment (`ratehelpers.rs`) - a dangling
+    /// handle there prices silently rather than failing (gate-probed: only the
+    /// convexity oracle's solved-vol pin caught a weak variant).
+    #[test]
+    fn an_unregistered_handle_keeps_its_pointee_alive() {
+        let h: Handle<dyn Quote> = Handle::new_unregistered(shared(SimpleQuote::new(0.25)));
+
+        assert!(
+            !h.is_empty(),
+            "the unregistered handle must own its pointee"
+        );
+        assert_eq!(h.current_link().unwrap().value().unwrap(), 0.25);
+    }
+
     /// Port of `testObservableHandle` (test-suite/quotes.cpp), extended with
     /// the subscription-move asserts: the detached pointee must stop notifying
     /// and the newly linked one must start.

--- a/crates/libitofin/src/handle.rs
+++ b/crates/libitofin/src/handle.rs
@@ -9,7 +9,9 @@
 //! relinking moves that registration to the new pointee. The port mirrors the
 //! `handle.hpp` precondition "class T must inherit from Observable" with the
 //! [`AsObservable`] bound on handle pointees and forwards every pointee
-//! notification to the link's own observers.
+//! notification to the link's own observers - unless the handle was built
+//! through [`Handle::new_unregistered`], the port of the C++
+//! `registerAsObserver = false` constructor flag.
 
 use std::rc::Weak;
 
@@ -102,6 +104,31 @@ impl<T: AsObservable + ?Sized> Link<T> {
         self.weak = Some(pointee);
         self.observable.clone()
     }
+
+    /// Repoints the link at an OWNING pointee it does not observe, dropping any
+    /// previous owning pointee's subscription and registering none on the new
+    /// one.
+    ///
+    /// The port of C++ `Handle(pointee, registerAsObserver=false)`
+    /// (`handle.hpp:80-82`): the pointee is kept alive and resolves normally, but
+    /// its value changes never reach the handle's observers. The futures-
+    /// convexity oracle needs exactly this - a `FuturesRateHelper` must hold
+    /// the convexity quote whose volatility the global bootstrap varies, and
+    /// observing it would invalidate the curve on every optimizer step
+    /// (`piecewiseyieldcurve.cpp:1516-1519`).
+    ///
+    /// This is the third state of the two slots: [`link_to`](Link::link_to)
+    /// owns AND observes, [`link_weak`](Link::link_weak) neither owns nor
+    /// observes, and this one owns without observing.
+    fn link_unregistered(&mut self, pointee: Shared<T>) -> Shared<Observable> {
+        let forwarder = self.forwarder.clone() as SharedMut<dyn Observer>;
+        if let Some(old) = &self.current {
+            old.observable().unregister_observer(&forwarder);
+        }
+        self.current = Some(pointee);
+        self.weak = None;
+        self.observable.clone()
+    }
 }
 
 /// Shared handle to an observable pointee.
@@ -124,6 +151,21 @@ impl<T: AsObservable + ?Sized> Handle<T> {
     pub fn new(pointee: Shared<T>) -> Self {
         Handle {
             link: shared_mut(Link::new(Some(pointee))),
+        }
+    }
+
+    /// Creates a handle OWNING `pointee` but not observing it, the port of C++
+    /// `Handle(pointee, registerAsObserver=false)` (`handle.hpp:80-82`).
+    ///
+    /// The pointee is dereferenced exactly as through [`new`](Self::new); only
+    /// the notification path is cut, so a change inside the pointee never
+    /// reaches this handle's observers. See `Link::link_unregistered` for why
+    /// the global bootstrap's futures-convexity oracle needs it.
+    pub fn new_unregistered(pointee: Shared<T>) -> Self {
+        let mut link = Link::new(None);
+        link.link_unregistered(pointee);
+        Handle {
+            link: shared_mut(link),
         }
     }
 }
@@ -376,6 +418,51 @@ mod tests {
         assert!(
             flag.borrow().up,
             "observer was not notified of quote change"
+        );
+    }
+
+    /// The `registerAsObserver = false` half of the C++ constructor flag: a
+    /// pointee change does NOT reach observers of an unregistered handle,
+    /// while the pointee still resolves through it.
+    ///
+    /// The mutant twin below is what gives this arm teeth - a handle wired to
+    /// nothing would pass this half on its own.
+    #[test]
+    #[allow(clippy::approx_constant)]
+    fn an_unregistered_handle_hides_pointee_changes() {
+        let quote = shared(SimpleQuote::new(0.0));
+        let h: Handle<dyn Quote> = Handle::new_unregistered(quote.clone());
+        let flag = shared_mut(Flag::default());
+        h.register_observer(&(flag.clone() as SharedMut<dyn Observer>));
+
+        quote.set_value(3.14);
+
+        assert!(
+            !flag.borrow().up,
+            "an unregistered handle must not forward pointee changes"
+        );
+        assert_eq!(
+            h.current_link().unwrap().value().unwrap(),
+            3.14,
+            "the pointee must still resolve, and at its new value"
+        );
+    }
+
+    /// The mutant twin of the arm above: the SAME setup through the ordinary
+    /// observing [`Handle::new`] does notify.
+    #[test]
+    #[allow(clippy::approx_constant)]
+    fn an_ordinary_handle_forwards_the_same_pointee_change() {
+        let quote = shared(SimpleQuote::new(0.0));
+        let h: Handle<dyn Quote> = Handle::new(quote.clone());
+        let flag = shared_mut(Flag::default());
+        h.register_observer(&(flag.clone() as SharedMut<dyn Observer>));
+
+        quote.set_value(3.14);
+
+        assert!(
+            flag.borrow().up,
+            "an ordinary handle must forward pointee changes"
         );
     }
 

--- a/crates/libitofin/src/quotes/futuresconvadjustmentquote.rs
+++ b/crates/libitofin/src/quotes/futuresconvadjustmentquote.rs
@@ -1,0 +1,363 @@
+//! Quote for the futures-convexity adjustment of an index.
+//!
+//! Port of `ql/quotes/futuresconvadjustmentquote.{hpp,cpp}`. The quote wraps
+//! [`convexity_bias`](crate::models::shortrate::hullwhite::convexity_bias) over
+//! a futures price, a Hull-White volatility and a mean reversion, and is what a
+//! [`FuturesRateHelper`](crate::termstructures::yields::FuturesRateHelper) reads
+//! as its convexity adjustment.
+//!
+//! The value is the BIAS itself, not a bias-adjusted rate: the helper adds it to
+//! the forward (`ratehelpers.cpp:168`).
+//!
+//! ## The evaluation date is explicit (D5)
+//!
+//! C++ reads `Settings::instance().evaluationDate()` inside `value()` and
+//! registers with it in the constructor. The core has no global settings
+//! singleton, so the quote carries a [`Shared<Settings<Date>>`](Settings) - the
+//! way the ibor indexes do - reads the evaluation date from it lazily in
+//! `value()`, and registers with its evaluation-date observable. An unset
+//! evaluation date is an error rather than a clock fallback (D10).
+
+use std::cell::Cell;
+
+use crate::ensure;
+use crate::errors::QlResult;
+use crate::handle::{AsObservable, Handle};
+use crate::indexes::iborindex::IborIndex;
+use crate::indexes::interestrateindex::InterestRateIndex;
+use crate::models::shortrate::hullwhite::convexity_bias;
+use crate::patterns::observable::{Observable, Observer, ResetThenNotify};
+use crate::settings::Settings;
+use crate::shared::{Shared, SharedMut};
+use crate::time::date::Date;
+use crate::time::daycounter::DayCounter;
+use crate::time::imm;
+use crate::types::Real;
+
+use super::{Quote, invalidator};
+
+/// Quote for the futures-convexity adjustment of an index.
+///
+/// Mirrors QuantLib's `FuturesConvAdjustmentQuote`: the index maturity of the
+/// futures date is resolved once at construction, the bias is computed lazily
+/// and cached, and any notification from the three source handles or from the
+/// evaluation date drops the cache and reaches this quote's observers.
+pub struct FuturesConvAdjustmentQuote {
+    day_counter: DayCounter,
+    futures_date: Date,
+    index_maturity_date: Date,
+    futures_quote: Handle<dyn Quote>,
+    volatility: Handle<dyn Quote>,
+    mean_reversion: Handle<dyn Quote>,
+    settings: Shared<Settings<Date>>,
+    cache: Shared<Cell<Option<Real>>>,
+    observable: Shared<Observable>,
+    _listener: SharedMut<ResetThenNotify>,
+}
+
+impl FuturesConvAdjustmentQuote {
+    /// The quote over an explicit futures date (C++ constructor #1).
+    ///
+    /// `index` is read only here, for its day counter and for the index
+    /// maturity of `futures_date`.
+    ///
+    /// # Errors
+    ///
+    /// Fails if the index cannot resolve the maturity of `futures_date`.
+    pub fn new(
+        index: &IborIndex,
+        futures_date: Date,
+        futures_quote: Handle<dyn Quote>,
+        volatility: Handle<dyn Quote>,
+        mean_reversion: Handle<dyn Quote>,
+        settings: Shared<Settings<Date>>,
+    ) -> QlResult<FuturesConvAdjustmentQuote> {
+        let index_maturity_date = index.maturity_date(futures_date)?;
+        let (cache, observable, listener) = invalidator();
+        let observer = listener.clone() as SharedMut<dyn Observer>;
+        futures_quote.register_observer(&observer);
+        volatility.register_observer(&observer);
+        mean_reversion.register_observer(&observer);
+        settings.register_eval_date_observer(&observer);
+        Ok(FuturesConvAdjustmentQuote {
+            day_counter: index.day_counter().clone(),
+            futures_date,
+            index_maturity_date,
+            futures_quote,
+            volatility,
+            mean_reversion,
+            settings,
+            cache,
+            observable,
+            _listener: listener,
+        })
+    }
+
+    /// The same over an IMM code (C++ constructor #2), resolved as the first
+    /// such IMM date on or after the evaluation date - C++ resolves it against
+    /// the same default.
+    ///
+    /// # Errors
+    ///
+    /// Fails on an unset evaluation date, on a string that is not an IMM code,
+    /// or as [`new`](Self::new) does.
+    pub fn from_imm_code(
+        index: &IborIndex,
+        imm_code: &str,
+        futures_quote: Handle<dyn Quote>,
+        volatility: Handle<dyn Quote>,
+        mean_reversion: Handle<dyn Quote>,
+        settings: Shared<Settings<Date>>,
+    ) -> QlResult<FuturesConvAdjustmentQuote> {
+        let Some(evaluation_date) = settings.evaluation_date() else {
+            crate::fail!("no evaluation date set");
+        };
+        let futures_date = imm::date(imm_code, evaluation_date)?;
+        Self::new(
+            index,
+            futures_date,
+            futures_quote,
+            volatility,
+            mean_reversion,
+            settings,
+        )
+    }
+
+    /// The futures price the adjustment is computed at.
+    ///
+    /// # Errors
+    ///
+    /// Fails if the futures handle is empty or holds no value.
+    pub fn futures_value(&self) -> QlResult<Real> {
+        self.futures_quote.current_link()?.value()
+    }
+
+    /// The Hull-White volatility.
+    ///
+    /// # Errors
+    ///
+    /// Fails if the volatility handle is empty or holds no value.
+    pub fn volatility(&self) -> QlResult<Real> {
+        self.volatility.current_link()?.value()
+    }
+
+    /// The Hull-White mean reversion.
+    ///
+    /// # Errors
+    ///
+    /// Fails if the mean-reversion handle is empty or holds no value.
+    pub fn mean_reversion(&self) -> QlResult<Real> {
+        self.mean_reversion.current_link()?.value()
+    }
+
+    /// The futures date the adjustment is computed for.
+    pub fn imm_date(&self) -> Date {
+        self.futures_date
+    }
+}
+
+impl AsObservable for FuturesConvAdjustmentQuote {
+    fn observable(&self) -> &Observable {
+        &self.observable
+    }
+}
+
+impl Quote for FuturesConvAdjustmentQuote {
+    fn value(&self) -> QlResult<Real> {
+        if let Some(cached) = self.cache.get() {
+            return Ok(cached);
+        }
+        ensure!(self.is_valid(), "invalid FuturesConvAdjustmentQuote");
+        let Some(settlement_date) = self.settings.evaluation_date() else {
+            crate::fail!("no evaluation date set");
+        };
+        let start_time = self
+            .day_counter
+            .year_fraction(settlement_date, self.futures_date);
+        let index_maturity = self
+            .day_counter
+            .year_fraction(settlement_date, self.index_maturity_date);
+        let value = convexity_bias(
+            self.futures_value()?,
+            start_time,
+            index_maturity,
+            self.volatility()?,
+            self.mean_reversion()?,
+        )?;
+        self.cache.set(Some(value));
+        Ok(value)
+    }
+
+    fn is_valid(&self) -> bool {
+        [&self.futures_quote, &self.volatility, &self.mean_reversion]
+            .iter()
+            .all(|handle| handle.current_link().is_ok_and(|quote| quote.is_valid()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::indexes::ibor::euribor::Euribor;
+    use crate::quotes::{SimpleQuote, make_quote_handle};
+    use crate::shared::shared;
+    use crate::time::date::Month;
+    use crate::time::imm;
+
+    /// The fixture of `testGlobalBootstrapVariables`
+    /// (`piecewiseyieldcurve.cpp:1486`), reduced to its first futures: a
+    /// Euribor 3M index at an evaluation date of 25 September 2019, the first
+    /// IMM date after it, and the 95.419 price of `immFutData[0]`.
+    fn fixture() -> (
+        Shared<Settings<Date>>,
+        Shared<IborIndex>,
+        Shared<SimpleQuote>,
+        FuturesConvAdjustmentQuote,
+    ) {
+        let settings = shared(Settings::<Date>::new());
+        let today = Date::new(25, Month::September, 2019);
+        settings.set_evaluation_date(today);
+        let index = shared(Euribor::three_months(Handle::empty(), settings.clone()));
+        let futures_date = imm::next_date(today, true);
+        let volatility = shared(SimpleQuote::new(1.0));
+        let quote = FuturesConvAdjustmentQuote::new(
+            &index,
+            futures_date,
+            Handle::new(shared(SimpleQuote::new(95.419)) as Shared<dyn Quote>),
+            Handle::new(Shared::clone(&volatility) as Shared<dyn Quote>),
+            make_quote_handle(0.03).handle(),
+            settings.clone(),
+        )
+        .expect("the index resolves the maturity of an IMM date");
+        (settings, index, volatility, quote)
+    }
+
+    /// The C++ value at the fixture's first futures, reproduced at full
+    /// precision by a harness run against a locally built QuantLib dylib
+    /// (`usingAtParCoupons()` set, which this quote does not depend on): the
+    /// IMM date is 18 December 2019, its index maturity 18 March 2020, and the
+    /// bias at vol 1.0 and mean reversion 0.03 is 0.085125076735947713.
+    ///
+    /// The year fractions are pinned too, because they are what fixes the
+    /// evaluation date as the reference: the SETTLEMENT date of that fixture
+    /// (27 September 2019) would give 82/360 rather than 84/360 and would still
+    /// leave a plausible-looking bias.
+    #[test]
+    fn futures_conv_adjustment_quote_reproduces_the_cpp_bias() {
+        let (_settings, index, _volatility, quote) = fixture();
+        let today = Date::new(25, Month::September, 2019);
+
+        assert_eq!(quote.imm_date(), Date::new(18, Month::December, 2019));
+        assert_eq!(
+            index.maturity_date(quote.imm_date()).unwrap(),
+            Date::new(18, Month::March, 2020)
+        );
+        let start_time = index.day_counter().year_fraction(today, quote.imm_date());
+        let index_maturity = index
+            .day_counter()
+            .year_fraction(today, index.maturity_date(quote.imm_date()).unwrap());
+        assert!((start_time - 0.233_333_333_333_333_34).abs() < 1.0e-15);
+        assert!((index_maturity - 0.486_111_111_111_111_1).abs() < 1.0e-15);
+
+        let value = quote.value().unwrap();
+        assert!(
+            (value - 0.085_125_076_735_947_71).abs() < 1.0e-12,
+            "bias at vol 1.0 is {value}"
+        );
+    }
+
+    /// The cache is dropped when the volatility changes through its ORDINARY
+    /// observing handle: the second dylib value (0.0034402599837630118 at vol
+    /// 0.2) is two orders of magnitude away from the first, so a quote that
+    /// kept its cache could not pass.
+    #[test]
+    fn a_volatility_change_drops_the_cached_bias() {
+        let (_settings, _index, volatility, quote) = fixture();
+        assert!((quote.value().unwrap() - 0.085_125_076_735_947_71).abs() < 1.0e-12);
+
+        volatility.set_value(0.2);
+
+        let value = quote.value().unwrap();
+        assert!(
+            (value - 0.003_440_259_983_763_012).abs() < 1.0e-12,
+            "bias at vol 0.2 is {value}"
+        );
+    }
+
+    /// The evaluation date is the reference of both year fractions and is read
+    /// lazily: moving it forward drops the cache and re-times the bias.
+    ///
+    /// No second dylib number is needed - the expectation is `convexity_bias`
+    /// at the year fractions off the NEW evaluation date, so a port that froze
+    /// the reference at construction (or one that never registered with the
+    /// evaluation-date observable, keeping its cache) fails.
+    #[test]
+    fn an_evaluation_date_change_re_times_the_bias() {
+        let (settings, index, _volatility, quote) = fixture();
+        assert!((quote.value().unwrap() - 0.085_125_076_735_947_71).abs() < 1.0e-12);
+
+        let moved = Date::new(25, Month::October, 2019);
+        settings.set_evaluation_date(moved);
+
+        let day_counter = index.day_counter();
+        let expected = convexity_bias(
+            95.419,
+            day_counter.year_fraction(moved, quote.imm_date()),
+            day_counter.year_fraction(moved, index.maturity_date(quote.imm_date()).unwrap()),
+            1.0,
+            0.03,
+        )
+        .unwrap();
+        let value = quote.value().unwrap();
+        assert!(
+            (value - expected).abs() < 1.0e-15,
+            "bias at the moved evaluation date is {value}, expected {expected}"
+        );
+        assert!(
+            (value - 0.085_125_076_735_947_71).abs() > 1.0e-3,
+            "the moved evaluation date must change the bias"
+        );
+    }
+
+    /// `isValid` is false as soon as one handle is empty, and `value` then
+    /// fails rather than reaching `convexity_bias`.
+    #[test]
+    fn an_empty_handle_makes_the_quote_invalid() {
+        let settings = shared(Settings::<Date>::new());
+        let today = Date::new(25, Month::September, 2019);
+        settings.set_evaluation_date(today);
+        let index = shared(Euribor::three_months(Handle::empty(), settings.clone()));
+        let quote = FuturesConvAdjustmentQuote::new(
+            &index,
+            imm::next_date(today, true),
+            Handle::new(shared(SimpleQuote::new(95.419)) as Shared<dyn Quote>),
+            Handle::empty(),
+            make_quote_handle(0.03).handle(),
+            settings,
+        )
+        .expect("the index resolves the maturity of an IMM date");
+
+        assert!(!quote.is_valid());
+        assert!(quote.value().is_err());
+    }
+
+    /// The IMM-code constructor resolves the same futures date as the fixture's
+    /// explicit one: `Z9` is December 2019 at an evaluation date in September
+    /// 2019.
+    #[test]
+    fn the_imm_code_constructor_resolves_the_futures_date() {
+        let (settings, index, _volatility, _quote) = fixture();
+        let quote = FuturesConvAdjustmentQuote::from_imm_code(
+            &index,
+            "Z9",
+            Handle::new(shared(SimpleQuote::new(95.419)) as Shared<dyn Quote>),
+            Handle::new(shared(SimpleQuote::new(1.0)) as Shared<dyn Quote>),
+            make_quote_handle(0.03).handle(),
+            settings,
+        )
+        .expect("Z9 is an IMM code");
+
+        assert_eq!(quote.imm_date(), Date::new(18, Month::December, 2019));
+        assert!((quote.value().unwrap() - 0.085_125_076_735_947_71).abs() < 1.0e-12);
+    }
+}

--- a/crates/libitofin/src/quotes/mod.rs
+++ b/crates/libitofin/src/quotes/mod.rs
@@ -13,19 +13,20 @@
 //!
 //! The remaining `ql/quotes/` classes depend on layers not yet ported and
 //! follow with them: `ForwardValueQuote` and `LastFixingQuote` (Index),
-//! `ForwardSwapQuote` (SwapIndex/VanillaSwap), `FuturesConvAdjustmentQuote`
-//! (IborIndex), `ImpliedStdDevQuote` and
+//! `ForwardSwapQuote` (SwapIndex/VanillaSwap), `ImpliedStdDevQuote` and
 //! `EurodollarFuturesImpliedStdDevQuote` (`blackFormulaImpliedStdDev`).
 
 mod compositequote;
 mod deltavolquote;
 mod derivedquote;
+mod futuresconvadjustmentquote;
 mod multicompositequote;
 mod simplequote;
 
 pub use compositequote::CompositeQuote;
 pub use deltavolquote::{AtmType, DeltaType, DeltaVolQuote};
 pub use derivedquote::DerivedQuote;
+pub use futuresconvadjustmentquote::FuturesConvAdjustmentQuote;
 pub use multicompositequote::MultiCompositeQuote;
 pub use simplequote::{SimpleQuote, make_quote_handle};
 

--- a/crates/libitofin/src/termstructures/globalbootstrap.rs
+++ b/crates/libitofin/src/termstructures/globalbootstrap.rs
@@ -1541,4 +1541,164 @@ mod tests {
             "the extended range must be queryable without extrapolation"
         );
     }
+    /// The recording [`AdditionalBootstrapVariables`] of the arm below: it
+    /// delegates to a real [`SimpleQuoteVariables`] and records what the driver
+    /// hands it.
+    struct RecordingVariables {
+        inner: SimpleQuoteVariables,
+        valid_data_flags: RefCell<Vec<bool>>,
+        trial_lengths: RefCell<Vec<Size>>,
+        trial_firsts: RefCell<Vec<Real>>,
+    }
+
+    /// Lets the test keep reading the recordings after the boxed trait object
+    /// has been handed to the bootstrap.
+    impl AdditionalBootstrapVariables for Shared<RecordingVariables> {
+        fn initialize(&self, valid_data: bool) -> QlResult<Vec<Real>> {
+            self.as_ref().initialize(valid_data)
+        }
+
+        fn update(&self, x: &[Real]) -> QlResult<()> {
+            self.as_ref().update(x)
+        }
+    }
+
+    impl AdditionalBootstrapVariables for RecordingVariables {
+        fn initialize(&self, valid_data: bool) -> QlResult<Vec<Real>> {
+            self.valid_data_flags.borrow_mut().push(valid_data);
+            self.inner.initialize(valid_data)
+        }
+
+        fn update(&self, x: &[Real]) -> QlResult<()> {
+            self.trial_lengths.borrow_mut().push(x.len());
+            self.trial_firsts.borrow_mut().push(x[0]);
+            self.inner.update(x)
+        }
+    }
+
+    /// The three additional-variable splices - the appended guess, the
+    /// `x[interior..]` argument tail and the solution pin - end to end, plus
+    /// what only a recording implementation can see.
+    ///
+    /// The system is deliberately minimal and SQUARE: a one-deposit strip is
+    /// two nodes, so one interior node, and one external quote is one more
+    /// variable; the residuals are the deposit's quote error and one penalty
+    /// `q - 0.5`. The two halves are independent, so the solved answer is known
+    /// in closed form - the deposit reprices and `q` lands on 0.5 - which is
+    /// what pins the splices without a dylib. The variable is FLOORED at 0.0
+    /// and guessed at 2.0, so it also travels through the `exp`/`ln` transform
+    /// pair. The first recorded trial point is what pins that: the solver
+    /// evaluates the guess first, so `x[interior]` must arrive as the value
+    /// `initialize` returned, `ln(2 - 0)`. A guess appended in QUOTE space
+    /// would arrive as 2, and one written before the nodes rather than after
+    /// them would arrive as the node coordinate 0. The guess of 2.0 is what
+    /// separates those three - a guess of 1.0 maps to 0 in optimizer space,
+    /// which is also this strip's node coordinate, and the misplacement arm
+    /// goes vacuous (probed both ways). The converged answer alone is blind to
+    /// all of it: a guess is a start point, and the solve converges from any of
+    /// them.
+    ///
+    /// The recorded flags are the ONLY way the warm-restart branch of
+    /// `initialize` is observable: the converged answer is the same whether the
+    /// second solve seeds itself from the previous solution or from the
+    /// configured guess. Likewise the recorded lengths are the only direct
+    /// evidence of where the argument vector is split.
+    ///
+    /// HONEST NEGATIVE: the solution-pin `update` is NOT pinned here, and is
+    /// not pinnable through any converged value. The optimizer's last trial
+    /// point already sits within the stopping accuracy of the solution it
+    /// returns, so rewriting the variables from that solution moves them by
+    /// less than the tolerance any assert can use (probed - dropping the pin
+    /// leaves every arm green). It is carried for consistency with the node
+    /// pin, which rewrites the curve from the same vector.
+    #[test]
+    fn the_additional_variables_receive_the_guess_the_trial_tail_and_the_solution() {
+        let calendar = Target::new();
+        let today = calendar.adjust(
+            Date::new(15, Month::June, 2026),
+            BusinessDayConvention::Following,
+        );
+        let settings = shared(Settings::<Date>::new());
+        settings.set_evaluation_date(today);
+        let index = Euribor::new(Period::new(3, TimeUnit::Months), Handle::empty(), settings)
+            .expect("a 3M tenor is valid");
+        let deposit_quote = shared(SimpleQuote::new(0.04557));
+        let deposit = DepositRateHelper::new(
+            Handle::new(Shared::clone(&deposit_quote) as Shared<dyn Quote>),
+            &index,
+        ) as Shared<dyn RateHelper>;
+
+        let solved = shared(SimpleQuote::new(None));
+        let variables = Shared::new(RecordingVariables {
+            inner: SimpleQuoteVariables::new(vec![Shared::clone(&solved)], vec![2.0], vec![0.0])
+                .expect("one guess and one bound for one quote"),
+            valid_data_flags: RefCell::new(Vec::new()),
+            trial_lengths: RefCell::new(Vec::new()),
+            trial_firsts: RefCell::new(Vec::new()),
+        });
+        let penalty_quote = Shared::clone(&solved);
+        let curve = PiecewiseYieldCurve::<SimpleZeroYield, Linear, _>::with_bootstrap(
+            calendar.advance(
+                today,
+                2,
+                TimeUnit::Days,
+                BusinessDayConvention::Following,
+                false,
+            ),
+            vec![deposit],
+            Actual365Fixed::new(),
+            Linear,
+            GlobalBootstrap::with_grid_independent_penalties(
+                Vec::new(),
+                None,
+                Some(1.0e-12),
+                None,
+                Vec::new(),
+                move || {
+                    let value = penalty_quote
+                        .value()
+                        .expect("the variable holds a trial value");
+                    vec![value - 0.5]
+                },
+            )
+            .with_additional_variables(Box::new(Shared::clone(&variables))),
+        )
+        .expect("a one-deposit strip builds a curve");
+
+        curve.data().expect("the square system solves");
+
+        let value = solved.value().expect("the variable is solved");
+        assert!(
+            (value - 0.5).abs() < 1.0e-8,
+            "the additional variable solved to {value}, not 0.5"
+        );
+        assert_eq!(
+            *variables.valid_data_flags.borrow(),
+            vec![false],
+            "the first solve is a cold start"
+        );
+
+        deposit_quote.set_value(0.05);
+        curve.data().expect("the strip re-solves on the same grid");
+
+        assert_eq!(
+            *variables.valid_data_flags.borrow(),
+            vec![false, true],
+            "a re-solve over an unchanged grid must warm-restart"
+        );
+        let lengths = variables.trial_lengths.borrow();
+        assert!(
+            !lengths.is_empty(),
+            "the trial tail never reached the variables"
+        );
+        assert!(
+            lengths.iter().all(|length| *length == 1),
+            "the argument vector was split at the wrong index: {lengths:?}"
+        );
+        let first_trial = variables.trial_firsts.borrow()[0];
+        assert!(
+            (first_trial - Real::ln(2.0)).abs() < 1.0e-15,
+            "the solver's first trial point is {first_trial}, not the appended guess"
+        );
+    }
 }

--- a/crates/libitofin/src/termstructures/globalbootstrap.rs
+++ b/crates/libitofin/src/termstructures/globalbootstrap.rs
@@ -15,15 +15,13 @@
 //!
 //! ## What is ported, and what is deferred
 //!
-//! The single-curve path is ported, together with the `additionalPenalties`
-//! residual terms (#974) and the `additionalHelpers`/`additionalDates`
-//! restrictions (#976); it equals the C++ path with the remaining
-//! `additional*` argument empty and `parentBootstrapper_` null. Deferred
-//! visibly, each as its own follow-up issue referencing #949:
+//! The single-curve path is ported in full: the `additionalPenalties`
+//! residual terms (#974), the `additionalHelpers`/`additionalDates`
+//! restrictions (#976) and the `additionalVariables` optimizer coordinates
+//! with their `SimpleQuoteVariables` implementation (#977). It equals the C++
+//! path with `parentBootstrapper_` null. Deferred visibly, as its own
+//! follow-up issue referencing #949:
 //!
-//! - **Additional variables** (`additionalVariables`, plus the
-//!   `SimpleQuoteVariables` helper, #977): the extra optimizer coordinates the
-//!   futures-convexity oracle test (`piecewiseyieldcurve.cpp:1486`) exercises.
 //! - **Multi-curve orchestration** (`MultiCurveBootstrap`,
 //!   `MultiCurveBootstrapContributor`, `setParentBootstrapper`/`setToValid`,
 //!   the `parentBootstrapper_` branch of `calculate`).
@@ -33,8 +31,8 @@
 //! accuracy)` (`globalbootstrap.hpp:225`) is built per run. The Rust
 //! [`OptimizationMethod`](crate::math::optimization::method::OptimizationMethod)
 //! `minimize` takes `&mut self`, which a stored trait object cannot offer
-//! from the `&self` [`Bootstrap::calculate`]; an override can ride with the
-//! deferred additional-variables slice if a use case needs it. The
+//! from the `&self` [`Bootstrap::calculate`]; an override can be added if a
+//! use case needs it. The
 //! `EndCriteria` override is carried (it is `Copy`), defaulting to
 //! `EndCriteria(1000, 10, accuracy, accuracy, accuracy)`
 //! (`globalbootstrap.hpp:228`) - deliberately different literals from
@@ -136,13 +134,53 @@ pub type AdditionalPenalties = dyn Fn(&[Time], &[Real]) -> Vec<Real>;
 /// curve date are dropped (`hpp:268-274`).
 pub type AdditionalDates = dyn Fn() -> Vec<Date>;
 
+/// The additional optimizer variables (`AdditionalBootstrapVariables`,
+/// `globalbootstrap.hpp:69-76`).
+///
+/// Coordinates the global solve varies alongside the curve nodes, living
+/// OUTSIDE the curve: they are appended after the node coordinates in the
+/// optimizer's vector, and each trial point's tail is written back into
+/// whatever the implementation drives - upstream, external quotes the rate
+/// helpers read ([`SimpleQuoteVariables`]).
+///
+/// A variable adds a degree of freedom without adding a residual, so a system
+/// that gains variables this way needs matching [`AdditionalPenalties`] terms
+/// to stay solvable.
+///
+/// Both methods take `&self`, as the driver holds the variables behind a shared
+/// reference through the solve, and both return [`QlResult`] (D4): reading a
+/// quote back is fallible.
+///
+/// [`SimpleQuoteVariables`]: crate::termstructures::globalbootstrapvars::SimpleQuoteVariables
+pub trait AdditionalBootstrapVariables {
+    /// The initial guesses, in optimizer space, one per variable.
+    ///
+    /// `valid_data` is the driver's warm-restart flag: on a re-solve over an
+    /// unchanged grid the previous solution is still in place, and an
+    /// implementation may seed itself from it rather than from its configured
+    /// guesses.
+    ///
+    /// # Errors
+    ///
+    /// Implementation-defined; the driver propagates it out of `calculate`.
+    fn initialize(&self, valid_data: bool) -> QlResult<Vec<Real>>;
+
+    /// Writes a trial point, in optimizer space, back into the variables.
+    ///
+    /// # Errors
+    ///
+    /// Implementation-defined; the driver parks it like a failed reprice.
+    fn update(&self, x: &[Real]) -> QlResult<()>;
+}
+
 /// The global bootstrap (`GlobalBootstrap`, single-curve core).
 ///
 /// Carries the stopping-accuracy override, the `EndCriteria` override, the
 /// per-instrument residual weights, the additional penalty terms, and the
-/// additional helpers and dates those penalties are built around; defaults
-/// mirror the C++ constructor (`accuracy = Null`, `endCriteria = nullptr`,
-/// `instrumentWeights = {}`, no penalties, no additional restrictions,
+/// additional helpers and dates those penalties are built around, and the
+/// additional optimizer variables; defaults mirror the C++ constructor
+/// (`accuracy = Null`, `endCriteria = nullptr`, `instrumentWeights = {}`, no
+/// penalties, no additional restrictions, no additional variables,
 /// `globalbootstrap.hpp:112-115`), with everything resolved from the curve at
 /// calculation time.
 ///
@@ -157,6 +195,7 @@ pub struct GlobalBootstrap {
     end_criteria: Option<EndCriteria>,
     instrument_weights: Vec<Real>,
     penalties: Option<Box<AdditionalPenalties>>,
+    additional_variables: Option<Box<dyn AdditionalBootstrapVariables>>,
 }
 
 impl Default for GlobalBootstrap {
@@ -182,6 +221,7 @@ impl GlobalBootstrap {
             end_criteria,
             instrument_weights,
             penalties: None,
+            additional_variables: None,
         }
     }
 
@@ -193,8 +233,8 @@ impl GlobalBootstrap {
     ///
     /// The additional helpers are handed the curve and registered with it, but
     /// contribute neither a pillar date nor a residual: they exist so a penalty
-    /// can read their `implied_quote`. Its `additionalVariables` argument is
-    /// still deferred.
+    /// can read their `implied_quote`. Its `additionalVariables` argument is a
+    /// separate step, [`with_additional_variables`](Self::with_additional_variables).
     pub fn with_penalties<F>(
         additional_helpers: Vec<Shared<dyn RateHelper>>,
         additional_dates: Option<Box<AdditionalDates>>,
@@ -213,6 +253,7 @@ impl GlobalBootstrap {
             end_criteria,
             instrument_weights,
             penalties: Some(Box::new(penalties)),
+            additional_variables: None,
         }
     }
 
@@ -240,14 +281,32 @@ impl GlobalBootstrap {
             move |_, _| penalties(),
         )
     }
+
+    /// Attaches the [`AdditionalBootstrapVariables`] the solve varies alongside
+    /// the curve nodes (the `additionalVariables` argument of C++ constructors
+    /// #2 and #3, `globalbootstrap.hpp:122`/`:130`).
+    ///
+    /// A consuming builder rather than a further constructor parameter: the
+    /// C++ argument is trailing and defaulted, so every existing call site
+    /// means "no additional variables", and a builder step keeps them
+    /// unchanged.
+    #[must_use]
+    pub fn with_additional_variables(
+        mut self,
+        variables: Box<dyn AdditionalBootstrapVariables>,
+    ) -> GlobalBootstrap {
+        self.additional_variables = Some(variables);
+        self
+    }
 }
 
 /// The global cost (`setCostFunctionArgument` + `evaluateCostFunction`,
 /// `globalbootstrap.hpp:379-403`): writes every interior trial node into the
 /// node vector through `transform_direct`, rebuilds the full-grid
-/// interpolation, and returns the alive helpers' weighted quote errors -
-/// followed by the [`AdditionalPenalties`] terms, if any - as the residual
-/// vector.
+/// interpolation, hands the remaining tail of the trial point to the
+/// [`AdditionalBootstrapVariables`], and returns the alive helpers' weighted
+/// quote errors - followed by the [`AdditionalPenalties`] terms, if any - as
+/// the residual vector.
 ///
 /// The [`CostFunction`] trait is infallible, so a failed rebuild or reprice
 /// parks its error in `error` and returns NaN residuals, which the solver
@@ -262,6 +321,7 @@ where
     alive: &'a [Shared<C::Helper>],
     alive_weights: &'a [Real],
     penalties: Option<&'a AdditionalPenalties>,
+    variables: Option<&'a dyn AdditionalBootstrapVariables>,
     /// The number of interior nodes, `times.len() - 1`, and the number of
     /// variables the solve carries; the residual count is `alive.len()` plus
     /// the penalty terms. The two are equal for a strip of distinct pillars
@@ -289,6 +349,18 @@ where
             }
             cd.rebuild(self.curve.interpolator(), self.interior)?;
         }
+        // The trial point's tail goes to the additional variables (`:386-388`),
+        // still inside the C++ `setCostFunctionArgument` step and so before the
+        // penalties. It writes no curve cell - upstream it writes external
+        // quotes - but it does notify, which is why the helpers reaching those
+        // quotes must hold them through an unregistered handle
+        // (`Handle::new_unregistered`); an observing one would invalidate the
+        // curve on every evaluation.
+        if let Some(variables) = self.variables {
+            let trial: &[Real] = x;
+            variables.update(&trial[self.interior..])?;
+        }
+
         // Only now that the `borrow_mut` above has dropped, so a penalty that
         // reads the curve back can take its own shared borrow (`:392-395`).
         let penalty_errors = match self.penalties {
@@ -466,10 +538,17 @@ where
             helper.set_term_structure(&term_structure);
         }
 
-        // The initial guess (`:360-372`): update each interior node through
-        // Traits::guess - which depends on the previously updated nodes, so
-        // the writes are sequential - then map it into the optimizer space.
-        let mut guess = Array::with_size(interior);
+        // The initial guess (`:360-374`): the additional variables initialize
+        // FIRST, then each interior node is updated through Traits::guess -
+        // which depends on the previously updated nodes, so the writes are
+        // sequential - and mapped into the optimizer space. The additional
+        // guesses are APPENDED after the node guesses, which is the layout the
+        // cost function's `x[interior..]` split relies on.
+        let additional_guesses = match &self.additional_variables {
+            Some(variables) => variables.initialize(valid_data)?,
+            None => Vec::new(),
+        };
+        let mut guess = Array::with_size(interior + additional_guesses.len());
         {
             let mut cd = curve.curve_data().borrow_mut();
             for i in 0..interior {
@@ -478,6 +557,9 @@ where
                 guess[i] = C::Traits::transform_inverse(cd.data()[i + 1], cd.times()[i + 1]);
             }
             cd.rebuild(curve.interpolator(), interior)?;
+        }
+        for (i, additional_guess) in additional_guesses.into_iter().enumerate() {
+            guess[interior + i] = additional_guess;
         }
 
         // Solver configuration (`:222-229`): the LM tolerances and the
@@ -495,6 +577,7 @@ where
             alive: &alive,
             alive_weights: &alive_weights,
             penalties: self.penalties.as_deref(),
+            variables: self.additional_variables.as_deref(),
             interior,
             penalty_len: Cell::new(0),
             error: RefCell::new(None),
@@ -528,6 +611,15 @@ where
             }
             cd.rebuild(curve.interpolator(), interior)?;
             cd.set_valid(true);
+        }
+        // The additional variables are pinned to the solution too, after that
+        // `borrow_mut` has dropped. C++ has no pin loop at all and simply
+        // leaves the quotes at the optimizer's last trial point; this port
+        // rewrites the nodes from the returned solution, so the quotes are
+        // rewritten from the same vector and the two stay consistent.
+        if let Some(variables) = &self.additional_variables {
+            let solved: &[Real] = &solution;
+            variables.update(&solved[interior..])?;
         }
         Ok(())
     }
@@ -587,6 +679,7 @@ mod tests {
     use crate::termstructures::TermStructure;
     use crate::termstructures::bootstraphelper::RateHelper;
     use crate::termstructures::bootstraptraits::{ForwardRate, SimpleZeroYield};
+    use crate::termstructures::globalbootstrapvars::SimpleQuoteVariables;
     use crate::termstructures::yields::{
         DepositRateHelper, FraRateHelper, PiecewiseYieldCurve, Pillar, SwapRateHelper,
     };

--- a/crates/libitofin/src/termstructures/globalbootstrapvars.rs
+++ b/crates/libitofin/src/termstructures/globalbootstrapvars.rs
@@ -1,0 +1,216 @@
+//! External [`SimpleQuote`]s as additional bootstrap variables.
+//!
+//! Port of `ql/termstructures/globalbootstrapvars.{hpp,cpp}`: the one concrete
+//! [`AdditionalBootstrapVariables`] implementation upstream ships. The quotes
+//! it drives are read by rate helpers, so the global solve fits them jointly
+//! with the curve nodes - the futures-convexity oracle
+//! (`piecewiseyieldcurve.cpp:1486`) fits a Hull-White volatility this way.
+//!
+//! Each variable is optionally floored. With a lower bound the optimizer works
+//! in log space (`exp(x) + lb` out, `ln(x - lb)` in); without one the transform
+//! is the identity. A missing entry is C++'s `detail::get(v, i, Null<Real>())`
+//! over a vector shorter than the quotes - here simply `Vec::get`.
+
+use crate::errors::QlResult;
+use crate::quotes::{Quote, SimpleQuote};
+use crate::require;
+use crate::shared::Shared;
+use crate::termstructures::globalbootstrap::AdditionalBootstrapVariables;
+use crate::types::{Real, Size};
+
+/// External [`SimpleQuote`]s as additional bootstrap variables.
+///
+/// Mirrors QuantLib's `SimpleQuoteVariables`. `initial_guesses` and
+/// `lower_bounds` may each be shorter than `quotes`, defaulting per variable to
+/// a guess of 0.0 and to no lower bound.
+pub struct SimpleQuoteVariables {
+    quotes: Vec<Shared<SimpleQuote>>,
+    initial_guesses: Vec<Real>,
+    lower_bounds: Vec<Real>,
+}
+
+impl SimpleQuoteVariables {
+    /// The variables over `quotes` (`globalbootstrapvars.cpp:10-17`).
+    ///
+    /// # Errors
+    ///
+    /// Fails if more initial guesses or more lower bounds than quotes are
+    /// given.
+    pub fn new(
+        quotes: Vec<Shared<SimpleQuote>>,
+        initial_guesses: Vec<Real>,
+        lower_bounds: Vec<Real>,
+    ) -> QlResult<SimpleQuoteVariables> {
+        require!(
+            initial_guesses.len() <= quotes.len(),
+            "too many initialGuesses ({}) for {} quotes",
+            initial_guesses.len(),
+            quotes.len()
+        );
+        require!(
+            lower_bounds.len() <= quotes.len(),
+            "too many lowerBounds ({}) for {} quotes",
+            lower_bounds.len(),
+            quotes.len()
+        );
+        Ok(SimpleQuoteVariables {
+            quotes,
+            initial_guesses,
+            lower_bounds,
+        })
+    }
+
+    /// Optimizer space to quote space (`globalbootstrapvars.cpp:39-42`).
+    fn transform_direct(&self, x: Real, i: Size) -> Real {
+        match self.lower_bounds.get(i) {
+            Some(lower_bound) => x.exp() + lower_bound,
+            None => x,
+        }
+    }
+
+    /// Quote space to optimizer space (`globalbootstrapvars.cpp:44-47`).
+    fn transform_inverse(&self, x: Real, i: Size) -> Real {
+        match self.lower_bounds.get(i) {
+            Some(lower_bound) => (x - lower_bound).ln(),
+            None => x,
+        }
+    }
+}
+
+impl AdditionalBootstrapVariables for SimpleQuoteVariables {
+    /// The initial guesses (`globalbootstrapvars.cpp:19-32`). On a warm restart
+    /// each quote's CURRENT value is the guess; otherwise the configured
+    /// initial guess is both returned and WRITTEN INTO the quote, so the
+    /// helpers reading it see a defined starting point before the first cost
+    /// evaluation.
+    fn initialize(&self, valid_data: bool) -> QlResult<Vec<Real>> {
+        let mut guesses = Vec::with_capacity(self.quotes.len());
+        for (i, quote) in self.quotes.iter().enumerate() {
+            let guess = if valid_data {
+                quote.value()?
+            } else {
+                let initial = self.initial_guesses.get(i).copied().unwrap_or(0.0);
+                quote.set_value(initial);
+                initial
+            };
+            guesses.push(self.transform_inverse(guess, i));
+        }
+        Ok(guesses)
+    }
+
+    /// Writes a trial point back into the quotes
+    /// (`globalbootstrapvars.cpp:34-37`).
+    ///
+    /// # Errors
+    ///
+    /// Fails on a trial point longer than the variable count - C++ indexes
+    /// `quotes_[i]` over `x` unguarded.
+    fn update(&self, x: &[Real]) -> QlResult<()> {
+        require!(
+            x.len() <= self.quotes.len(),
+            "trial point of size {} for {} quotes",
+            x.len(),
+            self.quotes.len()
+        );
+        for (i, (quote, value)) in self.quotes.iter().zip(x).enumerate() {
+            quote.set_value(self.transform_direct(*value, i));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::shared::shared;
+
+    fn variables(
+        initial_guesses: Vec<Real>,
+        lower_bounds: Vec<Real>,
+    ) -> (Shared<SimpleQuote>, SimpleQuoteVariables) {
+        let quote = shared(SimpleQuote::new(None));
+        let variables =
+            SimpleQuoteVariables::new(vec![Shared::clone(&quote)], initial_guesses, lower_bounds)
+                .expect("one guess and one bound for one quote");
+        (quote, variables)
+    }
+
+    /// The floored branch: `initialize` writes the initial guess into the quote
+    /// and returns `ln(guess - lb)`, and `update` inverts it.
+    ///
+    /// The floor 0.25 is deliberately non-zero, so a port that dropped the
+    /// `- lb` / `+ lb` term fails on both halves rather than only on one.
+    #[test]
+    fn a_lower_bound_puts_the_variable_in_log_space() {
+        let (quote, variables) = variables(vec![1.25], vec![0.25]);
+
+        let guesses = variables.initialize(false).unwrap();
+        assert_eq!(quote.value().unwrap(), 1.25);
+        assert!((guesses[0] - Real::ln(1.0)).abs() < 1.0e-15);
+
+        variables.update(&[Real::ln(0.75)]).unwrap();
+        assert!((quote.value().unwrap() - 1.0).abs() < 1.0e-15);
+    }
+
+    /// The identity branch (no lower bound for this variable): the guess is
+    /// returned unchanged and `update` writes the trial value straight through.
+    ///
+    /// This branch is an honest gap in the oracle - `testGlobalBootstrapVariables`
+    /// passes a lower bound - so it is pinned here directly.
+    #[test]
+    fn a_variable_without_a_lower_bound_is_untransformed() {
+        let (quote, variables) = variables(vec![-0.5], Vec::new());
+
+        let guesses = variables.initialize(false).unwrap();
+        assert_eq!(quote.value().unwrap(), -0.5);
+        assert_eq!(guesses[0], -0.5);
+
+        variables.update(&[-2.0]).unwrap();
+        assert_eq!(quote.value().unwrap(), -2.0);
+    }
+
+    /// The defaults for a short configuration vector: no initial guess means
+    /// 0.0, no lower bound means the identity transform.
+    #[test]
+    fn a_missing_configuration_entry_falls_back_to_its_default() {
+        let first = shared(SimpleQuote::new(None));
+        let second = shared(SimpleQuote::new(None));
+        let variables = SimpleQuoteVariables::new(
+            vec![Shared::clone(&first), Shared::clone(&second)],
+            vec![3.0],
+            Vec::new(),
+        )
+        .unwrap();
+
+        let guesses = variables.initialize(false).unwrap();
+
+        assert_eq!(first.value().unwrap(), 3.0);
+        assert_eq!(second.value().unwrap(), 0.0);
+        assert_eq!(guesses, vec![3.0, 0.0]);
+    }
+
+    /// The warm-restart branch reads each quote's CURRENT value instead of the
+    /// configured guess, and leaves the quote alone.
+    #[test]
+    fn valid_data_seeds_the_guess_from_the_current_quote_value() {
+        let (quote, variables) = variables(vec![1.0], vec![0.0]);
+        quote.set_value(4.0);
+
+        let guesses = variables.initialize(true).unwrap();
+
+        assert_eq!(quote.value().unwrap(), 4.0);
+        assert!((guesses[0] - Real::ln(4.0)).abs() < 1.0e-15);
+    }
+
+    /// The two size preconditions (`globalbootstrapvars.cpp:15-16`), also
+    /// unexercised by the oracle.
+    #[test]
+    fn more_configuration_entries_than_quotes_are_rejected() {
+        let quote = shared(SimpleQuote::new(None));
+        assert!(
+            SimpleQuoteVariables::new(vec![Shared::clone(&quote)], vec![1.0, 2.0], Vec::new())
+                .is_err()
+        );
+        assert!(SimpleQuoteVariables::new(vec![quote], Vec::new(), vec![0.0, 0.0]).is_err());
+    }
+}

--- a/crates/libitofin/src/termstructures/iterativebootstrap.rs
+++ b/crates/libitofin/src/termstructures/iterativebootstrap.rs
@@ -50,13 +50,13 @@
 //! two `require!` checks below (a duplicate pillar, then a non-monotone
 //! latest-relevant date). That is faithful, not a defect: `IterativeBootstrap`
 //! has **no** redundant-helper pruning upstream. The only dedup in QuantLib
-//! lives in the separate, unported `GlobalBootstrap` (`globalbootstrap.hpp:288`),
+//! lives in the separate `GlobalBootstrap` (`globalbootstrap.hpp:288`),
 //! and even there it dedups a date grid for a least-squares solve rather than
 //! dropping a helper. So there is nothing to port. This corrects the original
 //! #532 premise that the bootstrap "should prune redundant helpers"; the correct
 //! behaviour for a genuine duplicate is the error, and callers must supply a
 //! strip with distinct pillars. `GlobalBootstrap` itself (a global
-//! least-squares fit) is a separate, still-unported slice.
+//! least-squares fit) is a separate algorithm, ported alongside this one.
 
 use std::cell::RefCell;
 

--- a/crates/libitofin/src/termstructures/mod.rs
+++ b/crates/libitofin/src/termstructures/mod.rs
@@ -36,6 +36,7 @@ pub mod bootstraphelper;
 pub mod bootstraptraits;
 pub mod credit;
 pub mod globalbootstrap;
+pub mod globalbootstrapvars;
 pub mod inflation;
 pub mod interpolatedcurve;
 pub mod iterativebootstrap;

--- a/crates/libitofin/src/termstructures/yields/piecewiseyieldcurve.rs
+++ b/crates/libitofin/src/termstructures/yields/piecewiseyieldcurve.rs
@@ -358,7 +358,7 @@ mod tests {
     };
     use crate::time::businessdayconvention::BusinessDayConvention;
     use crate::time::calendars::target::Target;
-    use crate::time::date::Month;
+    use crate::time::date::{Day, Month, Year};
     use crate::time::daycounters::actual360::Actual360;
     use crate::time::daycounters::actual365fixed::Actual365Fixed;
     use crate::time::daycounters::thirty360::{Convention, Thirty360};
@@ -406,11 +406,16 @@ mod tests {
     }
 
     fn common_vars() -> CommonVars {
+        common_vars_on(Date::new(15, Month::June, 2026))
+    }
+
+    /// The same fixture at an explicit evaluation date, the port of the C++
+    /// `CommonVars(Date)` constructor (`piecewiseyieldcurve.cpp:167`).
+    /// `testGlobalBootstrapVariables` pins its evaluation date to make the
+    /// solve reproducible.
+    fn common_vars_on(evaluation_date: Date) -> CommonVars {
         let calendar = Target::new();
-        let today = calendar.adjust(
-            Date::new(15, Month::June, 2026),
-            BusinessDayConvention::Following,
-        );
+        let today = calendar.adjust(evaluation_date, BusinessDayConvention::Following);
         let settings = shared(Settings::<Date>::new());
         settings.set_evaluation_date(today);
         let settlement = calendar.advance(
@@ -1377,5 +1382,216 @@ mod tests {
             !curve.lazy.borrow().is_calculated(),
             "an observing convexity handle must invalidate the curve"
         );
+    }
+    /// The IMM futures quotes of `CommonVars` (`piecewiseyieldcurve.cpp:116`,
+    /// turned into prices at `:266`): `100 - rate`.
+    const IMM_FUTURES_PRICE: [Real; 3] = [95.419, 95.427, 95.443];
+
+    /// The 22 pillar dates of the plain curve, from the C++ dylib run.
+    const REF_PILLAR: [(Day, Month, Year); 22] = [
+        (27, Month::September, 2019),
+        (4, Month::October, 2019),
+        (28, Month::October, 2019),
+        (27, Month::November, 2019),
+        (27, Month::December, 2019),
+        (27, Month::March, 2020),
+        (29, Month::June, 2020),
+        (28, Month::September, 2020),
+        (27, Month::September, 2021),
+        (27, Month::September, 2022),
+        (27, Month::September, 2023),
+        (27, Month::September, 2024),
+        (29, Month::September, 2025),
+        (28, Month::September, 2026),
+        (27, Month::September, 2027),
+        (27, Month::September, 2028),
+        (27, Month::September, 2029),
+        (29, Month::September, 2031),
+        (27, Month::September, 2034),
+        (27, Month::September, 2039),
+        (27, Month::September, 2044),
+        (27, Month::September, 2049),
+    ];
+
+    /// Port of `testGlobalBootstrapVariables`
+    /// (`piecewiseyieldcurve.cpp:1486-1545`): a `PiecewiseYieldCurve<Discount,
+    /// LogLinear, GlobalBootstrap>` over the `CommonVars` strip, and a second
+    /// one where the first swap is replaced by three IMM futures whose
+    /// convexity volatility is fitted AS PART OF the same global solve.
+    ///
+    /// The joint system is SQUARE: 23 interior nodes plus one volatility
+    /// variable against 6 deposit residuals, 14 swap residuals, 3 futures
+    /// residuals and 1 penalty term. The removed first swap carries no residual
+    /// of its own - it is an additional helper, and reaches the solve only
+    /// through the penalty `1e4 * quote_error`, which is what ties the futures
+    /// strip back to the swap level the volatility has to reproduce.
+    ///
+    /// TWO HANDLES, TWO BEHAVIOURS, and the distinction is load-bearing. The
+    /// volatility handle INSIDE each convexity quote is the ordinary observing
+    /// one, so a trial volatility drops the quote's cached bias and the next
+    /// residual is computed at the new one. Only the futures helper's handle TO
+    /// the convexity quote is unregistered, so that same write does not
+    /// invalidate the curve mid-solve.
+    ///
+    /// The reference numbers come from a harness run against a locally built
+    /// QuantLib dylib with `usingAtParCoupons()` set, since the `.cpp` prints
+    /// none: the two pillar lists, the solved volatility, and the pillar
+    /// discounts of both curves. The C++ arms are a pillar-list inequality and
+    /// a repricing comparison at `QL_CHECK_CLOSE` 1e-6, which is a PERCENTAGE
+    /// tolerance and so 1e-8 relative; the port asserts 1e-9, and the dylib's
+    /// own worst disagreement between the two curves is 2.5e-15 against this
+    /// port's 2.0e-15.
+    ///
+    /// The SOLVED-VOLATILITY pin is not in the C++ test and is what carries
+    /// this oracle. Both upstream arms are blind to the convexity model: the
+    /// joint solve reprices every original instrument for whatever volatility
+    /// the futures leg is fitted at, so the discount comparison passes on a
+    /// bias timed from the wrong reference date, and passes even when the
+    /// volatility never moves off its initial guess. Probed both ways - a bias
+    /// referenced to settlement rather than to the evaluation date leaves the
+    /// discount arm green and shifts the fitted volatility to 0.0993827, and an
+    /// unregistered inner volatility handle leaves it stuck at exactly 1.0.
+    #[test]
+    fn global_bootstrap_variables_fit_a_futures_convexity_volatility() {
+        use crate::indexes::interestrateindex::InterestRateIndex;
+        use crate::instruments::FuturesType;
+        use crate::termstructures::globalbootstrap::GlobalBootstrap;
+        use crate::termstructures::globalbootstrapvars::SimpleQuoteVariables;
+
+        let vars = common_vars_on(Date::new(25, Month::September, 2019));
+        let curve = PiecewiseYieldCurve::<Discount, LogLinear, GlobalBootstrap>::new(
+            vars.settlement,
+            vars.instruments.clone(),
+            Actual365Fixed::new(),
+            LogLinear,
+        )
+        .expect("the plain strip builds a curve");
+
+        let mut helpers = vars.instruments.clone();
+        let first_swap = helpers.remove(DEPOSIT_DATA.len());
+
+        let index = shared(Euribor::three_months(
+            Handle::empty(),
+            vars.settings.clone(),
+        ));
+        let volatility = shared(SimpleQuote::new(None));
+        let mean_reversion = make_quote_handle(0.03);
+        let mut futures_date = vars.today;
+        for price in IMM_FUTURES_PRICE {
+            futures_date = imm::next_date(futures_date, true);
+            if index.fixing_date(futures_date) < vars.today {
+                futures_date = imm::next_date(futures_date, true);
+            }
+            let price = Handle::new(shared(SimpleQuote::new(price)) as Shared<dyn Quote>);
+            let conv_adj = shared(
+                FuturesConvAdjustmentQuote::new(
+                    &index,
+                    futures_date,
+                    price.clone(),
+                    Handle::new(Shared::clone(&volatility) as Shared<dyn Quote>),
+                    mean_reversion.handle(),
+                    vars.settings.clone(),
+                )
+                .expect("the index resolves the maturity of an IMM date"),
+            ) as Shared<dyn Quote>;
+            helpers.push(
+                FuturesRateHelper::from_index(
+                    price,
+                    futures_date,
+                    &index,
+                    Handle::new_unregistered(conv_adj),
+                    FuturesType::Imm,
+                )
+                .expect("an IMM date builds a futures helper")
+                    as Shared<dyn RateHelper>,
+            );
+        }
+
+        let penalty_helper = Shared::clone(&first_swap);
+        let curve_futures = PiecewiseYieldCurve::<Discount, LogLinear, _>::with_bootstrap(
+            vars.settlement,
+            helpers,
+            Actual365Fixed::new(),
+            LogLinear,
+            GlobalBootstrap::with_grid_independent_penalties(
+                vec![Shared::clone(&first_swap)],
+                None,
+                Some(1.0e-12),
+                None,
+                Vec::new(),
+                move || {
+                    let error = penalty_helper
+                        .quote_error()
+                        .expect("the first swap reprices off the trial curve");
+                    vec![1.0e4 * error]
+                },
+            )
+            .with_additional_variables(Box::new(
+                SimpleQuoteVariables::new(vec![Shared::clone(&volatility)], vec![1.0], vec![0.0])
+                    .expect("one guess and one bound for one quote"),
+            )),
+        )
+        .expect("the futures strip builds a curve");
+
+        let pillars: Vec<Date> = REF_PILLAR
+            .iter()
+            .map(|(day, month, year)| Date::new(*day, *month, *year))
+            .collect();
+        assert_eq!(
+            curve.dates().expect("the plain strip solves"),
+            pillars,
+            "the plain curve's pillar list"
+        );
+
+        // The futures curve drops the first swap's pillar (28 Sep 2020) and
+        // gains the three futures maturities, so 24 dates against 22.
+        let mut futures_pillars: Vec<Date> = pillars
+            .iter()
+            .copied()
+            .filter(|date| *date != Date::new(28, Month::September, 2020))
+            .chain([
+                Date::new(18, Month::March, 2020),
+                Date::new(18, Month::June, 2020),
+                Date::new(17, Month::September, 2020),
+            ])
+            .collect();
+        futures_pillars.sort_unstable();
+        assert_eq!(futures_pillars.len(), 24);
+        assert_eq!(
+            curve_futures
+                .dates()
+                .expect("the futures strip solves")
+                .clone(),
+            futures_pillars,
+            "the futures curve's pillar list"
+        );
+
+        let solved = volatility.value().expect("the volatility is solved");
+        assert!(
+            (solved - 0.098_615_063_557_902_12).abs() < 1.0e-8,
+            "the fitted convexity volatility is {solved}"
+        );
+        assert!(
+            (solved - 1.0).abs() > 0.5,
+            "the volatility never moved off its initial guess of 1.0"
+        );
+
+        let mut worst = 0.0_f64;
+        for helper in &vars.instruments {
+            let pillar = helper.pillar_date();
+            let plain = curve
+                .discount_date(pillar, false)
+                .expect("the plain curve discounts its own pillar");
+            let with_futures = curve_futures
+                .discount_date(pillar, false)
+                .expect("the futures curve discounts the plain pillar");
+            let relative = (plain - with_futures).abs() / plain;
+            worst = worst.max(relative);
+            assert!(
+                relative < 1.0e-9,
+                "{pillar} discounts to {plain} without futures and {with_futures} with them"
+            );
+        }
+        assert!(worst < 1.0e-9, "worst relative discount gap is {worst}");
     }
 }

--- a/crates/libitofin/src/termstructures/yields/piecewiseyieldcurve.rs
+++ b/crates/libitofin/src/termstructures/yields/piecewiseyieldcurve.rs
@@ -344,7 +344,7 @@ mod tests {
     use crate::math::interpolations::linear::Linear;
     use crate::math::interpolations::loglinear::LogLinear;
     use crate::pricingengines::credit::isda_node_grid;
-    use crate::quotes::{Quote, SimpleQuote};
+    use crate::quotes::{FuturesConvAdjustmentQuote, Quote, SimpleQuote, make_quote_handle};
     use crate::settings::Settings;
     use crate::shared::shared;
     use crate::termstructures::bootstraptraits::{
@@ -353,14 +353,17 @@ mod tests {
     use crate::termstructures::credit::defaulttermstructure::DefaultProbabilityTermStructure;
     use crate::termstructures::credit::flathazardrate::FlatHazardRate;
     use crate::termstructures::yields::{
-        DepositRateHelper, FraRateHelper, InterpolatedSimpleZeroCurve, Pillar, SwapRateHelper,
+        DepositRateHelper, FraRateHelper, FuturesRateHelper, InterpolatedSimpleZeroCurve, Pillar,
+        SwapRateHelper,
     };
     use crate::time::businessdayconvention::BusinessDayConvention;
     use crate::time::calendars::target::Target;
     use crate::time::date::Month;
     use crate::time::daycounters::actual360::Actual360;
+    use crate::time::daycounters::actual365fixed::Actual365Fixed;
     use crate::time::daycounters::thirty360::{Convention, Thirty360};
     use crate::time::frequency::Frequency;
+    use crate::time::imm;
     use crate::time::period::Period;
     use crate::time::timeunit::TimeUnit;
     use crate::types::Rate;
@@ -1275,5 +1278,104 @@ mod tests {
                 "node {i} moved on an additional helper's quote: {old} vs {new}"
             );
         }
+    }
+    /// The curve-level half of the `registerAsObserver = false` contract
+    /// (`piecewiseyieldcurve.cpp:1516-1519`): a futures helper holding its
+    /// convexity quote through [`Handle::new_unregistered`] does not let a
+    /// volatility change invalidate the bootstrapped curve, while the SAME
+    /// setup through the ordinary [`Handle::new`] does.
+    ///
+    /// This is what makes a joint solve over the volatility possible at all -
+    /// an observing handle clears the lazy flag on every optimizer step, and
+    /// the penalty's reprice then re-enters `calculate`.
+    ///
+    /// The pair is built with a FIXED volatility and no additional variables,
+    /// deliberately: the observing arm cannot be run under a variables solve,
+    /// because that is precisely the configuration the C++ comment says breaks
+    /// bootstrapping. Only the handle constructor differs between the two
+    /// halves.
+    fn futures_curve_on(
+        observing: bool,
+    ) -> (
+        Shared<SimpleQuote>,
+        Shared<PiecewiseYieldCurve<Discount, LogLinear>>,
+    ) {
+        use crate::instruments::FuturesType;
+
+        let calendar = Target::new();
+        let today = calendar.adjust(
+            Date::new(25, Month::September, 2019),
+            BusinessDayConvention::Following,
+        );
+        let settings = shared(Settings::<Date>::new());
+        settings.set_evaluation_date(today);
+        let settlement = calendar.advance(
+            today,
+            2,
+            TimeUnit::Days,
+            BusinessDayConvention::Following,
+            false,
+        );
+        let index = shared(Euribor::three_months(Handle::empty(), settings.clone()));
+        let futures_date = imm::next_date(today, true);
+        let price = Handle::new(shared(SimpleQuote::new(95.419)) as Shared<dyn Quote>);
+        let volatility = shared(SimpleQuote::new(0.2));
+        let conv_adj = shared(
+            FuturesConvAdjustmentQuote::new(
+                &index,
+                futures_date,
+                price.clone(),
+                Handle::new(Shared::clone(&volatility) as Shared<dyn Quote>),
+                make_quote_handle(0.03).handle(),
+                settings,
+            )
+            .expect("the index resolves the maturity of an IMM date"),
+        ) as Shared<dyn Quote>;
+        let conv_adj = if observing {
+            Handle::new(conv_adj)
+        } else {
+            Handle::new_unregistered(conv_adj)
+        };
+        let helper =
+            FuturesRateHelper::from_index(price, futures_date, &index, conv_adj, FuturesType::Imm)
+                .expect("an IMM date builds a futures helper")
+                as Shared<dyn RateHelper>;
+
+        let curve = PiecewiseYieldCurve::<Discount, LogLinear>::new(
+            settlement,
+            vec![helper],
+            Actual365Fixed::new(),
+            LogLinear,
+        )
+        .expect("a one-futures strip builds a curve");
+        (volatility, curve)
+    }
+
+    #[test]
+    fn an_unregistered_convexity_handle_survives_a_volatility_change() {
+        let (volatility, curve) = futures_curve_on(false);
+        curve.data().expect("the one-futures strip solves");
+        assert!(curve.lazy.borrow().is_calculated());
+
+        volatility.set_value(0.3);
+
+        assert!(
+            curve.lazy.borrow().is_calculated(),
+            "an unregistered convexity handle must not invalidate the curve"
+        );
+    }
+
+    #[test]
+    fn an_observing_convexity_handle_invalidates_the_curve() {
+        let (volatility, curve) = futures_curve_on(true);
+        curve.data().expect("the one-futures strip solves");
+        assert!(curve.lazy.borrow().is_calculated());
+
+        volatility.set_value(0.3);
+
+        assert!(
+            !curve.lazy.borrow().is_calculated(),
+            "an observing convexity handle must invalidate the curve"
+        );
     }
 }

--- a/crates/libitofin/src/termstructures/yields/ratehelpers.rs
+++ b/crates/libitofin/src/termstructures/yields/ratehelpers.rs
@@ -243,9 +243,10 @@ fn determine_maturity(
 /// curve (`ratehelpers.cpp:157`): the simple forward over the window is
 /// `(discount(earliest)/discount(maturity) - 1)/year_fraction`, and the price is
 /// `100 * (1 - (forward + convexity_adjustment))`. The convexity adjustment is a
-/// plain [`Handle<Quote>`](Handle) value with no convexity model (the C++
-/// `FuturesConvAdjustmentQuote` is not ported); it may be negative, as futures
-/// margining can push the futures rate either side of the forward.
+/// plain [`Handle<Quote>`](Handle) value, whatever quote the caller supplies -
+/// a [`FuturesConvAdjustmentQuote`](crate::quotes::FuturesConvAdjustmentQuote)
+/// prices one off a Hull-White model; it may be negative, as futures margining
+/// can push the futures rate either side of the forward.
 pub struct FuturesRateHelper {
     base: BootstrapHelperBase,
     year_fraction: Real,


### PR DESCRIPTION
- **feat(quotes): add FuturesConvAdjustmentQuote for convexity pricing**
- **feat(handle): add unregistered handle that owns without observing**
- **feat(termstructures): add additional variables to global bootstrap**
- **test(termstructures): pin global bootstrap variable splices and handle contract**
- **test(crates): port testGlobalBootstrapVariables futures convexity solve**
- **test(handle): pin that unregistered handle owns its pointee**

close #977