### PR TITLE
docs(itofin-py): sync facade doc comments with the hand-written stubs

### DIFF
--- a/crates/itofin-py/src/calibration.rs
+++ b/crates/itofin-py/src/calibration.rs
@@ -1,5 +1,5 @@
-//! Facades for the calibration machinery: [`PyLevenbergMarquardt`],
-//! [`PyEndCriteria`] and [`PyCalibrationErrorType`].
+//! Facades for the calibration machinery: LevenbergMarquardt, EndCriteria and
+//! CalibrationErrorType.
 //!
 //! These are the optimizer, stopping rule and error measure shared by the
 //! Heston and Hull-White calibrations (follow-up tickets H2/W2).
@@ -125,7 +125,7 @@ pub enum PyCalibrationErrorType {
 }
 
 impl PyCalibrationErrorType {
-    /// The core [`CalibrationErrorType`] this variant stands for.
+    /// The core CalibrationErrorType this variant stands for.
     pub(crate) fn inner(self) -> CalibrationErrorType {
         match self {
             PyCalibrationErrorType::RelativePriceError => CalibrationErrorType::RelativePriceError,

--- a/crates/itofin-py/src/calibration.rs
+++ b/crates/itofin-py/src/calibration.rs
@@ -10,11 +10,11 @@ use libitofin::math::optimization::levenbergmarquardt::LevenbergMarquardt;
 use libitofin::models::CalibrationErrorType;
 use pyo3::prelude::*;
 
-/// Python `LevenbergMarquardt`: the least-squares optimizer used to fit model
-/// parameters (`math::optimization::levenbergmarquardt`).
+/// The least-squares optimizer used to fit model parameters.
 ///
-/// Holds the method by value so a later calibration facade can hand out the
-/// `&mut dyn OptimizationMethod` that the core `calibrate` free function takes.
+/// Wraps the MINPACK lmdif routine. The Jacobian comes from a built-in
+/// forward-difference scheme by default; the cost function's own jacobian
+/// method is used instead when use_cost_functions_jacobian is set.
 #[pyclass(name = "LevenbergMarquardt", unsendable)]
 pub struct PyLevenbergMarquardt {
     inner: LevenbergMarquardt,
@@ -22,6 +22,16 @@ pub struct PyLevenbergMarquardt {
 
 #[pymethods]
 impl PyLevenbergMarquardt {
+    /// Initialize the optimizer; the defaults are QuantLib's.
+    ///
+    /// Args:
+    ///     epsfcn (float): The finite-difference step seed used when the Jacobian is
+    ///         computed by differences.
+    ///     xtol (float): The tolerance on the independent variable.
+    ///     gtol (float): The tolerance on the gradient.
+    ///     use_cost_functions_jacobian (bool): Use the cost function's own jacobian
+    ///         method (a central difference, order 2 but costlier) instead of
+    ///         the built-in forward-difference scheme.
     #[new]
     #[pyo3(signature = (epsfcn = 1e-8, xtol = 1e-8, gtol = 1e-8, use_cost_functions_jacobian = false))]
     fn new(epsfcn: f64, xtol: f64, gtol: f64, use_cost_functions_jacobian: bool) -> Self {
@@ -38,13 +48,10 @@ impl PyLevenbergMarquardt {
     }
 }
 
-/// Python `EndCriteria`: the optimizer stopping rule
-/// (`math::optimization::endcriteria`).
+/// The optimizer stopping rule.
 ///
-/// The core constructor is fallible - it requires
-/// `1 < max_stationary_state_iterations < max_iterations` and finite,
-/// non-negative epsilons - so the ctor routes its `QlResult` through
-/// [`struct@crate::ItofinError`].
+/// Carries the iteration cap and the stationarity thresholds an optimization
+/// run is tested against.
 #[pyclass(name = "EndCriteria", unsendable)]
 pub struct PyEndCriteria {
     inner: EndCriteria,
@@ -52,6 +59,24 @@ pub struct PyEndCriteria {
 
 #[pymethods]
 impl PyEndCriteria {
+    /// Initialize the criteria.
+    ///
+    /// Args:
+    ///     max_iterations (int): The iteration count at which the run stops.
+    ///     max_stationary_state_iterations (int | None): How many consecutive stationary
+    ///         iterations are tolerated before the run is called converged;
+    ///         None defaults to min(max_iterations / 2, 100).
+    ///     root_epsilon (float): The variation of the independent variable below which
+    ///         an iteration counts as stationary.
+    ///     function_epsilon (float): The variation of the function value below which an
+    ///         iteration counts as stationary, and, for a cost function known
+    ///         to be positive, the value below which the run has converged.
+    ///     gradient_norm_epsilon (float | None): The gradient norm below which the run has
+    ///         converged; None defaults to function_epsilon.
+    ///
+    /// Raises:
+    ///     ItofinError: Unless 1 < max_stationary_state_iterations <
+    ///         max_iterations, or if any epsilon is negative or non-finite.
     #[new]
     #[pyo3(signature = (
         max_iterations,
@@ -86,11 +111,10 @@ impl PyEndCriteria {
     }
 }
 
-/// Python `CalibrationErrorType`: how market and model prices are compared
-/// during calibration (`models::CalibrationErrorType`).
+/// How market and model prices are compared during calibration.
 ///
-/// A fieldless pyo3 enum mirroring the core variants; the comparison formulas
-/// live in the core, so the facade only maps the variant across.
+/// RelativePriceError is |market - model| / market, PriceError is
+/// market - model, and ImpliedVolError compares the two implied volatilities.
 #[pyclass(name = "CalibrationErrorType", eq, eq_int, from_py_object)]
 #[derive(Clone, Copy, PartialEq)]
 #[allow(clippy::enum_variant_names)]

--- a/crates/itofin-py/src/capfloor.rs
+++ b/crates/itofin-py/src/capfloor.rs
@@ -1,26 +1,24 @@
-//! Facades for the cap/floor stack: the [`PyCapFloorType`] flag and the
-//! [`PyCapFloor`] instrument.
+//! Facades for the cap/floor stack: the CapFloorType flag and the CapFloor
+//! instrument.
 //!
 //! A cap or floor reaches Python two ways. The standard market builder
-//! [`MakeCapFloor`] backs the constructor: a tenor, an ibor index, a single
-//! strike and a forward start, the shape the core's own market fixtures use. It
+//! MakeCapFloor backs the constructor: a tenor, an ibor index, a single strike
+//! and a forward start, the shape the core's own market fixtures use. It
 //! derives the floating leg off `MakeVanillaSwap`, so a zero `forward_start`
 //! drops the spot caplet (`makecapfloor.cpp:34`): the cap needs no historical
 //! fixing at the evaluation date, which is what makes it buildable under the
 //! explicit-fixings design (D5/D11).
 //!
-//! The core's raw constructors (`CapFloor::cap` / `floor` / `collar`) back the
-//! three staticmethods instead. They take a leg of concrete `IborCoupon`s,
-//! which [`IborLeg`](crate::cashflows::PyIborLeg) now builds (#626), so a leg
-//! laid out coupon by coupon - its own notional, day counter and fixing days,
-//! spot caplet kept - can be capped from Python. That is the only route to a
-//! collar on this side: [`MakeCapFloor`] carries a single strike and refuses
-//! one outright (`makecapfloor.rs:135`).
+//! The core's raw cap, floor and collar constructors back the three
+//! staticmethods instead. They take a leg of concrete `IborCoupon`s,
+//! which IborLeg now builds (#626), so a leg laid out coupon by coupon - its
+//! own notional, day counter and fixing days, spot caplet kept - can be capped
+//! from Python. That is the only route to a collar on this side: MakeCapFloor
+//! carries a single strike and refuses one outright.
 //!
-//! Deferred (visible): the general `CapFloor::new` taking a type flag with both
-//! strike vectors (`capfloor.rs:129`), which the three named constructors cover
-//! between them, and the leg accessors on a built instrument beyond
-//! [`coupon_count`](PyCapFloor::coupon_count).
+//! Deferred (visible): the general constructor taking a type flag with both
+//! strike vectors, which the three named constructors cover between them, and
+//! the leg accessors on a built instrument beyond coupon_count().
 
 use crate::PyQlError;
 use crate::capfloorengine::PyBlackCapFloorEngine;
@@ -47,7 +45,7 @@ pub enum PyCapFloorType {
 }
 
 impl PyCapFloorType {
-    /// The core [`CapFloorType`] this variant stands for.
+    /// The core CapFloorType this variant stands for.
     pub(crate) fn inner(&self) -> CapFloorType {
         match self {
             PyCapFloorType::Cap => CapFloorType::Cap,

--- a/crates/itofin-py/src/capfloor.rs
+++ b/crates/itofin-py/src/capfloor.rs
@@ -70,6 +70,8 @@ impl PyCapFloorType {
 /// a collar on this side, and the route a hand-built leg's own notional, day
 /// counter and fixing days reach the coupons by. Either way the core pads a
 /// short strike list across every coupon by repeating its last entry.
+///
+/// Pricing needs an engine: call set_black_engine() before npv().
 #[pyclass(name = "CapFloor", unsendable)]
 pub struct PyCapFloor {
     inner: CapFloor,

--- a/crates/itofin-py/src/capfloor.rs
+++ b/crates/itofin-py/src/capfloor.rs
@@ -33,15 +33,11 @@ use libitofin::instrument::Instrument;
 use libitofin::instruments::{CapFloor, CapFloorType, MakeCapFloor};
 use pyo3::prelude::*;
 
-/// Python `CapFloorType`: whether the instrument caps or floors its floating leg
-/// (`instruments::capfloor::CapFloorType`).
+/// Whether the instrument caps, floors or collars its floating leg.
 ///
-/// A fieldless pyo3 enum. Its third variant, `Collar`, reaches an instrument
-/// only through a raw coupon-vector constructor - [`PyCapFloor::collar`] here,
-/// or the
-/// [`YoYInflationCapFloor`](crate::inflation::PyYoYInflationCapFloor) ones on
-/// the inflation side. [`MakeCapFloor`] refuses it, so the flag is not
-/// accepted by [`PyCapFloor::new`].
+/// Collar reaches an instrument only through a raw coupon-vector constructor:
+/// CapFloor.collar here, or the YoYInflationCapFloor ones on the inflation
+/// side. MakeCapFloor refuses it, so CapFloor(...) does not accept it.
 #[pyclass(name = "CapFloorType", eq, eq_int, from_py_object)]
 #[derive(Clone, Copy, PartialEq)]
 pub enum PyCapFloorType {
@@ -61,19 +57,19 @@ impl PyCapFloorType {
     }
 }
 
-/// Python `CapFloor`: a cap or floor over a floating (ibor) leg
-/// (`instruments::capfloor::CapFloor`).
+/// A cap, floor or collar over a floating (ibor) leg.
 ///
-/// Built two ways. The constructor runs [`MakeCapFloor`] (fallible: it derives
-/// the floating leg, so a degenerate schedule or an unset evaluation date
-/// surfaces as an `ItofinError`), whose leg carries a unit nominal and drops the
-/// spot caplet. The [`cap`](Self::cap), [`floor`](Self::floor) and
-/// [`collar`](Self::collar) staticmethods take a leg the caller laid out through
-/// [`IborLeg`](crate::cashflows::PyIborLeg) instead, and cap exactly it. Either
-/// way the core pads a short strike list across every coupon.
+/// The constructor runs the standard market builder MakeCapFloor: its leg
+/// carries a unit nominal and one strike, and a zero forward_start excludes the
+/// spot caplet, so the leg is one coupon shorter than the schedule - that is
+/// what lets the cap price without a historical index fixing at the evaluation
+/// date.
 ///
-/// Pricing needs an engine: call
-/// [`set_black_engine`](Self::set_black_engine) before [`npv`](Self::npv).
+/// The cap/floor/collar staticmethods take an IborLeg the caller laid out
+/// instead and cap exactly it, spot caplet and all. They are the only route to
+/// a collar on this side, and the route a hand-built leg's own notional, day
+/// counter and fixing days reach the coupons by. Either way the core pads a
+/// short strike list across every coupon by repeating its last entry.
 #[pyclass(name = "CapFloor", unsendable)]
 pub struct PyCapFloor {
     inner: CapFloor,
@@ -81,11 +77,23 @@ pub struct PyCapFloor {
 
 #[pymethods]
 impl PyCapFloor {
-    /// A standard market cap or floor of `tenor` on `ibor_index`, struck at
-    /// `strike` and starting `forward_start` after spot.
+    /// Build a standard market cap or floor through MakeCapFloor.
     ///
-    /// A zero `forward_start` excludes the spot caplet, so the leg is one coupon
-    /// shorter than the schedule; see the module docs.
+    /// Args:
+    ///     cap_floor_type (CapFloorType): Cap or Floor; the builder refuses
+    ///         Collar.
+    ///     tenor (Period): The length of the capped leg.
+    ///     ibor_index (IborIndex): The index the floating leg fixes off.
+    ///     strike (float): The single strike, padded across every coupon.
+    ///     forward_start (Period): The delay before the leg starts; a zero
+    ///         period excludes the spot caplet.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date and the stored fixings.
+    ///
+    /// Raises:
+    ///     ItofinError: If cap_floor_type is Collar, if the derived schedule
+    ///         is degenerate, or if the start has to be derived and no
+    ///         evaluation date is set.
     #[new]
     fn new(
         cap_floor_type: PyCapFloorType,
@@ -109,17 +117,25 @@ impl PyCapFloor {
         })
     }
 
-    /// A cap over the coupons `leg` builds, struck at `cap_rates`.
+    /// Build a cap over the coupons leg builds, struck at cap_rates.
     ///
-    /// The strike list is padded to the leg length by repeating its last entry,
-    /// so a single rate caps every coupon. Unlike [`new`](Self::new) this keeps
-    /// whatever leg it is given: the spot caplet stays, and the leg's own
-    /// notional, day counter and fixing days reach the coupons.
+    /// Unlike the constructor this keeps whatever leg it is given: the spot
+    /// caplet stays, and the leg's own notional, day counter and fixing days
+    /// reach the coupons.
     ///
-    /// # Errors
+    /// Args:
+    ///     leg (IborLeg): The leg whose coupons are capped.
+    ///     cap_rates (list[float]): The cap strikes, padded to the leg length
+    ///         by repeating the last entry.
+    ///     settings (Settings): The explicit settings the instrument resolves
+    ///         its dates against.
     ///
-    /// Reports an empty `cap_rates` list, and whatever building the leg's
-    /// coupons reports - a missing notional above all.
+    /// Returns:
+    ///     CapFloor: The cap over that leg.
+    ///
+    /// Raises:
+    ///     ItofinError: On an empty cap_rates list, or on whatever building
+    ///         the leg's coupons reports, a missing notional above all.
     #[staticmethod]
     fn cap(leg: &PyIborLeg, cap_rates: Vec<f64>, settings: &PySettings) -> PyResult<Self> {
         Ok(PyCapFloor {
@@ -128,8 +144,20 @@ impl PyCapFloor {
         })
     }
 
-    /// A floor over the coupons `leg` builds, struck at `floor_rates`. Padded
-    /// and fallible as [`cap`](Self::cap).
+    /// Build a floor over the coupons leg builds, struck at floor_rates.
+    ///
+    /// Args:
+    ///     leg (IborLeg): The leg whose coupons are floored.
+    ///     floor_rates (list[float]): The floor strikes, padded as cap() pads.
+    ///     settings (Settings): The explicit settings the instrument resolves
+    ///         its dates against.
+    ///
+    /// Returns:
+    ///     CapFloor: The floor over that leg.
+    ///
+    /// Raises:
+    ///     ItofinError: Fallible as cap(), on an empty list or a leg whose
+    ///         coupons cannot be built.
     #[staticmethod]
     fn floor(leg: &PyIborLeg, floor_rates: Vec<f64>, settings: &PySettings) -> PyResult<Self> {
         Ok(PyCapFloor {
@@ -138,12 +166,24 @@ impl PyCapFloor {
         })
     }
 
-    /// A collar over the coupons `leg` builds: long the cap at `cap_rates`,
-    /// short the floor at `floor_rates`, so it is worth the one less the other.
+    /// Build a collar: long the cap at cap_rates, short the floor at floor_rates.
     ///
-    /// The only route to a collar over a floating leg; see the module docs.
-    /// Both lists are padded and both are required. Fallible as
-    /// [`cap`](Self::cap), reporting either list empty.
+    /// The collar is worth the one less the other, and this is the only route
+    /// to one over a floating leg.
+    ///
+    /// Args:
+    ///     leg (IborLeg): The leg whose coupons are collared.
+    ///     cap_rates (list[float]): The cap strikes, padded as cap() pads.
+    ///     floor_rates (list[float]): The floor strikes, padded the same way.
+    ///     settings (Settings): The explicit settings the instrument resolves
+    ///         its dates against.
+    ///
+    /// Returns:
+    ///     CapFloor: The collar over that leg.
+    ///
+    /// Raises:
+    ///     ItofinError: On either list being empty, both being required, or on
+    ///         a leg whose coupons cannot be built.
     #[staticmethod]
     fn collar(
         leg: &PyIborLeg,
@@ -157,67 +197,100 @@ impl PyCapFloor {
         })
     }
 
-    /// The cap strikes, one per coupon; empty for a floor.
+    /// Return the cap strikes, one per coupon.
+    ///
+    /// Returns:
+    ///     list[float]: The cap strikes; empty for a floor.
     fn cap_rates(&self) -> Vec<f64> {
         self.inner.cap_rates().to_vec()
     }
 
-    /// The floor strikes, one per coupon; empty for a cap.
+    /// Return the floor strikes, one per coupon.
+    ///
+    /// Returns:
+    ///     list[float]: The floor strikes; empty for a cap.
     fn floor_rates(&self) -> Vec<f64> {
         self.inner.floor_rates().to_vec()
     }
 
-    /// The number of optionlets, one per floating coupon.
+    /// Return the number of optionlets.
+    ///
+    /// Returns:
+    ///     int: One per floating coupon on the leg.
     fn coupon_count(&self) -> usize {
         self.inner.coupons().len()
     }
 
-    /// Attaches a [`PyBlackCapFloorEngine`] so the cap/floor prices each
-    /// optionlet off an optionlet volatility surface.
+    /// Attach a Black engine, pricing each optionlet off a volatility surface.
     ///
-    /// The engine is built separately and installed here, so the same engine can
-    /// be shared across instruments. It must resolve its dates against the same
-    /// `Settings` object this cap/floor was built with: two different settings
-    /// would price the leg and the optionlets on different dates without any
-    /// error being raised.
+    /// The engine is built separately, so the same one can be shared across
+    /// instruments. It must resolve its dates against the same Settings object
+    /// as this cap/floor: two different settings would price the leg and the
+    /// optionlets on different dates with no error raised.
+    ///
+    /// Args:
+    ///     engine (BlackCapFloorEngine): The engine and its optionlet
+    ///         volatility surface.
     fn set_black_engine(&mut self, engine: &PyBlackCapFloorEngine) {
         self.inner.base_mut().set_pricing_engine(engine.engine());
     }
 
-    /// Forces the valuation, idempotent and fallible as
-    /// [`VanillaOption.calculate`](crate::option::PyVanillaOption::calculate).
+    /// Force the valuation. Idempotent.
+    ///
+    /// Raises:
+    ///     ItofinError: If no engine is attached, no evaluation date is set,
+    ///         or the engine refuses the instrument.
     fn calculate(&mut self) -> PyResult<()> {
         Ok(self.inner.calculate().map_err(PyQlError::from)?)
     }
 
-    /// Whether the cached results are currently valid.
+    /// Return whether the cached results are currently valid.
     ///
-    /// This one has a live lever behind it: the Black engine observes its
-    /// volatility handle (`blackcapfloorengine.rs:88-89`), so moving a quote the
-    /// engine was built over reaches the cap and flips this back to `False`.
+    /// The Black engine observes its volatility handle, so moving a quote the
+    /// engine was built over reaches the cap and flips this back to False.
+    ///
+    /// Returns:
+    ///     bool: True when the next accessor reads the cache.
     fn is_calculated(&self) -> bool {
         self.inner.base().is_calculated()
     }
 
-    /// Attaches `engine` and returns the NPV: the one-shot form of
-    /// [`set_black_engine`](Self::set_black_engine) followed by
-    /// [`npv`](Self::npv).
+    /// Attach engine and return the NPV.
+    ///
+    /// Args:
+    ///     engine (BlackCapFloorEngine): The engine to install and price on.
+    ///
+    /// Returns:
+    ///     float: The cap/floor value.
+    ///
+    /// Raises:
+    ///     ItofinError: On anything that makes the valuation fail.
     fn price(&mut self, engine: &PyBlackCapFloorEngine) -> PyResult<f64> {
         self.set_black_engine(engine);
         self.calculate()?;
         self.npv()
     }
 
-    /// A frozen [`Results`] copy of the valuation, calculating first.
+    /// Return a frozen snapshot of the valuation, calculating first.
+    ///
+    /// Returns:
+    ///     Results: A copy of the valuation results.
+    ///
+    /// Raises:
+    ///     ItofinError: On anything that makes the valuation fail.
     fn results(&mut self) -> PyResult<Results> {
         self.calculate()?;
         Ok(Results::snapshot(self.inner.base()))
     }
 
-    /// The cap/floor NPV under the attached engine.
+    /// Return the cap/floor NPV under the attached engine.
     ///
-    /// Fallible: with no engine attached the core reports `"null pricing
-    /// engine"` as an `ItofinError`.
+    /// Returns:
+    ///     float: The present value.
+    ///
+    /// Raises:
+    ///     ItofinError: If no engine is attached, which the core reports as
+    ///         "null pricing engine".
     fn npv(&mut self) -> PyResult<f64> {
         Ok(self.inner.npv().map_err(PyQlError::from)?)
     }

--- a/crates/itofin-py/src/capfloorengine.rs
+++ b/crates/itofin-py/src/capfloorengine.rs
@@ -1,19 +1,17 @@
-//! Facade for the Black cap/floor pricing engine: [`PyBlackCapFloorEngine`].
+//! Facade for the Black cap/floor pricing engine: BlackCapFloorEngine.
 //!
-//! The engine prices each optionlet of a [`CapFloor`](crate::capfloor::PyCapFloor)
-//! with the Black 1976 formula over an optionlet volatility surface, discounting
-//! on a separate yield curve.
+//! The engine prices each optionlet of a CapFloor with the Black 1976 formula
+//! over an optionlet volatility surface, discounting on a separate yield curve.
 //!
 //! Both core constructors are exposed. The surface form takes a
-//! [`PyOptionletVolatilityStructure`] and an optional displacement; the flat-vol
-//! form takes a single quote and wraps it in a moving constant surface with zero
+//! OptionletVolatilityStructure and an optional displacement; the flat-vol form
+//! takes a single quote and wraps it in a moving constant surface with zero
 //! settlement days on a null calendar, so that surface's reference date IS the
 //! evaluation date carried by `settings`.
 //!
 //! Deferred (visible): the Bachelier cap/floor engine is not exposed - the core
-//! prices only the shifted-lognormal path
-//! (`blackcapfloorengine.rs:22-25`), so a normal-volatility surface is rejected
-//! by the constructor rather than bound to a second engine here.
+//! prices only the shifted-lognormal path, so a normal-volatility surface is
+//! rejected by the constructor rather than bound to a second engine here.
 
 use crate::PyQlError;
 use crate::curve::PyYieldTermStructure;

--- a/crates/itofin-py/src/capfloorengine.rs
+++ b/crates/itofin-py/src/capfloorengine.rs
@@ -26,12 +26,13 @@ use libitofin::pricingengines::capfloor::BlackCapFloorEngine;
 use libitofin::shared::{SharedMut, shared_mut};
 use pyo3::prelude::*;
 
-/// Python `BlackCapFloorEngine`: the shifted-lognormal Black-formula cap/floor
-/// engine (`pricingengines::capfloor::BlackCapFloorEngine`).
+/// The shifted-lognormal Black-formula cap/floor engine, one Black 1976
+/// optionlet per coupon.
 ///
-/// The `settings` behind the instrument this engine prices must be the same
-/// object the engine resolves its own dates against, or the two disagree on the
-/// evaluation date and the NPV is silently wrong.
+/// Only the shifted-lognormal path is priced in the core, so a normal-volatility
+/// surface is rejected by the constructor rather than bound to a Bachelier
+/// engine. The instrument this engine prices must resolve its dates against the
+/// same Settings object the engine does.
 #[pyclass(name = "BlackCapFloorEngine", unsendable)]
 pub struct PyBlackCapFloorEngine {
     inner: SharedMut<BlackCapFloorEngine>,
@@ -39,12 +40,22 @@ pub struct PyBlackCapFloorEngine {
 
 #[pymethods]
 impl PyBlackCapFloorEngine {
-    /// An engine reading volatilities off `vol` and discounting on `discount`.
+    /// Build an engine reading volatilities off vol and discounting on discount.
     ///
-    /// Fallible at construction, unlike the swaption engine: the surface must be
-    /// shifted-lognormal, and a `displacement` given here must equal the
-    /// surface's own (`blackcapfloorengine.rs:75-82`). `None` adopts the
-    /// surface's displacement.
+    /// Fallible at construction, unlike the swaption engines.
+    ///
+    /// Args:
+    ///     vol (OptionletVolatilityStructure): The optionlet surface
+    ///         volatilities are read off; must be shifted-lognormal.
+    ///     discount (YieldTermStructure): The curve the optionlets are
+    ///         discounted on.
+    ///     displacement (float | None): The lognormal shift; None adopts the
+    ///         surface's own.
+    ///
+    /// Raises:
+    ///     ItofinError: If the surface handle is empty, the surface is
+    ///         normal-volatility, or a given displacement differs from the
+    ///         surface's own.
     #[new]
     #[pyo3(signature = (vol, discount, displacement = None))]
     fn new(
@@ -60,13 +71,25 @@ impl PyBlackCapFloorEngine {
         })
     }
 
-    /// An engine over a flat volatility quote, which it wraps in a constant
-    /// optionlet surface on a null calendar whose reference date tracks the
-    /// evaluation date. `displacement` is the surface's lognormal shift.
+    /// Build an engine over a flat volatility quote.
     ///
-    /// `displacement` carries no default, mirroring
-    /// [`BlackSwaptionEngine.with_flat_vol`](crate::swaptionengine::PyBlackSwaptionEngine):
-    /// a trailing `settings` cannot follow a defaulted argument.
+    /// The quote is wrapped internally in a constant optionlet surface on a
+    /// null calendar whose reference date tracks the evaluation date.
+    /// displacement carries no default, mirroring the swaption engine: a
+    /// trailing settings cannot follow a defaulted argument.
+    ///
+    /// Args:
+    ///     discount (YieldTermStructure): The curve the optionlets are
+    ///         discounted on.
+    ///     vol (SimpleQuote): The flat Black volatility.
+    ///     day_counter (DayCounter): The day count the constant surface
+    ///         measures time on.
+    ///     displacement (float): The constant surface's lognormal shift.
+    ///     settings (Settings): The explicit settings the constant surface's
+    ///         reference date tracks.
+    ///
+    /// Returns:
+    ///     BlackCapFloorEngine: The engine over the flat surface.
     #[staticmethod]
     fn with_flat_vol(
         discount: &PyYieldTermStructure,
@@ -89,7 +112,10 @@ impl PyBlackCapFloorEngine {
         })
     }
 
-    /// The lognormal shift the engine applies to forwards and strikes.
+    /// Return the lognormal shift the engine applies to forwards and strikes.
+    ///
+    /// Returns:
+    ///     float: The displacement.
     fn displacement(&self) -> f64 {
         self.inner.borrow().displacement()
     }

--- a/crates/itofin-py/src/capfloortermvol.rs
+++ b/crates/itofin-py/src/capfloortermvol.rs
@@ -38,15 +38,23 @@ use libitofin::termstructures::volatility::{
 use libitofin::time::period::Period;
 use pyo3::prelude::*;
 
-/// Python `CapFloorTermVolSurface`: the market cap/floor term-volatility
-/// surface, bicubic over an option-tenor x strike grid
-/// (`termstructures::volatility::CapFloorTermVolSurface`).
+/// The market cap/floor TERM-volatility surface, bicubic over an option-tenor
+/// x strike grid.
 ///
-/// The grid is a row per option tenor and a column per strike, both strictly
-/// increasing. The three query forms address the same surface by cap tenor, by
-/// cap end date and by cap end time; the tenor form resolves against the
-/// surface's own calendar and business-day convention, so it is the one to
-/// reach for unless a date is already in hand.
+/// This is the flat volatility of a WHOLE cap by cap length, which is how the
+/// market quotes caps, not the volatility of the individual caplets it
+/// decomposes into: it is the optionlet stripper's input, and it is not an
+/// OptionletVolatilityStructure.
+///
+/// volatilities is a row per option tenor and a column per strike; both axes
+/// must be strictly increasing.
+///
+/// All four constructors are exposed. __init__ and with_quotes pin the
+/// reference date, so every query's option time runs from reference_date rather
+/// than the evaluation date. moving and moving_with_quotes float it
+/// settlement_days off the evaluation date, and are what the optionlet
+/// stripping pipeline runs on: StrippedOptionletAdapter reads its settlement
+/// days back off this surface, and a pinned-reference surface has none.
 #[pyclass(name = "CapFloorTermVolSurface", unsendable)]
 pub struct PyCapFloorTermVolSurface {
     inner: Shared<CapFloorTermVolSurface>,
@@ -54,9 +62,29 @@ pub struct PyCapFloorTermVolSurface {
 
 #[pymethods]
 impl PyCapFloorTermVolSurface {
-    /// A surface on a pinned reference date over fixed volatilities: every
-    /// query's option time runs from `reference_date`, not from the evaluation
-    /// date, and no later mutation can reach the grid.
+    /// Build the surface on a pinned reference date over fixed volatilities.
+    ///
+    /// Every query's option time runs from reference_date, not from the
+    /// evaluation date, and no later mutation can reach the grid.
+    ///
+    /// Args:
+    ///     reference_date (Date): The date option times run from.
+    ///     calendar (Calendar): The calendar cap tenors resolve on.
+    ///     business_day_convention (BusinessDayConvention): The roll applied
+    ///         when resolving a tenor to a date.
+    ///     option_tenors (list[Period]): The cap-length axis, one per grid
+    ///         row; strictly increasing.
+    ///     strikes (list[float]): The strike axis, one per grid column;
+    ///         strictly increasing.
+    ///     volatilities (list[list[float]]): The flat cap volatilities, one
+    ///         row per option tenor.
+    ///     day_counter (DayCounter): The day count option times are measured
+    ///         in.
+    ///
+    /// Raises:
+    ///     ItofinError: On an empty or ragged grid, on a grid whose shape does
+    ///         not match the tenors and strikes, and on a non-increasing tenor
+    ///         or strike axis.
     #[new]
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (reference_date, calendar, business_day_convention, option_tenors, strikes, volatilities, day_counter))]
@@ -85,9 +113,27 @@ impl PyCapFloorTermVolSurface {
         Ok(PyCapFloorTermVolSurface { inner })
     }
 
-    /// The same pinned-reference surface reading each node from the caller's
-    /// quote: a later `set_value` on any of them rebuilds the interpolation and
-    /// notifies the surface's observers.
+    /// Build the pinned-reference surface over live quotes.
+    ///
+    /// Args:
+    ///     reference_date (Date): The date option times run from.
+    ///     calendar (Calendar): The calendar cap tenors resolve on.
+    ///     business_day_convention (BusinessDayConvention): The roll applied
+    ///         when resolving a tenor to a date.
+    ///     option_tenors (list[Period]): The cap-length axis, strictly
+    ///         increasing.
+    ///     strikes (list[float]): The strike axis, strictly increasing.
+    ///     volatilities (list[list[SimpleQuote]]): The volatility quotes, one
+    ///         row per option tenor; a later set_value rebuilds the
+    ///         interpolation and notifies the surface's observers.
+    ///     day_counter (DayCounter): The day count option times are measured
+    ///         in.
+    ///
+    /// Returns:
+    ///     CapFloorTermVolSurface: The surface over those quotes.
+    ///
+    /// Raises:
+    ///     ItofinError: On the same conditions __init__ reports.
     #[staticmethod]
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (reference_date, calendar, business_day_convention, option_tenors, strikes, volatilities, day_counter))]
@@ -120,12 +166,33 @@ impl PyCapFloorTermVolSurface {
         Ok(PyCapFloorTermVolSurface { inner })
     }
 
-    /// A surface whose reference date floats `settlement_days` business days
-    /// off the evaluation date, over fixed volatilities.
+    /// Build a surface whose reference date floats off the evaluation date.
     ///
     /// This is the form the optionlet stripping pipeline needs: unlike the
     /// pinned-reference constructors, it carries the settlement days
-    /// `StrippedOptionletAdapter` reads back off the stripper.
+    /// StrippedOptionletAdapter reads back off the stripper.
+    ///
+    /// Args:
+    ///     settlement_days (int): The business days the reference date sits
+    ///         past the evaluation date.
+    ///     calendar (Calendar): The calendar cap tenors resolve on.
+    ///     business_day_convention (BusinessDayConvention): The roll applied
+    ///         when resolving a tenor to a date.
+    ///     option_tenors (list[Period]): The cap-length axis, strictly
+    ///         increasing.
+    ///     strikes (list[float]): The strike axis, strictly increasing.
+    ///     volatilities (list[list[float]]): The flat cap volatilities, one
+    ///         row per option tenor.
+    ///     day_counter (DayCounter): The day count option times are measured
+    ///         in.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date the reference date floats off.
+    ///
+    /// Returns:
+    ///     CapFloorTermVolSurface: The floating-reference surface.
+    ///
+    /// Raises:
+    ///     ItofinError: On the same conditions __init__ reports.
     #[staticmethod]
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (settlement_days, calendar, business_day_convention, option_tenors, strikes, volatilities, day_counter, settings))]
@@ -156,8 +223,30 @@ impl PyCapFloorTermVolSurface {
         Ok(PyCapFloorTermVolSurface { inner })
     }
 
-    /// The same floating-reference surface reading each node from the caller's
-    /// quote.
+    /// Build the floating-reference surface over live quotes.
+    ///
+    /// Args:
+    ///     settlement_days (int): The business days the reference date sits
+    ///         past the evaluation date.
+    ///     calendar (Calendar): The calendar cap tenors resolve on.
+    ///     business_day_convention (BusinessDayConvention): The roll applied
+    ///         when resolving a tenor to a date.
+    ///     option_tenors (list[Period]): The cap-length axis, strictly
+    ///         increasing.
+    ///     strikes (list[float]): The strike axis, strictly increasing.
+    ///     volatilities (list[list[SimpleQuote]]): The volatility quotes, one
+    ///         row per option tenor.
+    ///     day_counter (DayCounter): The day count option times are measured
+    ///         in.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date the reference date floats off.
+    ///
+    /// Returns:
+    ///     CapFloorTermVolSurface: The floating-reference surface over those
+    ///         quotes.
+    ///
+    /// Raises:
+    ///     ItofinError: On the same conditions __init__ reports.
     #[staticmethod]
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (settlement_days, calendar, business_day_convention, option_tenors, strikes, volatilities, day_counter, settings))]
@@ -192,7 +281,23 @@ impl PyCapFloorTermVolSurface {
         Ok(PyCapFloorTermVolSurface { inner })
     }
 
-    /// The cap volatility for a cap tenor and strike.
+    /// Return the flat cap volatility for a cap tenor and strike.
+    ///
+    /// The tenor form resolves against the surface's own calendar and
+    /// business-day convention, so it is the one to reach for unless a date is
+    /// already in hand.
+    ///
+    /// Args:
+    ///     option_tenor (Period): The cap's length.
+    ///     strike (float): The strike the volatility is read at.
+    ///     extrapolate (bool): Whether to answer outside the surface's grid.
+    ///
+    /// Returns:
+    ///     float: The flat cap volatility.
+    ///
+    /// Raises:
+    ///     ItofinError: If the query falls outside the grid and extrapolation
+    ///         is not allowed.
     #[pyo3(signature = (option_tenor, strike, extrapolate = false))]
     fn volatility(&self, option_tenor: &PyPeriod, strike: f64, extrapolate: bool) -> PyResult<f64> {
         Ok(self
@@ -201,7 +306,19 @@ impl PyCapFloorTermVolSurface {
             .map_err(PyQlError::from)?)
     }
 
-    /// The cap volatility for a cap end date and strike.
+    /// Return the flat cap volatility for a cap end date and strike.
+    ///
+    /// Args:
+    ///     end_date (Date): The cap's end date.
+    ///     strike (float): The strike the volatility is read at.
+    ///     extrapolate (bool): Whether to answer outside the surface's grid.
+    ///
+    /// Returns:
+    ///     float: The flat cap volatility.
+    ///
+    /// Raises:
+    ///     ItofinError: If the query falls outside the grid and extrapolation
+    ///         is not allowed.
     #[pyo3(signature = (end_date, strike, extrapolate = false))]
     fn volatility_date(&self, end_date: &PyDate, strike: f64, extrapolate: bool) -> PyResult<f64> {
         Ok(self
@@ -210,8 +327,20 @@ impl PyCapFloorTermVolSurface {
             .map_err(PyQlError::from)?)
     }
 
-    /// The cap volatility for a cap end time (a year fraction off the reference
-    /// date, in the surface's own day count) and strike.
+    /// Return the flat cap volatility for a cap end time and strike.
+    ///
+    /// Args:
+    ///     length (float): A year fraction off the reference date, in the
+    ///         surface's own day count.
+    ///     strike (float): The strike the volatility is read at.
+    ///     extrapolate (bool): Whether to answer outside the surface's grid.
+    ///
+    /// Returns:
+    ///     float: The flat cap volatility.
+    ///
+    /// Raises:
+    ///     ItofinError: If the query falls outside the grid and extrapolation
+    ///         is not allowed.
     #[pyo3(signature = (length, strike, extrapolate = false))]
     fn volatility_time(&self, length: f64, strike: f64, extrapolate: bool) -> PyResult<f64> {
         Ok(self

--- a/crates/itofin-py/src/capfloortermvol.rs
+++ b/crates/itofin-py/src/capfloortermvol.rs
@@ -1,12 +1,12 @@
 //! Facade for the market cap/floor TERM-volatility surface
-//! [`PyCapFloorTermVolSurface`].
+//! CapFloorTermVolSurface.
 //!
 //! This is a `CapFloorTermVolatilityStructure`, not an
-//! [`OptionletVolatilityStructure`](crate::optionletvol::PyOptionletVolatilityStructure):
-//! it quotes the flat volatility of a WHOLE cap by cap length, which is how the
-//! market quotes caps, whereas an optionlet surface quotes the individual
-//! caplets a cap decomposes into. It is therefore the optionlet stripper's
-//! input, not its output, and it does not extend the optionlet base.
+//! OptionletVolatilityStructure: it quotes the flat volatility of a WHOLE cap
+//! by cap length, which is how the market quotes caps, whereas an optionlet
+//! surface quotes the individual caplets a cap decomposes into. It is therefore
+//! the optionlet stripper's input, not its output, and it does not extend the
+//! optionlet base.
 //!
 //! It is exposed standalone rather than under a shared base: it is the only
 //! implementor of its trait in the core, so a Python base class would have a
@@ -19,10 +19,9 @@
 //! volatilities or over the caller's quotes. The moving pair is not optional
 //! polish here - it is what the optionlet stripping pipeline runs on. The
 //! adapter that serves the stripped surface reads its settlement days from this
-//! surface (`strippedoptionletadapter.rs:87` through
-//! `optionletstripper.rs:241`), and a fixed-reference term structure has none,
-//! so a surface built by the fixed forms fails the adapter with `"settlement
-//! days not provided for this instance"`.
+//! surface, and a fixed-reference term structure has none, so a surface built
+//! by the fixed forms fails the adapter with `"settlement days not provided for
+//! this instance"`.
 
 use crate::PyQlError;
 use crate::market::PySimpleQuote;
@@ -384,7 +383,7 @@ fn check_grid<T>(rows: &[Vec<T>]) -> PyResult<usize> {
     Ok(columns)
 }
 
-/// A `list[list[float]]` as a core [`Matrix`], one row per option tenor.
+/// A `list[list[float]]` as a core Matrix, one row per option tenor.
 pub(crate) fn matrix_from_rows(rows: &[Vec<f64>]) -> PyResult<Matrix> {
     let columns = check_grid(rows)?;
     let mut matrix = Matrix::with_size(rows.len(), columns);

--- a/crates/itofin-py/src/cashflows.rs
+++ b/crates/itofin-py/src/cashflows.rs
@@ -39,20 +39,10 @@ use libitofin::time::period::Period;
 use libitofin::time::schedule::Schedule;
 use pyo3::prelude::*;
 
-/// Python `YoYInflationCoupon`: one coupon of a year-on-year inflation leg
-/// (`cashflows::yoyinflationcoupon::YoYInflationCoupon`).
+/// One coupon of a year-on-year inflation leg.
 ///
-/// Built only through [`YoYInflationLeg`](PyYoYInflationLeg), which is where the
-/// coupon's pricer comes from: a coupon holds no rate of its own and answers
-/// [`rate`](Self::rate) and [`amount`](Self::amount) only once one is attached,
-/// so a standalone constructor here would hand Python an object whose two
-/// headline methods report `"pricer not set"`. This mirrors
-/// [`YoYInflationCapFloor`](crate::inflation::PyYoYInflationCapFloor), which is
-/// likewise factory-only.
-///
-/// Deferred (visible): a direct constructor and the
-/// `SwapletYoYInflationCouponPricer` binding it would need, plus the
-/// `accrued_amount` and reference-period accessors no fixture reads yet.
+/// Built only through YoYInflationLeg, which attaches the pricer rate() and
+/// amount() need.
 #[pyclass(name = "YoYInflationCoupon", unsendable)]
 pub struct PyYoYInflationCoupon {
     inner: Shared<YoYInflationCoupon>,
@@ -60,101 +50,142 @@ pub struct PyYoYInflationCoupon {
 
 #[pymethods]
 impl PyYoYInflationCoupon {
-    /// The rate the coupon accrues at: its pricer's swaplet rate, the geared
-    /// index fixing plus the spread.
+    /// Return the rate the coupon accrues at: the geared index fixing plus the spread.
     ///
-    /// # Errors
+    /// Returns:
+    ///     float: The pricer's swaplet rate.
     ///
-    /// Reports a coupon with no pricer attached, and whatever resolving the
-    /// fixing reports - a missing history entry, or a forecast off an index with
-    /// no curve linked.
+    /// Raises:
+    ///     ItofinError: If no pricer is attached, or resolving the fixing
+    ///         fails - a missing history entry, or a forecast off an index with
+    ///         no curve linked.
     fn rate(&self) -> PyResult<f64> {
         Ok(Coupon::rate(&*self.inner).map_err(PyQlError::from)?)
     }
 
-    /// What the coupon pays on its [`date`](Self::date), undiscounted: the
-    /// [`rate`](Self::rate) over the [`accrual_period`](Self::accrual_period) on
-    /// the [`nominal`](Self::nominal). Fallible as [`rate`](Self::rate).
+    /// Return what the coupon pays on its payment date, undiscounted.
+    ///
+    /// Returns:
+    ///     float: rate() * accrual_period() * nominal().
+    ///
+    /// Raises:
+    ///     ItofinError: As rate().
     fn amount(&self) -> PyResult<f64> {
         Ok(Coupon::amount(&*self.inner).map_err(PyQlError::from)?)
     }
 
-    /// The date the observation is published on: the reference-period end moved
-    /// back by the observation lag, then back the fixing days.
+    /// Return the date the observation is published on.
     ///
-    /// This is *not* the date the rate resolves at. An inflation index has no
-    /// fixing calendar, so with no fixing days the roll is inert.
+    /// The reference-period end moved back by the observation lag, then back
+    /// the fixing days. This is not the date the rate resolves at: an inflation
+    /// index has no fixing calendar, so with no fixing days the roll is inert.
+    ///
+    /// Returns:
+    ///     Date: The publication date.
     fn fixing_date(&self) -> PyDate {
         PyDate::from_inner(self.inner.fixing_date())
     }
 
-    /// The year-on-year rate the coupon observes, before gearing and spread.
+    /// Return the year-on-year rate observed, before gearing and spread.
     ///
-    /// It lags off the [`accrual_end_date`](Self::accrual_end_date), not off
-    /// [`fixing_date`](Self::fixing_date): a year-on-year coupon overrides the
-    /// base rule that reads the index at its fixing date.
+    /// It lags off accrual_end_date(), not off fixing_date(): a year-on-year
+    /// coupon overrides the base rule that reads the index at its fixing date.
     ///
-    /// # Errors
+    /// Returns:
+    ///     float: The observed rate.
     ///
-    /// As [`rate`](Self::rate), bar the missing pricer.
+    /// Raises:
+    ///     ItofinError: As rate(), bar the missing pricer.
     fn index_fixing(&self) -> PyResult<f64> {
         Ok(self.inner.index_fixing().map_err(PyQlError::from)?)
     }
 
-    /// The nominal the coupon accrues on.
+    /// Return the nominal the coupon accrues on.
+    ///
+    /// Returns:
+    ///     float: The nominal.
     fn nominal(&self) -> f64 {
         Coupon::nominal(&*self.inner)
     }
 
-    /// The start of the accrual period.
+    /// Return the start of the accrual period.
+    ///
+    /// Returns:
+    ///     Date: The accrual start.
     fn accrual_start_date(&self) -> PyDate {
         PyDate::from_inner(Coupon::accrual_start_date(&*self.inner))
     }
 
-    /// The end of the accrual period, which is also where the observation lags
-    /// from.
+    /// Return the end of the accrual period, which is also where the observation lags from.
+    ///
+    /// Returns:
+    ///     Date: The accrual end.
     fn accrual_end_date(&self) -> PyDate {
         PyDate::from_inner(Coupon::accrual_end_date(&*self.inner))
     }
 
-    /// The whole accrual period as a fraction of a year, measured with the
-    /// [`day_counter`](Self::day_counter) over the reference period.
+    /// Return the whole accrual period as a fraction of a year.
+    ///
+    /// Measured with day_counter() over the reference period.
+    ///
+    /// Returns:
+    ///     float: The year fraction.
     fn accrual_period(&self) -> f64 {
         Coupon::accrual_period(&*self.inner)
     }
 
-    /// The payment date, which is the accrual end rolled on the leg's payment
-    /// calendar.
+    /// Return the payment date: the accrual end rolled on the leg's payment calendar.
+    ///
+    /// Returns:
+    ///     Date: The payment date.
     fn date(&self) -> PyDate {
         PyDate::from_inner(Event::date(&*self.inner))
     }
 
-    /// The day counter the accrual is measured with.
+    /// Return the day counter the accrual is measured with.
+    ///
+    /// Returns:
+    ///     DayCounter: The coupon day count.
     fn day_counter(&self) -> PyDayCounter {
         PyDayCounter::from_inner(Coupon::day_counter(&*self.inner))
     }
 
-    /// The multiplicative coefficient applied to the index fixing.
+    /// Return the multiplicative coefficient applied to the index fixing.
+    ///
+    /// Returns:
+    ///     float: The gearing.
     fn gearing(&self) -> f64 {
         self.inner.gearing()
     }
 
-    /// The spread paid over the geared fixing.
+    /// Return the spread paid over the geared fixing.
+    ///
+    /// Returns:
+    ///     float: The spread.
     fn spread(&self) -> f64 {
         self.inner.spread()
     }
 
-    /// How far back the coupon observes the index.
+    /// Return how far back the coupon observes the index.
+    ///
+    /// Returns:
+    ///     Period: The observation lag.
     fn observation_lag(&self) -> PyPeriod {
         PyPeriod::from_inner(self.inner.observation_lag())
     }
 
-    /// How the observation interpolates between index fixings.
+    /// Return how the observation interpolates between index fixings.
+    ///
+    /// Returns:
+    ///     CpiInterpolationType: Flat or Linear.
     fn interpolation(&self) -> PyCpiInterpolationType {
         PyCpiInterpolationType::from_inner(self.inner.interpolation())
     }
 
-    /// The number of business days the fixing date rolls back by.
+    /// Return the number of business days the fixing date rolls back by.
+    ///
+    /// Returns:
+    ///     int: The fixing days.
     fn fixing_days(&self) -> u32 {
         self.inner.fixing_days()
     }
@@ -182,25 +213,13 @@ impl PyYoYInflationCoupon {
     }
 }
 
-/// Python `YoYInflationOptionletCouponPricer`: the coupon pricer that values a
-/// capped or floored year-on-year coupon's optionlets off a volatility surface
-/// (`cashflows::yoyinflationoptionletpricer`).
+/// Values a capped or floored year-on-year coupon's optionlets off a
+/// volatility surface.
 ///
-/// The distribution is chosen by the constructor rather than passed as an
-/// argument, mirroring the core's three constructors and C++'s three pricer
-/// classes, as
-/// [`YoYInflationCapFloorEngine`](crate::inflation::PyYoYInflationCapFloorEngine)
-/// does: [`black`](Self::black) is lognormal, [`unit_displaced`](Self::unit_displaced)
-/// lognormal in `1 + rate` and [`bachelier`](Self::bachelier) normal.
-///
-/// The `settings` behind `volatility` and behind the index the priced coupons
-/// observe must be the same object, or the two resolve their dates against
-/// different evaluation dates and the rate is silently wrong.
-///
-/// `nominal_ts` is optional because only the discounted `swaplet_price` path
-/// reads it: a pricer built without one still answers every rate a
-/// [`CappedFlooredYoYInflationCoupon`](PyCappedFlooredYoYInflationCoupon) asks
-/// of it.
+/// The distribution is chosen by the constructor: black is lognormal,
+/// unit_displaced lognormal in 1 + rate and bachelier normal. The settings
+/// behind volatility and behind the priced coupons' index must be the same
+/// object. nominal_ts is optional: only the discounted price path reads it.
 #[pyclass(name = "YoYInflationOptionletCouponPricer", unsendable)]
 pub struct PyYoYInflationOptionletCouponPricer {
     inner: SharedMut<YoYInflationOptionletCouponPricer>,
@@ -208,8 +227,16 @@ pub struct PyYoYInflationOptionletCouponPricer {
 
 #[pymethods]
 impl PyYoYInflationOptionletCouponPricer {
-    /// Optionlets under the lognormal model (C++
-    /// `BlackYoYInflationCouponPricer`).
+    /// Build a pricer valuing optionlets under the lognormal model.
+    ///
+    /// Args:
+    ///     volatility (ConstantYoYOptionletVolatility): The surface optionlet
+    ///         volatilities are read off.
+    ///     nominal_ts (YieldTermStructure | None): The discount curve; only the
+    ///         discounted price path reads it.
+    ///
+    /// Returns:
+    ///     YoYInflationOptionletCouponPricer: The lognormal pricer.
     #[staticmethod]
     #[pyo3(signature = (volatility, nominal_ts = None))]
     fn black(
@@ -224,9 +251,19 @@ impl PyYoYInflationOptionletCouponPricer {
         }
     }
 
-    /// Optionlets under the unit-displaced lognormal model (C++
-    /// `UnitDisplacedBlackYoYInflationCouponPricer`), the usual quoting
-    /// convention for an inflation rate that may go negative.
+    /// Build a pricer valuing optionlets under the unit-displaced lognormal model.
+    ///
+    /// Lognormal in 1 + rate, the usual quoting convention for an inflation
+    /// rate that may go negative.
+    ///
+    /// Args:
+    ///     volatility (ConstantYoYOptionletVolatility): The surface optionlet
+    ///         volatilities are read off.
+    ///     nominal_ts (YieldTermStructure | None): The discount curve; only the
+    ///         discounted price path reads it.
+    ///
+    /// Returns:
+    ///     YoYInflationOptionletCouponPricer: The unit-displaced pricer.
     #[staticmethod]
     #[pyo3(signature = (volatility, nominal_ts = None))]
     fn unit_displaced(
@@ -241,8 +278,16 @@ impl PyYoYInflationOptionletCouponPricer {
         }
     }
 
-    /// Optionlets under the normal model (C++
-    /// `BachelierYoYInflationCouponPricer`).
+    /// Build a pricer valuing optionlets under the normal model.
+    ///
+    /// Args:
+    ///     volatility (ConstantYoYOptionletVolatility): The surface optionlet
+    ///         volatilities are read off.
+    ///     nominal_ts (YieldTermStructure | None): The discount curve; only the
+    ///         discounted price path reads it.
+    ///
+    /// Returns:
+    ///     YoYInflationOptionletCouponPricer: The normal pricer.
     #[staticmethod]
     #[pyo3(signature = (volatility, nominal_ts = None))]
     fn bachelier(
@@ -271,24 +316,11 @@ fn nominal_handle(nominal_ts: Option<&PyYieldTermStructure>) -> Handle<dyn Yield
     nominal_ts.map_or_else(Handle::empty, PyYieldTermStructure::handle)
 }
 
-/// Python `CappedFlooredYoYInflationCoupon`: a year-on-year coupon with a cap
-/// and/or floor layered on its rate
-/// (`cashflows::capflooredyoyinflationcoupon`).
+/// A year-on-year inflation coupon with a cap and/or floor on its rate.
 ///
-/// Built only through
-/// [`YoYInflationLeg.capped_floored_coupons`](PyYoYInflationLeg::capped_floored_coupons),
-/// which is also where the optionlet pricer comes from, as
-/// [`YoYInflationCoupon`](PyYoYInflationCoupon) is built only through
-/// [`coupons`](PyYoYInflationLeg::coupons).
-///
-/// A negative gearing swaps the two roles: the cap the leg was given becomes
-/// this coupon's floor and vice versa, which is why
-/// [`is_capped`](Self::is_capped) and [`effective_cap`](Self::effective_cap)
-/// answer off the stored level rather than off what was passed.
-///
-/// Deferred (visible): the delegated [`Coupon`] face - the nominal, the accrual
-/// dates and the payment date - which is reachable on the plain coupons of the
-/// same leg, and the `underlying` accessor no fixture reads.
+/// Built only through YoYInflationLeg.capped_floored_coupons. A negative
+/// gearing swaps the two roles, so is_capped and effective_cap answer off the
+/// stored level rather than off what the leg was given.
 #[pyclass(name = "CappedFlooredYoYInflationCoupon", unsendable)]
 pub struct PyCappedFlooredYoYInflationCoupon {
     inner: Shared<CappedFlooredYoYInflationCoupon>,
@@ -296,43 +328,66 @@ pub struct PyCappedFlooredYoYInflationCoupon {
 
 #[pymethods]
 impl PyCappedFlooredYoYInflationCoupon {
-    /// The rate the coupon accrues at: the underlying's swaplet rate plus the
-    /// floorlet, less the caplet.
+    /// Return the rate the coupon accrues at.
     ///
-    /// # Errors
+    /// The underlying's swaplet rate plus the floorlet, less the caplet.
     ///
-    /// Reports a coupon with no pricer attached, whatever resolving the fixing
-    /// reports, and a volatility the surface refuses - a strike outside its
-    /// domain, or an observation before its base date.
+    /// Returns:
+    ///     float: The capped and floored rate.
+    ///
+    /// Raises:
+    ///     ItofinError: If no pricer is attached, if resolving the fixing
+    ///         fails, or if the surface refuses the volatility - a strike
+    ///         outside its domain, or an observation before its base date.
     fn rate(&self) -> PyResult<f64> {
         Ok(Coupon::rate(&*self.inner).map_err(PyQlError::from)?)
     }
 
-    /// What the coupon pays on its payment date, undiscounted: the
-    /// [`rate`](Self::rate) over the accrual period on the nominal. Fallible as
-    /// [`rate`](Self::rate).
+    /// Return what the coupon pays on its payment date, undiscounted.
+    ///
+    /// Returns:
+    ///     float: rate() * accrual_period() * nominal().
+    ///
+    /// Raises:
+    ///     ItofinError: As rate().
     fn amount(&self) -> PyResult<f64> {
         Ok(Coupon::amount(&*self.inner).map_err(PyQlError::from)?)
     }
 
-    /// Whether a cap applies.
+    /// Return whether a cap applies.
+    ///
+    /// Returns:
+    ///     bool: True if the stored cap level is set.
     fn is_capped(&self) -> bool {
         self.inner.is_capped()
     }
 
-    /// Whether a floor applies.
+    /// Return whether a floor applies.
+    ///
+    /// Returns:
+    ///     bool: True if the stored floor level is set.
     fn is_floored(&self) -> bool {
         self.inner.is_floored()
     }
 
-    /// The de-spread, de-geared cap the caplet is struck at,
-    /// `(cap - spread) / gearing`, off the stored level.
+    /// Return the de-spread, de-geared cap the caplet is struck at.
+    ///
+    /// Read off the stored level, so a negative gearing has already swapped the
+    /// two roles.
+    ///
+    /// Returns:
+    ///     float: (cap - spread) / gearing.
     fn effective_cap(&self) -> f64 {
         self.inner.effective_cap()
     }
 
-    /// The de-spread, de-geared floor the floorlet is struck at,
-    /// `(floor - spread) / gearing`, off the stored level.
+    /// Return the de-spread, de-geared floor the floorlet is struck at.
+    ///
+    /// Read off the stored level, so a negative gearing has already swapped the
+    /// two roles.
+    ///
+    /// Returns:
+    ///     float: (floor - spread) / gearing.
     fn effective_floor(&self) -> f64 {
         self.inner.effective_floor()
     }
@@ -353,35 +408,17 @@ impl PyCappedFlooredYoYInflationCoupon {
     }
 }
 
-/// Python `YoYInflationLeg`: the builder turning a schedule into a sequence of
-/// [`YoYInflationCoupon`](PyYoYInflationCoupon)s (`cashflows::yoyinflationleg`).
+/// Builds a sequence of year-on-year inflation coupons from a schedule.
 ///
 /// The core builder is a consumed-self fluent chain, which does not cross the
 /// FFI boundary; this facade takes the whole configuration up front and
-/// assembles the chain inside [`coupons`](Self::coupons), as
-/// [`MakeYoYInflationCapFloor`](crate::inflation::PyMakeYoYInflationCapFloor)
-/// does. An unset optional leaves the core default in place: a
-/// `ModifiedFollowing` payment roll, no fixing days, a unit gearing and no
-/// spread.
+/// assembles the chain inside coupons(). An unset optional leaves the core
+/// default in place: a ModifiedFollowing payment roll, no fixing days, a unit
+/// gearing and no spread.
 ///
-/// `payment_day_counter` is required here although the core takes it through a
-/// setter: a leg built without one reports `"no payment daycounter given"` from
-/// [`coupons`](Self::coupons) rather than at construction, which is a build-time
-/// miss this facade need not reproduce. A notional is just as required by the
-/// core (`"no notional given"`) but stays optional, since the per-coupon
-/// `notionals` list is the other way to supply it; giving neither surfaces that
-/// error from [`coupons`](Self::coupons).
-///
-/// The `caps` and `floors` lists select which of the two coupon types the leg
-/// produces: given either, [`coupons`](Self::coupons) hands back coupons the
-/// core deliberately leaves unpriced and
-/// [`capped_floored_coupons`](Self::capped_floored_coupons) is the intended
-/// entry (#863).
-///
-/// The erased [`build`](Self::build) hands the leg back as a [`PyLeg`] of
-/// [`PyCashFlow`]s, which the module-level [`npv`] sums (#878). A standalone
-/// coupon constructor stays with #859's raw-constructor territory (deferred,
-/// visible).
+/// The caps and floors lists select which of the two coupon types the leg
+/// produces: given either, coupons() hands back coupons the core deliberately
+/// leaves unpriced and capped_floored_coupons is the intended entry.
 #[pyclass(name = "YoYInflationLeg", unsendable)]
 pub struct PyYoYInflationLeg {
     schedule: Schedule,
@@ -404,9 +441,39 @@ pub struct PyYoYInflationLeg {
 
 #[pymethods]
 impl PyYoYInflationLeg {
-    /// A leg over `schedule` paying `index` observed `observation_lag` back
-    /// under `interpolation`, paying on `payment_calendar` and accruing with
-    /// `payment_day_counter`.
+    /// Configure a leg over schedule paying index, observed observation_lag back.
+    ///
+    /// payment_day_counter is required here although the core takes it through
+    /// a setter, so a missing one is a build-time error rather than one raised
+    /// from coupons(). A notional is just as required by the core but stays
+    /// optional, since the per-coupon notionals list is the other way to supply
+    /// it; giving neither surfaces that error from coupons().
+    ///
+    /// Args:
+    ///     schedule (Schedule): The accrual schedule, one coupon per period.
+    ///     payment_calendar (Calendar): The calendar payment dates roll on.
+    ///     index (YoYInflationIndex): The index the coupons observe.
+    ///     observation_lag (Period): How far back each coupon observes it.
+    ///     interpolation (CpiInterpolationType): How the observation
+    ///         interpolates between index fixings.
+    ///     payment_day_counter (DayCounter): The day count the accruals are
+    ///         measured with.
+    ///     notional (float | None): One nominal for every coupon.
+    ///     notionals (list[float] | None): A per-coupon nominal, the
+    ///         alternative to notional.
+    ///     payment_adjustment (BusinessDayConvention | None): The payment roll;
+    ///         the core default is ModifiedFollowing.
+    ///     fixing_days (int | None): The business days the fixing date rolls
+    ///         back by; the core default is none.
+    ///     gearing (float | None): One gearing for every coupon; the core
+    ///         default is unit.
+    ///     gearings (list[float] | None): A per-coupon gearing.
+    ///     spread (float | None): One spread for every coupon; the core default
+    ///         is none.
+    ///     spreads (list[float] | None): A per-coupon spread.
+    ///     caps (list[float] | None): A per-coupon cap level; given either
+    ///         list, capped_floored_coupons is the intended entry.
+    ///     floors (list[float] | None): A per-coupon floor level.
     #[new]
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (
@@ -465,23 +532,20 @@ impl PyYoYInflationLeg {
         }
     }
 
-    /// The coupons the leg is made of, each already carrying the default
-    /// swaplet pricer, which is why no pricer facade is needed to read a
-    /// [`rate`](PyYoYInflationCoupon::rate).
+    /// Return the coupons, each carrying the default swaplet pricer.
     ///
-    /// Every call rebuilds the leg, so the coupons handed back are fresh objects
-    /// each time: bind the list once rather than calling this per read, or two
-    /// reads compare different objects.
+    /// Every call rebuilds the leg, so the coupons handed back are fresh
+    /// objects each time: bind the list once rather than calling this per read,
+    /// or two reads compare different objects. Given caps or floors the coupons
+    /// come back unpriced, and capped_floored_coupons is the intended entry.
     ///
-    /// # Errors
+    /// Returns:
+    ///     list[YoYInflationCoupon]: The freshly built coupons.
     ///
-    /// Reports a leg with no notional, a schedule holding fewer than two dates,
-    /// and more notionals, gearings or spreads than the schedule has periods.
-    ///
-    /// With a `caps` or `floors` list given the coupons come back *unpriced*,
-    /// the core withholding the default pricer, so
-    /// [`capped_floored_coupons`](Self::capped_floored_coupons) is the entry
-    /// there and the coupons handed back here answer only what needs no pricer.
+    /// Raises:
+    ///     ItofinError: If the leg has no notional, the schedule holds fewer
+    ///         than two dates, or there are more notionals, gearings or spreads
+    ///         than the schedule has periods.
     fn coupons(&self) -> PyResult<Vec<PyYoYInflationCoupon>> {
         Ok(self
             .leg()
@@ -492,23 +556,23 @@ impl PyYoYInflationLeg {
             .collect())
     }
 
-    /// The coupons wrapped in the leg's per-coupon `caps` and `floors`, each
-    /// carrying `pricer`.
+    /// Return the coupons wrapped in the leg's caps and floors, each carrying pricer.
     ///
     /// The pricer is required rather than optional: the core withholds its
     /// default swaplet pricer from a capped leg, and a swaplet pricer could not
-    /// value the optionlets anyway, so a coupon handed back without one would
-    /// report `"pricer not set"` from
-    /// [`rate`](PyCappedFlooredYoYInflationCoupon::rate). One pricer is
-    /// installed across every coupon, as the core's own `set_yoy_coupon_pricer`
-    /// does.
+    /// value the optionlets anyway. One pricer is installed across every
+    /// coupon. Rebuilt on every call, as coupons() is.
     ///
-    /// Rebuilt on every call, as [`coupons`](Self::coupons) is.
+    /// Args:
+    ///     pricer (YoYInflationOptionletCouponPricer): The pricer installed
+    ///         across every coupon.
     ///
-    /// # Errors
+    /// Returns:
+    ///     list[CappedFlooredYoYInflationCoupon]: The freshly built coupons.
     ///
-    /// As [`coupons`](Self::coupons), plus more caps or floors than the schedule
-    /// has periods, and a cap sitting below its floor.
+    /// Raises:
+    ///     ItofinError: As coupons(), plus more caps or floors than the
+    ///         schedule has periods, and a cap sitting below its floor.
     fn capped_floored_coupons(
         &self,
         pricer: &PyYoYInflationOptionletCouponPricer,
@@ -527,22 +591,20 @@ impl PyYoYInflationLeg {
             .collect())
     }
 
-    /// The leg with its coupon type erased, the form [`npv`] sums.
+    /// Return the leg with its coupon type erased, the form npv() sums.
     ///
     /// The plain path erases coupons already carrying the default swaplet
-    /// pricer. With a `caps` or `floors` list the core erases capped/floored
-    /// coupons *without* a pricer, and because every call rebuilds the leg a
-    /// pricer installed through
-    /// [`capped_floored_coupons`](Self::capped_floored_coupons) reaches that
-    /// call's coupons, not these: a capped erased leg therefore reports
-    /// `"pricer not set"` from [`amount`](PyCashFlow::amount), and the priced
-    /// capped path stays the concrete one.
+    /// pricer. With a caps or floors list the erased coupons carry NO pricer,
+    /// and because every call rebuilds the leg a pricer installed through
+    /// capped_floored_coupons() does not reach them: a capped erased leg
+    /// reports "pricer not set" from CashFlow.amount(), and the priced capped
+    /// path stays capped_floored_coupons(). Rebuilt on every call.
     ///
-    /// Rebuilt on every call, as [`coupons`](Self::coupons) is.
+    /// Returns:
+    ///     Leg: The freshly built erased leg.
     ///
-    /// # Errors
-    ///
-    /// As [`coupons`](Self::coupons).
+    /// Raises:
+    ///     ItofinError: As coupons().
     fn build(&self) -> PyResult<PyLeg> {
         Ok(PyLeg {
             inner: self.leg().build().map_err(PyQlError::from)?,
@@ -596,29 +658,18 @@ impl PyYoYInflationLeg {
     }
 }
 
-/// Python `IborLeg`: the builder turning a schedule into a sequence of
-/// floating `IborCoupon`s over an ibor index (`cashflows::iborleg`).
+/// Builds a sequence of floating ibor coupons from a schedule.
 ///
-/// The core builder is a consumed-self fluent chain, which does not cross the
-/// FFI boundary; this facade stores the configuration and assembles the chain
-/// afresh on every read, as [`YoYInflationLeg`](PyYoYInflationLeg) does. The
-/// setters keep the core's fluent shape rather than the constructor-kwargs one:
-/// each returns a new leg carrying the extra setting, so a builder bound to a
-/// name never changes under a later call. An unset optional leaves the core
-/// default in place: a `Following` payment roll and the index's own fixing days
-/// and day counter.
+/// The setters keep the core's fluent shape: each returns a NEW leg carrying
+/// the extra setting, so a leg bound to a name never changes under a later
+/// call. An unset optional leaves the core default in place: a Following
+/// payment roll and the index's own fixing days and day counter.
 ///
-/// The coupons are reachable only as the leg a
-/// [`CapFloor`](crate::capfloor::PyCapFloor) is built over, which is why no
-/// `IborCoupon` facade comes with this one: the coupons the core hands back are
-/// consumed by the raw cap/floor constructors, not read from Python. Only
-/// [`coupon_count`](Self::coupon_count) reads them here.
-///
-/// Deferred (visible): the per-coupon `notionals`, `fixing_days`, `gearings`
-/// and `spreads` lists, the payment lag and calendar, the fixing convention and
-/// the ex-coupon period, none of which the cap/floor fixtures set; the erased
-/// `build() -> Leg`, whose `CashFlow`s Python has no wrapper for; and the
-/// `caps`/`floors` setters, deliberately - see [`coupon_count`](Self::coupon_count).
+/// The coupons themselves are not exposed: they are consumed by the raw
+/// CapFloor.cap / floor / collar constructors, which is the reason this leg
+/// exists. No caps/floors setter is offered either - a capped leg withholds the
+/// default coupon pricer in the core, so the strikes belong on the cap/floor
+/// constructor.
 #[pyclass(name = "IborLeg", unsendable)]
 pub struct PyIborLeg {
     schedule: Schedule,
@@ -631,7 +682,11 @@ pub struct PyIborLeg {
 
 #[pymethods]
 impl PyIborLeg {
-    /// A leg over `schedule` paying `index`, on the schedule's own calendar.
+    /// Configure a leg over schedule paying index, on the schedule's own calendar.
+    ///
+    /// Args:
+    ///     schedule (Schedule): The accrual schedule, one coupon per period.
+    ///     index (IborIndex): The index the floating coupons fix off.
     #[new]
     fn new(schedule: &PySchedule, index: &PyIborIndex) -> Self {
         PyIborLeg {
@@ -644,8 +699,16 @@ impl PyIborLeg {
         }
     }
 
-    /// The leg with `notional` on every coupon. Required: a leg built without
-    /// one reports `"no notional given"` from [`coupon_count`](Self::coupon_count).
+    /// Return the leg with notional on every coupon.
+    ///
+    /// Required: a leg built without one reports "no notional given" from
+    /// coupon_count().
+    ///
+    /// Args:
+    ///     notional (float): The nominal every coupon accrues on.
+    ///
+    /// Returns:
+    ///     IborLeg: A new leg carrying the notional.
     fn with_notional(&self, notional: f64) -> Self {
         PyIborLeg {
             notional: Some(notional),
@@ -653,7 +716,14 @@ impl PyIborLeg {
         }
     }
 
-    /// The leg accruing with `day_counter`, overriding the index's.
+    /// Return the leg accruing with day_counter, overriding the index's.
+    ///
+    /// Args:
+    ///     day_counter (DayCounter): The day count the accruals are measured
+    ///         with.
+    ///
+    /// Returns:
+    ///     IborLeg: A new leg carrying the day counter.
     fn with_payment_day_counter(&self, day_counter: &PyDayCounter) -> Self {
         PyIborLeg {
             payment_day_counter: Some(day_counter.inner()),
@@ -661,7 +731,14 @@ impl PyIborLeg {
         }
     }
 
-    /// The leg rolling its payment dates with `convention`.
+    /// Return the leg rolling its payment dates with convention.
+    ///
+    /// Args:
+    ///     convention (BusinessDayConvention): The payment roll, overriding the
+    ///         core default of Following.
+    ///
+    /// Returns:
+    ///     IborLeg: A new leg carrying the convention.
     fn with_payment_adjustment(&self, convention: &PyBusinessDayConvention) -> Self {
         PyIborLeg {
             payment_adjustment: Some(convention.inner()),
@@ -669,8 +746,16 @@ impl PyIborLeg {
         }
     }
 
-    /// The leg fixing `fixing_days` business days before each accrual start,
-    /// overriding the index's own count.
+    /// Return the leg fixing fixing_days business days before each accrual start.
+    ///
+    /// Overrides the index's own count.
+    ///
+    /// Args:
+    ///     fixing_days (int): The business days each coupon fixes ahead of its
+    ///         accrual start.
+    ///
+    /// Returns:
+    ///     IborLeg: A new leg carrying the fixing days.
     fn with_fixing_days(&self, fixing_days: u32) -> Self {
         PyIborLeg {
             fixing_days: Some(fixing_days),
@@ -678,16 +763,18 @@ impl PyIborLeg {
         }
     }
 
-    /// The number of coupons the leg builds, one per schedule period.
+    /// Return the number of coupons the leg builds, one per schedule period.
     ///
     /// The leg is rebuilt on every call, here and in the cap/floor
     /// constructors, so this counts the coupons a construction would produce
     /// rather than a stored list.
     ///
-    /// # Errors
+    /// Returns:
+    ///     int: The coupon count.
     ///
-    /// Reports a leg with no notional, a schedule holding fewer than two dates,
-    /// and whatever a coupon's own preconditions reject.
+    /// Raises:
+    ///     ItofinError: If the leg has no notional, the schedule holds fewer
+    ///         than two dates, or a coupon's own preconditions reject.
     fn coupon_count(&self) -> PyResult<usize> {
         Ok(self.coupons()?.len())
     }
@@ -738,12 +825,10 @@ impl PyIborLeg {
     }
 }
 
-/// Python `CashFlow`: one erased flow of a [`Leg`](PyLeg)
-/// (`cashflow::CashFlow`).
+/// One erased flow of a Leg, read-only.
 ///
-/// A read-only view: it answers what it pays and when, which is all the
-/// leg-summing [`npv`] needs. The concrete coupon accessors (rate, accrual,
-/// fixing) stay on the typed coupon wrappers the leg builders hand back.
+/// It answers what it pays and when, which is all the leg-summing npv() needs;
+/// the concrete coupon accessors stay on the typed coupon wrappers.
 #[pyclass(name = "CashFlow", unsendable)]
 pub struct PyCashFlow {
     inner: Shared<dyn CashFlow>,
@@ -751,28 +836,32 @@ pub struct PyCashFlow {
 
 #[pymethods]
 impl PyCashFlow {
-    /// What the flow pays on its [`date`](Self::date), undiscounted.
+    /// Return what the flow pays on its date, undiscounted.
     ///
-    /// # Errors
+    /// Returns:
+    ///     float: The undiscounted payment amount.
     ///
-    /// Reports a coupon with no pricer attached, and whatever resolving its
-    /// fixing reports - a missing history entry, or a forecast off an index
-    /// with no curve linked.
+    /// Raises:
+    ///     ItofinError: On a coupon with no pricer attached, and on whatever
+    ///         resolving its fixing reports - a missing history entry, or a
+    ///         forecast off an index with no curve linked.
     fn amount(&self) -> PyResult<f64> {
         Ok(self.inner.amount().map_err(PyQlError::from)?)
     }
 
-    /// The date the flow pays on.
+    /// Return the date the flow pays on.
+    ///
+    /// Returns:
+    ///     Date: The payment date.
     fn date(&self) -> PyDate {
         PyDate::from_inner(self.inner.date())
     }
 }
 
-/// Python `Leg`: a sequence of erased cash flows
-/// (`cashflow::Leg`, a `Vec<Shared<dyn CashFlow>>`).
+/// A sequence of erased cash flows, built by a leg builder's build().
 ///
-/// Built by a leg builder's `build()`; indexable and sized, which with
-/// [`PyCashFlow`]'s two accessors is enough to hand-check what [`npv`] sums.
+/// Indexable and sized, which with CashFlow's two accessors is enough to
+/// hand-check what npv() sums.
 #[pyclass(name = "Leg", unsendable)]
 pub struct PyLeg {
     inner: Leg,
@@ -780,12 +869,24 @@ pub struct PyLeg {
 
 #[pymethods]
 impl PyLeg {
-    /// The number of flows on the leg.
+    /// Return the number of flows on the leg.
+    ///
+    /// Returns:
+    ///     int: The flow count.
     fn __len__(&self) -> usize {
         self.inner.len()
     }
 
-    /// The flow at `index`, counting from the end when negative.
+    /// Return the flow at index, counting from the end when negative.
+    ///
+    /// Args:
+    ///     index (int): The position, negative to count from the end.
+    ///
+    /// Returns:
+    ///     CashFlow: The flow at that position.
+    ///
+    /// Raises:
+    ///     IndexError: If index is out of range.
     fn __getitem__(&self, index: isize) -> PyResult<PyCashFlow> {
         let len = self.inner.len() as isize;
         let resolved = if index < 0 { index + len } else { index };
@@ -800,14 +901,27 @@ impl PyLeg {
     }
 }
 
-/// The NPV of `leg`: every surviving flow discounted on `discount_curve`
-/// (`cashflows::CashFlows::npv`).
+/// Return the NPV of leg: every surviving flow discounted on discount_curve.
 ///
-/// `settlement_date` decides which flows have occurred and defaults to the
-/// evaluation date, which must then be set on `settings`; `npv_date`, the date
-/// the sum is discounted to, defaults to `settlement_date`.
-/// `include_settlement_date_flows` defaults to the settings'
-/// `include_todays_cash_flows` policy. An empty leg is worth exactly zero.
+/// Args:
+///     leg (Leg): The erased flows to sum.
+///     discount_curve (YieldTermStructure): The curve the flows discount on.
+///     settings (Settings): The evaluation context deciding which flows have
+///         occurred.
+///     include_settlement_date_flows (bool | None): Whether a flow paying
+///         exactly on the settlement date counts; None defers to the settings'
+///         include_todays_cash_flows policy.
+///     settlement_date (Date | None): The date deciding which flows have
+///         occurred; None uses the evaluation date, which must then be set.
+///     npv_date (Date | None): The date the sum is discounted to; None uses
+///         settlement_date.
+///
+/// Returns:
+///     float: The discounted sum; exactly 0.0 for an empty leg.
+///
+/// Raises:
+///     ItofinError: On a flow or curve lookup failure, and without a
+///         settlement_date when the evaluation date is unset.
 #[pyfunction]
 #[pyo3(signature = (leg, discount_curve, settings, include_settlement_date_flows = None, settlement_date = None, npv_date = None))]
 pub(crate) fn npv(

--- a/crates/itofin-py/src/cashflows.rs
+++ b/crates/itofin-py/src/cashflows.rs
@@ -1,14 +1,11 @@
-//! Facades for the cash-flow slice: the [`PyYoYInflationCoupon`] a year-on-year
-//! inflation leg pays, the [`PyYoYInflationLeg`] builder producing it
-//! (`cashflows::yoyinflationcoupon`, `cashflows::yoyinflationleg`), the
-//! floating [`PyIborLeg`] (`cashflows::iborleg`), and the erased
-//! [`PyCashFlow`]/[`PyLeg`] pair with the leg-summing [`npv`] (#878).
+//! Facades for the cash-flow slice: the YoYInflationCoupon a year-on-year
+//! inflation leg pays, the YoYInflationLeg builder producing it, the floating
+//! IborLeg, and the erased CashFlow/Leg pair with the leg-summing npv() (#878).
 //!
 //! This is the first coupon facade in the crate (#848). Until now the coupons
 //! were reachable only *through* the instruments built over them - a
-//! [`YearOnYearInflationSwap`](crate::inflation::PyYearOnYearInflationSwap) or a
-//! [`YoYInflationCapFloor`](crate::inflation::PyYoYInflationCapFloor) - which
-//! covers the pricing path but not a caller who wants the leg itself.
+//! YearOnYearInflationSwap or a YoYInflationCapFloor - which covers the pricing
+//! path but not a caller who wants the leg itself.
 
 use crate::PyQlError;
 use crate::curve::PyYieldTermStructure;
@@ -205,8 +202,7 @@ impl PyYoYInflationCoupon {
         PyYoYInflationCoupon { inner }
     }
 
-    /// The wrapped coupon, which is what the raw
-    /// [`YoYInflationCapFloor`](crate::inflation::PyYoYInflationCapFloor)
+    /// The wrapped coupon, which is what the raw YoYInflationCapFloor
     /// constructors take a vector of.
     pub(crate) fn shared(&self) -> Shared<YoYInflationCoupon> {
         Shared::clone(&self.inner)
@@ -782,7 +778,7 @@ impl PyIborLeg {
 
 impl PyIborLeg {
     /// A copy of the stored configuration, which each setter overrides one
-    /// field of. Not a [`Clone`] implementation: deriving one on a `pyclass`
+    /// field of. Not a Clone implementation: deriving one on a `pyclass`
     /// changes how the type is extracted from Python.
     fn copied(&self) -> Self {
         PyIborLeg {
@@ -813,13 +809,13 @@ impl PyIborLeg {
         leg
     }
 
-    /// The coupons a [`CapFloor`](crate::capfloor::PyCapFloor) is built over,
-    /// each already carrying the core's default `BlackIborCouponPricer`.
+    /// The coupons a CapFloor is built over, each already carrying the core's
+    /// default `BlackIborCouponPricer`.
     ///
     /// This is the plain path deliberately. Setting a cap or a floor on the leg
     /// would switch the core to `capped_floored_coupons`, which withholds that
-    /// pricer (`iborleg.rs:340-348`), so the strikes belong on the cap/floor
-    /// constructors and no `caps`/`floors` setter is exposed here.
+    /// pricer, so the strikes belong on the cap/floor constructors and no
+    /// `caps`/`floors` setter is exposed here.
     pub(crate) fn coupons(&self) -> PyResult<Vec<Shared<IborCoupon>>> {
         Ok(self.leg().coupons().map_err(PyQlError::from)?)
     }

--- a/crates/itofin-py/src/credit.rs
+++ b/crates/itofin-py/src/credit.rs
@@ -434,6 +434,9 @@ impl PyFlatHazardRate {
 /// function and the survival probability is exp(-integral) over those steps.
 /// Finite in time: queries past the last node need extrapolate=True, which
 /// continues at the last node's rate.
+///
+/// No interpolation argument is offered, and the curve carries no calendar: the
+/// calendar-taking constructor is not exposed.
 #[pyclass(name = "InterpolatedHazardRateCurve", extends = PyDefaultProbabilityTermStructure, unsendable)]
 pub struct PyInterpolatedHazardRateCurve {
     concrete: Shared<InterpolatedHazardRateCurve<BackwardFlat>>,
@@ -641,6 +644,9 @@ impl PyPiecewiseDefaultCurve {
 /// cash_settlement_days. trade_date and an upfront are not set here but are
 /// reachable through MakeCreditDefaultSwap (with_trade_date and the upfront_rate
 /// constructor argument).
+///
+/// Pricing needs an engine: call set_engine() or set_isda_engine() before
+/// npv().
 #[pyclass(name = "CreditDefaultSwap", unsendable)]
 pub struct PyCreditDefaultSwap {
     inner: SharedMut<CreditDefaultSwap>,
@@ -1054,6 +1060,9 @@ impl PyCreditDefaultSwap {
 /// the term-date quotation is exposed; the tenor and explicit-schedule ones and
 /// the accrual-rebate flag are not, the latter being reachable through
 /// CreditDefaultSwap.with_terms.
+///
+/// Each build() runs a fresh chain, so one builder object cannot carry a
+/// setting into a later contract.
 #[pyclass(name = "MakeCreditDefaultSwap", unsendable)]
 pub struct PyMakeCreditDefaultSwap {
     term_date: Date,

--- a/crates/itofin-py/src/credit.rs
+++ b/crates/itofin-py/src/credit.rs
@@ -32,12 +32,8 @@ use libitofin::time::date::Date;
 use libitofin::types::Natural;
 use pyo3::prelude::*;
 
-/// Python `ProtectionSide`: which leg of a default-protection contract a party
-/// holds (core `instruments::ProtectionSide`).
-///
-/// A fieldless pyo3 enum exposing `ProtectionSide.Buyer` /
-/// `ProtectionSide.Seller`; the buyer pays the premium leg and receives the
-/// default payment, the seller the reverse.
+/// Which leg of a default-protection contract a party holds: the buyer pays
+/// the premium leg and receives the default payment, the seller the reverse.
 #[pyclass(name = "ProtectionSide", eq, eq_int, from_py_object)]
 #[derive(Clone, Copy, PartialEq)]
 pub enum PyProtectionSide {
@@ -55,14 +51,9 @@ impl PyProtectionSide {
     }
 }
 
-/// Python `PricingModel`: the model a quoted contract is inverted under
-/// (core `instruments::PricingModel`).
-///
-/// A fieldless pyo3 enum exposing `PricingModel.Midpoint` / `PricingModel.Isda`,
-/// the two choices
-/// [`CreditDefaultSwap.implied_hazard_rate`](PyCreditDefaultSwap::implied_hazard_rate)
-/// solves on. `Midpoint` is not ISDA conform; `Isda` carries the three fidelity
-/// flags the core fixes at that call site.
+/// The model a quoted contract is inverted under by
+/// CreditDefaultSwap.implied_hazard_rate: Midpoint is not ISDA conform, Isda
+/// carries the three fidelity flags the core fixes at that call site.
 #[pyclass(name = "PricingModel", eq, eq_int, from_py_object)]
 #[derive(Clone, Copy, PartialEq)]
 pub enum PyPricingModel {
@@ -80,14 +71,9 @@ impl PyPricingModel {
     }
 }
 
-/// Python `DefaultProbabilityTermStructure`: the shared base for every credit
-/// curve (`termstructures::credit::defaulttermstructure`).
-///
-/// Holds the erased `Handle<dyn DefaultProbabilityTermStructure>` and exposes
-/// the query surface every concrete curve inherits: survival and default
-/// probabilities, the default density, and the hazard rate, each in a
-/// year-fraction and a date form. Concrete curves such as [`PyFlatHazardRate`]
-/// subclass this and supply only their constructor.
+/// Shared base for every credit curve: survival and default probabilities,
+/// the default density and the hazard rate, each in a year-fraction and a date
+/// form.
 #[pyclass(name = "DefaultProbabilityTermStructure", subclass, unsendable)]
 pub struct PyDefaultProbabilityTermStructure {
     inner: Handle<dyn DefaultProbabilityTermStructure>,
@@ -95,7 +81,18 @@ pub struct PyDefaultProbabilityTermStructure {
 
 #[pymethods]
 impl PyDefaultProbabilityTermStructure {
-    /// The survival probability from the reference date to year-fraction `t`.
+    /// Return the survival probability from the reference date to year-fraction t.
+    ///
+    /// Args:
+    ///     t (float): The year fraction, in the curve's own day count.
+    ///     extrapolate (bool): Whether to answer past the curve's max date.
+    ///
+    /// Returns:
+    ///     float: The probability of surviving to t.
+    ///
+    /// Raises:
+    ///     ItofinError: If t is past the curve's range and extrapolation is
+    ///         not allowed.
     #[pyo3(signature = (t, extrapolate = false))]
     fn survival_probability(&self, t: f64, extrapolate: bool) -> PyResult<f64> {
         Ok(self
@@ -106,7 +103,18 @@ impl PyDefaultProbabilityTermStructure {
             .map_err(PyQlError::from)?)
     }
 
-    /// The survival probability from the reference date to `date`.
+    /// Return the survival probability from the reference date to date.
+    ///
+    /// Args:
+    ///     date (Date): The date survived to.
+    ///     extrapolate (bool): Whether to answer past the curve's max date.
+    ///
+    /// Returns:
+    ///     float: The survival probability.
+    ///
+    /// Raises:
+    ///     ItofinError: If date is past the curve's range and extrapolation is
+    ///         not allowed.
     #[pyo3(signature = (date, extrapolate = false))]
     fn survival_probability_date(&self, date: &PyDate, extrapolate: bool) -> PyResult<f64> {
         Ok(self
@@ -117,7 +125,18 @@ impl PyDefaultProbabilityTermStructure {
             .map_err(PyQlError::from)?)
     }
 
-    /// The default probability from the reference date to year-fraction `t`.
+    /// Return the default probability from the reference date to year-fraction t.
+    ///
+    /// Args:
+    ///     t (float): The year fraction, in the curve's own day count.
+    ///     extrapolate (bool): Whether to answer past the curve's max date.
+    ///
+    /// Returns:
+    ///     float: The probability of defaulting by t.
+    ///
+    /// Raises:
+    ///     ItofinError: If t is past the curve's range and extrapolation is
+    ///         not allowed.
     #[pyo3(signature = (t, extrapolate = false))]
     fn default_probability(&self, t: f64, extrapolate: bool) -> PyResult<f64> {
         Ok(self
@@ -128,7 +147,18 @@ impl PyDefaultProbabilityTermStructure {
             .map_err(PyQlError::from)?)
     }
 
-    /// The default probability from the reference date to `date`.
+    /// Return the default probability from the reference date to date.
+    ///
+    /// Args:
+    ///     date (Date): The date defaulted by.
+    ///     extrapolate (bool): Whether to answer past the curve's max date.
+    ///
+    /// Returns:
+    ///     float: The default probability.
+    ///
+    /// Raises:
+    ///     ItofinError: If date is past the curve's range and extrapolation is
+    ///         not allowed.
     #[pyo3(signature = (date, extrapolate = false))]
     fn default_probability_date(&self, date: &PyDate, extrapolate: bool) -> PyResult<f64> {
         Ok(self
@@ -139,7 +169,18 @@ impl PyDefaultProbabilityTermStructure {
             .map_err(PyQlError::from)?)
     }
 
-    /// The default density at year-fraction `t`.
+    /// Return the default density at year-fraction t.
+    ///
+    /// Args:
+    ///     t (float): The year fraction, in the curve's own day count.
+    ///     extrapolate (bool): Whether to answer past the curve's max date.
+    ///
+    /// Returns:
+    ///     float: The default density.
+    ///
+    /// Raises:
+    ///     ItofinError: If t is past the curve's range and extrapolation is
+    ///         not allowed.
     #[pyo3(signature = (t, extrapolate = false))]
     fn default_density(&self, t: f64, extrapolate: bool) -> PyResult<f64> {
         Ok(self
@@ -150,7 +191,18 @@ impl PyDefaultProbabilityTermStructure {
             .map_err(PyQlError::from)?)
     }
 
-    /// The default density at `date`.
+    /// Return the default density at date.
+    ///
+    /// Args:
+    ///     date (Date): The date the density is read at.
+    ///     extrapolate (bool): Whether to answer past the curve's max date.
+    ///
+    /// Returns:
+    ///     float: The default density.
+    ///
+    /// Raises:
+    ///     ItofinError: If date is past the curve's range and extrapolation is
+    ///         not allowed.
     #[pyo3(signature = (date, extrapolate = false))]
     fn default_density_date(&self, date: &PyDate, extrapolate: bool) -> PyResult<f64> {
         Ok(self
@@ -161,8 +213,19 @@ impl PyDefaultProbabilityTermStructure {
             .map_err(PyQlError::from)?)
     }
 
-    /// The hazard rate at year-fraction `t`, annual frequency and continuous
-    /// compounding.
+    /// Return the hazard rate at year-fraction t.
+    ///
+    /// Args:
+    ///     t (float): The year fraction, in the curve's own day count.
+    ///     extrapolate (bool): Whether to answer past the curve's max date.
+    ///
+    /// Returns:
+    ///     float: The hazard rate, at annual frequency and continuous
+    ///         compounding.
+    ///
+    /// Raises:
+    ///     ItofinError: If t is past the curve's range and extrapolation is
+    ///         not allowed.
     #[pyo3(signature = (t, extrapolate = false))]
     fn hazard_rate(&self, t: f64, extrapolate: bool) -> PyResult<f64> {
         Ok(self
@@ -173,7 +236,19 @@ impl PyDefaultProbabilityTermStructure {
             .map_err(PyQlError::from)?)
     }
 
-    /// The hazard rate at `date`, annual frequency and continuous compounding.
+    /// Return the hazard rate at date.
+    ///
+    /// Args:
+    ///     date (Date): The date the rate is read at.
+    ///     extrapolate (bool): Whether to answer past the curve's max date.
+    ///
+    /// Returns:
+    ///     float: The hazard rate, at annual frequency and continuous
+    ///         compounding.
+    ///
+    /// Raises:
+    ///     ItofinError: If date is past the curve's range and extrapolation is
+    ///         not allowed.
     #[pyo3(signature = (date, extrapolate = false))]
     fn hazard_rate_date(&self, date: &PyDate, extrapolate: bool) -> PyResult<f64> {
         Ok(self
@@ -198,26 +273,25 @@ impl PyDefaultProbabilityTermStructure {
     }
 }
 
-/// Python `FlatHazardRate`: a credit curve quoting one hazard rate for every
-/// maturity, with the closed-form survival probability `exp(-h t)`
-/// (`termstructures::credit::flathazardrate::FlatHazardRate`).
+/// A credit curve quoting one hazard rate for every maturity, whose survival
+/// probability is the closed form exp(-h t).
 ///
-/// Extends [`PyDefaultProbabilityTermStructure`], which carries the whole query
-/// surface. All four core constructors are infallible, so `__init__` hands back
-/// the initializer directly and the three alternates are staticmethods
-/// returning the built object, the shape [`PyFraRateHelper`](crate::helpers)
-/// already uses. The quote-backed forms retain the caller's [`PySimpleQuote`],
-/// so a later `set_value` moves the curve; the rate-backed forms wrap the value
-/// in a fresh, un-retained quote. The `moving` forms take an explicit
-/// [`PySettings`] (D5) and fix the reference date `settlement_days` business
-/// days past the evaluation date, so a query before one is set returns
-/// [`struct@crate::ItofinError`] rather than falling back to a system clock.
+/// The quote-backed forms retain the caller's SimpleQuote, so a later set_value
+/// moves the curve; the rate-backed forms wrap the value in a fresh, un-retained
+/// quote. The moving forms fix the reference date settlement_days business days
+/// past the evaluation date carried by settings.
 #[pyclass(name = "FlatHazardRate", extends = PyDefaultProbabilityTermStructure, unsendable)]
 pub struct PyFlatHazardRate;
 
 #[pymethods]
 impl PyFlatHazardRate {
-    /// A curve reading `hazard_rate` live, with a fixed `reference_date`.
+    /// Build a curve reading its hazard rate live, on a pinned reference date.
+    ///
+    /// Args:
+    ///     reference_date (Date): The date times are measured from.
+    ///     hazard_rate (SimpleQuote): The hazard rate; the caller keeps it, so
+    ///         a later set_value moves the curve.
+    ///     day_counter (DayCounter): The day count turning dates into times.
     #[new]
     fn new(
         reference_date: &PyDate,
@@ -235,7 +309,16 @@ impl PyFlatHazardRate {
         .add_subclass(PyFlatHazardRate)
     }
 
-    /// A curve at a fixed `rate`, with a fixed `reference_date`.
+    /// Build a curve at a fixed rate, on a pinned reference date.
+    ///
+    /// Args:
+    ///     reference_date (Date): The date times are measured from.
+    ///     rate (float): The hazard rate, wrapped in a fresh, un-retained
+    ///         quote.
+    ///     day_counter (DayCounter): The day count turning dates into times.
+    ///
+    /// Returns:
+    ///     FlatHazardRate: The curve at that rate.
     #[staticmethod]
     fn with_rate(
         py: Python<'_>,
@@ -257,8 +340,24 @@ impl PyFlatHazardRate {
         )
     }
 
-    /// A curve reading `hazard_rate` live, whose reference date moves off the
-    /// evaluation date held by `settings`.
+    /// Build a curve reading its hazard rate live, on a floating reference date.
+    ///
+    /// The reference date sits settlement_days business days past the
+    /// evaluation date, so a query made before settings carries one raises
+    /// rather than falling back to a system clock.
+    ///
+    /// Args:
+    ///     settlement_days (int): The business days the reference date sits
+    ///         past the evaluation date.
+    ///     calendar (Calendar): The calendar those days are counted on.
+    ///     hazard_rate (SimpleQuote): The hazard rate; the caller keeps it, so
+    ///         a later set_value moves the curve.
+    ///     day_counter (DayCounter): The day count turning dates into times.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date.
+    ///
+    /// Returns:
+    ///     FlatHazardRate: The moving curve.
     #[staticmethod]
     fn moving(
         py: Python<'_>,
@@ -284,8 +383,23 @@ impl PyFlatHazardRate {
         )
     }
 
-    /// A curve at a fixed `rate`, whose reference date moves off the evaluation
-    /// date held by `settings`.
+    /// Build a curve at a fixed rate, on a floating reference date.
+    ///
+    /// As moving(), a query made before settings carries an evaluation date
+    /// raises rather than falling back to a system clock.
+    ///
+    /// Args:
+    ///     settlement_days (int): The business days the reference date sits
+    ///         past the evaluation date.
+    ///     calendar (Calendar): The calendar those days are counted on.
+    ///     rate (float): The hazard rate, wrapped in a fresh, un-retained
+    ///         quote.
+    ///     day_counter (DayCounter): The day count turning dates into times.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date.
+    ///
+    /// Returns:
+    ///     FlatHazardRate: The moving curve at that rate.
     #[staticmethod]
     fn moving_with_rate(
         py: Python<'_>,
@@ -312,37 +426,14 @@ impl PyFlatHazardRate {
     }
 }
 
-/// Python `InterpolatedHazardRateCurve`: a credit curve built from
-/// (date, hazard-rate) nodes, interpolating backward-flat
-/// (`termstructures::credit::InterpolatedHazardRateCurve<BackwardFlat>`).
+/// A credit curve built from (date, hazard-rate) nodes, interpolating
+/// backward-flat.
 ///
-/// Extends [`PyDefaultProbabilityTermStructure`], which carries the whole query
-/// surface. The first date is the reference date, and the day counter turns the
-/// rest into node times. Backward-flat reads the right-hand node on every
-/// segment, so the hazard rate is a right-continuous step function and the
-/// survival probability is `exp(-integral)` over those steps. Finite in time:
-/// queries past the last node need `extrapolate=True`, which continues at the
-/// last node's rate.
-///
-/// The concrete curve is retained alongside the erased handle so the node
-/// inspectors [`dates`](Self::dates), [`hazard_rates`](Self::hazard_rates) and
-/// [`nodes`](Self::nodes) stay reachable, the shape
-/// [`PyPiecewiseLogLinearDiscount`](crate::curve) uses.
-///
-/// Fallible, like [`PySpreadCdsHelper`](crate::credithelpers) and unlike the
-/// [`PyFlatHazardRate`] chain: the core rejects too few dates, a dates/rates
-/// count mismatch, a negative hazard rate and unsorted dates
-/// (`interpolatedhazardratecurve.rs:75-88`), each as
-/// [`struct@crate::ItofinError`].
-///
-/// `BackwardFlat` is pinned at the boundary: it is the only interpolator the
-/// credit side wires (`interpolatedhazardratecurve.rs:148-152`), so no
-/// interpolation argument is offered.
-///
-/// Deferred (visible): the calendar-carrying `with_calendar` constructor
-/// (`interpolatedhazardratecurve.rs:68`) is not exposed, so the curve has no
-/// calendar; and `times()` / `data()` are omitted, the former derivable from
-/// the day counter and the latter identical to [`hazard_rates`](Self::hazard_rates).
+/// The first date is the reference date. Backward-flat reads the right-hand
+/// node on every segment, so the hazard rate is a right-continuous step
+/// function and the survival probability is exp(-integral) over those steps.
+/// Finite in time: queries past the last node need extrapolate=True, which
+/// continues at the last node's rate.
 #[pyclass(name = "InterpolatedHazardRateCurve", extends = PyDefaultProbabilityTermStructure, unsendable)]
 pub struct PyInterpolatedHazardRateCurve {
     concrete: Shared<InterpolatedHazardRateCurve<BackwardFlat>>,
@@ -350,8 +441,20 @@ pub struct PyInterpolatedHazardRateCurve {
 
 #[pymethods]
 impl PyInterpolatedHazardRateCurve {
-    /// A curve over the `(dates, hazard_rates)` nodes, with `dates[0]` as the
-    /// reference date.
+    /// Build the curve over its (date, hazard-rate) nodes.
+    ///
+    /// Backward-flat is pinned at the boundary: it is the only interpolator
+    /// the credit side wires, so no interpolation argument is offered.
+    ///
+    /// Args:
+    ///     dates (list[Date]): The node dates, the first being the reference
+    ///         date.
+    ///     hazard_rates (list[float]): The hazard rate at each node.
+    ///     day_counter (DayCounter): The day count turning dates into times.
+    ///
+    /// Raises:
+    ///     ItofinError: On too few dates, a dates and hazard_rates count
+    ///         mismatch, a negative hazard rate, or unsorted dates.
     #[new]
     fn new(
         dates: Vec<PyRef<PyDate>>,
@@ -377,7 +480,10 @@ impl PyInterpolatedHazardRateCurve {
         )
     }
 
-    /// The node dates, the first of which is the reference date.
+    /// Return the node dates.
+    ///
+    /// Returns:
+    ///     list[Date]: The nodes, the first of which is the reference date.
     fn dates(&self) -> Vec<PyDate> {
         self.concrete
             .dates()
@@ -387,12 +493,18 @@ impl PyInterpolatedHazardRateCurve {
             .collect()
     }
 
-    /// The node hazard rates.
+    /// Return the node hazard rates.
+    ///
+    /// Returns:
+    ///     list[float]: The rate at each node.
     fn hazard_rates(&self) -> Vec<f64> {
         self.concrete.hazard_rates().to_vec()
     }
 
-    /// The `(date, hazard rate)` nodes.
+    /// Return the curve's nodes as pairs.
+    ///
+    /// Returns:
+    ///     list[tuple[Date, float]]: One (date, hazard rate) pair per node.
     fn nodes(&self) -> Vec<(PyDate, f64)> {
         self.concrete
             .nodes()
@@ -402,37 +514,12 @@ impl PyInterpolatedHazardRateCurve {
     }
 }
 
-/// Python `PiecewiseDefaultCurve`: a credit curve bootstrapped from CDS helpers,
-/// solving one hazard-rate node per helper maturity
-/// (`termstructures::credit::PiecewiseDefaultCurve<HazardRate, BackwardFlat>`).
+/// A credit curve bootstrapped from CDS helpers, solving one hazard-rate
+/// node per helper maturity (PiecewiseDefaultCurve<HazardRate, BackwardFlat>).
 ///
-/// Extends [`PyDefaultProbabilityTermStructure`], which carries the whole query
-/// surface. Each helper's maturity marks a segment boundary, and its node is
-/// solved so the helper reprices its own quote off the curve; the resulting
-/// curve is the market-implied credit term structure the helpers quote.
-///
-/// Lazy, like the yield-side [`PyPiecewiseLogLinearDiscount`](crate::curve): the
-/// constructor only registers on the helpers, and the bootstrap runs on the
-/// first read - a query, an inspector, or an explicit
-/// [`calculate`](Self::calculate). A helper quote moving invalidates the cache,
-/// so the next read re-bootstraps. Both the helpers' `Settings` flags (notably
-/// `include_todays_cash_flows`) and the evaluation date must therefore be in
-/// place before the first read, not merely before the constructor.
-///
-/// The concrete curve is retained alongside the erased handle so the node
-/// inspectors stay reachable, as
-/// [`PyInterpolatedHazardRateCurve`] and [`PyPiecewiseLogLinearDiscount`](crate::curve)
-/// both do. All five are exposed here, where the interpolated curve omits
-/// `times()` and `data()`: on a bootstrapped curve the solved node values are
-/// the result rather than a constructor input, so there is nothing for a caller
-/// to read them back from.
-///
-/// Fallible: the core rejects an empty helper set, and every inspector
-/// propagates a bootstrap failure as [`struct@crate::ItofinError`].
-///
-/// `HazardRate` and `BackwardFlat` are pinned at the boundary: they are the only
-/// traits/interpolator pair the core wires
-/// (`piecewisedefaultcurve.rs:36-45`), so neither is offered as an argument.
+/// Lazy: the bootstrap runs on the first read, so the helpers' Settings flags
+/// and evaluation date must be in place before that read, not merely before
+/// the constructor. A helper quote moving invalidates the cache.
 #[pyclass(name = "PiecewiseDefaultCurve", extends = PyDefaultProbabilityTermStructure, unsendable)]
 pub struct PyPiecewiseDefaultCurve {
     concrete: Shared<PiecewiseDefaultCurve<HazardRate, BackwardFlat>>,
@@ -440,8 +527,16 @@ pub struct PyPiecewiseDefaultCurve {
 
 #[pymethods]
 impl PyPiecewiseDefaultCurve {
-    /// A curve over `helpers` with a fixed `reference_date`. `helpers` accepts
-    /// any [`DefaultProbabilityHelper`](PyDefaultProbabilityHelper) subclass.
+    /// Build the curve over helpers with a fixed reference date.
+    ///
+    /// Args:
+    ///     reference_date (Date): The curve's reference date.
+    ///     helpers (list[DefaultProbabilityHelper]): The bootstrap
+    ///         instruments; any subclass is accepted.
+    ///     day_counter (DayCounter): The day count turning dates into times.
+    ///
+    /// Raises:
+    ///     ItofinError: On an empty helper list.
     #[new]
     fn new(
         reference_date: &PyDate,
@@ -466,19 +561,35 @@ impl PyPiecewiseDefaultCurve {
         )
     }
 
-    /// Runs the bootstrap if the cache is stale, so a solver failure surfaces
-    /// here rather than inside a later query.
+    /// Run the bootstrap if the cache is stale.
+    ///
+    /// Calling it explicitly makes a solver failure surface here rather than
+    /// inside a later query.
+    ///
+    /// Raises:
+    ///     ItofinError: On a bootstrap failure.
     fn calculate(&self) -> PyResult<()> {
         Ok(self.concrete.calculate().map_err(PyQlError::from)?)
     }
 
-    /// The node times, in the curve's own day count (triggers the bootstrap).
+    /// Return the node times, triggering the bootstrap.
+    ///
+    /// Returns:
+    ///     list[float]: The nodes in the curve's own day count.
+    ///
+    /// Raises:
+    ///     ItofinError: On a bootstrap failure.
     fn times(&self) -> PyResult<Vec<f64>> {
         Ok(self.concrete.times().map_err(PyQlError::from)?)
     }
 
-    /// The node dates, the first of which is the reference date (triggers the
-    /// bootstrap).
+    /// Return the node dates, triggering the bootstrap.
+    ///
+    /// Returns:
+    ///     list[Date]: The nodes, the first of which is the reference date.
+    ///
+    /// Raises:
+    ///     ItofinError: On a bootstrap failure.
     fn dates(&self) -> PyResult<Vec<PyDate>> {
         Ok(self
             .concrete
@@ -489,12 +600,24 @@ impl PyPiecewiseDefaultCurve {
             .collect())
     }
 
-    /// The solved node hazard rates (triggers the bootstrap).
+    /// Return the solved node hazard rates, triggering the bootstrap.
+    ///
+    /// Returns:
+    ///     list[float]: The rate solved at each node.
+    ///
+    /// Raises:
+    ///     ItofinError: On a bootstrap failure.
     fn data(&self) -> PyResult<Vec<f64>> {
         Ok(self.concrete.data().map_err(PyQlError::from)?)
     }
 
-    /// The solved `(date, hazard rate)` nodes (triggers the bootstrap).
+    /// Return the solved nodes as pairs, triggering the bootstrap.
+    ///
+    /// Returns:
+    ///     list[tuple[Date, float]]: One (date, hazard rate) pair per node.
+    ///
+    /// Raises:
+    ///     ItofinError: On a bootstrap failure.
     fn nodes(&self) -> PyResult<Vec<(PyDate, f64)>> {
         Ok(self
             .concrete
@@ -506,31 +629,18 @@ impl PyPiecewiseDefaultCurve {
     }
 }
 
-/// Python `CreditDefaultSwap`: a credit-default swap quoted as a running spread
-/// (`instruments::creditdefaultswap::CreditDefaultSwap`).
+/// A credit-default swap quoted as a running spread.
 ///
-/// One side pays the premium leg and receives the protection payment, the other
-/// the reverse; [`ProtectionSide`] says which way round. The instrument is held
-/// behind a `SharedMut` because every priced accessor takes `&mut self`
-/// (`creditdefaultswap.rs:516-576`).
+/// __init__ takes the C++ default terms with settles_accrual and
+/// pays_at_default_time quoted; with_terms additionally exposes
+/// protection_start and rebates_accrual.
 ///
-/// `__init__` takes the C++ default terms with `settles_accrual` and
-/// `pays_at_default_time` quoted; [`with_terms`](Self::with_terms) additionally
-/// exposes `protection_start` and `rebates_accrual`. Both are fallible: the
-/// schedule must be non-empty, the protection start must not follow the first
-/// accrual date under a pre-Big-Bang date-generation rule, and the premium leg
-/// carries its own preconditions.
-///
-/// Pricing needs an engine: call [`set_engine`](Self::set_engine) before
-/// [`npv`](Self::npv).
-///
-/// Deferred (visible): five of the nine `CdsTerms` fields are not exposed and
-/// keep their core defaults - `claim` (a `FaceValueClaim`, which needs a claim
-/// facade that does not exist yet), `last_period_day_counter` (the spread's own
-/// day counter), `trade_date` (deduced from the protection start),
-/// `upfront_date` (deduced from the trade date) and `cash_settlement_days` (3).
-/// The core's upfront-quoted constructors are likewise not exposed here, so
-/// `upfront` is always absent.
+/// These direct constructors keep the remaining CdsTerms fields at their core
+/// defaults: claim (a face-value claim, which needs a claim facade that does
+/// not exist yet), last_period_day_counter, upfront_date and
+/// cash_settlement_days. trade_date and an upfront are not set here but are
+/// reachable through MakeCreditDefaultSwap (with_trade_date and the upfront_rate
+/// constructor argument).
 #[pyclass(name = "CreditDefaultSwap", unsendable)]
 pub struct PyCreditDefaultSwap {
     inner: SharedMut<CreditDefaultSwap>,
@@ -538,8 +648,28 @@ pub struct PyCreditDefaultSwap {
 
 #[pymethods]
 impl PyCreditDefaultSwap {
-    /// A contract on the C++ default terms, accruing and paying as
-    /// `settles_accrual` and `pays_at_default_time` say.
+    /// Build a contract on the C++ default terms.
+    ///
+    /// Args:
+    ///     side (ProtectionSide): Whether protection is bought or sold.
+    ///     notional (float): The notional the premium and protection are
+    ///         quoted on.
+    ///     spread (float): The running spread the premium leg pays.
+    ///     schedule (Schedule): The premium leg's payment schedule.
+    ///     payment_convention (BusinessDayConvention): The roll applied to the
+    ///         premium payment dates.
+    ///     day_counter (DayCounter): The day count the premium accrues on.
+    ///     settles_accrual (bool): Whether the accrued coupon settles on
+    ///         default.
+    ///     pays_at_default_time (bool): Whether the protection pays at default
+    ///         rather than at maturity.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date the contract prices against.
+    ///
+    /// Raises:
+    ///     ItofinError: If the schedule is empty, if the protection start
+    ///         follows the first accrual date under a pre-Big-Bang
+    ///         date-generation rule, or if the premium leg cannot be built.
     #[new]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -571,16 +701,38 @@ impl PyCreditDefaultSwap {
         })
     }
 
-    /// A contract quoting the terms `__init__` defaults.
+    /// Build a contract quoting the terms __init__ defaults.
     ///
-    /// `protection_start` is the first date a default triggers the contract;
-    /// `None` takes the schedule's first date, which is what `__init__` does.
     /// The three flags carry the core defaults verbatim, so calling this with
-    /// only the positional arguments builds exactly what `__init__` builds.
+    /// only the positional arguments builds exactly what __init__ builds.
     ///
-    /// `settings` precedes the defaulted terms because a Python signature
-    /// cannot put a required argument after an optional one; the positional
-    /// order otherwise matches `__init__`.
+    /// Args:
+    ///     side (ProtectionSide): Whether protection is bought or sold.
+    ///     notional (float): The notional the premium and protection are
+    ///         quoted on.
+    ///     spread (float): The running spread the premium leg pays.
+    ///     schedule (Schedule): The premium leg's payment schedule.
+    ///     payment_convention (BusinessDayConvention): The roll applied to the
+    ///         premium payment dates.
+    ///     day_counter (DayCounter): The day count the premium accrues on.
+    ///     settings (Settings): The explicit settings; it precedes the
+    ///         defaulted terms because a Python signature cannot put a
+    ///         required argument after an optional one.
+    ///     protection_start (Date | None): The first date a default triggers
+    ///         the contract; None takes the schedule's first date, which is
+    ///         what __init__ does.
+    ///     settles_accrual (bool): Whether the accrued coupon settles on
+    ///         default.
+    ///     pays_at_default_time (bool): Whether the protection pays at default
+    ///         rather than at maturity.
+    ///     rebates_accrual (bool): Whether the protection seller rebates the
+    ///         accrued current coupon.
+    ///
+    /// Returns:
+    ///     CreditDefaultSwap: The contract on those terms.
+    ///
+    /// Raises:
+    ///     ItofinError: On the same conditions __init__ reports.
     #[staticmethod]
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (
@@ -633,11 +785,15 @@ impl PyCreditDefaultSwap {
         })
     }
 
-    /// Attaches a [`PyMidPointCdsEngine`] so the contract prices.
+    /// Attach a mid-point engine so the contract prices.
     ///
-    /// The engine is built separately and installed here, so one engine can be
-    /// shared across contracts. It must resolve its dates against the same
-    /// `Settings` object this contract was built with.
+    /// The engine is built separately, so one engine can be shared across
+    /// contracts. It must resolve its dates against the same Settings object
+    /// as this contract.
+    ///
+    /// Args:
+    ///     engine (MidPointCdsEngine): The engine and its default-probability
+    ///         and discount curves.
     fn set_engine(&mut self, engine: &PyMidPointCdsEngine) {
         self.inner
             .borrow_mut()
@@ -645,14 +801,16 @@ impl PyCreditDefaultSwap {
             .set_pricing_engine(engine.engine());
     }
 
-    /// Attaches a [`PyIsdaCdsEngine`] so the contract prices under the ISDA
-    /// standard model.
+    /// Attach an ISDA engine so the contract prices under the standard model.
     ///
-    /// A separate setter rather than a widened [`set_engine`](Self::set_engine):
-    /// the two engine facades are unrelated pyo3 classes, so one argument cannot
-    /// name both. The same sharing and same-`Settings` rules apply, and the ISDA
-    /// engine additionally refuses curves outside its specification when the
-    /// contract prices.
+    /// A separate setter rather than a widened set_engine: the two engine
+    /// facades are unrelated classes, so one argument cannot name both. The
+    /// same sharing and same-Settings rules apply, and the ISDA engine
+    /// additionally refuses curves outside its specification when the contract
+    /// prices.
+    ///
+    /// Args:
+    ///     engine (IsdaCdsEngine): The ISDA engine and its curves.
     fn set_isda_engine(&mut self, engine: &PyIsdaCdsEngine) {
         self.inner
             .borrow_mut()
@@ -660,8 +818,11 @@ impl PyCreditDefaultSwap {
             .set_pricing_engine(engine.engine());
     }
 
-    /// Forces the valuation, idempotent and fallible as
-    /// [`VanillaOption.calculate`](crate::option::PyVanillaOption::calculate).
+    /// Force the valuation. Idempotent.
+    ///
+    /// Raises:
+    ///     ItofinError: If no engine is attached, no evaluation date is set,
+    ///         or the engine refuses the contract.
     fn calculate(&mut self) -> PyResult<()> {
         Ok(self
             .inner
@@ -670,43 +831,67 @@ impl PyCreditDefaultSwap {
             .map_err(PyQlError::from)?)
     }
 
-    /// Whether the cached results are currently valid.
+    /// Return whether the cached results are currently valid.
+    ///
+    /// Returns:
+    ///     bool: True when the next accessor reads the cache.
     fn is_calculated(&self) -> bool {
         self.inner.borrow().base().is_calculated()
     }
 
-    /// Attaches the mid-point engine `engine` and returns the NPV, the one-shot
-    /// form of [`set_engine`](Self::set_engine) followed by [`npv`](Self::npv).
+    /// Attach the mid-point engine and return the NPV.
     ///
-    /// The mid-point engine is the primary because it is the core's own default
-    /// CDS engine; [`set_isda_engine`](Self::set_isda_engine) stays a separate
-    /// setter and composes with [`calculate`](Self::calculate) and
-    /// [`results`](Self::results) as before.
+    /// set_engine followed by npv, in one call. The mid-point engine is the
+    /// primary because it is the core's own default CDS engine;
+    /// set_isda_engine stays a separate setter.
+    ///
+    /// Args:
+    ///     engine (MidPointCdsEngine): The engine to install and price on.
+    ///
+    /// Returns:
+    ///     float: The contract value.
+    ///
+    /// Raises:
+    ///     ItofinError: On anything that makes the valuation fail.
     fn price(&mut self, engine: &PyMidPointCdsEngine) -> PyResult<f64> {
         self.set_engine(engine);
         self.calculate()?;
         self.npv()
     }
 
-    /// A frozen [`Results`] copy of the valuation, calculating first.
+    /// Return a frozen snapshot of the valuation, calculating first.
+    ///
+    /// Returns:
+    ///     Results: A copy of the valuation results.
+    ///
+    /// Raises:
+    ///     ItofinError: On anything that makes the valuation fail.
     fn results(&mut self) -> PyResult<Results> {
         self.calculate()?;
         let inner = self.inner.borrow();
         Ok(Results::snapshot(inner.base()))
     }
 
-    /// The contract NPV under the attached engine.
+    /// Return the contract NPV under the attached engine.
     ///
-    /// Fallible: with no engine attached the core reports `"null pricing
-    /// engine"` as an `ItofinError`.
+    /// Returns:
+    ///     float: The present value.
+    ///
+    /// Raises:
+    ///     ItofinError: If no engine is attached, which the core reports as
+    ///         "null pricing engine".
     fn npv(&mut self) -> PyResult<f64> {
         Ok(self.inner.borrow_mut().npv().map_err(PyQlError::from)?)
     }
 
-    /// The running spread that prices the contract at zero.
+    /// Return the running spread that prices the contract at zero.
     ///
-    /// Fallible as [`npv`](Self::npv), and additionally when the engine priced
-    /// a worthless premium leg and so provided no fair spread.
+    /// Returns:
+    ///     float: The fair running spread.
+    ///
+    /// Raises:
+    ///     ItofinError: If no engine is attached, and when the engine priced a
+    ///         worthless premium leg and so provided no fair spread.
     fn fair_spread(&mut self) -> PyResult<f64> {
         Ok(self
             .inner
@@ -715,8 +900,13 @@ impl PyCreditDefaultSwap {
             .map_err(PyQlError::from)?)
     }
 
-    /// The upfront that prices the contract at zero, as a fraction of the
-    /// notional. Fallible as [`fair_spread`](Self::fair_spread).
+    /// Return the upfront that prices the contract at zero.
+    ///
+    /// Returns:
+    ///     float: The fair upfront, as a fraction of the notional.
+    ///
+    /// Raises:
+    ///     ItofinError: On the same conditions fair_spread reports.
     fn fair_upfront(&mut self) -> PyResult<f64> {
         Ok(self
             .inner
@@ -725,22 +915,26 @@ impl PyCreditDefaultSwap {
             .map_err(PyQlError::from)?)
     }
 
-    /// The notional the premium and the protection are quoted on.
+    /// Return the notional the premium and the protection are quoted on.
+    ///
+    /// Returns:
+    ///     float: The contract notional.
     fn notional(&self) -> f64 {
         self.inner.borrow().notional()
     }
 
-    /// The accrued coupon the protection seller rebates, or `None` when the
-    /// contract does not rebate accrual at all (`rebates_accrual` false).
+    /// Return the accrued coupon the protection seller rebates.
     ///
-    /// A contract traded in the past still carries the flow: the core builds it
-    /// whenever the flag is set, regardless of the trade date
-    /// (`creditdefaultswap.rs:515-544`), so `None` here means the flag, never a
-    /// stale trade. Such a flow carries a real accrued amount but settled on a
-    /// past date, so it no longer reaches the value.
+    /// A contract traded in the past still carries the flow: the core builds
+    /// it whenever the flag is set, regardless of the trade date, so None here
+    /// means the flag was off, never a stale trade. Such a flow carries a real
+    /// accrued amount but settled on a past date, so it no longer reaches the
+    /// value. The amount is returned bare rather than behind a cash-flow
+    /// facade, there being none.
     ///
-    /// The amount is returned bare rather than behind a cash-flow facade, there
-    /// being none. Fallible in principle, the core's amount being a `Result`.
+    /// Returns:
+    ///     float | None: The rebated amount, or None when the contract does
+    ///         not rebate accrual at all.
     fn accrual_rebate_amount(&self) -> PyResult<Option<f64>> {
         Ok(self
             .inner
@@ -751,9 +945,11 @@ impl PyCreditDefaultSwap {
             .map_err(PyQlError::from)?)
     }
 
-    /// The date the accrual rebate settles on, which is the cash-settlement
-    /// date the upfront also pays on, or `None` on the same terms as
-    /// [`accrual_rebate_amount`](Self::accrual_rebate_amount).
+    /// Return the date the accrual rebate settles on.
+    ///
+    /// Returns:
+    ///     Date | None: The cash-settlement date the upfront also pays on, or
+    ///         None on the same terms as accrual_rebate_amount.
     fn accrual_rebate_date(&self) -> Option<PyDate> {
         self.inner
             .borrow()
@@ -761,7 +957,13 @@ impl PyCreditDefaultSwap {
             .map(|rebate| PyDate::from_inner(Event::date(rebate.as_ref())))
     }
 
-    /// The premium leg's NPV. Fallible as [`fair_spread`](Self::fair_spread).
+    /// Return the premium leg's NPV.
+    ///
+    /// Returns:
+    ///     float: The present value of the premium leg.
+    ///
+    /// Raises:
+    ///     ItofinError: On the same conditions fair_spread reports.
     fn coupon_leg_npv(&mut self) -> PyResult<f64> {
         Ok(self
             .inner
@@ -770,8 +972,13 @@ impl PyCreditDefaultSwap {
             .map_err(PyQlError::from)?)
     }
 
-    /// The protection leg's NPV. Fallible as
-    /// [`fair_spread`](Self::fair_spread).
+    /// Return the protection leg's NPV.
+    ///
+    /// Returns:
+    ///     float: The present value of the protection leg.
+    ///
+    /// Raises:
+    ///     ItofinError: On the same conditions fair_spread reports.
     fn default_leg_npv(&mut self) -> PyResult<f64> {
         Ok(self
             .inner
@@ -780,22 +987,31 @@ impl PyCreditDefaultSwap {
             .map_err(PyQlError::from)?)
     }
 
-    /// The flat hazard rate at which this contract is worth `target_npv`.
+    /// Return the flat hazard rate at which this contract is worth target_npv.
     ///
     /// The solve stands on its own engine rather than on whichever one
-    /// [`set_engine`](Self::set_engine) attached: it builds a flat, quote-backed
-    /// probability curve counting `day_counter` and prices on `model` against
-    /// `discount`, solving to `accuracy` on the rate. There is therefore no
+    /// set_engine attached: it builds a flat, quote-backed probability curve
+    /// and prices on model against discount. There is therefore no
     /// probability-curve argument - the curve being solved for is the one the
     /// core builds.
     ///
-    /// `day_counter` is the day counter of that internal curve, not of the
-    /// contract. Under [`PricingModel`]`.Isda` both it and `discount` must count
-    /// Act/365 (Fixed), which is what the ISDA engine requires of its curves.
+    /// Args:
+    ///     target_npv (float): The value the contract is solved to.
+    ///     discount (YieldTermStructure): The curve the flows discount on.
+    ///     day_counter (DayCounter): The day count of the internal flat curve,
+    ///         not of the contract. Under PricingModel.Isda both it and
+    ///         discount must count Act/365 (Fixed), which is what the ISDA
+    ///         engine requires of its curves.
+    ///     recovery_rate (float): The recovery assumed on default.
+    ///     accuracy (float): The tolerance the solve stops at, on the rate.
+    ///     model (PricingModel): The model the contract is inverted under.
     ///
-    /// Fallible: on a malformed contract, and when the solve does not converge -
-    /// which includes a pricing failure at some hazard rate, since that reaches
-    /// the solver as the non-finite value it rejects.
+    /// Returns:
+    ///     float: The flat hazard rate.
+    ///
+    /// Raises:
+    ///     ItofinError: On a malformed contract, and when the solve does not
+    ///         converge, which includes a pricing failure at some hazard rate.
     fn implied_hazard_rate(
         &self,
         target_npv: f64,
@@ -828,28 +1044,16 @@ impl PyCreditDefaultSwap {
     }
 }
 
-/// Python `MakeCreditDefaultSwap`: the market-convention builder for a
-/// credit-default swap (`instruments::makecds::MakeCreditDefaultSwap`).
+/// Market-convention builder for a CreditDefaultSwap: derives the premium
+/// schedule from a maturity and the post-Big-Bang CDS conventions, and takes
+/// the trade date from the evaluation date settings carries.
 ///
-/// It derives the premium schedule from a maturity and the post-Big-Bang CDS
-/// conventions, and takes the trade date from the evaluation date the settings
-/// carry (D5). Only the term-date quotation is exposed here; the tenor and
-/// explicit-schedule quotations (`makecds.rs:111` and `:133`) are deferred.
-///
-/// The core builder is a consumed-self fluent chain, which does not cross the
-/// FFI boundary; this facade takes the whole configuration up front and
-/// assembles the chain inside [`build`](Self::build), as
-/// [`PyMakeYoYInflationCapFloor`](crate::inflation) and
-/// [`PyMakeVanillaSwap`](crate::swap) do. Each `build` runs a fresh chain, so
-/// one builder object cannot carry a setting into a later contract. An unset
-/// optional leaves the core default in place (`makecds.rs:150-171`).
-///
-/// Deferred (visible): four of the core's setters are exposed. The
-/// accrual-rebate flag (`makecds.rs:257`) stays unbound, the `with_terms`
-/// constructor on [`PyCreditDefaultSwap`] already reaching it; the rest keep
-/// their defaults, notably the 3M coupon tenor, the pre-CDS2015
-/// `DateGeneration::CDS` rule, the `Following` roll, the Act/360 day counter
-/// and the three cash-settlement days.
+/// An unset optional keeps the core default: a Buyer side, a nominal of 1, no
+/// upfront, a 3M coupon tenor, the pre-CDS2015 DateGeneration.CDS rule, a
+/// Following roll, an Act/360 day counter and three cash-settlement days. Only
+/// the term-date quotation is exposed; the tenor and explicit-schedule ones and
+/// the accrual-rebate flag are not, the latter being reachable through
+/// CreditDefaultSwap.with_terms.
 #[pyclass(name = "MakeCreditDefaultSwap", unsendable)]
 pub struct PyMakeCreditDefaultSwap {
     term_date: Date,
@@ -863,12 +1067,26 @@ pub struct PyMakeCreditDefaultSwap {
 
 #[pymethods]
 impl PyMakeCreditDefaultSwap {
-    /// A builder for a contract maturing on `term_date` and paying
-    /// `running_spread`.
+    /// Store the configuration the chain is assembled from in build().
     ///
-    /// `trade_date` overrides the evaluation date the trade would otherwise be
-    /// dated off (`makecds.rs:263`), which is how a contract traded in the past
-    /// is built.
+    /// Each build() runs a fresh chain, so one builder object cannot carry a
+    /// setting into a later contract.
+    ///
+    /// Args:
+    ///     term_date (Date): The maturity the premium schedule is derived
+    ///         from.
+    ///     running_spread (float): The running spread the premium leg pays.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date the trade is dated off.
+    ///     nominal (float | None): The notional; None keeps the core default
+    ///         of 1.
+    ///     upfront_rate (float | None): The upfront as a fraction of the
+    ///         notional; None keeps the core default of none.
+    ///     side (ProtectionSide | None): Which side the contract holds; None
+    ///         keeps the core default of Buyer.
+    ///     trade_date (Date | None): Overrides the evaluation date the trade
+    ///         is otherwise dated off, which is how a contract traded in the
+    ///         past is built.
     #[new]
     #[pyo3(signature = (
         term_date,
@@ -899,14 +1117,17 @@ impl PyMakeCreditDefaultSwap {
         }
     }
 
-    /// Builds the contract, which carries no engine: attach one with
-    /// [`set_engine`](PyCreditDefaultSwap::set_engine) or
-    /// [`set_isda_engine`](PyCreditDefaultSwap::set_isda_engine) before pricing.
+    /// Build the contract, which carries no engine.
     ///
-    /// # Errors
+    /// Attach one with set_engine or set_isda_engine before pricing.
     ///
-    /// Reports an unset evaluation date, which the trade date is derived from
-    /// (`makecds.rs:286-294`), and whatever the contract construction rejects.
+    /// Returns:
+    ///     CreditDefaultSwap: The contract on the market conventions.
+    ///
+    /// Raises:
+    ///     ItofinError: If no evaluation date is set, the trade date being
+    ///         derived from it, and on whatever the contract construction
+    ///         rejects.
     fn build(&self) -> PyResult<PyCreditDefaultSwap> {
         let mut maker = MakeCreditDefaultSwap::from_term_date(
             self.term_date,

--- a/crates/itofin-py/src/credit.rs
+++ b/crates/itofin-py/src/credit.rs
@@ -1,8 +1,8 @@
-//! Facades for the credit hierarchy: the [`PyDefaultProbabilityTermStructure`]
-//! base, the concrete [`PyFlatHazardRate`], [`PyInterpolatedHazardRateCurve`]
-//! and [`PyPiecewiseDefaultCurve`] curves, the [`PyProtectionSide`] and
-//! [`PyPricingModel`] flags, the [`PyCreditDefaultSwap`] instrument and its
-//! market-convention builder [`PyMakeCreditDefaultSwap`].
+//! Facades for the credit hierarchy: the DefaultProbabilityTermStructure base,
+//! the concrete FlatHazardRate, InterpolatedHazardRateCurve and
+//! PiecewiseDefaultCurve curves, the ProtectionSide and PricingModel flags, the
+//! CreditDefaultSwap instrument and its market-convention builder
+//! MakeCreditDefaultSwap.
 
 use crate::PyQlError;
 use crate::creditengine::{PyIsdaCdsEngine, PyMidPointCdsEngine};
@@ -42,7 +42,7 @@ pub enum PyProtectionSide {
 }
 
 impl PyProtectionSide {
-    /// The core [`ProtectionSide`] this variant stands for.
+    /// The core ProtectionSide this variant stands for.
     pub(crate) fn inner(self) -> ProtectionSide {
         match self {
             PyProtectionSide::Buyer => ProtectionSide::Buyer,
@@ -62,7 +62,7 @@ pub enum PyPricingModel {
 }
 
 impl PyPricingModel {
-    /// The core [`PricingModel`] this variant stands for.
+    /// The core PricingModel this variant stands for.
     pub(crate) fn inner(self) -> PricingModel {
         match self {
             PyPricingModel::Midpoint => PricingModel::Midpoint,
@@ -261,7 +261,7 @@ impl PyDefaultProbabilityTermStructure {
 }
 
 impl PyDefaultProbabilityTermStructure {
-    /// The base half of a concrete curve's [`PyClassInitializer`] chain.
+    /// The base half of a concrete curve's initializer chain.
     pub(crate) fn from_handle(inner: Handle<dyn DefaultProbabilityTermStructure>) -> Self {
         PyDefaultProbabilityTermStructure { inner }
     }
@@ -1044,7 +1044,7 @@ impl PyCreditDefaultSwap {
 
 impl PyCreditDefaultSwap {
     /// Wraps a contract another facade built, the shape
-    /// [`PyMakeCreditDefaultSwap::build`] hands back.
+    /// MakeCreditDefaultSwap.build() hands back.
     pub(crate) fn from_inner(inner: SharedMut<CreditDefaultSwap>) -> Self {
         PyCreditDefaultSwap { inner }
     }

--- a/crates/itofin-py/src/creditengine.rs
+++ b/crates/itofin-py/src/creditengine.rs
@@ -25,17 +25,15 @@ use libitofin::pricingengines::credit::{
 use libitofin::shared::{SharedMut, shared_mut};
 use pyo3::prelude::*;
 
-/// Python `MidPointCdsEngine`: the mid-point credit-default-swap engine
-/// (`pricingengines::credit::midpointcdsengine::MidPointCdsEngine`).
+/// The mid-point credit-default-swap engine: each live premium period is
+/// priced against the default probability over that period, with the default
+/// placed at the period's mid-point.
 ///
-/// Infallible at construction: it only stores the two curve handles, the
-/// recovery rate and the settings, and registers as an observer of both curves.
-/// Every precondition (an empty handle, an unset evaluation date) is reported
-/// when the instrument is priced.
-///
-/// The `settings` passed here must be the same object the instrument this
-/// engine prices was built with, or the two resolve their dates against
-/// different evaluation dates and the NPV is silently wrong.
+/// Infallible at construction - every precondition (an empty curve handle, an
+/// unset evaluation date) is reported when the contract is priced. The core's
+/// include_settlement_date_flows override is not exposed and is always None,
+/// so the settlement-date flow decision follows the settings' own flags. The
+/// contract this engine prices must carry the same Settings object.
 #[pyclass(name = "MidPointCdsEngine", unsendable)]
 pub struct PyMidPointCdsEngine {
     inner: SharedMut<MidPointCdsEngine>,
@@ -43,9 +41,17 @@ pub struct PyMidPointCdsEngine {
 
 #[pymethods]
 impl PyMidPointCdsEngine {
-    /// An engine reading default probabilities off `probability`, paying
-    /// `1 - recovery` of the notional on a default, and discounting on
-    /// `discount`.
+    /// Build an engine over a default-probability curve and a discount curve.
+    ///
+    /// Args:
+    ///     probability (DefaultProbabilityTermStructure): The curve default
+    ///         probabilities are read off.
+    ///     recovery (float): The recovery rate; a default pays 1 - recovery of
+    ///         the notional.
+    ///     discount (YieldTermStructure): The curve both legs are discounted
+    ///         on.
+    ///     settings (Settings): The explicit settings; must be the same object
+    ///         the contract this engine prices was built with.
     #[new]
     fn new(
         probability: &PyDefaultProbabilityTermStructure,
@@ -73,15 +79,11 @@ impl PyMidPointCdsEngine {
     }
 }
 
-/// Python `NumericalFix`: how the ISDA engine keeps the integrands'
-/// `f_i + h_i` denominators away from zero (core
-/// `pricingengines::credit::NumericalFix`).
+/// How the ISDA engine keeps the integrands' f + h denominators away from zero.
 ///
-/// `NumericalFix.NoFix` adds `10^-50` to the denominators instead; the default
-/// `NumericalFix.Taylor` replaces the quotient by its Taylor expansion once
-/// `f_i + h_i` falls below `10^-4`. The core already renames C++'s `None`
-/// variant to `NoFix` (`isdacdsengine.rs:71`), which is also what Python needs:
-/// `NumericalFix.None` is a syntax error.
+/// NoFix adds 10^-50 to them instead; Taylor, the default, replaces the
+/// quotient by its Taylor expansion once f + h falls below 10^-4. Spelled NoFix
+/// rather than C++'s None, which Python cannot name.
 #[pyclass(name = "NumericalFix", eq, eq_int, from_py_object)]
 #[derive(Clone, Copy, PartialEq)]
 pub enum PyNumericalFix {
@@ -99,13 +101,11 @@ impl PyNumericalFix {
     }
 }
 
-/// Python `AccrualBias`: whether the premium leg carries the ISDA standard
-/// model's half-day accrual bias (core `pricingengines::credit::AccrualBias`).
+/// Whether the premium leg carries the standard model's half-day accrual bias.
 ///
-/// The default `AccrualBias.HalfDayBias` includes the erroneous second term the
-/// standard model's C code carries before version 1.8.2, which shifts the
-/// accrual's `tstart` back by `1/730` of a year; `AccrualBias.NoBias` leaves it
-/// out, as from 1.8.2 on.
+/// The bias shifts the accrual's tstart back by 1/730 of a year. HalfDayBias,
+/// the default, includes it as the model's C code does before version 1.8.2;
+/// NoBias leaves it out, as from 1.8.2 on.
 #[pyclass(name = "AccrualBias", eq, eq_int, from_py_object)]
 #[derive(Clone, Copy, PartialEq)]
 pub enum PyAccrualBias {
@@ -123,14 +123,11 @@ impl PyAccrualBias {
     }
 }
 
-/// Python `ForwardsInCouponPeriod`: how the ISDA engine treats forward rates
-/// inside a coupon period (core
-/// `pricingengines::credit::ForwardsInCouponPeriod`).
+/// How the ISDA engine treats forward rates inside a coupon period.
 ///
-/// The default `ForwardsInCouponPeriod.Piecewise` subdivides each coupon period
-/// at the integration grid's own nodes; `ForwardsInCouponPeriod.Flat`
-/// integrates each period in a single step. The two part only where the grid
-/// has nodes strictly inside a coupon period, so two flat curves price
+/// Piecewise, the default, subdivides each period at the integration grid's own
+/// nodes; Flat integrates each period in a single step. The two part only where
+/// the grid has nodes strictly inside a coupon period, so two flat curves price
 /// identically under either.
 #[pyclass(name = "ForwardsInCouponPeriod", eq, eq_int, from_py_object)]
 #[derive(Clone, Copy, PartialEq)]
@@ -149,34 +146,22 @@ impl PyForwardsInCouponPeriod {
     }
 }
 
-/// Python `IsdaCdsEngine`: the ISDA standard-model credit-default-swap engine
-/// (`pricingengines::credit::isdacdsengine::IsdaCdsEngine`).
+/// The ISDA standard-model credit-default-swap engine: both legs are
+/// integrated over the pillar dates of the two curves the engine is built with
+/// rather than over the premium schedule alone.
 ///
-/// Both legs are integrated over the pillar dates of the two curves the engine
-/// is built with, so the price follows the standard model rather than the
-/// premium schedule alone.
-///
-/// The model is specified against curves of a fixed shape, and the engine
-/// refuses anything else when it prices (`isdacdsengine.rs:162-205`): both
-/// curves must count Act/365 (Fixed) and be referenced at the evaluation date,
-/// and the contract must settle its accrual, pay at the default time and carry a
-/// face-value claim. Construction is infallible, as for
-/// [`PyMidPointCdsEngine`], so every one of those is reported as
-/// [`struct@crate::ItofinError`] from
-/// [`npv`](crate::credit::PyCreditDefaultSwap::npv), not from `__init__`.
-///
-/// The `settings` passed here must be the same object the instrument this
-/// engine prices was built with, or the two resolve their dates against
-/// different evaluation dates and the NPV is silently wrong.
-///
-/// The three fidelity flags are trailing keyword arguments defaulting to the
-/// C++ defaults `Taylor` / `HalfDayBias` / `Piecewise` the core constructor
-/// bakes in (`isdacdsengine.rs:139-141`), so an engine built without them
-/// prices exactly as before. They are taken here rather than through a
-/// `with_fidelity` method because the core builder consumes the engine
-/// (`:148-158`) while [`set_isda_engine`](crate::credit::PyCreditDefaultSwap)
-/// has already cloned it into the contract, which a post-construction
-/// reconfiguration would leave behind on the unconfigured engine.
+/// Infallible at construction, like MidPointCdsEngine. The model is specified
+/// against curves of a fixed shape, so every check - both curves counting
+/// Act/365 (Fixed) and referenced at the evaluation date, the contract settling
+/// its accrual, paying at the default time and carrying a face-value claim - is
+/// reported as ItofinError when the contract is priced, not from __init__. The
+/// core's include_settlement_date_flows override is not exposed and is always
+/// None. The three fidelity flags are trailing keyword arguments defaulting to
+/// the C++ defaults Taylor / HalfDayBias / Piecewise, so an engine built
+/// without them prices as before; they are taken here rather than through a
+/// with_fidelity method because the core builder consumes the engine while
+/// set_isda_engine has already cloned it into the contract. The contract this
+/// engine prices must carry the same Settings object.
 #[pyclass(name = "IsdaCdsEngine", unsendable)]
 pub struct PyIsdaCdsEngine {
     inner: SharedMut<IsdaCdsEngine>,
@@ -184,9 +169,25 @@ pub struct PyIsdaCdsEngine {
 
 #[pymethods]
 impl PyIsdaCdsEngine {
-    /// An engine reading default probabilities off `probability`, paying
-    /// `1 - recovery` of the notional on a default, and discounting on
-    /// `discount`, under the three fidelity flags.
+    /// Build an ISDA standard-model engine under the three fidelity flags.
+    ///
+    /// Args:
+    ///     probability (DefaultProbabilityTermStructure): The curve default
+    ///         probabilities are read off; must count Act/365 (Fixed) and be
+    ///         referenced at the evaluation date, checked at pricing time.
+    ///     recovery (float): The recovery rate; a default pays 1 - recovery of
+    ///         the notional.
+    ///     discount (YieldTermStructure): The curve both legs are discounted
+    ///         on, under the same shape requirement.
+    ///     settings (Settings): The explicit settings; must be the same object
+    ///         the contract this engine prices was built with.
+    ///     numerical_fix (NumericalFix): How the integrand denominators are
+    ///         kept away from zero. Defaults to Taylor.
+    ///     accrual_bias (AccrualBias): Whether the premium leg carries the
+    ///         half-day accrual bias. Defaults to HalfDayBias.
+    ///     forwards_in_coupon_period (ForwardsInCouponPeriod): How forward
+    ///         rates inside a coupon period are integrated. Defaults to
+    ///         Piecewise.
     #[new]
     #[pyo3(signature = (
         probability,

--- a/crates/itofin-py/src/creditengine.rs
+++ b/crates/itofin-py/src/creditengine.rs
@@ -1,18 +1,17 @@
-//! Facades for the two credit-default-swap engines: [`PyMidPointCdsEngine`] and
-//! [`PyIsdaCdsEngine`].
+//! Facades for the two credit-default-swap engines: MidPointCdsEngine and
+//! IsdaCdsEngine.
 //!
-//! The mid-point engine prices each live premium period of a
-//! [`CreditDefaultSwap`](crate::credit::PyCreditDefaultSwap) against the default
-//! probability over that period, placing the default at the period's mid-point,
-//! and discounts on a separate yield curve. The ISDA engine prices the same
-//! contract the way the ISDA standard model does, integrating both legs over the
-//! pillar dates of the two curves rather than over the premium schedule alone.
+//! The mid-point engine prices each live premium period of a CreditDefaultSwap
+//! against the default probability over that period, placing the default at the
+//! period's mid-point, and discounts on a separate yield curve. The ISDA engine
+//! prices the same contract the way the ISDA standard model does, integrating
+//! both legs over the pillar dates of the two curves rather than over the
+//! premium schedule alone.
 //!
-//! Deferred (visible): the core's `include_settlement_date_flows` override
-//! (`midpointcdsengine.rs:73`, `isdacdsengine.rs:127`) is not exposed on either
-//! engine and is always passed as `None`, so the settlement-date flow decision
-//! follows the settings' own flags - the shape the C++ cached-value fixture uses
-//! (`creditdefaultswap.cpp:96`).
+//! Deferred (visible): the core's `include_settlement_date_flows` override is
+//! not exposed on either engine and is always passed as `None`, so the
+//! settlement-date flow decision follows the settings' own flags - the shape
+//! the C++ cached-value fixture uses (`creditdefaultswap.cpp:96`).
 
 use crate::credit::PyDefaultProbabilityTermStructure;
 use crate::curve::PyYieldTermStructure;
@@ -92,7 +91,7 @@ pub enum PyNumericalFix {
 }
 
 impl PyNumericalFix {
-    /// The core [`NumericalFix`] this variant stands for.
+    /// The core NumericalFix this variant stands for.
     pub(crate) fn inner(self) -> NumericalFix {
         match self {
             PyNumericalFix::NoFix => NumericalFix::NoFix,
@@ -114,7 +113,7 @@ pub enum PyAccrualBias {
 }
 
 impl PyAccrualBias {
-    /// The core [`AccrualBias`] this variant stands for.
+    /// The core AccrualBias this variant stands for.
     pub(crate) fn inner(self) -> AccrualBias {
         match self {
             PyAccrualBias::HalfDayBias => AccrualBias::HalfDayBias,
@@ -137,7 +136,7 @@ pub enum PyForwardsInCouponPeriod {
 }
 
 impl PyForwardsInCouponPeriod {
-    /// The core [`ForwardsInCouponPeriod`] this variant stands for.
+    /// The core ForwardsInCouponPeriod this variant stands for.
     pub(crate) fn inner(self) -> ForwardsInCouponPeriod {
         match self {
             PyForwardsInCouponPeriod::Flat => ForwardsInCouponPeriod::Flat,

--- a/crates/itofin-py/src/credithelpers.rs
+++ b/crates/itofin-py/src/credithelpers.rs
@@ -1,13 +1,12 @@
-//! Facades for the credit bootstrap helpers: the [`PyDefaultProbabilityHelper`]
-//! base and the concrete [`PySpreadCdsHelper`].
+//! Facades for the credit bootstrap helpers: the DefaultProbabilityHelper base
+//! and the concrete SpreadCdsHelper.
 //!
-//! The credit twin of [`crate::helpers`], which carries the yield-side rate
-//! helpers, split the same way the core splits them: a credit helper fits a
+//! The credit twin of helpers(), which carries the yield-side rate helpers,
+//! split the same way the core splits them: a credit helper fits a
 //! default-probability curve, not a yield curve, so it implements a separate
-//! trait (`defaultprobabilityhelpers.rs:66`) and cannot share the `dyn
-//! RateHelper` base. The base holds the already-upcast
-//! `Shared<dyn DefaultProbabilityHelper>` and the concrete subclasses supply
-//! only their constructors, mirroring the [`crate::credit`] base/subclass idiom.
+//! trait and cannot share the RateHelper base. The base holds the helper
+//! already upcast and type-erased, and the concrete subclasses supply only
+//! their constructors, mirroring the credit() base/subclass idiom.
 //!
 //! `UpfrontCdsHelper` (`defaultprobabilityhelpers.hpp:170`) has no core port yet
 //! and is omitted here rather than stubbed; it follows within EPIC Credit
@@ -58,7 +57,7 @@ impl PyDefaultProbabilityHelper {
 }
 
 impl PyDefaultProbabilityHelper {
-    /// The base half of a concrete helper's [`PyClassInitializer`] chain.
+    /// The base half of a concrete helper's initializer chain.
     pub(crate) fn from_shared(inner: Shared<dyn DefaultProbabilityHelper>) -> Self {
         PyDefaultProbabilityHelper { inner }
     }

--- a/crates/itofin-py/src/credithelpers.rs
+++ b/crates/itofin-py/src/credithelpers.rs
@@ -28,13 +28,11 @@ use libitofin::termstructures::credit::defaultprobabilityhelpers::{
 use libitofin::types::Integer;
 use pyo3::prelude::*;
 
-/// Python `DefaultProbabilityHelper`: the shared base for every credit
-/// bootstrap helper
-/// (`termstructures::credit::defaultprobabilityhelpers::DefaultProbabilityHelper`).
+/// Shared base for every credit bootstrap helper.
 ///
-/// Holds the erased `Shared<dyn DefaultProbabilityHelper>` and exposes the two
-/// dates the bootstrap places a curve node by. Concrete helpers such as
-/// [`PySpreadCdsHelper`] subclass this and supply only their constructor.
+/// A credit helper fits a default-probability curve rather than a yield curve,
+/// so it is a separate hierarchy from RateHelper. It exposes the two dates the
+/// bootstrap places a curve node by.
 #[pyclass(name = "DefaultProbabilityHelper", subclass, unsendable)]
 pub struct PyDefaultProbabilityHelper {
     inner: Shared<dyn DefaultProbabilityHelper>,
@@ -42,13 +40,18 @@ pub struct PyDefaultProbabilityHelper {
 
 #[pymethods]
 impl PyDefaultProbabilityHelper {
-    /// The pillar date, at which the curve node this helper sets sits.
+    /// Return the date the curve node this helper sets sits at.
+    ///
+    /// Returns:
+    ///     Date: The pillar date.
     fn pillar_date(&self) -> PyDate {
         PyDate::from_inner(self.inner.pillar_date())
     }
 
-    /// The latest date the helper needs curve data at (equal to the pillar
-    /// date).
+    /// Return the latest date the helper needs curve data at.
+    ///
+    /// Returns:
+    ///     Date: The latest date, equal to the pillar date.
     fn latest_date(&self) -> PyDate {
         PyDate::from_inner(self.inner.latest_date())
     }
@@ -67,27 +70,42 @@ impl PyDefaultProbabilityHelper {
     }
 }
 
-/// Python `SpreadCdsHelper`: the bootstrap helper fitting a CDS quoted as a
-/// running spread
-/// (`termstructures::credit::defaultprobabilityhelpers::SpreadCdsHelper`).
+/// Bootstrap helper fitting a CDS quoted as a running spread.
 ///
 /// The helper rebuilds its schedule and its contract off the evaluation date
-/// held by `settings`, so it tracks that date rather than freezing a maturity
-/// at construction. It retains the caller's [`PySimpleQuote`], so a later
-/// `set_value` re-drives the bootstrap, and it observes `discount_curve`.
-///
-/// Fallible, unlike the [`PyFlatHazardRate`](crate::credit::PyFlatHazardRate)
-/// chain it otherwise mirrors: under the three post-Big-Bang rules
-/// (`DateGeneration.OldCDS` / `.CDS` / `.CDS2015`) the maturity is rolled by
-/// `cdsMaturity`, which raises [`struct@crate::ItofinError`] on a tenor it
-/// cannot roll rather than building a schedule that ends on the wrong date.
+/// held by settings, so it tracks that date rather than freezing a maturity at
+/// construction. It retains the caller's quote, so a later set_value re-drives
+/// the bootstrap, and it observes the discount curve.
 #[pyclass(name = "SpreadCdsHelper", extends = PyDefaultProbabilityHelper, unsendable)]
 pub struct PySpreadCdsHelper;
 
 #[pymethods]
 impl PySpreadCdsHelper {
-    /// A helper fitting `running_spread` over `tenor`, on the C++ default CDS
-    /// terms.
+    /// Build the helper on the C++ default CDS terms.
+    ///
+    /// Args:
+    ///     running_spread (SimpleQuote): The quoted spread the helper fits.
+    ///     tenor (Period): The length of the contract.
+    ///     settlement_days (int): The days between the evaluation date and the
+    ///         contract's start.
+    ///     calendar (Calendar): The calendar the schedule rolls on.
+    ///     frequency (Frequency): The premium payment frequency.
+    ///     payment_convention (BusinessDayConvention): The roll applied to the
+    ///         payment dates.
+    ///     rule (DateGeneration): The schedule generation rule.
+    ///     day_counter (DayCounter): The day count the premium accrues on.
+    ///     recovery_rate (float): The recovery assumed on default.
+    ///     discount_curve (YieldTermStructure): The curve the flows discount
+    ///         on; the helper observes it.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date the schedule is rebuilt off.
+    ///
+    /// Raises:
+    ///     ItofinError: Under the three post-Big-Bang rules OldCDS, CDS and
+    ///         CDS2015, whose maturity is rolled by the CDS maturity rule: it
+    ///         refuses a tenor it cannot roll, or one it rolls to a contract
+    ///         that has already matured, rather than building a schedule that
+    ///         ends on the wrong date.
     #[new]
     #[allow(clippy::too_many_arguments)]
     fn new(

--- a/crates/itofin-py/src/credithelpers.rs
+++ b/crates/itofin-py/src/credithelpers.rs
@@ -76,6 +76,11 @@ impl PyDefaultProbabilityHelper {
 /// held by settings, so it tracks that date rather than freezing a maturity at
 /// construction. It retains the caller's quote, so a later set_value re-drives
 /// the bootstrap, and it observes the discount curve.
+///
+/// Fallible: under the three post-Big-Bang date-generation rules the maturity
+/// is rolled by the CDS maturity convention, which raises ItofinError on a
+/// tenor it cannot roll rather than building a schedule that ends on the wrong
+/// date.
 #[pyclass(name = "SpreadCdsHelper", extends = PyDefaultProbabilityHelper, unsendable)]
 pub struct PySpreadCdsHelper;
 

--- a/crates/itofin-py/src/currency.rs
+++ b/crates/itofin-py/src/currency.rs
@@ -1,16 +1,14 @@
-//! Facade for the currency specification [`PyCurrency`] (`currency::Currency`).
+//! Facade for the currency specification Currency.
 //!
-//! An index carries a currency, so the general [`PyIborIndex`](crate::hullwhite::PyIborIndex)
-//! constructor cannot be called without one. Only the four named currencies the
-//! core provides are exposed as staticmethods; the general
-//! [`Currency::new`](libitofin::currency::Currency::new) form is deliberately
-//! omitted, since the core itself ports only the currencies the indexes need and
-//! the full `ql/currencies/*` catalogue is deferred there (`currency.rs:9`).
+//! An index carries a currency, so the general IborIndex constructor cannot be
+//! called without one. Only the four named currencies the core provides are
+//! exposed as staticmethods; the general Currency.new() form is deliberately
+//! omitted, since the core itself ports only the currencies the indexes need
+//! and the full `ql/currencies/*` catalogue is deferred there.
 //!
 //! It is registered under `itofin.indexes` rather than a submodule of its own:
 //! the index constructors are its only consumers today, both the general
-//! [`PyIborIndex`](crate::hullwhite::PyIborIndex) one and, since #868,
-//! [`PySwapIndex`](crate::swapindex::PySwapIndex), which used to hard-code EUR.
+//! IborIndex one and, since #868, SwapIndex, which used to hard-code EUR.
 
 use libitofin::currency::Currency;
 use pyo3::prelude::*;
@@ -90,7 +88,7 @@ impl PyCurrency {
 
 impl PyCurrency {
     /// A clone of the inner currency for the index facades, whose constructors
-    /// take a [`Currency`] by value.
+    /// take a Currency by value.
     pub(crate) fn inner(&self) -> Currency {
         self.inner.clone()
     }

--- a/crates/itofin-py/src/currency.rs
+++ b/crates/itofin-py/src/currency.rs
@@ -15,11 +15,11 @@
 use libitofin::currency::Currency;
 use pyo3::prelude::*;
 
-/// Python `Currency`: an ISO 4217 currency specification (`currency::Currency`).
+/// An ISO 4217 currency specification.
 ///
-/// Two currencies compare equal on their name alone, matching the core's
-/// `PartialEq` (`currency.rs:132`), and `repr` prints the ISO code, matching its
-/// `Display` (`currency.rs:126`).
+/// Only the four named currencies the core provides are exposed; the general
+/// constructor is omitted, as the core ports only the currencies its indexes
+/// need and the full catalogue is deferred there.
 #[pyclass(name = "Currency", unsendable)]
 pub struct PyCurrency {
     inner: Currency,
@@ -27,7 +27,10 @@ pub struct PyCurrency {
 
 #[pymethods]
 impl PyCurrency {
-    /// The European Euro (ISO `EUR`).
+    /// Return the European Euro.
+    ///
+    /// Returns:
+    ///     Currency: The euro, ISO code "EUR".
     #[staticmethod]
     fn eur() -> Self {
         PyCurrency {
@@ -35,7 +38,10 @@ impl PyCurrency {
         }
     }
 
-    /// The U.S. dollar (ISO `USD`).
+    /// Return the U.S. dollar.
+    ///
+    /// Returns:
+    ///     Currency: The U.S. dollar, ISO code "USD".
     #[staticmethod]
     fn usd() -> Self {
         PyCurrency {
@@ -43,7 +49,10 @@ impl PyCurrency {
         }
     }
 
-    /// The British pound sterling (ISO `GBP`).
+    /// Return the British pound sterling.
+    ///
+    /// Returns:
+    ///     Currency: The pound sterling, ISO code "GBP".
     #[staticmethod]
     fn gbp() -> Self {
         PyCurrency {
@@ -51,7 +60,10 @@ impl PyCurrency {
         }
     }
 
-    /// The Japanese yen (ISO `JPY`).
+    /// Return the Japanese yen.
+    ///
+    /// Returns:
+    ///     Currency: The yen, ISO code "JPY".
     #[staticmethod]
     fn jpy() -> Self {
         PyCurrency {
@@ -59,11 +71,18 @@ impl PyCurrency {
         }
     }
 
-    /// The ISO 4217 three-letter code, e.g. `"EUR"`.
+    /// Return the ISO 4217 three-letter code.
+    ///
+    /// Returns:
+    ///     str: The three-letter code, e.g. "EUR".
     fn code(&self) -> &str {
         self.inner.code()
     }
 
+    /// Return the printable representation, which prints the ISO code.
+    ///
+    /// Returns:
+    ///     str: A string of the form Currency(EUR).
     fn __repr__(&self) -> String {
         format!("Currency({})", self.inner.code())
     }

--- a/crates/itofin-py/src/curve.rs
+++ b/crates/itofin-py/src/curve.rs
@@ -363,6 +363,8 @@ impl PyDiscountCurve {
 /// The first date is the reference date. Finite in time. Unlike ZeroCurve and
 /// DiscountCurve this curve offers no cubic option, QuantLib-SWIG exposing its
 /// cubic curve on the zero and discount curves only.
+///
+/// A query past the last node needs enable_extrapolation() or extrapolate=True.
 #[pyclass(name = "ForwardCurve", extends = PyYieldTermStructure, unsendable)]
 pub struct PyForwardCurve;
 
@@ -423,6 +425,9 @@ impl PyForwardCurve {
 /// the solver runs on the first query, re-running after a helper-quote or
 /// evaluation-date change. A bootstrap failure therefore surfaces from the
 /// query methods, not from the constructor.
+///
+/// max_date is the exception: it swallows a bootstrap failure and falls back to
+/// the last helper's date.
 #[pyclass(name = "PiecewiseYieldCurve", extends = PyYieldTermStructure, unsendable)]
 pub struct PyPiecewiseYieldCurve;
 

--- a/crates/itofin-py/src/curve.rs
+++ b/crates/itofin-py/src/curve.rs
@@ -24,13 +24,10 @@ use libitofin::termstructures::yieldtermstructure::YieldTermStructure;
 use libitofin::time::frequency::Frequency;
 use pyo3::prelude::*;
 
-/// Python `YieldTermStructure`: the shared base for every yield curve
-/// (`termstructures::yieldtermstructure::YieldTermStructure`).
+/// Shared base for every yield curve: discount factors, zero and forward rates.
 ///
-/// Holds the erased `Handle<dyn YieldTermStructure>` and exposes the query
-/// surface every concrete curve inherits (discount factors, zero and forward
-/// rates) plus the extrapolation toggles. Concrete curves such as
-/// [`PyFlatForward`] subclass this and supply only their constructor.
+/// Concrete curves subclass this and supply only their constructor; the whole
+/// query surface below is inherited.
 #[pyclass(name = "YieldTermStructure", subclass, unsendable)]
 pub struct PyYieldTermStructure {
     inner: Handle<dyn YieldTermStructure>,
@@ -38,7 +35,18 @@ pub struct PyYieldTermStructure {
 
 #[pymethods]
 impl PyYieldTermStructure {
-    /// The discount factor at year-fraction `t`.
+    /// Return the discount factor at year-fraction t.
+    ///
+    /// Args:
+    ///     t (float): The year fraction, in the curve's own day count.
+    ///     extrapolate (bool): Whether to answer past the curve's max date.
+    ///
+    /// Returns:
+    ///     float: The discount factor.
+    ///
+    /// Raises:
+    ///     ItofinError: If t is past the curve's range and neither extrapolate
+    ///         nor the curve's own extrapolation flag allows it.
     #[pyo3(signature = (t, extrapolate = false))]
     fn discount(&self, t: f64, extrapolate: bool) -> PyResult<f64> {
         Ok(self
@@ -49,7 +57,18 @@ impl PyYieldTermStructure {
             .map_err(PyQlError::from)?)
     }
 
-    /// The discount factor from `date` to the reference date.
+    /// Return the discount factor from date back to the reference date.
+    ///
+    /// Args:
+    ///     date (Date): The date discounted from.
+    ///     extrapolate (bool): Whether to answer past the curve's max date.
+    ///
+    /// Returns:
+    ///     float: The discount factor.
+    ///
+    /// Raises:
+    ///     ItofinError: If date is past the curve's range and extrapolation is
+    ///         not allowed.
     #[pyo3(signature = (date, extrapolate = false))]
     fn discount_date(&self, date: &PyDate, extrapolate: bool) -> PyResult<f64> {
         Ok(self
@@ -60,8 +79,18 @@ impl PyYieldTermStructure {
             .map_err(PyQlError::from)?)
     }
 
-    /// The continuously-compounded zero rate at year-fraction `t`, read back
-    /// with the convention the curve was built with.
+    /// Return the continuously-compounded zero rate at year-fraction t.
+    ///
+    /// Args:
+    ///     t (float): The year fraction, in the curve's own day count.
+    ///     extrapolate (bool): Whether to answer past the curve's max date.
+    ///
+    /// Returns:
+    ///     float: The zero rate, continuously compounded at annual frequency.
+    ///
+    /// Raises:
+    ///     ItofinError: If t is past the curve's range and extrapolation is
+    ///         not allowed.
     #[pyo3(signature = (t, extrapolate = false))]
     fn zero_rate(&self, t: f64, extrapolate: bool) -> PyResult<f64> {
         Ok(self
@@ -73,8 +102,20 @@ impl PyYieldTermStructure {
             .rate())
     }
 
-    /// The continuously-compounded forward rate between year-fractions `t1`
-    /// and `t2`.
+    /// Return the continuously-compounded forward rate between t1 and t2.
+    ///
+    /// Args:
+    ///     t1 (float): The start year fraction.
+    ///     t2 (float): The end year fraction.
+    ///     extrapolate (bool): Whether to answer past the curve's max date.
+    ///
+    /// Returns:
+    ///     float: The forward rate, continuously compounded at annual
+    ///         frequency.
+    ///
+    /// Raises:
+    ///     ItofinError: If either time is past the curve's range and
+    ///         extrapolation is not allowed.
     #[pyo3(signature = (t1, t2, extrapolate = false))]
     fn forward_rate(&self, t1: f64, t2: f64, extrapolate: bool) -> PyResult<f64> {
         Ok(self
@@ -92,7 +133,14 @@ impl PyYieldTermStructure {
             .rate())
     }
 
-    /// The date at which the discount factor is 1.0.
+    /// Return the date at which the discount factor is 1.0.
+    ///
+    /// Returns:
+    ///     Date: The curve's reference date.
+    ///
+    /// Raises:
+    ///     ItofinError: On a curve whose reference date moves with an
+    ///         evaluation date that is not set.
     fn reference_date(&self) -> PyResult<PyDate> {
         let date = self
             .inner
@@ -103,7 +151,10 @@ impl PyYieldTermStructure {
         Ok(PyDate::from_inner(date))
     }
 
-    /// The latest date for which the curve can return values.
+    /// Return the latest date for which the curve can return values.
+    ///
+    /// Returns:
+    ///     Date: The curve's maximum date.
     fn max_date(&self) -> PyResult<PyDate> {
         let date = self
             .inner
@@ -113,7 +164,10 @@ impl PyYieldTermStructure {
         Ok(PyDate::from_inner(date))
     }
 
-    /// Whether the curve answers dates/times beyond its maximum.
+    /// Return whether the curve answers dates and times beyond its maximum.
+    ///
+    /// Returns:
+    ///     bool: True when extrapolation is enabled on the curve itself.
     fn allows_extrapolation(&self) -> PyResult<bool> {
         Ok(self
             .inner
@@ -122,7 +176,7 @@ impl PyYieldTermStructure {
             .allows_extrapolation())
     }
 
-    /// Allows extrapolation past the maximum date/time.
+    /// Allow extrapolation past the maximum date and time.
     fn enable_extrapolation(&self) -> PyResult<()> {
         self.inner
             .current_link()
@@ -131,7 +185,7 @@ impl PyYieldTermStructure {
         Ok(())
     }
 
-    /// Forbids extrapolation past the maximum date/time.
+    /// Forbid extrapolation past the maximum date and time.
     fn disable_extrapolation(&self) -> PyResult<()> {
         self.inner
             .current_link()
@@ -149,20 +203,23 @@ impl PyYieldTermStructure {
     }
 }
 
-/// Python `FlatForward`: a flat continuously-compounded yield curve behind a
-/// [`Handle`] (`termstructures::yields::FlatForward`).
+/// A flat continuously-compounded yield curve behind a Handle.
 ///
-/// Built with `Compounding::Continuous` and `Frequency::Annual` - the
-/// convention every downstream Heston/Hull-White oracle assumes. The query
-/// surface is inherited from [`PyYieldTermStructure`]; the `Handle` is
-/// assembled internally so it never crosses the PyO3 boundary, and the pricing
-/// facades (H1/W1) take a clone of it through the base's crate-internal
-/// accessor.
+/// Built at annual frequency with continuous compounding, the convention every
+/// downstream Heston and Hull-White oracle assumes.
 #[pyclass(name = "FlatForward", extends = PyYieldTermStructure, unsendable)]
 pub struct PyFlatForward;
 
 #[pymethods]
 impl PyFlatForward {
+    /// Build the flat curve.
+    ///
+    /// Args:
+    ///     reference_date (Date): The date at which the discount factor is
+    ///         1.0.
+    ///     rate (float): The flat rate, continuously compounded at annual
+    ///         frequency.
+    ///     day_counter (DayCounter): The day count times are measured in.
     #[new]
     fn new(
         reference_date: &PyDate,
@@ -183,20 +240,29 @@ impl PyFlatForward {
     }
 }
 
-/// Python `ZeroCurve`: a yield curve built from (date, continuously-compounded
-/// zero-rate) nodes, interpolating linearly in zero-rate space
-/// (`termstructures::yields::ZeroCurve = InterpolatedZeroCurve<Linear>`).
+/// A yield curve interpolating continuously-compounded zero rates between nodes.
 ///
-/// Extends [`PyYieldTermStructure`]; the first date is the reference date and
-/// the query surface is inherited. `interpolation` selects the zero-rate
-/// interpolator: `"Linear"` (default, the shipped behaviour) or `"Cubic"` (the
-/// Kruger cubic factory, non-monotonic). Finite in time: queries past the last
-/// node require `enable_extrapolation()` or `extrapolate=True`.
+/// The first date is the reference date. Finite in time: queries past the last
+/// node require enable_extrapolation() or extrapolate=True.
 #[pyclass(name = "ZeroCurve", extends = PyYieldTermStructure, unsendable)]
 pub struct PyZeroCurve;
 
 #[pymethods]
 impl PyZeroCurve {
+    /// Build the curve over its (date, zero-rate) nodes.
+    ///
+    /// Args:
+    ///     dates (list[Date]): The node dates, the first being the reference
+    ///         date.
+    ///     yields (list[float]): The continuously-compounded zero rate at each
+    ///         node.
+    ///     day_counter (DayCounter): The day count turning dates into times.
+    ///     interpolation (str): "Linear", the shipped behaviour, or "Cubic",
+    ///         the Kruger cubic factory, which is non-monotonic.
+    ///
+    /// Raises:
+    ///     ItofinError: On an unknown interpolation name, and on whatever the
+    ///         core rejects about the nodes.
     #[new]
     #[pyo3(signature = (dates, yields, day_counter, interpolation = "Linear"))]
     fn new(
@@ -228,21 +294,32 @@ impl PyZeroCurve {
     }
 }
 
-/// Python `DiscountCurve`: a yield curve built from (date, discount-factor)
-/// nodes, interpolating log-linearly for piecewise-constant forwards
-/// (`termstructures::yields::DiscountCurve = InterpolatedDiscountCurve<LogLinear>`).
+/// A yield curve interpolating discount factors between nodes.
 ///
-/// Extends [`PyYieldTermStructure`]; the first date is the reference date and
-/// its discount must be 1.0. Unlike the other two curves this constructor
-/// accepts an optional calendar. `interpolation` selects the discount-factor
-/// interpolator: `"LogLinear"` (default, the shipped behaviour) or `"Cubic"`
-/// (the Kruger cubic factory, non-monotonic). Finite in time: queries past the
-/// last node require `enable_extrapolation()` or `extrapolate=True`.
+/// The first date is the reference date and its discount must be 1.0. Finite
+/// in time: queries past the last node require extrapolation.
 #[pyclass(name = "DiscountCurve", extends = PyYieldTermStructure, unsendable)]
 pub struct PyDiscountCurve;
 
 #[pymethods]
 impl PyDiscountCurve {
+    /// Build the curve over its (date, discount-factor) nodes.
+    ///
+    /// Args:
+    ///     dates (list[Date]): The node dates, the first being the reference
+    ///         date.
+    ///     discounts (list[float]): The discount factor at each node; the
+    ///         first must be 1.0.
+    ///     day_counter (DayCounter): The day count turning dates into times.
+    ///     calendar (Calendar | None): The curve's calendar; unlike the other
+    ///         two node curves this constructor accepts one.
+    ///     interpolation (str): "LogLinear", the shipped behaviour, giving
+    ///         piecewise-constant forwards, or "Cubic", which is
+    ///         non-monotonic.
+    ///
+    /// Raises:
+    ///     ItofinError: On an unknown interpolation name, and on whatever the
+    ///         core rejects about the nodes.
     #[new]
     #[pyo3(signature = (dates, discounts, day_counter, calendar = None, interpolation = "LogLinear"))]
     fn new(
@@ -281,22 +358,27 @@ impl PyDiscountCurve {
     }
 }
 
-/// Python `ForwardCurve`: a yield curve built from (date, instantaneous
-/// forward-rate) nodes, interpolating backward-flat
-/// (`termstructures::yields::ForwardCurve = InterpolatedForwardCurve<BackwardFlat>`).
+/// A yield curve interpolating instantaneous forward rates backward-flat.
 ///
-/// Extends [`PyYieldTermStructure`]; the first date is the reference date and
-/// the query surface is inherited. Finite in time: queries past the last node
-/// require `enable_extrapolation()` or `extrapolate=True`.
-///
-/// Unlike [`PyZeroCurve`] and [`PyDiscountCurve`], this curve offers no `Cubic`
-/// interpolation option: QuantLib-SWIG exposes its cubic curve on the zero and
-/// discount curves only, so the forward curve is intentionally left alone.
+/// The first date is the reference date. Finite in time. Unlike ZeroCurve and
+/// DiscountCurve this curve offers no cubic option, QuantLib-SWIG exposing its
+/// cubic curve on the zero and discount curves only.
 #[pyclass(name = "ForwardCurve", extends = PyYieldTermStructure, unsendable)]
 pub struct PyForwardCurve;
 
 #[pymethods]
 impl PyForwardCurve {
+    /// Build the curve over its (date, forward-rate) nodes.
+    ///
+    /// Args:
+    ///     dates (list[Date]): The node dates, the first being the reference
+    ///         date.
+    ///     forwards (list[float]): The instantaneous forward rate at each
+    ///         node.
+    ///     day_counter (DayCounter): The day count turning dates into times.
+    ///
+    /// Raises:
+    ///     ItofinError: On whatever the core rejects about the nodes.
     #[new]
     fn new(
         dates: Vec<PyRef<PyDate>>,
@@ -315,65 +397,59 @@ impl PyForwardCurve {
     }
 }
 
-/// Python `PiecewiseYieldCurve`: a yield curve bootstrapped from a strip of
-/// rate helpers, one curve node per helper maturity
-/// (`termstructures::yields::PiecewiseYieldCurve<Discount, I>`).
+/// A yield curve bootstrapped from a strip of rate helpers, one node per maturity.
 ///
-/// Extends [`PyYieldTermStructure`]; every helper is solved so it reprices its
-/// own market quote off the curve. This ergonomic string-dispatch alias covers
-/// the `Discount` convention over the `LogLinear` (default), `Linear` or
-/// `Cubic` interpolator selected by the `interpolation` string; all erase to
-/// the same `Handle<dyn YieldTermStructure>`, so no discriminant is stored.
-/// `Cubic` is a global interpolator, so its bootstrap runs the multi-pass
-/// convergence loop (#543) instead of a single pass. The other bootstrap
-/// conventions (`ZeroYield`, `ForwardRate`) are reached through the named
-/// [`PyPiecewiseLinearZero`], [`PyPiecewiseCubicZero`],
-/// [`PyPiecewiseLinearForward`], [`PyPiecewiseConvexMonotoneForward`] and
-/// [`PyPiecewiseFlatForward`] classes, which also expose node introspection.
-/// `(Discount, Linear)` deliberately gets no named class - QuantLib-SWIG has no
-/// equivalent - so it stays reachable only through this alias's `"Linear"` arm.
-/// `(ForwardRate, Cubic)` is deliberately not reachable at all: a piecewise
-/// cubic on instantaneous forwards settles into a period-2 cycle and never
-/// converges (the configuration upstream itself disables as unstable), so no
-/// named class offers it.
+/// Every helper is solved so it reprices its own market quote off the curve.
+/// This string-dispatch alias covers the Discount convention; the other
+/// bootstrap conventions are reached through the named Piecewise* classes,
+/// which also expose node introspection.
 ///
-/// `bootstrap` selects the bootstrap algorithm: `"iterative"` (the default)
-/// solves one node at a time, while `"global"` solves every node at once
-/// through a Levenberg-Marquardt fit of all helper residuals. The two are
-/// exactly determined on a plain strip, so they agree at every pillar to
-/// about 1e-13; `"global"` is a faithful superset, not a divergent algorithm.
-/// It is offered for `"LogLinear"` and `"Linear"` only - `(Discount, Cubic)`
-/// under the global solve has no core oracle, so it is rejected rather than
-/// shipped unverified.
+/// bootstrap selects the algorithm: "iterative" (the default) solves one node
+/// at a time, "global" solves every node at once through a
+/// Levenberg-Marquardt fit of all helper residuals. The two are exactly
+/// determined on a plain strip and agree at every pillar to about 1e-13, so
+/// "global" is a faithful superset rather than a divergent algorithm. It is
+/// offered for "LogLinear" and "Linear" only.
 ///
-/// What the global bootstrap adds is `additional_helpers`: instruments handed
-/// to the curve and registered with it that contribute neither a pillar date
-/// nor a residual. Their quote is inert here (reading it takes a penalty term,
-/// and penalties, additional dates and additional variables from Python are
-/// deferred to #981); what they do is extend the curve's `max_date` to their
-/// own `latest_relevant_date`, so a date past the last pillar becomes
-/// queryable without extrapolation. `"iterative"` cannot take them at all and
-/// rejects a non-empty list rather than silently ignoring it.
+/// What the global bootstrap adds is additional_helpers: instruments handed to
+/// the curve and registered with it that contribute neither a pillar nor a
+/// residual. Their quote is inert (reading it takes a penalty term, and
+/// penalties, additional dates and additional variables from Python are
+/// deferred), so all they do is extend the curve's max_date to their own
+/// latest_relevant_date, making dates past the last pillar queryable without
+/// extrapolation.
 ///
 /// The bootstrap is lazy: construction only rejects an empty helper list, and
-/// the solver runs on the first query (a `discount`/`zero_rate`), re-running
-/// after a helper-quote or evaluation-date change. A bootstrap failure surfaces
-/// from those query methods (the inherited base maps them), not the
-/// constructor; `max_date` swallows it and falls back to the reference date.
+/// the solver runs on the first query, re-running after a helper-quote or
+/// evaluation-date change. A bootstrap failure therefore surfaces from the
+/// query methods, not from the constructor.
 #[pyclass(name = "PiecewiseYieldCurve", extends = PyYieldTermStructure, unsendable)]
 pub struct PyPiecewiseYieldCurve;
 
 #[pymethods]
 impl PyPiecewiseYieldCurve {
-    /// A curve over `helpers` with a fixed `reference_date` (typically the
-    /// settlement date the caller computed via `Calendar.advance`). `helpers`
-    /// accepts any [`RateHelper`](PyRateHelper) subclass; `interpolation` is
-    /// `"LogLinear"`, `"Linear"` or `"Cubic"`; `bootstrap` is `"iterative"` or
-    /// `"global"`, and only the latter accepts `additional_helpers` (which
-    /// extend the curve's reach without adding a pillar). Fallible: an empty
-    /// helper list is rejected here, an unknown interpolation or bootstrap
-    /// name too, as are additional helpers under `"iterative"` and `"Cubic"`
-    /// under `"global"`.
+    /// Build the curve over helpers with a fixed reference date.
+    ///
+    /// Args:
+    ///     reference_date (Date): The curve's reference date, typically the
+    ///         settlement date the caller computed.
+    ///     helpers (list[RateHelper]): The bootstrap instruments; any
+    ///         RateHelper subclass is accepted.
+    ///     day_counter (DayCounter): The day count turning dates into times.
+    ///     interpolation (str): "LogLinear", "Linear" or "Cubic". Cubic is a
+    ///         global interpolator, so its bootstrap runs the multi-pass
+    ///         convergence loop instead of a single pass.
+    ///     bootstrap (str): "iterative" (the default) or "global". "global"
+    ///         supports "LogLinear" and "Linear" only.
+    ///     additional_helpers (list[RateHelper] | None): Instruments the
+    ///         global bootstrap registers without giving them a pillar or a
+    ///         residual. They only extend the curve's max_date to their
+    ///         latest_relevant_date; "iterative" rejects them.
+    ///
+    /// Raises:
+    ///     ItofinError: On an empty helper list, on an unknown interpolation
+    ///         or bootstrap name, on additional helpers under "iterative",
+    ///         and on "Cubic" under "global".
     #[new]
     #[pyo3(signature = (
         reference_date,
@@ -491,15 +567,13 @@ impl PyPiecewiseYieldCurve {
     }
 }
 
-/// Python `PiecewiseLogLinearDiscount`: a curve bootstrapped in discount-factor
-/// space with log-linear interpolation
-/// (`PiecewiseYieldCurve<Discount, LogLinear>`).
+/// A curve bootstrapped in discount-factor space with log-linear interpolation.
 ///
-/// The verbatim QuantLib-SWIG name for the blessed `(Discount, LogLinear)`
-/// combination. Unlike the string-dispatch [`PyPiecewiseYieldCurve`] alias, the
-/// named class retains the concrete curve so it can expose the bootstrapped
-/// node introspection (`dates`, `data`) the erased handle discards. Its stored
-/// `data()` are discount factors, so `data()[0]` is the reference node's `1.0`.
+/// The verbatim QuantLib-SWIG name for the blessed (Discount, LogLinear)
+/// combination. Unlike the PiecewiseYieldCurve alias, the named class retains
+/// the concrete curve so it can expose the node introspection the erased
+/// handle discards. data() are discount factors, so data()[0] is the reference
+/// node's 1.0.
 #[pyclass(name = "PiecewiseLogLinearDiscount", extends = PyYieldTermStructure, unsendable)]
 pub struct PyPiecewiseLogLinearDiscount {
     concrete: Shared<PiecewiseYieldCurve<Discount, LogLinear>>,
@@ -507,9 +581,16 @@ pub struct PyPiecewiseLogLinearDiscount {
 
 #[pymethods]
 impl PyPiecewiseLogLinearDiscount {
-    /// A curve over `helpers` with a fixed `reference_date`. `helpers` accepts
-    /// any [`RateHelper`](PyRateHelper) subclass. Fallible: an empty helper list
-    /// is rejected here.
+    /// Build the curve over helpers with a fixed reference date.
+    ///
+    /// Args:
+    ///     reference_date (Date): The curve's reference date.
+    ///     helpers (list[RateHelper]): The bootstrap instruments; any
+    ///         RateHelper subclass is accepted.
+    ///     day_counter (DayCounter): The day count turning dates into times.
+    ///
+    /// Raises:
+    ///     ItofinError: On an empty helper list.
     #[new]
     fn new(
         reference_date: &PyDate,
@@ -532,7 +613,13 @@ impl PyPiecewiseLogLinearDiscount {
         .add_subclass(PyPiecewiseLogLinearDiscount { concrete }))
     }
 
-    /// The bootstrapped node dates (triggers the lazy bootstrap).
+    /// Return the bootstrapped node dates, triggering the lazy bootstrap.
+    ///
+    /// Returns:
+    ///     list[Date]: One date per helper maturity, plus the reference node.
+    ///
+    /// Raises:
+    ///     ItofinError: On a bootstrap failure.
     fn dates(&self) -> PyResult<Vec<PyDate>> {
         Ok(self
             .concrete
@@ -543,20 +630,23 @@ impl PyPiecewiseLogLinearDiscount {
             .collect())
     }
 
-    /// The bootstrapped node values, discount factors here (triggers the lazy
-    /// bootstrap).
+    /// Return the bootstrapped node values, triggering the lazy bootstrap.
+    ///
+    /// Returns:
+    ///     list[float]: The discount factors, the first being 1.0.
+    ///
+    /// Raises:
+    ///     ItofinError: On a bootstrap failure.
     fn data(&self) -> PyResult<Vec<f64>> {
         Ok(self.concrete.data().map_err(PyQlError::from)?)
     }
 }
 
-/// Python `PiecewiseLinearZero`: a curve bootstrapped in zero-rate space with
-/// linear interpolation (`PiecewiseYieldCurve<ZeroYield, Linear>`).
+/// A curve bootstrapped in zero-rate space with linear interpolation.
 ///
-/// The verbatim QuantLib-SWIG name for the blessed `(ZeroYield, Linear)`
-/// combination. Its stored `data()` are continuously-compounded zero rates, so
-/// `data()[0]` mirrors the first solved pillar's rate rather than a `1.0`
-/// discount.
+/// The verbatim QuantLib-SWIG name for the blessed (ZeroYield, Linear)
+/// combination. data() are continuously-compounded zero rates, so data()[0]
+/// mirrors the first solved pillar's rate rather than a 1.0 discount.
 #[pyclass(name = "PiecewiseLinearZero", extends = PyYieldTermStructure, unsendable)]
 pub struct PyPiecewiseLinearZero {
     concrete: Shared<PiecewiseYieldCurve<ZeroYield, Linear>>,
@@ -564,8 +654,15 @@ pub struct PyPiecewiseLinearZero {
 
 #[pymethods]
 impl PyPiecewiseLinearZero {
-    /// A curve over `helpers` with a fixed `reference_date`. Fallible: an empty
-    /// helper list is rejected here.
+    /// Build the curve over helpers with a fixed reference date.
+    ///
+    /// Args:
+    ///     reference_date (Date): The curve's reference date.
+    ///     helpers (list[RateHelper]): The bootstrap instruments.
+    ///     day_counter (DayCounter): The day count turning dates into times.
+    ///
+    /// Raises:
+    ///     ItofinError: On an empty helper list.
     #[new]
     fn new(
         reference_date: &PyDate,
@@ -588,7 +685,13 @@ impl PyPiecewiseLinearZero {
         .add_subclass(PyPiecewiseLinearZero { concrete }))
     }
 
-    /// The bootstrapped node dates (triggers the lazy bootstrap).
+    /// Return the bootstrapped node dates, triggering the lazy bootstrap.
+    ///
+    /// Returns:
+    ///     list[Date]: One date per helper maturity, plus the reference node.
+    ///
+    /// Raises:
+    ///     ItofinError: On a bootstrap failure.
     fn dates(&self) -> PyResult<Vec<PyDate>> {
         Ok(self
             .concrete
@@ -599,21 +702,24 @@ impl PyPiecewiseLinearZero {
             .collect())
     }
 
-    /// The bootstrapped node values, zero rates here (triggers the lazy
-    /// bootstrap).
+    /// Return the bootstrapped node values, triggering the lazy bootstrap.
+    ///
+    /// Returns:
+    ///     list[float]: The zero rates at the nodes.
+    ///
+    /// Raises:
+    ///     ItofinError: On a bootstrap failure.
     fn data(&self) -> PyResult<Vec<f64>> {
         Ok(self.concrete.data().map_err(PyQlError::from)?)
     }
 }
 
-/// Python `PiecewiseCubicZero`: a curve bootstrapped in zero-rate space with
-/// Kruger cubic interpolation (`PiecewiseYieldCurve<ZeroYield, Cubic>`).
+/// A curve bootstrapped in zero-rate space with Kruger cubic interpolation.
 ///
-/// The QuantLib-SWIG name for the `(ZeroYield, Cubic)` combination. `Cubic` is
-/// a global interpolator (every node depends on all others), so the bootstrap
-/// runs the multi-pass convergence loop (#543) instead of a single pass. Its
-/// stored `data()` are continuously-compounded zero rates, so `data()[0]`
-/// mirrors the first solved pillar's rate rather than a `1.0` discount.
+/// The QuantLib-SWIG name for the (ZeroYield, Cubic) combination. Cubic is a
+/// global interpolator, so the bootstrap runs the multi-pass convergence loop
+/// instead of a single pass. data() are continuously-compounded zero rates, so
+/// data()[0] mirrors the first solved pillar's rate rather than a 1.0 discount.
 #[pyclass(name = "PiecewiseCubicZero", extends = PyYieldTermStructure, unsendable)]
 pub struct PyPiecewiseCubicZero {
     concrete: Shared<PiecewiseYieldCurve<ZeroYield, Cubic>>,
@@ -621,8 +727,15 @@ pub struct PyPiecewiseCubicZero {
 
 #[pymethods]
 impl PyPiecewiseCubicZero {
-    /// A curve over `helpers` with a fixed `reference_date`. Fallible: an empty
-    /// helper list is rejected here.
+    /// Build the curve over helpers with a fixed reference date.
+    ///
+    /// Args:
+    ///     reference_date (Date): The curve's reference date.
+    ///     helpers (list[RateHelper]): The bootstrap instruments.
+    ///     day_counter (DayCounter): The day count turning dates into times.
+    ///
+    /// Raises:
+    ///     ItofinError: On an empty helper list.
     #[new]
     fn new(
         reference_date: &PyDate,
@@ -645,7 +758,13 @@ impl PyPiecewiseCubicZero {
         .add_subclass(PyPiecewiseCubicZero { concrete }))
     }
 
-    /// The bootstrapped node dates (triggers the lazy bootstrap).
+    /// Return the bootstrapped node dates, triggering the lazy bootstrap.
+    ///
+    /// Returns:
+    ///     list[Date]: One date per helper maturity, plus the reference node.
+    ///
+    /// Raises:
+    ///     ItofinError: On a bootstrap failure.
     fn dates(&self) -> PyResult<Vec<PyDate>> {
         Ok(self
             .concrete
@@ -656,19 +775,22 @@ impl PyPiecewiseCubicZero {
             .collect())
     }
 
-    /// The bootstrapped node values, zero rates here (triggers the lazy
-    /// bootstrap).
+    /// Return the bootstrapped node values, triggering the lazy bootstrap.
+    ///
+    /// Returns:
+    ///     list[float]: The zero rates at the nodes.
+    ///
+    /// Raises:
+    ///     ItofinError: On a bootstrap failure.
     fn data(&self) -> PyResult<Vec<f64>> {
         Ok(self.concrete.data().map_err(PyQlError::from)?)
     }
 }
 
-/// Python `PiecewiseLinearForward`: a curve bootstrapped in instantaneous
-/// forward-rate space with linear interpolation
-/// (`PiecewiseYieldCurve<ForwardRate, Linear>`).
+/// A curve bootstrapped in instantaneous forward-rate space, interpolating linearly.
 ///
-/// The verbatim QuantLib-SWIG name for the blessed `(ForwardRate, Linear)`
-/// combination. Its stored `data()` are instantaneous forward rates.
+/// The verbatim QuantLib-SWIG name for the blessed (ForwardRate, Linear)
+/// combination. data() are instantaneous forward rates.
 #[pyclass(name = "PiecewiseLinearForward", extends = PyYieldTermStructure, unsendable)]
 pub struct PyPiecewiseLinearForward {
     concrete: Shared<PiecewiseYieldCurve<ForwardRate, Linear>>,
@@ -676,8 +798,15 @@ pub struct PyPiecewiseLinearForward {
 
 #[pymethods]
 impl PyPiecewiseLinearForward {
-    /// A curve over `helpers` with a fixed `reference_date`. Fallible: an empty
-    /// helper list is rejected here.
+    /// Build the curve over helpers with a fixed reference date.
+    ///
+    /// Args:
+    ///     reference_date (Date): The curve's reference date.
+    ///     helpers (list[RateHelper]): The bootstrap instruments.
+    ///     day_counter (DayCounter): The day count turning dates into times.
+    ///
+    /// Raises:
+    ///     ItofinError: On an empty helper list.
     #[new]
     fn new(
         reference_date: &PyDate,
@@ -700,7 +829,13 @@ impl PyPiecewiseLinearForward {
         .add_subclass(PyPiecewiseLinearForward { concrete }))
     }
 
-    /// The bootstrapped node dates (triggers the lazy bootstrap).
+    /// Return the bootstrapped node dates, triggering the lazy bootstrap.
+    ///
+    /// Returns:
+    ///     list[Date]: One date per helper maturity, plus the reference node.
+    ///
+    /// Raises:
+    ///     ItofinError: On a bootstrap failure.
     fn dates(&self) -> PyResult<Vec<PyDate>> {
         Ok(self
             .concrete
@@ -711,8 +846,13 @@ impl PyPiecewiseLinearForward {
             .collect())
     }
 
-    /// The bootstrapped node values, forward rates here (triggers the lazy
-    /// bootstrap).
+    /// Return the bootstrapped node values, triggering the lazy bootstrap.
+    ///
+    /// Returns:
+    ///     list[float]: The instantaneous forward rates at the nodes.
+    ///
+    /// Raises:
+    ///     ItofinError: On a bootstrap failure.
     fn data(&self) -> PyResult<Vec<f64>> {
         Ok(self.concrete.data().map_err(PyQlError::from)?)
     }
@@ -723,24 +863,14 @@ enum ConvexMonotoneCurve {
     Local(Shared<PiecewiseYieldCurve<ForwardRate, ConvexMonotone, LocalBootstrap>>),
 }
 
-/// Python `PiecewiseConvexMonotoneForward`: a curve bootstrapped in
-/// instantaneous forward-rate space with convex-monotone interpolation
-/// (`PiecewiseYieldCurve<ForwardRate, ConvexMonotone>`).
+/// A curve bootstrapped in forward-rate space with convex-monotone interpolation.
 ///
-/// The QuantLib-SWIG name for the `(ForwardRate, ConvexMonotone)` combination,
+/// The QuantLib-SWIG name for the (ForwardRate, ConvexMonotone) combination,
 /// built with QuantLib's defaults (quadraticity 0.3, monotonicity 0.7, forced
-/// positive). `ConvexMonotone` is a global interpolator that reads the solved
+/// positive). ConvexMonotone is a global interpolator that reads the solved
 /// nodes as discrete forwards, so the bootstrap runs the multi-pass
-/// convergence loop (#543). Its stored `data()` are instantaneous forward
-/// rates; the interpolation itself ignores node `[0]`, which only mirrors the
-/// first solved pillar.
-///
-/// `bootstrap` selects the bootstrap algorithm: `"iterative"` (default, the
-/// shipped behaviour) solves one node at a time, while `"local"`
-/// least-squares-fits a trailing window of nodes at each step so the
-/// non-local interpolation keeps a localised risk profile. The two reprice
-/// every pillar (the local solve to its own tolerance, about 1e-7 on the
-/// oracle strip) and diverge between them.
+/// convergence loop. data() are instantaneous forward rates; the interpolation
+/// ignores node [0], which only mirrors the first solved pillar.
 #[pyclass(name = "PiecewiseConvexMonotoneForward", extends = PyYieldTermStructure, unsendable)]
 pub struct PyPiecewiseConvexMonotoneForward {
     concrete: ConvexMonotoneCurve,
@@ -748,9 +878,22 @@ pub struct PyPiecewiseConvexMonotoneForward {
 
 #[pymethods]
 impl PyPiecewiseConvexMonotoneForward {
-    /// A curve over `helpers` with a fixed `reference_date`, bootstrapped by
-    /// the algorithm `bootstrap` names. Fallible: an empty helper list and an
-    /// unknown bootstrap name are both rejected here.
+    /// Build the curve over helpers with a fixed reference date.
+    ///
+    /// Args:
+    ///     reference_date (Date): The curve's reference date.
+    ///     helpers (list[RateHelper]): The bootstrap instruments.
+    ///     day_counter (DayCounter): The day count turning dates into times.
+    ///     bootstrap (str): "iterative", the shipped behaviour, solving one
+    ///         node at a time, or "local", least-squares-fitting a trailing
+    ///         window of nodes at each step so the non-local interpolation
+    ///         keeps a localised risk profile. The two reprice every pillar
+    ///         (the local solve to its own tolerance, about 1e-7 on the
+    ///         oracle strip) and diverge between them.
+    ///
+    /// Raises:
+    ///     ItofinError: On an empty helper list, and on an unknown bootstrap
+    ///         name.
     #[new]
     #[pyo3(signature = (reference_date, helpers, day_counter, bootstrap = "iterative"))]
     fn new(
@@ -800,7 +943,13 @@ impl PyPiecewiseConvexMonotoneForward {
         .add_subclass(PyPiecewiseConvexMonotoneForward { concrete }))
     }
 
-    /// The bootstrapped node dates (triggers the lazy bootstrap).
+    /// Return the bootstrapped node dates, triggering the lazy bootstrap.
+    ///
+    /// Returns:
+    ///     list[Date]: One date per helper maturity, plus the reference node.
+    ///
+    /// Raises:
+    ///     ItofinError: On a bootstrap failure.
     fn dates(&self) -> PyResult<Vec<PyDate>> {
         let dates = match &self.concrete {
             ConvexMonotoneCurve::Iterative(curve) => curve.dates(),
@@ -813,8 +962,13 @@ impl PyPiecewiseConvexMonotoneForward {
             .collect())
     }
 
-    /// The bootstrapped node values, forward rates here (triggers the lazy
-    /// bootstrap).
+    /// Return the bootstrapped node values, triggering the lazy bootstrap.
+    ///
+    /// Returns:
+    ///     list[float]: The instantaneous forward rates at the nodes.
+    ///
+    /// Raises:
+    ///     ItofinError: On a bootstrap failure.
     fn data(&self) -> PyResult<Vec<f64>> {
         let data = match &self.concrete {
             ConvexMonotoneCurve::Iterative(curve) => curve.data(),
@@ -824,16 +978,12 @@ impl PyPiecewiseConvexMonotoneForward {
     }
 }
 
-/// Python `PiecewiseFlatForward`: a curve bootstrapped in instantaneous
-/// forward-rate space with backward-flat interpolation
-/// (`PiecewiseYieldCurve<ForwardRate, BackwardFlat>`).
+/// A curve bootstrapped in forward-rate space, interpolating backward-flat.
 ///
-/// The verbatim QuantLib-SWIG name for the blessed `(ForwardRate, BackwardFlat)`
-/// combination. Piecewise-constant instantaneous forwards produce a curve
-/// numerically identical to [`PyPiecewiseLogLinearDiscount`] under every
-/// discount/zero/forward query (log-linear in discount space *is* piecewise
-/// constant forwards); only the stored `data()` (forward rates vs discount
-/// factors) tell the two apart.
+/// The verbatim QuantLib-SWIG name for the blessed (ForwardRate, BackwardFlat)
+/// combination. Piecewise-constant instantaneous forwards make it numerically
+/// identical to PiecewiseLogLinearDiscount under every query; only data(),
+/// forward rates against discount factors, tells the two apart.
 #[pyclass(name = "PiecewiseFlatForward", extends = PyYieldTermStructure, unsendable)]
 pub struct PyPiecewiseFlatForward {
     concrete: Shared<PiecewiseYieldCurve<ForwardRate, BackwardFlat>>,
@@ -841,8 +991,15 @@ pub struct PyPiecewiseFlatForward {
 
 #[pymethods]
 impl PyPiecewiseFlatForward {
-    /// A curve over `helpers` with a fixed `reference_date`. Fallible: an empty
-    /// helper list is rejected here.
+    /// Build the curve over helpers with a fixed reference date.
+    ///
+    /// Args:
+    ///     reference_date (Date): The curve's reference date.
+    ///     helpers (list[RateHelper]): The bootstrap instruments.
+    ///     day_counter (DayCounter): The day count turning dates into times.
+    ///
+    /// Raises:
+    ///     ItofinError: On an empty helper list.
     #[new]
     fn new(
         reference_date: &PyDate,
@@ -865,7 +1022,13 @@ impl PyPiecewiseFlatForward {
         .add_subclass(PyPiecewiseFlatForward { concrete }))
     }
 
-    /// The bootstrapped node dates (triggers the lazy bootstrap).
+    /// Return the bootstrapped node dates, triggering the lazy bootstrap.
+    ///
+    /// Returns:
+    ///     list[Date]: One date per helper maturity, plus the reference node.
+    ///
+    /// Raises:
+    ///     ItofinError: On a bootstrap failure.
     fn dates(&self) -> PyResult<Vec<PyDate>> {
         Ok(self
             .concrete
@@ -876,8 +1039,13 @@ impl PyPiecewiseFlatForward {
             .collect())
     }
 
-    /// The bootstrapped node values, forward rates here (triggers the lazy
-    /// bootstrap).
+    /// Return the bootstrapped node values, triggering the lazy bootstrap.
+    ///
+    /// Returns:
+    ///     list[float]: The instantaneous forward rates at the nodes.
+    ///
+    /// Raises:
+    ///     ItofinError: On a bootstrap failure.
     fn data(&self) -> PyResult<Vec<f64>> {
         Ok(self.concrete.data().map_err(PyQlError::from)?)
     }

--- a/crates/itofin-py/src/curve.rs
+++ b/crates/itofin-py/src/curve.rs
@@ -1,5 +1,5 @@
-//! Facades for the yield term-structure hierarchy: the [`PyYieldTermStructure`]
-//! base and the concrete [`PyFlatForward`] curve.
+//! Facades for the yield term-structure hierarchy: the YieldTermStructure base
+//! and the concrete FlatForward curve.
 
 use crate::helpers::PyRateHelper;
 use crate::time::{PyCalendar, PyDate, PyDayCounter};

--- a/crates/itofin-py/src/fra.rs
+++ b/crates/itofin-py/src/fra.rs
@@ -1,12 +1,11 @@
-//! Facades for the forward rate agreement: [`PyPosition`] and
-//! [`PyForwardRateAgreement`].
+//! Facades for the forward rate agreement: Position and ForwardRateAgreement.
 //!
-//! The FRA prices without an engine (`forwardrateagreement.rs`), so the facade
-//! exposes the valuation accessors directly; no `set_engine` step exists. The
-//! core keeps its value and maturity dates private with no accessors, so the
-//! facade stores both at construction - they are immutable on the core
-//! instrument too - with the maturity adjusted through the instrument's own
-//! calendar and convention, the same computation the core constructor runs.
+//! The FRA prices without an engine, so the facade exposes the valuation
+//! accessors directly; no `set_engine` step exists. The core keeps its value
+//! and maturity dates private with no accessors, so the facade stores both at
+//! construction - they are immutable on the core instrument too - with the
+//! maturity adjusted through the instrument's own calendar and convention, the
+//! same computation the core constructor runs.
 
 use crate::PyQlError;
 use crate::curve::PyYieldTermStructure;
@@ -35,7 +34,7 @@ pub enum PyPosition {
 }
 
 impl PyPosition {
-    /// The core [`Position`] this variant stands for.
+    /// The core Position this variant stands for.
     pub(crate) fn inner(self) -> Position {
         match self {
             PyPosition::Long => Position::Long,

--- a/crates/itofin-py/src/fra.rs
+++ b/crates/itofin-py/src/fra.rs
@@ -49,6 +49,9 @@ impl PyPosition {
 /// The FRA prices without an engine, so the valuation accessors work as soon
 /// as it is built. It settles and expires on its value date - the day the
 /// underlying loan begins - not on the later maturity date.
+///
+/// Passing None for the discount curve discounts on the forwarding curve
+/// instead.
 #[pyclass(name = "ForwardRateAgreement", unsendable)]
 pub struct PyForwardRateAgreement {
     inner: ForwardRateAgreement,

--- a/crates/itofin-py/src/fra.rs
+++ b/crates/itofin-py/src/fra.rs
@@ -22,10 +22,11 @@ use libitofin::termstructures::yieldtermstructure::YieldTermStructure;
 use libitofin::time::date::Date;
 use pyo3::prelude::*;
 
-/// Python `Position`: the side taken in a contract (core `position::Position`).
+/// The side taken in a contract.
 ///
-/// A fieldless pyo3 enum exposing `Position.Long` / `Position.Short`; the
-/// signed `+1`/`-1` settlement multiplier stays in the core.
+/// A fieldless enum; Long is an FRA purchase (a future long loan, short
+/// deposit), Short an FRA sale. The signed settlement multiplier the two
+/// variants stand for stays in the core.
 #[pyclass(name = "Position", eq, eq_int, from_py_object)]
 #[derive(Clone, Copy, PartialEq)]
 pub enum PyPosition {
@@ -43,15 +44,11 @@ impl PyPosition {
     }
 }
 
-/// Python `ForwardRateAgreement`: a FRA over an Ibor index
-/// (`instruments::forwardrateagreement::ForwardRateAgreement`).
+/// A forward rate agreement over an Ibor index.
 ///
-/// The default constructor is the indexed-coupon one (`useIndexedCoupon =
-/// true`): the maturity is the index's own maturity of the value date and the
-/// forward rate is the index fixing. `with_maturity` is the explicit-window
-/// constructor, forward-rated by the par approximation off the index's
-/// forwarding curve. Passing `None` for the discount curve discounts on the
-/// forwarding curve instead (`forwardrateagreement.rs:311`).
+/// The FRA prices without an engine, so the valuation accessors work as soon
+/// as it is built. It settles and expires on its value date - the day the
+/// underlying loan begins - not on the later maturity date.
 #[pyclass(name = "ForwardRateAgreement", unsendable)]
 pub struct PyForwardRateAgreement {
     inner: ForwardRateAgreement,
@@ -61,6 +58,24 @@ pub struct PyForwardRateAgreement {
 
 #[pymethods]
 impl PyForwardRateAgreement {
+    /// Build the indexed-coupon FRA.
+    ///
+    /// The maturity is the index's own maturity of the value date and the
+    /// forward rate is the index fixing.
+    ///
+    /// Args:
+    ///     index (IborIndex): The index the forward rate is forecast by.
+    ///     value_date (Date): The day the underlying loan begins.
+    ///     fra_type (Position): The side taken, Long or Short.
+    ///     strike_forward_rate (float): The simple rate agreed on.
+    ///     notional_amount (float): The notional the settlement accrues on.
+    ///     discount_curve (YieldTermStructure | None): The curve the
+    ///         settlement discounts on; None discounts on the index's
+    ///         forwarding curve instead.
+    ///
+    /// Raises:
+    ///     ItofinError: If the notional is not positive or the maturity
+    ///         cannot be derived from the value date.
     #[new]
     #[pyo3(signature = (index, value_date, fra_type, strike_forward_rate, notional_amount, discount_curve))]
     fn new(
@@ -94,13 +109,31 @@ impl PyForwardRateAgreement {
         })
     }
 
-    /// The explicit-window constructor (`with_maturity`,
-    /// `forwardrateagreement.rs:120`, `useIndexedCoupon = false`): the FRA
-    /// spans `[value_date, maturity_date]` with the maturity adjusted on the
-    /// index's fixing calendar under the index's convention.
+    /// Build the FRA over an explicit [value_date, maturity_date] window.
     ///
-    /// Fallible: the notional must be positive and the value date earlier than
-    /// the adjusted maturity date.
+    /// The forward rate is the par approximation off the index's forwarding
+    /// curve; the maturity is adjusted on the index's fixing calendar under
+    /// the index's convention.
+    ///
+    /// Args:
+    ///     index (IborIndex): The index supplying the forwarding curve and
+    ///         the conventions.
+    ///     value_date (Date): The day the underlying loan begins.
+    ///     maturity_date (Date): The day the underlying loan ends, before
+    ///         adjustment.
+    ///     fra_type (Position): The side taken, Long or Short.
+    ///     strike_forward_rate (float): The simple rate agreed on.
+    ///     notional_amount (float): The notional the settlement accrues on.
+    ///     discount_curve (YieldTermStructure | None): The curve the
+    ///         settlement discounts on; None discounts on the index's
+    ///         forwarding curve instead.
+    ///
+    /// Returns:
+    ///     ForwardRateAgreement: The explicit-window FRA.
+    ///
+    /// Raises:
+    ///     ItofinError: If the notional is not positive or the value date is
+    ///         not earlier than the adjusted maturity date.
     #[staticmethod]
     #[pyo3(signature = (index, value_date, maturity_date, fra_type, strike_forward_rate, notional_amount, discount_curve))]
     #[allow(clippy::too_many_arguments)]
@@ -133,37 +166,60 @@ impl PyForwardRateAgreement {
         })
     }
 
-    /// The relevant forward rate associated with the FRA term (`forwardRate`),
-    /// as a simple Simple/Once rate.
+    /// Return the forward rate associated with the FRA term.
     ///
-    /// Fallible: the index needs a forwarding curve (or a fixing) covering the
-    /// term.
+    /// Returns:
+    ///     float: The simple forward rate over the FRA window.
+    ///
+    /// Raises:
+    ///     ItofinError: If the index has no forwarding curve or fixing
+    ///         covering the term.
     fn forward_rate(&mut self) -> PyResult<f64> {
         Ok(self.inner.forward_rate().map_err(PyQlError::from)?.rate())
     }
 
-    /// The payoff on the value date (`amount`).
+    /// Return the payoff on the value date.
     ///
-    /// Fallible: an expired FRA has no settlement amount (the core surfaces
-    /// the C++ undefined read as an error, D10).
+    /// Returns:
+    ///     float: The settlement amount, signed by the position.
+    ///
+    /// Raises:
+    ///     ItofinError: On an expired FRA, which has no settlement amount.
     fn amount(&mut self) -> PyResult<f64> {
         Ok(self.inner.amount().map_err(PyQlError::from)?)
     }
 
-    /// The NPV: the settlement amount discounted to the value date on the
-    /// discount curve, or on the forwarding curve when none was given.
+    /// Return the settlement amount discounted to the value date.
+    ///
+    /// Discounts on the discount curve, or on the index's forwarding curve
+    /// when none was given.
+    ///
+    /// Returns:
+    ///     float: The present value.
+    ///
+    /// Raises:
+    ///     ItofinError: If no evaluation date is set or the curves cannot
+    ///         cover the term.
     fn npv(&mut self) -> PyResult<f64> {
         Ok(self.inner.npv().map_err(PyQlError::from)?)
     }
 
-    /// The value date: the day the underlying loan begins, on which the FRA
-    /// settles and expires.
+    /// Return the day the underlying loan begins.
+    ///
+    /// The FRA settles and expires on this date.
+    ///
+    /// Returns:
+    ///     Date: The value date.
     fn value_date(&self) -> PyDate {
         PyDate::from_inner(self.value_date)
     }
 
-    /// The maturity date of the underlying loan, adjusted on the index's
-    /// fixing calendar under the index's convention.
+    /// Return the day the underlying loan ends.
+    ///
+    /// Adjusted on the index's fixing calendar under the index's convention.
+    ///
+    /// Returns:
+    ///     Date: The adjusted maturity date.
     fn maturity_date(&self) -> PyDate {
         PyDate::from_inner(self.maturity_date)
     }

--- a/crates/itofin-py/src/helpers.rs
+++ b/crates/itofin-py/src/helpers.rs
@@ -38,14 +38,11 @@ use libitofin::time::calendars::nullcalendar::NullCalendar;
 use libitofin::types::{Integer, Natural, Real};
 use pyo3::prelude::*;
 
-/// Python `RateHelper`: the shared base for every bootstrap helper
-/// (`termstructures::bootstraphelper::RateHelper`).
+/// Shared base for every bootstrap helper: implied/market quotes and dates.
 ///
-/// Holds the erased `Shared<dyn RateHelper>` and exposes the inspectors the
-/// bootstrap and its oracles read: the curve-implied quote and its error
-/// (fallible, needing a linked curve), the maturity and pillar dates
-/// (infallible), and the fitted market quote's current value. Concrete helpers
-/// such as [`PyDepositRateHelper`] subclass this and supply only their
+/// A rate helper wraps a market quote plus the schedule of a single
+/// instrument; a piecewise curve is bootstrapped so every helper reprices its
+/// own quote. Concrete helpers subclass this and supply only their
 /// constructor.
 #[pyclass(name = "RateHelper", subclass, unsendable)]
 pub struct PyRateHelper {
@@ -54,47 +51,77 @@ pub struct PyRateHelper {
 
 #[pymethods]
 impl PyRateHelper {
-    /// The quote implied by the curve the helper is linked to. Fallible: with
-    /// no curve set (the pre-bootstrap state) there is nothing to imply from.
+    /// Return the quote implied by the curve the helper is linked to.
+    ///
+    /// Returns:
+    ///     float: The curve-implied quote.
+    ///
+    /// Raises:
+    ///     ItofinError: With no curve set, the pre-bootstrap state, there
+    ///         being nothing to imply from.
     fn implied_quote(&self) -> PyResult<f64> {
         Ok(self.inner.implied_quote().map_err(PyQlError::from)?)
     }
 
-    /// The bootstrap root the solver drives to zero: market quote minus implied
-    /// quote. Fallible for the same reason as [`Self::implied_quote`].
+    /// Return the bootstrap root: market quote minus implied quote.
+    ///
+    /// Returns:
+    ///     float: The residual the solver drives to zero.
+    ///
+    /// Raises:
+    ///     ItofinError: On the same condition implied_quote reports.
     fn quote_error(&self) -> PyResult<f64> {
         Ok(self.inner.quote_error().map_err(PyQlError::from)?)
     }
 
-    /// The current value of the market quote the helper fits. Reads back through
-    /// the retained quote handle, so a `set_value` on the `SimpleQuote` passed
-    /// to the constructor is observed here (the same-object wiring the laziness
-    /// contract relies on). Fallible: the quote handle may be empty.
+    /// Return the current value of the market quote the helper fits.
+    ///
+    /// Reads back through the retained quote handle, so a set_value on the
+    /// SimpleQuote passed to the constructor is observed here: the same-object
+    /// wiring the laziness contract relies on.
+    ///
+    /// Returns:
+    ///     float: The market quote's current value.
     fn quote_value(&self) -> PyResult<f64> {
         Ok(self.inner.base().quote_value().map_err(PyQlError::from)?)
     }
 
-    /// The instrument's maturity date.
+    /// Return the instrument's maturity date.
+    ///
+    /// Returns:
+    ///     Date: The maturity.
     fn maturity_date(&self) -> PyDate {
         PyDate::from_inner(self.inner.maturity_date())
     }
 
-    /// The pillar date, at which the curve node this helper sets sits.
+    /// Return the date the curve node this helper sets sits at.
+    ///
+    /// Returns:
+    ///     Date: The pillar date.
     fn pillar_date(&self) -> PyDate {
         PyDate::from_inner(self.inner.pillar_date())
     }
 
-    /// The earliest date the helper needs curve data at.
+    /// Return the earliest date the helper needs curve data at.
+    ///
+    /// Returns:
+    ///     Date: The earliest relevant date.
     fn earliest_date(&self) -> PyDate {
         PyDate::from_inner(self.inner.earliest_date())
     }
 
-    /// The latest date the helper needs curve data at (equal to the pillar date).
+    /// Return the latest date the helper needs curve data at.
+    ///
+    /// Returns:
+    ///     Date: The latest date, equal to the pillar date.
     fn latest_date(&self) -> PyDate {
         PyDate::from_inner(self.inner.latest_date())
     }
 
-    /// The latest date whose data the helper is relevant for.
+    /// Return the latest date whose data the helper is relevant for.
+    ///
+    /// Returns:
+    ///     Date: The latest relevant date.
     fn latest_relevant_date(&self) -> PyDate {
         PyDate::from_inner(self.inner.latest_relevant_date())
     }
@@ -109,19 +136,18 @@ impl PyRateHelper {
     }
 }
 
-/// Python `DepositRateHelper`: a helper fitting a deposit rate
-/// (`termstructures::yields::ratehelpers::DepositRateHelper`).
-///
-/// The quote-form constructor retains the caller's [`PySimpleQuote`] so a later
-/// `set_value` re-drives the bootstrap; `from_rate` is a convenience that wraps
-/// a fixed rate in a fresh, un-retained quote.
+/// A helper fitting a deposit rate.
 #[pyclass(name = "DepositRateHelper", extends = PyRateHelper, unsendable)]
 pub struct PyDepositRateHelper;
 
 #[pymethods]
 impl PyDepositRateHelper {
-    /// A deposit helper fitting `quote`, whose schedule comes from `index`. The
-    /// caller keeps `quote`; mutating it later invalidates the bootstrap.
+    /// Build the helper over a live quote.
+    ///
+    /// Args:
+    ///     quote (SimpleQuote): The deposit rate; the caller keeps it, and
+    ///         mutating it later invalidates the bootstrap.
+    ///     index (IborIndex): The index supplying the deposit's schedule.
     #[new]
     fn new(quote: &PySimpleQuote, index: &PyIborIndex) -> PyClassInitializer<Self> {
         let idx = index.inner();
@@ -129,8 +155,15 @@ impl PyDepositRateHelper {
         PyClassInitializer::from(PyRateHelper { inner: helper }).add_subclass(PyDepositRateHelper)
     }
 
-    /// A deposit helper fitting a fixed `rate`, wrapped in an internal quote the
-    /// caller cannot later mutate.
+    /// Build the helper over a fixed rate.
+    ///
+    /// Args:
+    ///     rate (float): The deposit rate, wrapped in an internal quote the
+    ///         caller cannot later mutate.
+    ///     index (IborIndex): The index supplying the deposit's schedule.
+    ///
+    /// Returns:
+    ///     DepositRateHelper: The helper fitting that rate.
     #[staticmethod]
     fn from_rate(py: Python<'_>, rate: f64, index: &PyIborIndex) -> PyResult<Py<Self>> {
         let idx = index.inner();
@@ -143,20 +176,25 @@ impl PyDepositRateHelper {
     }
 }
 
-/// Python `SwapRateHelper`: a helper fitting a par swap rate
-/// (`termstructures::yields::ratehelpers::SwapRateHelper`).
+/// A helper fitting a par swap rate (spot-starting, no spread).
 ///
 /// The spot-starting form the curve-consistency oracle builds: no spread, no
-/// forward start, no exogenous discounting curve, and the default
-/// `Pillar::LastRelevantDate`.
+/// forward start, no exogenous discounting curve, and the default pillar.
 #[pyclass(name = "SwapRateHelper", extends = PyRateHelper, unsendable)]
 pub struct PySwapRateHelper;
 
 #[pymethods]
 impl PySwapRateHelper {
-    /// A swap helper fitting `quote` with the schedule of a spot-starting swap
-    /// of `tenor`, its fixed leg built from the given frequency, convention, and
-    /// day count, floating off `ibor_index`.
+    /// Build the helper over the schedule of a spot-starting swap.
+    ///
+    /// Args:
+    ///     quote (SimpleQuote): The par swap rate the helper fits.
+    ///     tenor (Period): The length of the swap.
+    ///     calendar (Calendar): The calendar the schedule rolls on.
+    ///     fixed_frequency (Frequency): The fixed leg's payment frequency.
+    ///     fixed_convention (BusinessDayConvention): The fixed leg's roll.
+    ///     fixed_day_count (DayCounter): The fixed leg's day count.
+    ///     ibor_index (IborIndex): The index the floating leg fixes off.
     #[new]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -182,14 +220,12 @@ impl PySwapRateHelper {
     }
 }
 
-/// Python `FuturesType`: the date convention an interest-rate future settles on
-/// (`instruments::FuturesType`).
+/// The date convention an interest-rate future settles on.
 ///
-/// A fieldless pyo3 enum exposing `Imm`, `Asx` and `Custom`. `Imm` and `Custom`
-/// are fully usable from Python; `Asx` validates and prices against an explicitly
-/// supplied ASX start date, but the ASX date navigators (`is_asx_date`/
-/// `next_asx_date`, the analogues of the faced IMM functions) are deferred, so
-/// there is no helper to derive the next ASX date from Python yet.
+/// Imm and Custom are fully usable from Python. Asx validates and prices against
+/// an explicitly supplied ASX start date, but the ASX date navigators (the
+/// analogues of itofin.time.is_imm_date / next_imm_date) are deferred, so there
+/// is no helper to derive the next ASX date from Python yet.
 #[pyclass(name = "FuturesType", eq, eq_int, from_py_object)]
 #[derive(Clone, Copy, PartialEq)]
 pub enum PyFuturesType {
@@ -209,16 +245,12 @@ impl PyFuturesType {
     }
 }
 
-/// Python `FuturesRateHelper`: a helper fitting an exchange-traded interest-rate
-/// future's quoted price at a fixed IMM/ASX window
-/// (`termstructures::yields::ratehelpers::FuturesRateHelper`).
+/// A helper fitting an exchange-traded interest-rate future's quoted price.
 ///
 /// Unlike the deposit and swap helpers the window is absolute: it is computed
-/// once from the supplied dates and never rebuilt on an evaluation-date change.
-/// The convexity adjustment is usually absent; pass `None` to leave it empty
-/// (an empty handle reports a zero adjustment). The subclass retains the concrete
-/// `Shared<FuturesRateHelper>` so [`Self::convexity_adjustment`], which is not on
-/// the [`RateHelper`] trait, stays reachable.
+/// once from the supplied dates and never rebuilt on an evaluation-date
+/// change. The convexity adjustment is usually absent; pass conv_adj=None to
+/// leave it empty, which reports a zero adjustment.
 #[pyclass(name = "FuturesRateHelper", extends = PyRateHelper, unsendable)]
 pub struct PyFuturesRateHelper {
     futures: Shared<FuturesRateHelper>,
@@ -226,11 +258,26 @@ pub struct PyFuturesRateHelper {
 
 #[pymethods]
 impl PyFuturesRateHelper {
-    /// A futures helper over a length-in-months window off `ibor_start_date`: the
-    /// maturity is the start advanced `length_in_months` months on `calendar`
-    /// under `convention`/`end_of_month`. `conv_adj` is the convexity quote, or
-    /// `None` for an empty (zero) adjustment. Fallible: an `Imm`/`Asx` start that
-    /// is not a valid date of that convention is rejected.
+    /// Build the helper over a length-in-months window off the start date.
+    ///
+    /// Args:
+    ///     price (SimpleQuote): The future's quoted price.
+    ///     ibor_start_date (Date): The window's start.
+    ///     length_in_months (int): The months the start is advanced by to
+    ///         reach maturity.
+    ///     calendar (Calendar): The calendar the maturity rolls on.
+    ///     convention (BusinessDayConvention): The roll applied to the
+    ///         maturity.
+    ///     end_of_month (bool): Whether the maturity roll keeps to month ends.
+    ///     day_counter (DayCounter): The day count the year fraction uses.
+    ///     conv_adj (SimpleQuote | None): The convexity quote, or None for an
+    ///         empty, zero adjustment.
+    ///     futures_type (FuturesType): The date convention the future settles
+    ///         on.
+    ///
+    /// Raises:
+    ///     ItofinError: If an Imm or Asx start is not a valid date of that
+    ///         convention.
     #[new]
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (
@@ -270,11 +317,27 @@ impl PyFuturesRateHelper {
         Ok(init(helper))
     }
 
-    /// A futures helper over an explicit window. With `ibor_end_date` `None` the
-    /// maturity is three IMM/ASX periods past the start; with a date, that date
-    /// (which must be past the start). Divergence from C++: a `Custom` helper with
-    /// no end date is an error here, not a null-maturity helper. Fallible for that
-    /// case and for a start that is not a valid date of the chosen convention.
+    /// Build the helper over an explicit window.
+    ///
+    /// Args:
+    ///     price (SimpleQuote): The future's quoted price.
+    ///     ibor_start_date (Date): The window's start.
+    ///     ibor_end_date (Date | None): The window's end, which must be past
+    ///         the start; None puts the maturity three IMM/ASX periods past
+    ///         the start.
+    ///     day_counter (DayCounter): The day count the year fraction uses.
+    ///     conv_adj (SimpleQuote | None): The convexity quote, or None for an
+    ///         empty, zero adjustment.
+    ///     futures_type (FuturesType): The date convention the future settles
+    ///         on.
+    ///
+    /// Returns:
+    ///     FuturesRateHelper: The helper over that window.
+    ///
+    /// Raises:
+    ///     ItofinError: On a Custom helper with no end date - a divergence
+    ///         from C++, which builds a null-maturity helper instead - and on
+    ///         a start that is not a valid date of the chosen convention.
     #[staticmethod]
     #[pyo3(signature = (
         price,
@@ -305,10 +368,26 @@ impl PyFuturesRateHelper {
         Py::new(py, init(helper))
     }
 
-    /// A futures helper whose window follows `index`'s conventions: the maturity
-    /// is the start advanced by the index tenor on the index's fixing calendar,
-    /// and the year fraction uses the index day counter. Fallible for a start that
-    /// is not a valid date of the chosen convention.
+    /// Build the helper with a window following the index's conventions.
+    ///
+    /// The maturity is the start advanced by the index tenor on the index's
+    /// fixing calendar, and the year fraction uses the index day counter.
+    ///
+    /// Args:
+    ///     price (SimpleQuote): The future's quoted price.
+    ///     ibor_start_date (Date): The window's start.
+    ///     index (IborIndex): The index supplying the conventions.
+    ///     conv_adj (SimpleQuote | None): The convexity quote, or None for an
+    ///         empty, zero adjustment.
+    ///     futures_type (FuturesType): The date convention the future settles
+    ///         on.
+    ///
+    /// Returns:
+    ///     FuturesRateHelper: The helper over that window.
+    ///
+    /// Raises:
+    ///     ItofinError: If the start is not a valid date of the chosen
+    ///         convention.
     #[staticmethod]
     #[pyo3(signature = (price, ibor_start_date, index, conv_adj, futures_type))]
     fn from_index(
@@ -331,9 +410,10 @@ impl PyFuturesRateHelper {
         Py::new(py, init(helper))
     }
 
-    /// The convexity adjustment applied to the forward: the convexity quote's
-    /// value, or zero when none was supplied. The quantity the convexity oracle
-    /// pins.
+    /// Return the convexity adjustment applied to the forward.
+    ///
+    /// Returns:
+    ///     float: The convexity quote's value, or zero when none was supplied.
     fn convexity_adjustment(&self) -> PyResult<f64> {
         Ok(self
             .futures
@@ -362,14 +442,11 @@ fn init(helper: Shared<FuturesRateHelper>) -> PyClassInitializer<PyFuturesRateHe
     PyClassInitializer::from(base).add_subclass(PyFuturesRateHelper { futures: helper })
 }
 
-/// Python `Pillar`: the date the curve node a helper fits sits at
-/// (`termstructures::yields::Pillar`).
+/// The date the curve node a helper fits sits at.
 ///
-/// A fieldless pyo3 enum exposing the two schedule-derived choices `MaturityDate`
-/// and `LastRelevantDate` (the C++ default). `Pillar::CustomDate` is deferred in
-/// the core (#343) - it needs an explicit pillar date threaded through
-/// construction plus its bounds check - so its omission here is deliberate, not
-/// an oversight.
+/// MaturityDate and LastRelevantDate (the default) are the two schedule-derived
+/// choices. Pillar.CustomDate is deferred in the core (#343), so its omission
+/// here is deliberate, not an oversight.
 #[pyclass(name = "Pillar", eq, eq_int, from_py_object)]
 #[derive(Clone, Copy, PartialEq)]
 pub enum PyPillar {
@@ -387,26 +464,28 @@ impl PyPillar {
     }
 }
 
-/// Python `FraRateHelper`: a helper fitting a forward-rate-agreement rate over the
-/// window starting `period_to_start` after spot and spanning the index tenor
-/// (`termstructures::yields::ratehelpers::FraRateHelper`).
-///
-/// All four constructors are infallible, so `__init__` and the staticmethods hand
-/// back the initializer directly. `use_indexed_coupon` selects the implied-quote
-/// mode (C++ default `True`, the index fixing forecast off the curve; `False` is
-/// the par simple-forward over the raw window); it and `pillar` (default
-/// `Pillar.LastRelevantDate`) are exposed explicitly. Like the other relative
-/// helpers the quote-form constructors retain the caller's [`PySimpleQuote`] so a
-/// later `set_value` re-drives the bootstrap; `from_rate` wraps a fixed rate in a
-/// fresh, un-retained quote. `from_dates` fixes the window at construction, and it
-/// does not shift when the evaluation date changes.
+/// A helper fitting a forward-rate-agreement rate over the window starting
+/// period_to_start after spot and spanning the index tenor. use_indexed_coupon
+/// (default True) selects the indexed implied-quote mode; False is the par simple
+/// forward. from_dates fixes the window at construction (it does not shift on an
+/// evaluation-date change).
 #[pyclass(name = "FraRateHelper", extends = PyRateHelper, unsendable)]
 pub struct PyFraRateHelper;
 
 #[pymethods]
 impl PyFraRateHelper {
-    /// A FRA helper fitting `quote` over the window `period_to_start` past spot
-    /// spanning `index`'s tenor. The constructor the mixed strip uses.
+    /// Build the helper over the window period_to_start past spot.
+    ///
+    /// Args:
+    ///     quote (SimpleQuote): The FRA rate; the caller keeps it, so a later
+    ///         set_value re-drives the bootstrap.
+    ///     period_to_start (Period): How long after spot the window starts.
+    ///     index (IborIndex): The index whose tenor the window spans.
+    ///     use_indexed_coupon (bool): True selects the indexed implied-quote
+    ///         mode, the index fixing forecast off the curve; False is the par
+    ///         simple forward over the raw window.
+    ///     pillar (Pillar): The date the curve node sits at; defaults to
+    ///         LastRelevantDate.
     #[new]
     #[pyo3(signature = (
         quote,
@@ -433,8 +512,18 @@ impl PyFraRateHelper {
         PyClassInitializer::from(PyRateHelper { inner: helper }).add_subclass(PyFraRateHelper)
     }
 
-    /// A FRA helper fitting a fixed `rate`, wrapped in an internal quote the caller
-    /// cannot later mutate.
+    /// Build the helper over a fixed rate.
+    ///
+    /// Args:
+    ///     rate (float): The FRA rate, wrapped in an internal quote the caller
+    ///         cannot later mutate.
+    ///     period_to_start (Period): How long after spot the window starts.
+    ///     index (IborIndex): The index whose tenor the window spans.
+    ///     use_indexed_coupon (bool): The implied-quote mode; see __init__.
+    ///     pillar (Pillar): The date the curve node sits at.
+    ///
+    /// Returns:
+    ///     FraRateHelper: The helper fitting that rate.
     #[staticmethod]
     #[pyo3(signature = (
         rate,
@@ -465,7 +554,18 @@ impl PyFraRateHelper {
         )
     }
 
-    /// A FRA helper whose start is `months_to_start` months after spot.
+    /// Build the helper with a start given in months after spot.
+    ///
+    /// Args:
+    ///     quote (SimpleQuote): The FRA rate the helper fits.
+    ///     months_to_start (int): How many months after spot the window
+    ///         starts.
+    ///     index (IborIndex): The index whose tenor the window spans.
+    ///     use_indexed_coupon (bool): The implied-quote mode; see __init__.
+    ///     pillar (Pillar): The date the curve node sits at.
+    ///
+    /// Returns:
+    ///     FraRateHelper: The helper over that window.
     #[staticmethod]
     #[pyo3(signature = (
         quote,
@@ -496,8 +596,21 @@ impl PyFraRateHelper {
         )
     }
 
-    /// A FRA helper over the explicit `[start_date, end_date]` window. Its schedule
-    /// is fixed at construction and does not shift on an evaluation-date change.
+    /// Build the helper over an explicit window.
+    ///
+    /// The schedule is fixed at construction and does not shift when the
+    /// evaluation date changes.
+    ///
+    /// Args:
+    ///     quote (SimpleQuote): The FRA rate the helper fits.
+    ///     start_date (Date): The window's start.
+    ///     end_date (Date): The window's end.
+    ///     index (IborIndex): The index the forward is read off.
+    ///     use_indexed_coupon (bool): The implied-quote mode; see __init__.
+    ///     pillar (Pillar): The date the curve node sits at.
+    ///
+    /// Returns:
+    ///     FraRateHelper: The helper over that window.
     #[staticmethod]
     #[pyo3(signature = (
         quote,
@@ -532,17 +645,12 @@ impl PyFraRateHelper {
     }
 }
 
-/// Python `OvernightIndex`: the base of the overnight index families
-/// (`indexes::iborindex::OvernightIndex`).
+/// The base of the overnight index families.
 ///
-/// Abstract from Python: it has no constructor, because the core builds an
-/// overnight index only through a family factory such as [`PyEstr`], which is
-/// what supplies the conventions. It exists so the facades consuming an
-/// overnight index - [`PyOISRateHelper`] and the OIS-swap builder - name one
-/// type and accept any family, mirroring [`PyIborIndex`] under
-/// [`PyEuribor`]. The `fixing` accessor stays on the family facade rather than
-/// being lifted here; nothing reads a fixing off the base yet, so widening it
-/// is deferred.
+/// Abstract: it has no constructor, because the core builds an overnight index
+/// only through a family factory such as Estr. It exists so OISRateHelper and
+/// MakeOis name one type and accept any family. The fixing accessor stays on
+/// the family facade; lifting it here is deferred.
 #[pyclass(name = "OvernightIndex", subclass, unsendable)]
 pub struct PyOvernightIndex {
     inner: Shared<OvernightIndex>,
@@ -556,20 +664,12 @@ impl PyOvernightIndex {
     }
 }
 
-/// Python `Estr`: the Euro Short-Term Rate overnight index (`indexes::Estr`).
+/// The Euro Short-Term Rate overnight index.
 ///
-/// `Estr::new` returns an `OvernightIndex` by value (it adds no behaviour over
-/// the base, so the C++ subclass is pure configuration, `estr.rs:7`); it is
-/// wrapped in `shared()` so [`PyOISRateHelper`] can hold the same object and
-/// hand the core ctor the `&OvernightIndex` it takes. Passing `None` for the
-/// curve builds the index over an empty forwarding handle, the form the OIS
-/// bootstrap needs. Infallible (unlike `Euribor::new`, which rejects daily
-/// tenors): the overnight tenor is fixed to `1*Days` by the base.
-///
-/// A subclass of [`PyOvernightIndex`], so an ESTR index is accepted wherever
-/// the general overnight index is. It retains its own clone of the index the
-/// base holds - the same object, not a rebuild - so a facade typed on either
-/// half reads exactly the same core index.
+/// A subclass of OvernightIndex, so an ESTR index is accepted wherever the
+/// general overnight index is. It retains its own clone of the index the base
+/// holds - the same object, not a rebuild - so a facade typed on either half
+/// reads exactly the same core index.
 #[pyclass(name = "Estr", extends = PyOvernightIndex, unsendable)]
 pub struct PyEstr {
     inner: Shared<OvernightIndex>,
@@ -577,8 +677,17 @@ pub struct PyEstr {
 
 #[pymethods]
 impl PyEstr {
-    /// An ESTR index forwarding off `curve`, or off an empty handle when `curve`
-    /// is `None`.
+    /// Build an ESTR index forwarding off curve.
+    ///
+    /// Infallible, unlike the Euribor constructor: the overnight tenor is fixed
+    /// to one day by the base rather than taken from the caller.
+    ///
+    /// Args:
+    ///     curve (YieldTermStructure | None): The forwarding curve; None builds
+    ///         the index over an empty forwarding handle, the form the OIS
+    ///         bootstrap needs.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date and the stored fixings.
     #[new]
     #[pyo3(signature = (curve, settings))]
     fn new(
@@ -592,9 +701,23 @@ impl PyEstr {
         init_overnight(shared(Estr::new(forwarding, settings.inner())))
     }
 
-    /// The index's fixing for `fixing_date`, forecast off the forwarding curve
-    /// for a future date or read from stored fixings for a past one. Fallible:
-    /// an empty forwarding handle or an unset evaluation date is an error.
+    /// Return the index fixing for fixing_date.
+    ///
+    /// Forecast off the forwarding curve for a future date, or read from the
+    /// stored fixings for a past one.
+    ///
+    /// Args:
+    ///     fixing_date (Date): The date the fixing is read or forecast for.
+    ///     forecast_todays_fixing (bool): Whether a fixing dated today is
+    ///         forecast rather than looked up.
+    ///
+    /// Returns:
+    ///     float: The fixing rate.
+    ///
+    /// Raises:
+    ///     ItofinError: If the fixing date is not a valid one, the evaluation
+    ///         date is unset, a past fixing is missing from the store, or the
+    ///         forwarding handle is empty on a forecast.
     fn fixing(&self, fixing_date: &PyDate, forecast_todays_fixing: bool) -> PyResult<f64> {
         Ok(self
             .inner
@@ -613,11 +736,10 @@ fn init_overnight(index: Shared<OvernightIndex>) -> PyClassInitializer<PyEstr> {
     PyClassInitializer::from(base).add_subclass(PyEstr { inner: index })
 }
 
-/// Python `RateAveraging`: how an overnight coupon combines its daily fixings
-/// (`cashflows::RateAveraging`).
+/// How an overnight coupon combines its daily fixings.
 ///
-/// A fieldless pyo3 enum exposing `Simple` (arithmetic average) and `Compound`
-/// (daily compounding, the coupon default the OIS oracle uses).
+/// Simple is the arithmetic average; Compound (daily compounding) is the coupon
+/// default the OIS conventions use.
 #[pyclass(name = "RateAveraging", eq, eq_int, from_py_object)]
 #[derive(Clone, Copy, PartialEq)]
 pub enum PyRateAveraging {
@@ -635,27 +757,46 @@ impl PyRateAveraging {
     }
 }
 
-/// Python `OISRateHelper`: a helper fitting an overnight-indexed swap rate
-/// (`termstructures::yields::ratehelpers::OISRateHelper`).
+/// A helper fitting an overnight-indexed swap rate (spot-starting, floating
+/// off an overnight index).
 ///
-/// The spot-starting OIS the bootstrap oracle builds: a swap of `tenor` starting
-/// `settlement_days` after the evaluation date, floating off `overnight_index`.
-/// The Python signature lists the required knobs first (so `settings` can sit
-/// among them rather than illegally after the defaulted trailing ones), then the
-/// four optional knobs the issue defaults; the body reorders these into the core
-/// ctor's 13-argument positional order. `discounting_curve` `None` discounts off
-/// the bootstrapping curve; `overnight_spread` `None` becomes an empty (zero)
-/// spread handle. The deferred core knobs past `averaging_method` (telescopic
-/// value dates, lookback, lockout, observation shift, custom pillar, per-leg
-/// calendars, `ratehelpers.rs:1036-1039`) take their benign defaults.
+/// The required knobs come first so settings can sit among them; the four
+/// optional knobs trail with defaults. discounting_curve=None discounts off the
+/// bootstrapping curve; overnight_spread=None is an empty (zero) spread. The
+/// deferred core knobs past averaging_method (telescopic value dates, lookback,
+/// lockout, observation shift, custom pillar, per-leg calendars) take benign
+/// defaults.
 #[pyclass(name = "OISRateHelper", extends = PyRateHelper, unsendable)]
 pub struct PyOISRateHelper;
 
 #[pymethods]
 impl PyOISRateHelper {
-    /// An OIS helper fitting `quote` with the schedule of a spot-starting OIS of
-    /// `tenor` floating off `overnight_index`. The caller keeps `quote` (and
-    /// `overnight_spread`); mutating either later re-drives the bootstrap.
+    /// Build the helper over the schedule of a spot-starting OIS.
+    ///
+    /// Args:
+    ///     settlement_days (int): The days after the evaluation date the swap
+    ///         starts.
+    ///     tenor (Period): The length of the swap.
+    ///     quote (SimpleQuote): The OIS rate; the caller keeps it, so a later
+    ///         set_value re-drives the bootstrap.
+    ///     overnight_index (OvernightIndex): The index the floating leg
+    ///         compounds.
+    ///     payment_lag (int): The days between accrual end and payment.
+    ///     payment_convention (BusinessDayConvention): The roll applied to the
+    ///         payment dates.
+    ///     payment_frequency (Frequency): The payment frequency.
+    ///     forward_start (Period): How long after spot the swap starts.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date and the stored fixings.
+    ///     discounting_curve (YieldTermStructure | None): The curve the flows
+    ///         discount on; None discounts off the bootstrapping curve.
+    ///     overnight_spread (SimpleQuote | None): The spread over the index;
+    ///         None leaves it empty, so zero. The caller keeps it, and
+    ///         mutating it re-drives the bootstrap.
+    ///     pillar (Pillar): The date the curve node sits at; defaults to
+    ///         LastRelevantDate.
+    ///     averaging_method (RateAveraging): How the daily fixings combine;
+    ///         defaults to Compound.
     #[new]
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (
@@ -710,14 +851,12 @@ impl PyOISRateHelper {
     }
 }
 
-/// Python `BondPriceType`: the price convention a bond helper fits
-/// (`instruments::BondPriceType`).
+/// The price convention a bond helper fits.
 ///
-/// A fieldless pyo3 enum exposing `Clean`, the quoted price with the accrued
-/// interest stripped out, and `Dirty`, the full settlement price. The two differ
-/// by exactly the bond's accrued amount at settlement (`bondhelpers.rs:367`), so
-/// the choice moves the bootstrapped curve for any bond settling mid-coupon and
-/// is a no-op for one settling on a coupon date.
+/// Clean is the quoted price with the accrued interest stripped out; Dirty is
+/// the full settlement price. The two differ by exactly the bond's accrued
+/// amount at settlement, so the choice moves the bootstrapped curve for any
+/// bond settling mid-coupon and is a no-op for one settling on a coupon date.
 #[pyclass(name = "BondPriceType", eq, eq_int, from_py_object)]
 #[derive(Clone, Copy, PartialEq)]
 pub enum PyBondPriceType {
@@ -735,47 +874,65 @@ impl PyBondPriceType {
     }
 }
 
-/// Python `FixedRateBondHelper`: a helper fitting the quoted price of a
-/// fixed-coupon bond it builds internally
-/// (`termstructures::yields::bondhelpers::FixedRateBondHelper`).
+/// A helper fitting the quoted price of a fixed-coupon bond it builds itself.
 ///
-/// Unlike the schedule-derived helpers this one is a fixed-date helper: its bond
-/// and its dates are built once and do not shift when the evaluation date moves.
-/// The pillar is the bond's last cash-flow date, which rolls past the maturity
-/// whenever the final payment is date-adjusted (`bondhelpers.rs:84-88`), so read
-/// it off [`PyRateHelper::pillar_date`] rather than assuming the maturity.
+/// Unlike the schedule-derived helpers this one is a fixed-date helper: its
+/// bond and its dates are built once and do not shift when the evaluation date
+/// moves. The pillar is the bond's last cash-flow date, which rolls past the
+/// maturity whenever the final payment is date-adjusted, so read pillar_date()
+/// rather than assuming the maturity.
 ///
-/// The Python constructor is contained: it takes eleven of the core's sixteen
-/// arguments and defaults the rest, which are documented deferrals rather than
-/// silent omissions.
+/// The constructor is contained: it takes eleven of the core's sixteen
+/// arguments and defaults the rest. Those defaults are deferrals, not
+/// oversights:
 ///
-/// - The four ex-coupon knobs (`ex_coupon_period`, `ex_coupon_calendar`,
-///   `ex_coupon_convention`, `ex_coupon_end_of_month`) take the no-ex-coupon
-///   defaults the core oracle passes (`bondhelpers.rs:536-541`): no period, a
-///   null calendar, `Unadjusted`, and `false`. An ex-coupon bond is not
-///   constructible from Python yet.
-/// - `payment_calendar` is defaulted to `None`, so the schedule's own calendar
+/// - The four ex-coupon knobs (period, calendar, convention, end-of-month) take
+///   the no-ex-coupon defaults the core oracle passes: no period, a null
+///   calendar, Unadjusted, and False. An ex-coupon bond is not constructible
+///   from Python yet.
+/// - payment_calendar is defaulted to None, so the schedule's own calendar
 ///   rolls the payment dates, again as the core oracle does. A bond paying on a
 ///   calendar other than its schedule's is not constructible from Python yet.
-/// - The generic `BondHelper`, over an arbitrary pre-built bond, is not faced at
+/// - The generic BondHelper, over an arbitrary pre-built bond, is not faced at
 ///   all: it needs a bond-instrument facade, which does not exist.
-/// - [`PySchedule`] exposes no `end_of_month` knob (its builder leaves the core
-///   default `false`), so an end-of-month coupon schedule is not constructible
-///   from Python yet. Deferred with the schedule facade rather than here.
+/// - Schedule takes no end_of_month knob, so an end-of-month bond schedule is
+///   not constructible from Python yet.
 ///
-/// `issue_date` is the one core argument moved out of position: it is optional,
-/// so it trails the required `price_type` and `settings` rather than sitting
-/// between `redemption` and them as it does in the core signature.
+/// issue_date is the one core argument moved out of position: it is optional,
+/// so it trails the required price_type and settings.
 #[pyclass(name = "FixedRateBondHelper", extends = PyRateHelper, unsendable)]
 pub struct PyFixedRateBondHelper;
 
 #[pymethods]
 impl PyFixedRateBondHelper {
-    /// A bond helper fitting `price` - read as a clean or dirty quote per
-    /// `price_type` - for the fixed-coupon bond built from `schedule`. The caller
-    /// keeps `price`; mutating it later re-drives the bootstrap. Fallible: the
-    /// bond build and the helper's next-cash-flow date both resolve off the
-    /// evaluation date, which must be set on `settings`.
+    /// Build the helper over a fixed-coupon bond assembled from the schedule.
+    ///
+    /// Args:
+    ///     price (SimpleQuote): The bond's quoted price, read as clean or dirty
+    ///         per price_type. The caller keeps it, so a later set_value
+    ///         re-drives the bootstrap.
+    ///     settlement_days (int): The days between the evaluation date and the
+    ///         bond's settlement date.
+    ///     face_amount (float): The notional the coupons accrue on.
+    ///     schedule (Schedule): The coupon schedule; its calendar also rolls
+    ///         the payment dates.
+    ///     coupons (list[float]): The coupon rates, one per period or a single
+    ///         rate applied to every period.
+    ///     day_counter (DayCounter): The day count the coupons accrue under.
+    ///     payment_convention (BusinessDayConvention): The roll applied to the
+    ///         payment dates.
+    ///     redemption (float): The redemption amount, per 100 of face.
+    ///     price_type (BondPriceType): Whether price is a clean or a dirty
+    ///         quote.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date.
+    ///     issue_date (Date | None): The bond's issue date; None leaves it
+    ///         unset.
+    ///
+    /// Raises:
+    ///     ItofinError: On whatever the core rejects about the bond, and when
+    ///         the evaluation date is unset, since the helper resolves the
+    ///         bond's next cash-flow date off it.
     #[new]
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (

--- a/crates/itofin-py/src/helpers.rs
+++ b/crates/itofin-py/src/helpers.rs
@@ -1,18 +1,17 @@
-//! Facades for the bootstrap rate helpers: the [`PyRateHelper`] base and the
-//! concrete [`PyDepositRateHelper`] and [`PySwapRateHelper`] instruments.
+//! Facades for the bootstrap rate helpers: the RateHelper base and the concrete
+//! DepositRateHelper and SwapRateHelper instruments.
 //!
 //! A rate helper wraps a market quote plus the schedule of a single instrument;
 //! a piecewise curve is bootstrapped so every helper reprices its own quote.
-//! The base holds the already-upcast `Shared<dyn RateHelper>` (the four
-//! inspectors are all `&self`, so no interior mutability is needed here) and
-//! the concrete subclasses supply only their constructors, mirroring the
-//! [`crate::curve::PyYieldTermStructure`] base/subclass idiom.
+//! The base holds the helper already upcast and type-erased, and the concrete
+//! subclasses supply only their constructors, mirroring the YieldTermStructure
+//! base/subclass idiom.
 //!
-//! The `OIS` helper, with its [`PyEstr`] overnight index and
-//! [`PyRateAveraging`] convention, lands in this module (#551), as does
-//! [`PyFixedRateBondHelper`], which builds its own bond internally and so needs
-//! no bond facade (#530). The generic `BondHelper`, over an arbitrary pre-built
-//! bond, stays deferred: there is no bond-instrument facade to hand it one.
+//! The `OIS` helper, with its Estr overnight index and RateAveraging
+//! convention, lands in this module (#551), as does FixedRateBondHelper, which
+//! builds its own bond internally and so needs no bond facade (#530). The
+//! generic `BondHelper`, over an arbitrary pre-built bond, stays deferred:
+//! there is no bond-instrument facade to hand it one.
 
 use crate::PyQlError;
 use crate::curve::PyYieldTermStructure;
@@ -235,7 +234,7 @@ pub enum PyFuturesType {
 }
 
 impl PyFuturesType {
-    /// The core [`FuturesType`] this variant stands for.
+    /// The core FuturesType this variant stands for.
     pub(crate) fn inner(&self) -> FuturesType {
         match self {
             PyFuturesType::Imm => FuturesType::Imm,
@@ -423,7 +422,7 @@ impl PyFuturesRateHelper {
 }
 
 /// The convexity handle for a futures helper: the caller's quote, or an empty
-/// handle when `None`. `PySimpleQuote::handle` is never empty, so the empty case
+/// handle when `None`. A SimpleQuote handle is never empty, so the empty case
 /// (the zero-adjustment default the core tests pass) must be built here.
 fn empty_or_handle(conv_adj: Option<&PySimpleQuote>) -> Handle<dyn Quote> {
     match conv_adj {
@@ -433,8 +432,8 @@ fn empty_or_handle(conv_adj: Option<&PySimpleQuote>) -> Handle<dyn Quote> {
 }
 
 /// The base/subclass initializer shared by the three constructors: the erased
-/// upcast helper feeds the [`PyRateHelper`] base, and the concrete clone is
-/// retained on the subclass for [`PyFuturesRateHelper::convexity_adjustment`].
+/// upcast helper feeds the RateHelper base, and the concrete clone is retained
+/// on the subclass for FuturesRateHelper.convexity_adjustment().
 fn init(helper: Shared<FuturesRateHelper>) -> PyClassInitializer<PyFuturesRateHelper> {
     let base = PyRateHelper {
         inner: Shared::clone(&helper) as Shared<dyn RateHelper>,
@@ -455,7 +454,7 @@ pub enum PyPillar {
 }
 
 impl PyPillar {
-    /// The core [`Pillar`] this variant stands for.
+    /// The core Pillar this variant stands for.
     pub(crate) fn inner(&self) -> Pillar {
         match self {
             PyPillar::MaturityDate => Pillar::MaturityDate,
@@ -730,8 +729,8 @@ impl PyEstr {
 }
 
 /// The base/subclass initializer the ESTR constructor builds: one index object
-/// feeds both halves, so the base [`PyOvernightIndex`] the OIS facades read and
-/// the [`PyEstr`] its own `fixing` reads are the same core index.
+/// feeds both halves, so the base OvernightIndex the OIS facades read and the
+/// Estr its own `fixing` reads are the same core index.
 fn init_overnight(index: Shared<OvernightIndex>) -> PyClassInitializer<PyEstr> {
     let base = PyOvernightIndex {
         inner: Shared::clone(&index),
@@ -751,7 +750,7 @@ pub enum PyRateAveraging {
 }
 
 impl PyRateAveraging {
-    /// The core [`RateAveraging`] this variant stands for.
+    /// The core RateAveraging this variant stands for.
     pub(crate) fn inner(&self) -> RateAveraging {
         match self {
             PyRateAveraging::Simple => RateAveraging::Simple,
@@ -868,7 +867,7 @@ pub enum PyBondPriceType {
 }
 
 impl PyBondPriceType {
-    /// The core [`BondPriceType`] this variant stands for.
+    /// The core BondPriceType this variant stands for.
     pub(crate) fn inner(&self) -> BondPriceType {
         match self {
             PyBondPriceType::Clean => BondPriceType::Clean,

--- a/crates/itofin-py/src/helpers.rs
+++ b/crates/itofin-py/src/helpers.rs
@@ -670,6 +670,9 @@ impl PyOvernightIndex {
 /// general overnight index is. It retains its own clone of the index the base
 /// holds - the same object, not a rebuild - so a facade typed on either half
 /// reads exactly the same core index.
+///
+/// Construction is infallible, unlike the Euribor one that rejects daily
+/// tenors: the overnight tenor is fixed to one day by the base.
 #[pyclass(name = "Estr", extends = PyOvernightIndex, unsendable)]
 pub struct PyEstr {
     inner: Shared<OvernightIndex>,

--- a/crates/itofin-py/src/heston.rs
+++ b/crates/itofin-py/src/heston.rs
@@ -1,5 +1,5 @@
-//! Facades for the Heston stack: [`PyHestonProcess`], [`PyHestonModel`] and
-//! [`PyHestonModelHelper`].
+//! Facades for the Heston stack: HestonProcess, HestonModel and
+//! HestonModelHelper.
 
 use crate::PyQlError;
 use crate::calibration::{PyCalibrationErrorType, PyEndCriteria, PyLevenbergMarquardt};

--- a/crates/itofin-py/src/heston.rs
+++ b/crates/itofin-py/src/heston.rs
@@ -20,13 +20,10 @@ use libitofin::termstructures::yieldtermstructure::YieldTermStructure;
 use libitofin::time::frequency::Frequency;
 use pyo3::prelude::*;
 
-/// Python `HestonProcess`: the square-root stochastic-variance process
-/// (`processes::HestonProcess`).
+/// The square-root stochastic-variance process.
 ///
 /// The two flat yield curves and the spot quote are assembled behind their
-/// `Handle`s internally so no `Handle` crosses the PyO3 boundary. The core
-/// ctor takes `(risk_free_rate, dividend_yield, s0, ...)` in that order; the
-/// two curves are bound by name and placed at the single call site.
+/// handles internally, so no handle crosses the binding boundary.
 #[pyclass(name = "HestonProcess", unsendable)]
 pub struct PyHestonProcess {
     inner: Shared<HestonProcess>,
@@ -34,6 +31,21 @@ pub struct PyHestonProcess {
 
 #[pymethods]
 impl PyHestonProcess {
+    /// Build the process from scalar market inputs and the five parameters.
+    ///
+    /// Args:
+    ///     risk_free_rate (float): The flat risk-free rate, made into a curve
+    ///         compounded continuously on an annual frequency.
+    ///     dividend_yield (float): The flat dividend yield, made into a curve on the
+    ///         same convention as the risk-free rate.
+    ///     spot (float): The spot level, held as a quote.
+    ///     v0 (float): The initial variance.
+    ///     kappa (float): The mean-reversion speed.
+    ///     theta (float): The long-run variance.
+    ///     sigma (float): The volatility of variance.
+    ///     rho (float): The spot/variance correlation.
+    ///     reference_date (Date): The date the two flat curves are anchored on.
+    ///     day_counter (DayCounter): The day count the curves accrue on.
     #[new]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -81,27 +93,42 @@ impl PyHestonProcess {
         }
     }
 
-    /// The initial variance `v0`.
+    /// Return the initial variance.
+    ///
+    /// Returns:
+    ///     float: The initial variance v0.
     fn v0(&self) -> f64 {
         self.inner.v0()
     }
 
-    /// The mean-reversion speed `kappa`.
+    /// Return the mean-reversion speed.
+    ///
+    /// Returns:
+    ///     float: The mean-reversion speed kappa.
     fn kappa(&self) -> f64 {
         self.inner.kappa()
     }
 
-    /// The long-run variance `theta`.
+    /// Return the long-run variance.
+    ///
+    /// Returns:
+    ///     float: The long-run variance theta.
     fn theta(&self) -> f64 {
         self.inner.theta()
     }
 
-    /// The volatility of variance `sigma`.
+    /// Return the volatility of variance.
+    ///
+    /// Returns:
+    ///     float: The volatility of variance sigma.
     fn sigma(&self) -> f64 {
         self.inner.sigma()
     }
 
-    /// The spot/variance correlation `rho`.
+    /// Return the spot/variance correlation.
+    ///
+    /// Returns:
+    ///     float: The spot/variance correlation rho.
     fn rho(&self) -> f64 {
         self.inner.rho()
     }
@@ -114,12 +141,10 @@ impl PyHestonProcess {
     }
 }
 
-/// Python `HestonModel`: the five-parameter calibrated Heston model
-/// (`models::HestonModel`).
+/// The five-parameter calibrated Heston model.
 ///
-/// The ctor is fallible: it seeds its arguments from the process parameters
-/// under their constraints (`theta`, `kappa`, `sigma`, `v0` strictly positive,
-/// `rho` in `[-1, 1]`), so a violating parameter surfaces as an `ItofinError`.
+/// The parameters are seeded from the process it is built on and overwritten in
+/// place by a calibration, so the getters read the fitted values afterwards.
 #[pyclass(name = "HestonModel", unsendable)]
 pub struct PyHestonModel {
     inner: SharedMut<HestonModel>,
@@ -127,45 +152,78 @@ pub struct PyHestonModel {
 
 #[pymethods]
 impl PyHestonModel {
+    /// Seed the model from a process.
+    ///
+    /// Args:
+    ///     process (HestonProcess): The process whose five parameters seed the model.
+    ///
+    /// Raises:
+    ///     ItofinError: If a seeded parameter violates its constraint: theta,
+    ///         kappa, sigma and v0 must be strictly positive and rho must lie
+    ///         in [-1, 1].
     #[new]
     fn new(process: &PyHestonProcess) -> PyResult<Self> {
         let inner = HestonModel::new(process.inner()).map_err(PyQlError::from)?;
         Ok(PyHestonModel { inner })
     }
 
-    /// The long-run variance `theta`.
+    /// Return the long-run variance.
+    ///
+    /// Returns:
+    ///     float: The current value of theta.
     fn theta(&self) -> f64 {
         self.inner.borrow().theta()
     }
 
-    /// The mean-reversion speed `kappa`.
+    /// Return the mean-reversion speed.
+    ///
+    /// Returns:
+    ///     float: The current value of kappa.
     fn kappa(&self) -> f64 {
         self.inner.borrow().kappa()
     }
 
-    /// The volatility of variance `sigma`.
+    /// Return the volatility of variance.
+    ///
+    /// Returns:
+    ///     float: The current value of sigma.
     fn sigma(&self) -> f64 {
         self.inner.borrow().sigma()
     }
 
-    /// The spot/variance correlation `rho`.
+    /// Return the spot/variance correlation.
+    ///
+    /// Returns:
+    ///     float: The current value of rho.
     fn rho(&self) -> f64 {
         self.inner.borrow().rho()
     }
 
-    /// The initial variance `v0`.
+    /// Return the initial variance.
+    ///
+    /// Returns:
+    ///     float: The current value of v0.
     fn v0(&self) -> f64 {
         self.inner.borrow().v0()
     }
 
-    /// Calibrates the model to `helpers` with `method` under `end_criteria`,
-    /// then writes the fitted parameters back (readable through the getters).
+    /// Fit the five parameters to the helpers and write them back.
     ///
-    /// Mirrors the core oracle (`hestonmodelhelper.rs:556-581`): one
-    /// [`AnalyticHestonEngine`] of `integration_order` is built on this model and
-    /// installed on every helper, so all helpers price through the same engine
-    /// the optimizer drives. The engine ctor is fallible (order > 192 errors);
-    /// [`calibrate`](libitofin::models::calibrate) fails on an empty helper list.
+    /// One analytic Heston engine of the given integration order is built on
+    /// this model and installed on every helper, so all helpers price through
+    /// the same engine the optimizer drives. The fitted parameters are readable
+    /// through the getters afterwards.
+    ///
+    /// Args:
+    ///     helpers (list[HestonModelHelper]): The calibration instruments to fit; must not be empty.
+    ///     method (LevenbergMarquardt): The optimizer driving the fit.
+    ///     end_criteria (EndCriteria): The stopping rule handed to the optimizer.
+    ///     integration_order (int): The order of the Gauss-Laguerre integration the
+    ///         engine uses; at most 192.
+    ///
+    /// Raises:
+    ///     ItofinError: If integration_order exceeds 192, if helpers is empty,
+    ///         or if the optimization itself fails.
     fn calibrate(
         &mut self,
         helpers: Vec<PyRef<PyHestonModelHelper>>,
@@ -209,17 +267,10 @@ impl PyHestonModel {
     }
 }
 
-/// Python `HestonModelHelper`: a Black-vol calibration helper over a flat-vol
-/// surface (`models::equity::HestonModelHelper`).
+/// A Black-vol calibration helper over a flat-vol surface.
 ///
-/// The core ctor takes the spot as a bare `Real`, the volatility as a
-/// `Handle<dyn Quote>` and the two curves as `Handle<dyn YieldTermStructure>`.
-/// This facade takes scalar market inputs plus a `reference_date`/`day_counter`
-/// used only to assemble the vol quote handle and the two flat `FlatForward`
-/// curves inline (the same `Continuous`/`Annual` convention the other facades
-/// use); those two arguments are not forwarded to the core ctor. The helper is
-/// held as `SharedMut` so a calibration can install a pricing engine on it and
-/// upcast it to `SharedMut<dyn CalibrationHelper>`.
+/// Assembles its own volatility quote and two flat curves from the scalar
+/// market inputs, so no handle crosses the binding boundary.
 #[pyclass(name = "HestonModelHelper", unsendable)]
 pub struct PyHestonModelHelper {
     inner: SharedMut<HestonModelHelper>,
@@ -227,6 +278,23 @@ pub struct PyHestonModelHelper {
 
 #[pymethods]
 impl PyHestonModelHelper {
+    /// Build the helper from scalar market inputs.
+    ///
+    /// Args:
+    ///     maturity (Period): The option tenor.
+    ///     calendar (Calendar): The calendar the maturity rolls on.
+    ///     s0 (float): The spot level.
+    ///     strike (float): The option strike.
+    ///     volatility (float): The market Black volatility, held as a quote.
+    ///     risk_free_rate (float): The flat risk-free rate, made into a curve compounded
+    ///         continuously on an annual frequency.
+    ///     dividend_yield (float): The flat dividend yield, made into a curve on the
+    ///         same convention as the risk-free rate.
+    ///     error_type (CalibrationErrorType): How the market and model prices are compared.
+    ///     reference_date (Date): The date the two flat curves are anchored on; it is
+    ///         used only to assemble them, not forwarded to the core.
+    ///     day_counter (DayCounter): The day count the curves accrue on, used the same way.
+    ///     settings (Settings): The evaluation-date store the helper reads.
     #[new]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -276,8 +344,17 @@ impl PyHestonModelHelper {
         }
     }
 
-    /// The calibration error under the helper's error type, after a calibration
-    /// has installed a pricing engine on it.
+    /// Return the error between the market and model values.
+    ///
+    /// Meaningful once a calibration has installed a pricing engine on the
+    /// helper; the comparison follows the helper's error type.
+    ///
+    /// Returns:
+    ///     float: The calibration error under the configured error type.
+    ///
+    /// Raises:
+    ///     ItofinError: If the market or model valuation fails, or the implied
+    ///         volatility solve does.
     fn calibration_error(&mut self) -> PyResult<f64> {
         Ok(self
             .inner

--- a/crates/itofin-py/src/hullwhite.rs
+++ b/crates/itofin-py/src/hullwhite.rs
@@ -25,12 +25,10 @@ use libitofin::termstructures::volatility::VolatilityType;
 use libitofin::types::Natural;
 use pyo3::prelude::*;
 
-/// Python `HullWhite`: the one-factor Hull-White short-rate model
-/// (`models::shortrate::hullwhite::HullWhite`).
+/// The one-factor Hull-White short-rate model.
 ///
-/// The ctor is fallible (`hullwhite.rs:188`): it reads the curve's forward rate
-/// at `0` and applies the Vasicek positivity constraints on `a`/`sigma`, so an
-/// empty curve or a constraint-violating parameter surfaces as an `ItofinError`.
+/// Fitted to the term structure it is built on; a calibration overwrites a and
+/// sigma in place, so the getters read the fitted values afterwards.
 #[pyclass(name = "HullWhite", unsendable)]
 pub struct PyHullWhite {
     inner: SharedMut<HullWhite>,
@@ -38,36 +36,65 @@ pub struct PyHullWhite {
 
 #[pymethods]
 impl PyHullWhite {
+    /// Fit the model to a term structure.
+    ///
+    /// Args:
+    ///     curve (YieldTermStructure): The term structure the model fits; its forward rate at 0 is
+    ///         read at construction.
+    ///     a (float): The mean-reversion speed, under the Vasicek positivity
+    ///         constraint.
+    ///     sigma (float): The short-rate volatility, under the same constraint.
+    ///
+    /// Raises:
+    ///     ItofinError: If the curve is empty or a parameter violates its
+    ///         constraint.
     #[new]
     fn new(curve: &PyYieldTermStructure, a: f64, sigma: f64) -> PyResult<Self> {
         let inner = HullWhite::new(curve.handle(), a, sigma).map_err(PyQlError::from)?;
         Ok(PyHullWhite { inner })
     }
 
-    /// The mean-reversion speed `a`, read as `params()[0]`.
+    /// Return the mean-reversion speed.
     ///
-    /// `HullWhite` exposes no direct `a()` (the Vasicek base field is private).
-    /// The public route is the flattened calibrated-model parameters, whose
-    /// `[0]`/`[1]` order (`a`, then `sigma`) is pinned by the core calibration
-    /// oracle (`hullwhite.rs:892,898`).
+    /// Returns:
+    ///     float: The current value of a, read as the first calibrated-model
+    ///     parameter.
     fn a(&self) -> f64 {
         self.inner.borrow().calibrated_model().params()[0]
     }
 
-    /// The short-rate volatility `sigma`, read as `params()[1]`.
+    /// Return the short-rate volatility.
+    ///
+    /// Returns:
+    ///     float: The current value of sigma, read as the second calibrated-model
+    ///     parameter.
     fn sigma(&self) -> f64 {
         self.inner.borrow().calibrated_model().params()[1]
     }
 
-    /// The fitted initial short rate `r0` (`hullwhite.rs:225`).
+    /// Return the fitted initial short rate.
+    ///
+    /// Returns:
+    ///     float: The short rate r0 implied by the fitted term structure.
     fn r0(&self) -> f64 {
         self.inner.borrow().r0()
     }
 
-    /// The price of a European option, exercised at `maturity`, on a zero-coupon
-    /// bond maturing at `bond_maturity` (`hullwhite.rs:263`, the 4-argument
-    /// overload). Fallible: the fitted curve must be linked and the underlying
-    /// `black_formula` arguments valid.
+    /// Price a European option on a zero-coupon bond.
+    ///
+    /// Args:
+    ///     option_type (OptionType): Call or put.
+    ///     strike (float): The option strike, as a bond price.
+    ///     maturity (float): The option expiry, as a time in years.
+    ///     bond_maturity (float): The maturity of the underlying zero-coupon bond, as a
+    ///         time in years.
+    ///
+    /// Returns:
+    ///     float: The option price.
+    ///
+    /// Raises:
+    ///     ItofinError: If the fitted curve is not linked or the arguments are
+    ///         rejected by the underlying Black formula.
     fn discount_bond_option(
         &self,
         option_type: PyOptionType,
@@ -82,17 +109,21 @@ impl PyHullWhite {
             .map_err(PyQlError::from)?)
     }
 
-    /// Calibrates the model to `helpers` with `method` under `end_criteria`,
-    /// then writes the fitted `a`/`sigma` back (readable through the getters).
+    /// Fit a and sigma to the helpers and write them back.
     ///
-    /// Mirrors the core oracle (`hullwhite.rs:809-864`): one
-    /// [`JamshidianSwaptionEngine`] is built on this model and installed on every
-    /// helper, so all swaptions price through the same analytic engine the
-    /// optimizer drives (keeping W2 independent of the user-facing engine facade).
-    /// `fix_reversion` pins the mean reversion `a` and frees only `sigma`
-    /// (`fix_parameters = [true, false]`, `hullwhite.rs:1043`); otherwise both are
-    /// free. [`calibrate`](libitofin::models::calibrate) fails on an empty helper
-    /// list.
+    /// One Jamshidian swaption engine is built on this model and installed on
+    /// every helper, so all swaptions price through the same analytic engine
+    /// the optimizer drives.
+    ///
+    /// Args:
+    ///     helpers (list[SwaptionHelper]): The calibration instruments to fit; must not be empty.
+    ///     method (LevenbergMarquardt): The optimizer driving the fit.
+    ///     end_criteria (EndCriteria): The stopping rule handed to the optimizer.
+    ///     fix_reversion (bool): Pin the mean reversion a and free only sigma; when
+    ///         False both parameters are free.
+    ///
+    /// Raises:
+    ///     ItofinError: If helpers is empty or the optimization itself fails.
     fn calibrate(
         &mut self,
         helpers: Vec<PyRef<PySwaptionHelper>>,
@@ -140,21 +171,17 @@ impl PyHullWhite {
     }
 }
 
-/// Python `IborIndex`: a general Inter-Bank-Offered-Rate index
-/// (`indexes::iborindex::IborIndex`).
+/// A general Inter-Bank-Offered-Rate index, spelling out every convention.
 ///
-/// The constructor spells out every convention the core ctor takes
-/// (`iborindex.rs:58`), so an index outside the named families - the USD-3M
-/// `IsdaIbor` the ISDA CDS curve bootstraps off, say - is expressible without a
-/// dedicated facade. `forwarding` `None` builds the index over an empty handle,
-/// the form the bootstrap rate helpers need, exactly as the C++ default
-/// `Handle<YieldTermStructure> h = {}` allows.
+/// The form for an index outside the named families (the USD-3M IsdaIbor the
+/// ISDA CDS curve bootstraps off, say). Pass forwarding=None to build it over
+/// an empty handle, the form the bootstrap rate helpers need.
 ///
-/// It is the base of [`PyEuribor`], and since #868 every Ibor-index consumer
-/// takes this type and accepts either: the deposit, swap, FRA and futures rate
-/// helpers, and the swap, swap-index, optionlet-volatility, cap/floor and
-/// swaption-helper facades. The OIS helper is not one of them; it takes the
-/// overnight [`PyEstr`](crate::helpers::PyEstr), which is not an `IborIndex`.
+/// It is the base of Euribor, and every Ibor-index consumer takes this type and
+/// accepts either: the deposit, swap, FRA and futures rate helpers, and the
+/// swap, swap-index, optionlet-volatility, cap/floor and swaption-helper
+/// facades. The OIS helper is not one of them; it takes the overnight Estr,
+/// which is not an IborIndex.
 #[pyclass(name = "IborIndex", subclass, unsendable)]
 pub struct PyIborIndex {
     inner: Shared<IborIndex>,
@@ -162,10 +189,29 @@ pub struct PyIborIndex {
 
 #[pymethods]
 impl PyIborIndex {
-    /// An index of `tenor` fixing `settlement_days` before its value date on
-    /// `fixing_calendar`, rolling to maturity under `convention`/`end_of_month`,
-    /// accruing on `day_counter` and forecasting off `forwarding` (or off an
-    /// empty handle when `None`).
+    /// Build an index spelling out every convention the core constructor takes.
+    ///
+    /// The index fixes settlement_days before its value date on the fixing
+    /// calendar, rolls to maturity under convention and end_of_month, accrues
+    /// on day_counter and forecasts off forwarding.
+    ///
+    /// Args:
+    ///     family_name (str): The index family the fixings are stored under.
+    ///     tenor (Period): The index tenor, normalized at construction.
+    ///     settlement_days (int): The business days between the fixing date and
+    ///         the value date.
+    ///     currency (Currency): The currency the index is quoted in.
+    ///     fixing_calendar (Calendar): The calendar the fixing and value dates
+    ///         roll on.
+    ///     convention (BusinessDayConvention): The convention applied when
+    ///         rolling the value date to maturity.
+    ///     end_of_month (bool): Whether the maturity roll keeps to month ends.
+    ///     day_counter (DayCounter): The day count the index accrues on.
+    ///     forwarding (YieldTermStructure | None): The curve fixings are
+    ///         forecast off; None builds the index over an empty handle, the
+    ///         form the bootstrap rate helpers need.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date and the stored fixings.
     #[new]
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (
@@ -210,9 +256,23 @@ impl PyIborIndex {
         }
     }
 
-    /// The index's fixing for `fixing_date`, forecast off the forwarding curve
-    /// for a future date or read from stored fixings for a past one. Fallible:
-    /// an empty forwarding handle or an unset evaluation date is an error.
+    /// Return the index fixing for fixing_date.
+    ///
+    /// Forecast off the forwarding curve for a future date, or read from the
+    /// stored fixings for a past one.
+    ///
+    /// Args:
+    ///     fixing_date (Date): The date the fixing is read or forecast for.
+    ///     forecast_todays_fixing (bool): Whether a fixing dated today is
+    ///         forecast rather than looked up.
+    ///
+    /// Returns:
+    ///     float: The fixing rate.
+    ///
+    /// Raises:
+    ///     ItofinError: If the fixing date is not a valid one, the evaluation
+    ///         date is unset, a past fixing is missing from the store, or the
+    ///         forwarding handle is empty on a forecast.
     fn fixing(&self, fixing_date: &PyDate, forecast_todays_fixing: bool) -> PyResult<f64> {
         Ok(self
             .inner
@@ -220,10 +280,20 @@ impl PyIborIndex {
             .map_err(PyQlError::from)?)
     }
 
-    /// The value date of the loan fixed on `fixing_date`: the fixing date moved
-    /// forward `fixing_days` business days on the fixing calendar
-    /// (`interestrateindex.rs:210`). Fallible: the core rejects a `fixing_date`
-    /// that is not a business day there.
+    /// Return the value date of the loan fixed on fixing_date.
+    ///
+    /// The fixing date moved forward by the index's fixing days on the fixing
+    /// calendar.
+    ///
+    /// Args:
+    ///     fixing_date (Date): The fixing date to advance.
+    ///
+    /// Returns:
+    ///     Date: The value date.
+    ///
+    /// Raises:
+    ///     ItofinError: If fixing_date is not a business day on the fixing
+    ///         calendar.
     fn value_date(&self, fixing_date: &PyDate) -> PyResult<PyDate> {
         Ok(PyDate::from_inner(
             self.inner
@@ -232,16 +302,30 @@ impl PyIborIndex {
         ))
     }
 
-    /// The fixing date of the loan starting on `value_date`: the value date
-    /// moved back `fixing_days` business days (`interestrateindex.rs:197`), the
-    /// inverse of [`Self::value_date`].
+    /// Return the fixing date of the loan starting on value_date.
+    ///
+    /// The value date moved back by the index's fixing days, the inverse of
+    /// value_date.
+    ///
+    /// Args:
+    ///     value_date (Date): The value date to step back from.
+    ///
+    /// Returns:
+    ///     Date: The fixing date.
     fn fixing_date(&self, value_date: &PyDate) -> PyDate {
         PyDate::from_inner(self.inner.fixing_date(value_date.inner()))
     }
 
-    /// The maturity of the loan starting on `value_date`: the value date rolled
-    /// on by the index tenor under the index's own convention and end-of-month
-    /// flag (`iborindex.rs:154`).
+    /// Return the maturity of the loan starting on value_date.
+    ///
+    /// The value date rolled on by the index tenor under the index's own
+    /// convention and end-of-month flag.
+    ///
+    /// Args:
+    ///     value_date (Date): The date the loan starts on.
+    ///
+    /// Returns:
+    ///     Date: The maturity date.
     fn maturity_date(&self, value_date: &PyDate) -> PyResult<PyDate> {
         Ok(PyDate::from_inner(
             self.inner
@@ -250,41 +334,58 @@ impl PyIborIndex {
         ))
     }
 
-    /// The index tenor, normalized at construction
-    /// (`interestrateindex.rs:176`).
+    /// Return the index tenor, normalized at construction.
+    ///
+    /// Returns:
+    ///     Period: The index tenor.
     fn tenor(&self) -> PyPeriod {
         PyPeriod::from_inner(self.inner.tenor())
     }
 
-    /// The day counter the index accrues on (`interestrateindex.rs:191`).
+    /// Return the day counter the index accrues on.
+    ///
+    /// Returns:
+    ///     DayCounter: The index day count.
     fn day_counter(&self) -> PyDayCounter {
         PyDayCounter::from_inner(self.inner.day_counter().clone())
     }
 
-    /// The calendar the fixing and value dates roll on
-    /// (`interestrateindex.rs:234`).
+    /// Return the calendar the fixing and value dates roll on.
+    ///
+    /// Returns:
+    ///     Calendar: The fixing calendar.
     fn fixing_calendar(&self) -> PyCalendar {
         PyCalendar::from_inner(self.inner.fixing_calendar())
     }
 
-    /// The convention applied when rolling the value date to maturity
-    /// (`iborindex.rs:89`). Infallible: the core returns the stored field.
+    /// Return the convention applied when rolling the value date to maturity.
+    ///
+    /// Returns:
+    ///     BusinessDayConvention: The stored convention.
     fn business_day_convention(&self) -> PyBusinessDayConvention {
         PyBusinessDayConvention::from_inner(self.inner.business_day_convention())
     }
 
-    /// Whether the maturity roll keeps to month ends (`iborindex.rs:94`).
+    /// Return whether the maturity roll keeps to month ends.
+    ///
+    /// Returns:
+    ///     bool: True if the roll is end-of-month.
     fn end_of_month(&self) -> bool {
         self.inner.end_of_month()
     }
 
-    /// The composed index name the fixings are stored under
-    /// (`interestrateindex.rs:230`), e.g. `Euribor6M Actual/360`.
+    /// Return the composed index name, e.g. "Euribor6M Actual/360".
+    ///
+    /// Returns:
+    ///     str: The name the fixings are stored under.
     fn name(&self) -> String {
         self.inner.name()
     }
 
-    /// The currency the index is quoted in (`interestrateindex.rs:186`).
+    /// Return the currency the index is quoted in.
+    ///
+    /// Returns:
+    ///     Currency: The index currency.
     fn currency(&self) -> PyCurrency {
         PyCurrency::from_inner(self.inner.currency().clone())
     }
@@ -298,19 +399,15 @@ impl PyIborIndex {
     }
 }
 
-/// Python `CustomIborIndex`: an Ibor index with three separate calendars
-/// (`indexes::ibor::CustomIborIndex`).
+/// An Ibor index with three separate calendars.
 ///
-/// The general form of what [`PyEurLibor`] configures: fixing dates roll back
-/// on the value calendar and adjust `Preceding` on the fixing calendar, value
-/// dates advance on the value calendar, and maturity dates advance on the
-/// maturity calendar (`custom.rs:5-13`). Passing the same calendar three times
-/// reproduces a plain [`PyIborIndex`], so this is the escape hatch for a
-/// LIBOR-like index outside the named families.
-///
-/// `CustomIborIndex::new` returns the newtype; `upcast()` (`custom.rs:105`)
-/// hands out the inner `IborIndex` carrying the three-calendar roll as data, so
-/// a consumer taking the base half rolls all three dates the way C++ does.
+/// The general form of what EurLibor configures: fixing dates roll back on the
+/// value calendar and adjust Preceding on the fixing calendar, value dates
+/// advance on the value calendar, and maturity dates advance on the maturity
+/// calendar. Passing the same calendar three times reproduces a plain
+/// IborIndex, so this is the escape hatch for a Libor-like index outside the
+/// named families. A subclass of IborIndex, so it is accepted wherever the
+/// general index is, and the base half carries the three-calendar roll.
 #[pyclass(name = "CustomIborIndex", extends = PyIborIndex, unsendable)]
 pub struct PyCustomIborIndex {
     inner: Shared<IborIndex>,
@@ -318,10 +415,29 @@ pub struct PyCustomIborIndex {
 
 #[pymethods]
 impl PyCustomIborIndex {
-    /// An index of `tenor` fixing `settlement_days` before its value date,
-    /// with each of the three date calculations rolling on its own calendar,
-    /// accruing on `day_counter` and forecasting off `forwarding` (or off an
-    /// empty handle when `None`).
+    /// Build a three-calendar Ibor index.
+    ///
+    /// Args:
+    ///     family_name (str): The family name the composed index name is built
+    ///         from.
+    ///     tenor (Period): The index tenor.
+    ///     settlement_days (int): The business days between a fixing and its
+    ///         value date.
+    ///     currency (Currency): The currency the index is quoted in.
+    ///     fixing_calendar (Calendar): The calendar fixing dates are adjusted
+    ///         Preceding on.
+    ///     value_calendar (Calendar): The calendar value dates are advanced on.
+    ///     maturity_calendar (Calendar): The calendar maturity dates are
+    ///         advanced on.
+    ///     convention (BusinessDayConvention): The convention the roll to
+    ///         maturity applies.
+    ///     end_of_month (bool): Whether the maturity roll keeps to month ends.
+    ///     day_counter (DayCounter): The day counter the index accrues on.
+    ///     forwarding (YieldTermStructure | None): The forwarding curve; None
+    ///         builds the index over an empty handle, the form the bootstrap
+    ///         rate helpers need.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date and the stored fixings.
     #[new]
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (
@@ -375,9 +491,23 @@ impl PyCustomIborIndex {
         PyClassInitializer::from(base).add_subclass(PyCustomIborIndex { inner: index })
     }
 
-    /// The index's fixing for `fixing_date`, forecast off the forwarding curve
-    /// for a future date or read from stored fixings for a past one. Fallible:
-    /// an empty forwarding handle or an unset evaluation date is an error.
+    /// Return the index fixing for fixing_date.
+    ///
+    /// Forecast off the forwarding curve for a future date, or read from the
+    /// stored fixings for a past one.
+    ///
+    /// Args:
+    ///     fixing_date (Date): The date the fixing is read or forecast for.
+    ///     forecast_todays_fixing (bool): Whether a fixing dated today is
+    ///         forecast rather than looked up.
+    ///
+    /// Returns:
+    ///     float: The fixing rate.
+    ///
+    /// Raises:
+    ///     ItofinError: If the fixing date is not a valid one, the evaluation
+    ///         date is unset, a past fixing is missing from the store, or the
+    ///         forwarding handle is empty on a forecast.
     fn fixing(&self, fixing_date: &PyDate, forecast_todays_fixing: bool) -> PyResult<f64> {
         Ok(self
             .inner
@@ -386,20 +516,11 @@ impl PyCustomIborIndex {
     }
 }
 
-/// Python `Euribor`: the Euribor IBOR index family (`indexes::Euribor`).
+/// The Euribor IBOR index family.
 ///
-/// The general constructor takes a tenor, an optional forwarding curve, and the
-/// settings; passing `None` for the curve builds the index over an empty
-/// handle, the form the bootstrap rate helpers need (#528). The `six_months`
-/// and `three_months` staticmethods keep the curve-required convenience
-/// constructors. `Euribor::new` returns an `IborIndex` by value; it is wrapped
-/// in `shared()` so downstream ctors that take a `Shared<IborIndex>`
-/// (VanillaSwap/SwaptionHelper/rate helpers) can hold the same object.
-///
-/// A subclass of [`PyIborIndex`], so a Euribor is accepted wherever the general
-/// index is. It retains its own clone of the index the base holds - the same
-/// object, not a rebuild - so its own `fixing` reads exactly what the base
-/// reads.
+/// A subclass of IborIndex, so a Euribor is accepted wherever the general index
+/// is. It retains its own clone of the index the base holds - the same object,
+/// not a rebuild - so its own fixing reads exactly what the base reads.
 #[pyclass(name = "Euribor", extends = PyIborIndex, unsendable)]
 pub struct PyEuribor {
     inner: Shared<IborIndex>,
@@ -407,9 +528,19 @@ pub struct PyEuribor {
 
 #[pymethods]
 impl PyEuribor {
-    /// A Euribor index of `tenor` forwarding off `curve`, or off an empty
-    /// handle when `curve` is `None`. Fallible: the core rejects daily tenors
-    /// (`euribor.rs:65`), which need the dedicated `DailyTenor` constructor.
+    /// Build a Euribor index of the given tenor.
+    ///
+    /// Args:
+    ///     tenor (Period): The index tenor.
+    ///     curve (YieldTermStructure | None): The forwarding curve; None builds
+    ///         the index over an empty handle, the form the bootstrap rate
+    ///         helpers need.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date and the stored fixings.
+    ///
+    /// Raises:
+    ///     ItofinError: If tenor is a daily tenor, which needs the dedicated
+    ///         daily-tenor constructor the core keeps separate.
     #[new]
     #[pyo3(signature = (tenor, curve, settings))]
     fn new(
@@ -426,7 +557,15 @@ impl PyEuribor {
         Ok(init_euribor(shared(index)))
     }
 
-    /// The 3-month Euribor index (`Euribor3M`) forwarding off `curve`.
+    /// Return the 3-month Euribor index forwarding off curve.
+    ///
+    /// Args:
+    ///     curve (YieldTermStructure): The forwarding curve.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date and the stored fixings.
+    ///
+    /// Returns:
+    ///     Euribor: The Euribor3M index.
     #[staticmethod]
     fn three_months(
         py: Python<'_>,
@@ -437,7 +576,15 @@ impl PyEuribor {
         Py::new(py, init_euribor(index))
     }
 
-    /// The 6-month Euribor index (`Euribor6M`) forwarding off `curve`.
+    /// Return the 6-month Euribor index forwarding off curve.
+    ///
+    /// Args:
+    ///     curve (YieldTermStructure): The forwarding curve.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date and the stored fixings.
+    ///
+    /// Returns:
+    ///     Euribor: The Euribor6M index.
     #[staticmethod]
     fn six_months(
         py: Python<'_>,
@@ -448,9 +595,23 @@ impl PyEuribor {
         Py::new(py, init_euribor(index))
     }
 
-    /// The index's fixing for `fixing_date`, forecast off the forwarding curve
-    /// for a future date or read from stored fixings for a past one. Fallible:
-    /// an empty forwarding handle or an unset evaluation date is an error.
+    /// Return the index fixing for fixing_date.
+    ///
+    /// Forecast off the forwarding curve for a future date, or read from the
+    /// stored fixings for a past one.
+    ///
+    /// Args:
+    ///     fixing_date (Date): The date the fixing is read or forecast for.
+    ///     forecast_todays_fixing (bool): Whether a fixing dated today is
+    ///         forecast rather than looked up.
+    ///
+    /// Returns:
+    ///     float: The fixing rate.
+    ///
+    /// Raises:
+    ///     ItofinError: If the fixing date is not a valid one, the evaluation
+    ///         date is unset, a past fixing is missing from the store, or the
+    ///         forwarding handle is empty on a forecast.
     fn fixing(&self, fixing_date: &PyDate, forecast_todays_fixing: bool) -> PyResult<f64> {
         Ok(self
             .inner
@@ -469,18 +630,11 @@ fn init_euribor(index: Shared<IborIndex>) -> PyClassInitializer<PyEuribor> {
     PyClassInitializer::from(base).add_subclass(PyEuribor { inner: index })
 }
 
-/// Python `UsdLibor`: the USD Libor index family (`indexes::UsdLibor`).
+/// The USD Libor index family.
 ///
-/// The constructor takes a tenor, an optional forwarding curve, and the
-/// settings; passing `None` for the curve builds the index over an empty
-/// handle, the form the bootstrap rate helpers need. `UsdLibor::new` returns
-/// a plain `IborIndex` by value (`usdlibor.rs:42`); it is wrapped in
-/// `shared()` exactly as the Euribor facade wraps its family.
-///
-/// A subclass of [`PyIborIndex`], so a USD Libor is accepted wherever the
-/// general index is. It retains its own clone of the index the base holds -
-/// the same object, not a rebuild - so its own `fixing` reads exactly what
-/// the base reads.
+/// A subclass of IborIndex, so a USD Libor is accepted wherever the general
+/// index is. It retains its own clone of the index the base holds - the same
+/// object, not a rebuild - so its own fixing reads exactly what the base reads.
 #[pyclass(name = "UsdLibor", extends = PyIborIndex, unsendable)]
 pub struct PyUsdLibor {
     inner: Shared<IborIndex>,
@@ -488,10 +642,19 @@ pub struct PyUsdLibor {
 
 #[pymethods]
 impl PyUsdLibor {
-    /// A USD Libor index of `tenor` forwarding off `curve`, or off an empty
-    /// handle when `curve` is `None`. Fallible: the Libor base rejects daily
-    /// tenors (`libor.rs:89`), which need a dedicated `DailyTenor`
-    /// constructor the core has not ported.
+    /// Build a USD Libor index of the given tenor.
+    ///
+    /// Args:
+    ///     tenor (Period): The index tenor.
+    ///     curve (YieldTermStructure | None): The forwarding curve; None builds
+    ///         the index over an empty handle, the form the bootstrap rate
+    ///         helpers need.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date and the stored fixings.
+    ///
+    /// Raises:
+    ///     ItofinError: If tenor is a daily tenor, which needs a dedicated
+    ///         daily-tenor constructor the core has not ported.
     #[new]
     #[pyo3(signature = (tenor, curve, settings))]
     fn new(
@@ -512,9 +675,23 @@ impl PyUsdLibor {
         Ok(PyClassInitializer::from(base).add_subclass(PyUsdLibor { inner: index }))
     }
 
-    /// The index's fixing for `fixing_date`, forecast off the forwarding curve
-    /// for a future date or read from stored fixings for a past one. Fallible:
-    /// an empty forwarding handle or an unset evaluation date is an error.
+    /// Return the index fixing for fixing_date.
+    ///
+    /// Forecast off the forwarding curve for a future date, or read from the
+    /// stored fixings for a past one.
+    ///
+    /// Args:
+    ///     fixing_date (Date): The date the fixing is read or forecast for.
+    ///     forecast_todays_fixing (bool): Whether a fixing dated today is
+    ///         forecast rather than looked up.
+    ///
+    /// Returns:
+    ///     float: The fixing rate.
+    ///
+    /// Raises:
+    ///     ItofinError: If the fixing date is not a valid one, the evaluation
+    ///         date is unset, a past fixing is missing from the store, or the
+    ///         forwarding handle is empty on a forecast.
     fn fixing(&self, fixing_date: &PyDate, forecast_todays_fixing: bool) -> PyResult<f64> {
         Ok(self
             .inner
@@ -523,18 +700,11 @@ impl PyUsdLibor {
     }
 }
 
-/// Python `JpyLibor`: the JPY Libor index family (`indexes::ibor::JpyLibor`).
+/// The JPY Libor index family.
 ///
-/// The constructor takes a tenor, an optional forwarding curve, and the
-/// settings; passing `None` for the curve builds the index over an empty
-/// handle, the form the bootstrap rate helpers need. `JpyLibor::new` returns
-/// a plain `IborIndex` by value (`jpylibor.rs:43`); it is wrapped in
-/// `shared()` exactly as the Euribor facade wraps its family.
-///
-/// A subclass of [`PyIborIndex`], so a JPY Libor is accepted wherever the
-/// general index is. It retains its own clone of the index the base holds -
-/// the same object, not a rebuild - so its own `fixing` reads exactly what
-/// the base reads.
+/// A subclass of IborIndex, so a JPY Libor is accepted wherever the general
+/// index is. It retains its own clone of the index the base holds - the same
+/// object, not a rebuild - so its own fixing reads exactly what the base reads.
 #[pyclass(name = "JpyLibor", extends = PyIborIndex, unsendable)]
 pub struct PyJpyLibor {
     inner: Shared<IborIndex>,
@@ -542,10 +712,19 @@ pub struct PyJpyLibor {
 
 #[pymethods]
 impl PyJpyLibor {
-    /// A JPY Libor index of `tenor` forwarding off `curve`, or off an empty
-    /// handle when `curve` is `None`. Fallible: the Libor base rejects daily
-    /// tenors (`libor.rs:89`), which need a dedicated `DailyTenor`
-    /// constructor the core has not ported.
+    /// Build a JPY Libor index of the given tenor.
+    ///
+    /// Args:
+    ///     tenor (Period): The index tenor.
+    ///     curve (YieldTermStructure | None): The forwarding curve; None builds
+    ///         the index over an empty handle, the form the bootstrap rate
+    ///         helpers need.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date and the stored fixings.
+    ///
+    /// Raises:
+    ///     ItofinError: If tenor is a daily tenor, which needs a dedicated
+    ///         daily-tenor constructor the core has not ported.
     #[new]
     #[pyo3(signature = (tenor, curve, settings))]
     fn new(
@@ -566,9 +745,23 @@ impl PyJpyLibor {
         Ok(PyClassInitializer::from(base).add_subclass(PyJpyLibor { inner: index }))
     }
 
-    /// The index's fixing for `fixing_date`, forecast off the forwarding curve
-    /// for a future date or read from stored fixings for a past one. Fallible:
-    /// an empty forwarding handle or an unset evaluation date is an error.
+    /// Return the index fixing for fixing_date.
+    ///
+    /// Forecast off the forwarding curve for a future date, or read from the
+    /// stored fixings for a past one.
+    ///
+    /// Args:
+    ///     fixing_date (Date): The date the fixing is read or forecast for.
+    ///     forecast_todays_fixing (bool): Whether a fixing dated today is
+    ///         forecast rather than looked up.
+    ///
+    /// Returns:
+    ///     float: The fixing rate.
+    ///
+    /// Raises:
+    ///     ItofinError: If the fixing date is not a valid one, the evaluation
+    ///         date is unset, a past fixing is missing from the store, or the
+    ///         forwarding handle is empty on a forecast.
     fn fixing(&self, fixing_date: &PyDate, forecast_todays_fixing: bool) -> PyResult<f64> {
         Ok(self
             .inner
@@ -577,18 +770,11 @@ impl PyJpyLibor {
     }
 }
 
-/// Python `GbpLibor`: the GBP Libor index family (`indexes::ibor::GbpLibor`).
+/// The GBP Libor index family.
 ///
-/// The constructor takes a tenor, an optional forwarding curve, and the
-/// settings; passing `None` for the curve builds the index over an empty
-/// handle, the form the bootstrap rate helpers need. `GbpLibor::new` returns
-/// a plain `IborIndex` by value (`gbplibor.rs:45`); it is wrapped in
-/// `shared()` exactly as the Euribor facade wraps its family.
-///
-/// A subclass of [`PyIborIndex`], so a GBP Libor is accepted wherever the
-/// general index is. It retains its own clone of the index the base holds -
-/// the same object, not a rebuild - so its own `fixing` reads exactly what
-/// the base reads.
+/// A subclass of IborIndex, so a GBP Libor is accepted wherever the general
+/// index is. It retains its own clone of the index the base holds - the same
+/// object, not a rebuild - so its own fixing reads exactly what the base reads.
 #[pyclass(name = "GbpLibor", extends = PyIborIndex, unsendable)]
 pub struct PyGbpLibor {
     inner: Shared<IborIndex>,
@@ -596,10 +782,19 @@ pub struct PyGbpLibor {
 
 #[pymethods]
 impl PyGbpLibor {
-    /// A GBP Libor index of `tenor` forwarding off `curve`, or off an empty
-    /// handle when `curve` is `None`. Fallible: the Libor base rejects daily
-    /// tenors (`libor.rs:89`), which need a dedicated `DailyTenor`
-    /// constructor the core has not ported.
+    /// Build a GBP Libor index of the given tenor.
+    ///
+    /// Args:
+    ///     tenor (Period): The index tenor.
+    ///     curve (YieldTermStructure | None): The forwarding curve; None builds
+    ///         the index over an empty handle, the form the bootstrap rate
+    ///         helpers need.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date and the stored fixings.
+    ///
+    /// Raises:
+    ///     ItofinError: If tenor is a daily tenor, which needs a dedicated
+    ///         daily-tenor constructor the core has not ported.
     #[new]
     #[pyo3(signature = (tenor, curve, settings))]
     fn new(
@@ -620,9 +815,23 @@ impl PyGbpLibor {
         Ok(PyClassInitializer::from(base).add_subclass(PyGbpLibor { inner: index }))
     }
 
-    /// The index's fixing for `fixing_date`, forecast off the forwarding curve
-    /// for a future date or read from stored fixings for a past one. Fallible:
-    /// an empty forwarding handle or an unset evaluation date is an error.
+    /// Return the index fixing for fixing_date.
+    ///
+    /// Forecast off the forwarding curve for a future date, or read from the
+    /// stored fixings for a past one.
+    ///
+    /// Args:
+    ///     fixing_date (Date): The date the fixing is read or forecast for.
+    ///     forecast_todays_fixing (bool): Whether a fixing dated today is
+    ///         forecast rather than looked up.
+    ///
+    /// Returns:
+    ///     float: The fixing rate.
+    ///
+    /// Raises:
+    ///     ItofinError: If the fixing date is not a valid one, the evaluation
+    ///         date is unset, a past fixing is missing from the store, or the
+    ///         forwarding handle is empty on a forecast.
     fn fixing(&self, fixing_date: &PyDate, forecast_todays_fixing: bool) -> PyResult<f64> {
         Ok(self
             .inner
@@ -631,21 +840,15 @@ impl PyGbpLibor {
     }
 }
 
-/// Python `EurLibor`: the EUR Libor index family (`indexes::ibor::EurLibor`).
+/// The EUR Libor index family, the Euro ICE Libor fixed in London.
 ///
-/// The constructor takes a tenor, an optional forwarding curve, and the
-/// settings; passing `None` for the curve builds the index over an empty
-/// handle, the form the bootstrap rate helpers need. `EurLibor::new` returns a
-/// `CustomIborIndex` (`eurlibor.rs:64`), the three-calendar index whose fixing
-/// dates roll on the joint UK-Exchange-plus-TARGET calendar and whose value and
-/// maturity dates roll on TARGET alone; `upcast()` (`custom.rs:105`) hands out
-/// the inner `IborIndex` carrying that roll as data, so the facade holds one
-/// shared index like the other families.
-///
-/// A subclass of [`PyIborIndex`], so a EUR Libor is accepted wherever the
-/// general index is. It retains its own clone of the index the base holds -
-/// the same object, not a rebuild - so its own `fixing` reads exactly what
-/// the base reads.
+/// Three calendars, not one: fixing dates roll on the joint UK-Exchange plus
+/// TARGET calendar while value and maturity dates roll on TARGET alone. A
+/// subclass of IborIndex, so a EUR Libor is accepted wherever the general index
+/// is, and the base half carries the three-calendar roll rather than a
+/// single-calendar approximation of it. It retains its own clone of the index
+/// the base holds - the same object, not a rebuild - so its own fixing reads
+/// exactly what the base reads.
 #[pyclass(name = "EurLibor", extends = PyIborIndex, unsendable)]
 pub struct PyEurLibor {
     inner: Shared<IborIndex>,
@@ -653,10 +856,19 @@ pub struct PyEurLibor {
 
 #[pymethods]
 impl PyEurLibor {
-    /// A EUR Libor index of `tenor` forwarding off `curve`, or off an empty
-    /// handle when `curve` is `None`. Fallible: the core rejects daily tenors
-    /// (`eurlibor.rs:87`), which need the dedicated `DailyTenorEURLibor`
-    /// constructor the core has not ported.
+    /// Build a EUR Libor index of the given tenor.
+    ///
+    /// Args:
+    ///     tenor (Period): The index tenor.
+    ///     curve (YieldTermStructure | None): The forwarding curve; None builds
+    ///         the index over an empty handle, the form the bootstrap rate
+    ///         helpers need.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date and the stored fixings.
+    ///
+    /// Raises:
+    ///     ItofinError: If tenor is a daily tenor, which needs a dedicated
+    ///         daily-tenor constructor the core has not ported.
     #[new]
     #[pyo3(signature = (tenor, curve, settings))]
     fn new(
@@ -677,9 +889,23 @@ impl PyEurLibor {
         Ok(PyClassInitializer::from(base).add_subclass(PyEurLibor { inner: index }))
     }
 
-    /// The index's fixing for `fixing_date`, forecast off the forwarding curve
-    /// for a future date or read from stored fixings for a past one. Fallible:
-    /// an empty forwarding handle or an unset evaluation date is an error.
+    /// Return the index fixing for fixing_date.
+    ///
+    /// Forecast off the forwarding curve for a future date, or read from the
+    /// stored fixings for a past one.
+    ///
+    /// Args:
+    ///     fixing_date (Date): The date the fixing is read or forecast for.
+    ///     forecast_todays_fixing (bool): Whether a fixing dated today is
+    ///         forecast rather than looked up.
+    ///
+    /// Returns:
+    ///     float: The fixing rate.
+    ///
+    /// Raises:
+    ///     ItofinError: If the fixing date is not a valid one, the evaluation
+    ///         date is unset, a past fixing is missing from the store, or the
+    ///         forwarding handle is empty on a forecast.
     fn fixing(&self, fixing_date: &PyDate, forecast_todays_fixing: bool) -> PyResult<f64> {
         Ok(self
             .inner
@@ -688,17 +914,12 @@ impl PyEurLibor {
     }
 }
 
-/// Python `SwaptionHelper`: a co-terminal swaption calibration instrument
-/// (`models::shortrate::calibrationhelpers::swaptionhelper::SwaptionHelper`).
+/// A co-terminal swaption calibration instrument.
 ///
-/// The helper builds its own European swaption from the maturity/length and the
-/// index, so no swap or swaption facade is needed. The volatility is assembled
-/// into a `Handle<dyn Quote>` internally from a `SimpleQuote`. The oracle's fixed
-/// defaults are pinned here (`hullwhite.rs:839-844`): `strike = None` (struck at
-/// the forward), `ShiftedLognormal` volatility with zero shift, the index's own
-/// settlement days, and `Compound` averaging. Held as `SharedMut` so a
-/// calibration can install the Jamshidian engine on it and upcast it to
-/// `SharedMut<dyn CalibrationHelper>`.
+/// Builds its own European swaption from the maturity, length and index, so no
+/// swap or swaption object is needed. The swaption is struck at the forward on
+/// shifted-lognormal volatility with zero shift, takes the index's own
+/// settlement days, and compounds its averaging.
 #[pyclass(name = "SwaptionHelper", unsendable)]
 pub struct PySwaptionHelper {
     inner: SharedMut<SwaptionHelper>,
@@ -706,6 +927,19 @@ pub struct PySwaptionHelper {
 
 #[pymethods]
 impl PySwaptionHelper {
+    /// Build the helper and the swaption underlying it.
+    ///
+    /// Args:
+    ///     maturity (Period): The option tenor, the time to the swaption expiry.
+    ///     length (Period): The tenor of the underlying swap.
+    ///     volatility (float): The market volatility, held as a quote.
+    ///     index (IborIndex): The index the floating leg fixes on.
+    ///     fixed_leg_tenor (Period): The payment tenor of the fixed leg.
+    ///     fixed_leg_day_counter (DayCounter): The day count the fixed leg accrues on.
+    ///     floating_leg_day_counter (DayCounter): The day count the floating leg accrues on.
+    ///     curve (YieldTermStructure): The discount curve.
+    ///     error_type (CalibrationErrorType): How the market and model prices are compared.
+    ///     nominal (float): The notional of the underlying swap.
     #[new]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -742,8 +976,17 @@ impl PySwaptionHelper {
         }
     }
 
-    /// The calibration error under the helper's error type, after a calibration
-    /// has installed a pricing engine on it.
+    /// Return the error between the market and model values.
+    ///
+    /// Meaningful once a calibration has installed a pricing engine on the
+    /// helper; the comparison follows the helper's error type.
+    ///
+    /// Returns:
+    ///     float: The calibration error under the configured error type.
+    ///
+    /// Raises:
+    ///     ItofinError: If the market or model valuation fails, or the implied
+    ///         volatility solve does.
     fn calibration_error(&mut self) -> PyResult<f64> {
         Ok(self
             .inner

--- a/crates/itofin-py/src/hullwhite.rs
+++ b/crates/itofin-py/src/hullwhite.rs
@@ -1,7 +1,6 @@
-//! Facades for the Hull-White short-rate stack: [`PyHullWhite`] and the
-//! [`PyIborIndex`] index base with its [`PyEuribor`], [`PyUsdLibor`],
-//! [`PyJpyLibor`], [`PyGbpLibor`], [`PyEurLibor`] and [`PyCustomIborIndex`]
-//! subclasses.
+//! Facades for the Hull-White short-rate stack: HullWhite and the IborIndex
+//! index base with its Euribor, UsdLibor, JpyLibor, GbpLibor, EurLibor and
+//! CustomIborIndex subclasses.
 
 use crate::PyQlError;
 use crate::calibration::{PyCalibrationErrorType, PyEndCriteria, PyLevenbergMarquardt};
@@ -621,8 +620,8 @@ impl PyEuribor {
 }
 
 /// The base/subclass initializer shared by the three Euribor constructors: one
-/// index object feeds both halves, so the base [`PyIborIndex`] every consumer
-/// reads and the [`PyEuribor`] the subclass holds are the same core index.
+/// index object feeds both halves, so the base IborIndex every consumer reads
+/// and the Euribor the subclass holds are the same core index.
 fn init_euribor(index: Shared<IborIndex>) -> PyClassInitializer<PyEuribor> {
     let base = PyIborIndex {
         inner: Shared::clone(&index),

--- a/crates/itofin-py/src/inflation.rs
+++ b/crates/itofin-py/src/inflation.rs
@@ -83,23 +83,14 @@ use libitofin::time::daycounter::DayCounter;
 use libitofin::time::period::Period;
 use pyo3::prelude::*;
 
-/// Python `DiscountingSwapEngine`: discounts each leg of a swap over a single
-/// yield curve (`pricingengines::swap::discountingswapengine`).
+/// Discounts every leg of a swap over a single yield curve.
 ///
-/// Infallible at construction: it stores the discount handle and the settings
-/// and registers as an observer of the curve. Every precondition (an empty
-/// handle, an unset evaluation date) is reported when the swap is priced.
-///
-/// Deferred (visible): the core's `include_settlement_date_flows`,
-/// `settlement_date` and `npv_date` overrides
-/// (`discountingswapengine.rs:58-63`) are not exposed and are always passed as
-/// `None`, so the flow decision follows the settings' own flags and both dates
-/// fall back to the curve reference date. That is the shape every ported
-/// fixture uses.
-///
-/// The `settings` passed here must be the same object the swap this engine
-/// prices was built with, or the two resolve their dates against different
-/// evaluation dates and the NPV is silently wrong.
+/// Infallible at construction - every precondition (an empty curve handle, an
+/// unset evaluation date) is reported when the swap is priced. The core's
+/// include_settlement_date_flows, settlement_date and npv_date overrides are
+/// not exposed and are always None, so the flow decision follows the settings'
+/// own flags and both dates fall back to the curve reference date. The swap
+/// this engine prices must carry the same Settings object.
 #[pyclass(name = "DiscountingSwapEngine", unsendable)]
 pub struct PyDiscountingSwapEngine {
     inner: SharedMut<DiscountingSwapEngine>,
@@ -107,7 +98,15 @@ pub struct PyDiscountingSwapEngine {
 
 #[pymethods]
 impl PyDiscountingSwapEngine {
-    /// An engine discounting every leg on `discount`.
+    /// Build an engine discounting every leg on discount.
+    ///
+    /// Args:
+    ///     discount (YieldTermStructure): The curve every leg is discounted on;
+    ///         the engine registers as an observer of it.
+    ///     settings (Settings): The explicit settings; must be the same object
+    ///         the swap this engine prices was built with, or the two resolve
+    ///         their dates against different evaluation dates and the NPV is
+    ///         silently wrong.
     #[new]
     fn new(discount: &PyYieldTermStructure, settings: &PySettings) -> Self {
         PyDiscountingSwapEngine {
@@ -130,16 +129,12 @@ impl PyDiscountingSwapEngine {
     }
 }
 
-/// Python `CpiInterpolationType`: how an observation interpolates between the
-/// index fixings bracketing it (core `indexes::CpiInterpolationType`).
+/// How a CPI observation interpolates between the index fixings bracketing it.
 ///
-/// A fieldless pyo3 enum exposing `CpiInterpolationType.Flat` /
-/// `CpiInterpolationType.Linear`: `Flat` reads the fixing of the lagged period
-/// outright, `Linear` advances from it to the next period's fixing by how far
-/// the observation date has run into its own period.
-///
-/// The core's deprecated `AsIndex` variant is not ported and so has no
-/// counterpart here.
+/// Flat reads the fixing of the lagged period outright; Linear advances from it
+/// to the next period's fixing by how far the observation date has run into its
+/// own period. The core's deprecated AsIndex variant is not ported and so has
+/// no counterpart here.
 #[pyclass(name = "CpiInterpolationType", eq, eq_int, from_py_object)]
 #[derive(Clone, Copy, PartialEq)]
 pub enum PyCpiInterpolationType {
@@ -166,18 +161,13 @@ impl PyCpiInterpolationType {
     }
 }
 
-/// Python `ZeroInflationIndex`: a price index publishing one level per period,
-/// reading back either a stored figure or a forecast off its inflation curve
-/// (core `indexes::inflationindex::ZeroInflationIndex`).
+/// A price index publishing one level per period, reading back either a
+/// stored figure or a forecast off its inflation curve.
 ///
-/// The curve is reached through a [`RelinkableHandle`] the facade owns. The
-/// core's `with_term_structure` consumes the index and takes a plain
-/// [`Handle`](libitofin::handle::Handle), so an index built against a curve
-/// that does not exist yet could never be pointed at one later; linking the
-/// index to this facade's own relinkable handle at construction moves that
-/// choice to `link_to`, which is how the bootstrapped-curve fixtures need it.
-/// The handle starts empty, exactly as the core's own constructor leaves it, so
-/// a forecast before any link raises the empty-handle error.
+/// The curve is reached through a relinkable handle the index owns, so an
+/// index can be built before the curve it forecasts off exists. The handle
+/// starts empty and a forecast before any link raises ItofinError; link_to
+/// fills it.
 #[pyclass(name = "ZeroInflationIndex", unsendable)]
 pub struct PyZeroInflationIndex {
     inner: Shared<ZeroInflationIndex>,
@@ -197,7 +187,14 @@ impl PyZeroInflationIndex {
 
 #[pymethods]
 impl PyZeroInflationIndex {
-    /// The UK Retail Price Index: "RPI", monthly, one-month availability lag.
+    /// Return the UK Retail Price Index: monthly, one-month availability lag.
+    ///
+    /// Args:
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date and the stored fixings.
+    ///
+    /// Returns:
+    ///     ZeroInflationIndex: The "UK RPI" index, over an empty curve handle.
     #[staticmethod]
     fn uk_rpi(settings: &PySettings) -> Self {
         PyZeroInflationIndex::with_curve_handle(|curve| {
@@ -205,7 +202,14 @@ impl PyZeroInflationIndex {
         })
     }
 
-    /// The UK harmonised index of consumer prices.
+    /// Return the UK harmonised index of consumer prices.
+    ///
+    /// Args:
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date and the stored fixings.
+    ///
+    /// Returns:
+    ///     ZeroInflationIndex: The UK HICP index, over an empty curve handle.
     #[staticmethod]
     fn uk_hicp(settings: &PySettings) -> Self {
         PyZeroInflationIndex::with_curve_handle(|curve| {
@@ -213,7 +217,14 @@ impl PyZeroInflationIndex {
         })
     }
 
-    /// The euro-area harmonised index of consumer prices.
+    /// Return the euro-area harmonised index of consumer prices.
+    ///
+    /// Args:
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date and the stored fixings.
+    ///
+    /// Returns:
+    ///     ZeroInflationIndex: The EU HICP index, over an empty curve handle.
     #[staticmethod]
     fn eu_hicp(settings: &PySettings) -> Self {
         PyZeroInflationIndex::with_curve_handle(|curve| {
@@ -221,13 +232,28 @@ impl PyZeroInflationIndex {
         })
     }
 
-    /// The index name, e.g. `"UK RPI"`, under which fixings are stored.
+    /// Return the index name, under which fixings are stored.
+    ///
+    /// Returns:
+    ///     str: The name, e.g. "UK RPI".
     fn name(&self) -> String {
         self.inner.name()
     }
 
-    /// Records a published figure across the whole inflation period it
-    /// describes, so a later read on any day inside that period finds it.
+    /// Record a published figure across the whole inflation period.
+    ///
+    /// The figure is stored on every date of the period fixing_date falls in,
+    /// so a later read on any day inside that period finds it.
+    ///
+    /// Args:
+    ///     fixing_date (Date): Any date inside the inflation period the figure
+    ///         describes.
+    ///     value (float): The published index level.
+    ///
+    /// Raises:
+    ///     ItofinError: If the index frequency has no expressible inflation
+    ///         period, or a different figure is already stored on a date in
+    ///         that period.
     fn add_fixing(&self, fixing_date: &PyDate, value: f64) -> PyResult<()> {
         Ok(self
             .inner
@@ -235,13 +261,19 @@ impl PyZeroInflationIndex {
             .map_err(PyQlError::from)?)
     }
 
-    /// The fixing at `fixing_date`, stored or forecast off the linked curve.
+    /// Return the fixing at fixing_date, stored or forecast off the linked curve.
     ///
-    /// `forecast_todays_fixing` is accepted and ignored, as in the core: the
-    /// choice between history and forecast is made by
-    /// [`needs_forecast`](Self::needs_forecast) alone. A date the store should
-    /// cover but does not is an error rather than a forecast, and a forecast
-    /// with no curve linked raises the empty-handle error.
+    /// Args:
+    ///     fixing_date (Date): The date the level is read or forecast for.
+    ///     forecast_todays_fixing (bool): Accepted and ignored, as in the core:
+    ///         needs_forecast alone decides between history and forecast.
+    ///
+    /// Returns:
+    ///     float: The index level.
+    ///
+    /// Raises:
+    ///     ItofinError: If a date the store should cover has no figure, or a
+    ///         forecast is asked for with no curve linked.
     #[pyo3(signature = (fixing_date, forecast_todays_fixing = false))]
     fn fixing(&self, fixing_date: &PyDate, forecast_todays_fixing: bool) -> PyResult<f64> {
         Ok(self
@@ -250,37 +282,51 @@ impl PyZeroInflationIndex {
             .map_err(PyQlError::from)?)
     }
 
-    /// The first day of the inflation period the latest stored figure
-    /// describes. An index with no history is an error.
+    /// Return the first day of the period the latest stored figure describes.
+    ///
+    /// Returns:
+    ///     Date: The start of that inflation period.
+    ///
+    /// Raises:
+    ///     ItofinError: If the index has no fixing history.
     fn last_fixing_date(&self) -> PyResult<PyDate> {
         Ok(PyDate::from_inner(
             self.inner.last_fixing_date().map_err(PyQlError::from)?,
         ))
     }
 
-    /// Points the index at `curve`, so every forecast from here on compounds
-    /// off it.
+    /// Point the index at curve, so every forecast from here on compounds off it.
     ///
-    /// Takes the [`PyZeroInflationTermStructure`] base, so any subclass links:
-    /// the directly-built [`PyInterpolatedZeroInflationCurve`] as much as the
-    /// bootstrapped curves that follow. The base's handle is filled at
-    /// construction, so it always dereferences here.
+    /// Takes the ZeroInflationTermStructure base, so any subclass links. It is
+    /// the curve behind that facade's handle at call time that is stored, not
+    /// the handle itself: relinking the facade afterwards leaves this index on
+    /// the curve it was given, and a later link_to is how it moves.
     ///
-    /// It is the curve *behind* `curve`'s handle at call time that is stored,
-    /// not the handle itself: relinking the facade afterwards leaves this index
-    /// on the curve it was given, and a later `link_to` is how it moves.
+    /// Args:
+    ///     curve (ZeroInflationTermStructure): The curve forecasts compound
+    ///         off.
     ///
-    /// # Errors
-    ///
-    /// Reports the empty-handle error if `curve` somehow carries no link.
+    /// Raises:
+    ///     ItofinError: If curve somehow carries no link.
     fn link_to(&self, curve: &PyZeroInflationTermStructure) -> PyResult<()> {
         self.relink(curve.handle().current_link().map_err(PyQlError::from)?);
         Ok(())
     }
 
-    /// Whether `fixing_date` has to be forecast rather than read from history,
-    /// decided against the latest period that could have been published by the
+    /// Return whether fixing_date has to be forecast rather than read from history.
+    ///
+    /// Decided against the latest period that could have been published by the
     /// settings' evaluation date.
+    ///
+    /// Args:
+    ///     fixing_date (Date): The date in question.
+    ///
+    /// Returns:
+    ///     bool: True if the date has to be forecast off the curve.
+    ///
+    /// Raises:
+    ///     ItofinError: If the evaluation date is unset, or the index frequency
+    ///         has no expressible inflation period.
     fn needs_forecast(&self, fixing_date: &PyDate) -> PyResult<bool> {
         Ok(self
             .inner
@@ -288,6 +334,10 @@ impl PyZeroInflationIndex {
             .map_err(PyQlError::from)?)
     }
 
+    /// Return the printable representation.
+    ///
+    /// Returns:
+    ///     str: A string of the form ZeroInflationIndex(UK RPI).
     fn __repr__(&self) -> String {
         format!("ZeroInflationIndex({})", self.inner.name())
     }
@@ -307,34 +357,19 @@ impl PyZeroInflationIndex {
     }
 }
 
-/// Python `MultiplicativePriceSeasonality`: the seasonal correction a price
-/// index carries, whose factors multiply the index level itself
-/// (`termstructures::inflation::seasonality::MultiplicativePriceSeasonality`).
+/// The seasonal correction a price index carries, whose factors multiply
+/// the index level itself.
 ///
-/// Seasonality fills an inflation curve in between the integer-year maturities
-/// the market quotes. The factors are given in whole multiples of the count the
-/// frequency dictates - twelve for [`Frequency.Monthly`](crate::time::PyFrequency)
-/// - and are reused as long as needed, so twelve of them are stationary and
-/// twenty-four repeat every two years. They are not applied raw: the factor at
-/// the queried date is normalized against the one at a reference date, which for
-/// a zero rate is the curve's own base date, so the correction is the identity
-/// there.
+/// The factors are given in whole multiples of the count the frequency
+/// dictates - twelve for Frequency.Monthly - and are reused as long as needed,
+/// so twelve of them are stationary and twenty-four repeat every two years.
+/// They are not applied raw: the factor at the queried date is normalized
+/// against the one at a reference date, which for a zero rate is the curve's
+/// own base date, so the correction is the identity there.
 ///
-/// Install it with
-/// [`ZeroInflationTermStructure.set_seasonality`](PyZeroInflationTermStructure::set_seasonality).
-/// Only the date-taking rate query folds the correction in; the year-fraction
-/// one cannot, a time not naming the date the factors are a function of.
-///
-/// Fallible at construction: the core rejects a frequency outside
-/// semiannual-through-daily - `Frequency.Annual` among them - an empty factor
-/// set, and a factor count that is not a whole multiple of the frequency, each
-/// as [`struct@crate::ItofinError`].
-///
-/// Deferred (visible): the core's `set`, which replaces the whole
-/// specification in place, is not exposed - building a new object and
-/// installing it says the same thing without a second mutation path. The core's
-/// `is_consistent` is not exposed either: it is what `set_seasonality` runs as
-/// its gate, and is reported from there.
+/// Install it with ZeroInflationTermStructure.set_seasonality. Only the
+/// date-taking rate query folds the correction in; the year-fraction one
+/// cannot, a time not naming the date the factors are a function of.
 #[pyclass(name = "MultiplicativePriceSeasonality", unsendable)]
 pub struct PyMultiplicativePriceSeasonality {
     inner: Shared<MultiplicativePriceSeasonality>,
@@ -342,8 +377,19 @@ pub struct PyMultiplicativePriceSeasonality {
 
 #[pymethods]
 impl PyMultiplicativePriceSeasonality {
-    /// The seasonality whose `seasonality_factors` start at
-    /// `seasonality_base_date` and step at `frequency`.
+    /// Build the correction from a factor set anchored on a base date.
+    ///
+    /// Args:
+    ///     seasonality_base_date (Date): The date the factor set is anchored
+    ///         on.
+    ///     frequency (Frequency): The frequency the factors step at.
+    ///     seasonality_factors (list[float]): The factors, in order from the
+    ///         base date.
+    ///
+    /// Raises:
+    ///     ItofinError: On a frequency outside semiannual-through-daily,
+    ///         Frequency.Annual among them; on an empty factor set; and on a
+    ///         factor count that is not a whole multiple of the frequency.
     #[new]
     fn new(
         seasonality_base_date: &PyDate,
@@ -362,31 +408,47 @@ impl PyMultiplicativePriceSeasonality {
         })
     }
 
-    /// The date the factor set is anchored on.
+    /// Return the date the factor set is anchored on.
+    ///
+    /// Returns:
+    ///     Date: The seasonality base date.
     fn seasonality_base_date(&self) -> PyDate {
         PyDate::from_inner(self.inner.seasonality_base_date())
     }
 
-    /// The frequency the factors step at.
+    /// Return the frequency the factors step at.
+    ///
+    /// Returns:
+    ///     Frequency: The stepping frequency.
     fn frequency(&self) -> PyResult<PyFrequency> {
         PyFrequency::from_inner(self.inner.frequency())
     }
 
-    /// The factors, in order from the seasonality base date.
+    /// Return the factors, in order from the seasonality base date.
+    ///
+    /// Returns:
+    ///     list[float]: The factor set as given.
     fn seasonality_factors(&self) -> Vec<f64> {
         self.inner.seasonality_factors().to_vec()
     }
 
-    /// The raw factor covering `to`, before any normalization against a
-    /// reference date - not the correction the curve applies.
+    /// Return the raw factor covering to, before any normalization.
     ///
-    /// The offset from the seasonality base date is counted in whole factor
-    /// periods and wrapped modulo the factor count, so a set shorter than the
-    /// span repeats and dates before the anchor wrap backwards.
+    /// This is not the correction the curve applies, which is normalized
+    /// against a reference date. The offset from the seasonality base date is
+    /// counted in whole factor periods and wrapped modulo the factor count, so
+    /// a set shorter than the span repeats and dates before the anchor wrap
+    /// backwards.
     ///
-    /// # Errors
+    /// Args:
+    ///     to (Date): The date the factor is read at.
     ///
-    /// Reports a year-based factor period, which cannot express seasonality.
+    /// Returns:
+    ///     float: The raw seasonality factor.
+    ///
+    /// Raises:
+    ///     ItofinError: On a year-based factor period, which cannot express
+    ///         seasonality.
     fn seasonality_factor(&self, to: &PyDate) -> PyResult<f64> {
         Ok(self
             .inner
@@ -402,38 +464,15 @@ impl PyMultiplicativePriceSeasonality {
     }
 }
 
-/// Python `ZeroInflationTermStructure`: the shared base for every zero-coupon
-/// inflation curve (`termstructures::inflation::inflationtermstructure`).
+/// Shared base for every zero-coupon inflation curve: the zero-coupon
+/// inflation rate in a year-fraction and a date form, the base date, the
+/// fixing frequency and the seasonality correction the curve carries.
 ///
-/// Holds the erased `Handle<dyn ZeroInflationTermStructure>` and exposes the
-/// query surface every concrete curve inherits, the shape
-/// [`PyDefaultProbabilityTermStructure`](crate::credit) already uses on the
-/// credit side. Concrete curves such as [`PyInterpolatedZeroInflationCurve`]
-/// subclass this and supply only their constructor and node inspectors.
-///
-/// The two rate reads are not interchangeable.
-/// [`zero_rate_date`](Self::zero_rate_date) snaps its date to the start of the
-/// inflation period containing it before the curve sees it, because a fixing
-/// applies to a whole period; [`zero_rate`](Self::zero_rate) takes a
-/// year-fraction already measured under the curve's own day counter and
-/// quantizes nothing. A mid-period date therefore reads that period's rate
-/// through the first and an interpolated one through the second.
-///
-/// [`set_seasonality`](Self::set_seasonality) lives here rather than on either
-/// concrete curve: it is an `InflationTermStructure` method reached through the
-/// erased handle, and the handle holds the very object the subclass wraps, so
-/// the one method serves both.
-///
-/// Deferred (visible): `base_rate()` is not exposed. A zero curve carries no
-/// base rate, so the core accessor is an error on every curve reachable here
-/// (`inflationtermstructure.rs:159-166`); it follows with the year-on-year
-/// structures that do carry one. The core's `seasonality()` getter is omitted
-/// too: it hands back an erased `Shared<dyn Seasonality>`, and the trait carries
-/// no downcast surface to recover the concrete
-/// [`PyMultiplicativePriceSeasonality`] from, so the getter could only return
-/// something lossy. [`has_seasonality`](Self::has_seasonality) answers the
-/// question the fixtures ask, and the caller already holds the object it
-/// installed.
+/// The two rate reads are not interchangeable. zero_rate_date snaps its date
+/// to the start of the inflation period containing it, because a fixing
+/// applies to a whole period; zero_rate takes a year-fraction already measured
+/// under the curve's own day counter and quantizes nothing. Only the first
+/// folds in any seasonality.
 #[pyclass(name = "ZeroInflationTermStructure", subclass, unsendable)]
 pub struct PyZeroInflationTermStructure {
     inner: Handle<dyn ZeroInflationTermStructure>,
@@ -441,12 +480,23 @@ pub struct PyZeroInflationTermStructure {
 
 #[pymethods]
 impl PyZeroInflationTermStructure {
-    /// The zero-coupon inflation rate at year-fraction `t`, on the yearly
-    /// compounding ZCIIS quotes assume.
+    /// Return the zero-coupon inflation rate at year-fraction t.
     ///
-    /// `t` must be measured with the curve's own day counter, and is negative
-    /// for the base period. Nothing here accounts for observation lags or
-    /// period interpolation: the caller manages those.
+    /// Quoted on the yearly compounding zero-coupon swaps assume. Nothing here
+    /// accounts for observation lags or period interpolation: the caller
+    /// manages those.
+    ///
+    /// Args:
+    ///     t (float): The year fraction, measured with the curve's own day
+    ///         counter; it is negative for the base period.
+    ///     extrapolate (bool): Whether to answer past the curve's range.
+    ///
+    /// Returns:
+    ///     float: The zero-coupon inflation rate.
+    ///
+    /// Raises:
+    ///     ItofinError: If t is past the curve's range and extrapolation is
+    ///         not allowed.
     #[pyo3(signature = (t, extrapolate = false))]
     fn zero_rate(&self, t: f64, extrapolate: bool) -> PyResult<f64> {
         Ok(self
@@ -457,12 +507,22 @@ impl PyZeroInflationTermStructure {
             .map_err(PyQlError::from)?)
     }
 
-    /// The zero-coupon inflation rate for the inflation period containing
-    /// `date`.
+    /// Return the zero-coupon inflation rate for the period containing date.
     ///
     /// The date is quantized to that period's first day before both the range
     /// check and the time conversion, so every day inside one period reads the
-    /// same rate.
+    /// same rate. This is the only form that folds in seasonality.
+    ///
+    /// Args:
+    ///     date (Date): The date the rate is read at.
+    ///     extrapolate (bool): Whether to answer past the curve's range.
+    ///
+    /// Returns:
+    ///     float: The zero-coupon inflation rate for that period.
+    ///
+    /// Raises:
+    ///     ItofinError: If the period is past the curve's range and
+    ///         extrapolation is not allowed.
     #[pyo3(signature = (date, extrapolate = false))]
     fn zero_rate_date(&self, date: &PyDate, extrapolate: bool) -> PyResult<f64> {
         Ok(self
@@ -473,8 +533,11 @@ impl PyZeroInflationTermStructure {
             .map_err(PyQlError::from)?)
     }
 
-    /// The base date: the last date for which the fixing is known. It precedes
-    /// the reference date, so its year-fraction is negative.
+    /// Return the base date, the last date for which the fixing is known.
+    ///
+    /// Returns:
+    ///     Date: The base date; it precedes the reference date, so its year
+    ///         fraction is negative.
     fn base_date(&self) -> PyResult<PyDate> {
         Ok(PyDate::from_inner(
             self.inner
@@ -484,7 +547,10 @@ impl PyZeroInflationTermStructure {
         ))
     }
 
-    /// The frequency of the inflation fixings the curve is built on.
+    /// Return the frequency of the inflation fixings the curve is built on.
+    ///
+    /// Returns:
+    ///     Frequency: The fixing frequency.
     fn frequency(&self) -> PyResult<PyFrequency> {
         PyFrequency::from_inner(
             self.inner
@@ -494,20 +560,22 @@ impl PyZeroInflationTermStructure {
         )
     }
 
-    /// Installs `seasonality` on the curve, replacing whatever it carried;
-    /// `None` clears it.
+    /// Install seasonality on the curve, replacing whatever it carried.
     ///
     /// A curve that caches anything derived from the correction - every
     /// bootstrapped one does - is invalidated here, so the next read re-solves
     /// against the new correction.
     ///
-    /// # Errors
+    /// Args:
+    ///     seasonality (MultiplicativePriceSeasonality | None): The correction
+    ///         to install; None clears it.
     ///
-    /// Reports the consistency gate, which a multi-year factor set fails: the
-    /// whole-year comparison deciding those is a documented core deferral
-    /// (#807). The store happens *before* the gate runs, as C++'s does, so a
-    /// rejected correction is left installed and unannounced - clear it with
-    /// `None` before reading the curve again.
+    /// Raises:
+    ///     ItofinError: From the consistency gate, which a multi-year factor
+    ///         set fails, that comparison being a documented core deferral
+    ///         (#807). The store happens before the gate runs, as C++'s does,
+    ///         so a rejected correction is left installed and unannounced:
+    ///         clear it with None before reading the curve again.
     #[pyo3(signature = (seasonality))]
     fn set_seasonality(
         &self,
@@ -521,8 +589,11 @@ impl PyZeroInflationTermStructure {
             .map_err(PyQlError::from)?)
     }
 
-    /// Whether the curve carries a seasonality correction. Reports one left
-    /// installed by a [`set_seasonality`](Self::set_seasonality) that raised.
+    /// Return whether the curve carries a seasonality correction.
+    ///
+    /// Returns:
+    ///     bool: True also for a correction left installed by a
+    ///         set_seasonality that raised.
     fn has_seasonality(&self) -> PyResult<bool> {
         Ok(self
             .inner
@@ -545,33 +616,12 @@ impl PyZeroInflationTermStructure {
     }
 }
 
-/// Python `InterpolatedZeroInflationCurve`: a zero-coupon inflation curve built
-/// from (date, zero-rate) nodes, interpolating linearly in zero-rate space
-/// (`termstructures::inflation::InterpolatedZeroInflationCurve<Linear>`).
+/// A zero-coupon inflation curve built from (date, zero-rate) nodes,
+/// interpolating linearly in zero-rate space.
 ///
-/// Extends [`PyZeroInflationTermStructure`], which carries the whole query
-/// surface. The first date is the *base* date rather than the reference date,
-/// which is passed separately and normally follows it; node times are measured
-/// from the reference date, so the first one is negative. That is the
-/// divergence from the yield-side [`ZeroCurve`](crate::curve::PyZeroCurve),
-/// whose first node is its own reference date at time zero.
-///
-/// The concrete curve is retained alongside the erased handle so the node
-/// inspectors [`times`](Self::times), [`dates`](Self::dates) and
-/// [`nodes`](Self::nodes) stay reachable, the shape
-/// [`PyInterpolatedHazardRateCurve`](crate::credit) uses.
-///
-/// Fallible: the core rejects fewer than two dates, a dates/rates count
-/// mismatch, a rate at or below -100 % from the second node on, and unsorted
-/// dates (`interpolatedzeroinflationcurve.rs:95-106`), each as
-/// [`struct@crate::ItofinError`].
-///
-/// `Linear` is pinned at the boundary: it is the interpolator C++'s
-/// `ZeroInflationCurve` typedef fixes (`interpolatedzeroinflationcurve.rs:74`),
-/// so no interpolation argument is offered.
-///
-/// Deferred (visible): the core's `rates()` / `data()` inspectors are omitted,
-/// both being the rate half of [`nodes`](Self::nodes).
+/// The first date is the base date rather than the reference date, which is
+/// passed separately and normally follows it; node times are measured from the
+/// reference date, so the first one is negative.
 #[pyclass(
     name = "InterpolatedZeroInflationCurve",
     extends = PyZeroInflationTermStructure,
@@ -583,8 +633,23 @@ pub struct PyInterpolatedZeroInflationCurve {
 
 #[pymethods]
 impl PyInterpolatedZeroInflationCurve {
-    /// A curve through the `rates` quoted at `dates`, with `dates[0]` as the
-    /// base date and `reference_date` given separately.
+    /// Build the curve through the rates quoted at dates.
+    ///
+    /// Linear is pinned at the boundary: it is the interpolator the C++ zero
+    /// inflation curve typedef fixes, so no interpolation argument is offered.
+    ///
+    /// Args:
+    ///     reference_date (Date): The curve's reference date, given separately
+    ///         and normally following the base date.
+    ///     dates (list[Date]): The node dates, the first being the base date.
+    ///     rates (list[float]): The zero rate at each node.
+    ///     frequency (Frequency): The frequency of the inflation fixings.
+    ///     day_counter (DayCounter): The day count turning dates into times.
+    ///
+    /// Raises:
+    ///     ItofinError: On fewer than two dates, a dates and rates count
+    ///         mismatch, a rate at or below -100 per cent from the second node
+    ///         on, or unsorted dates.
     #[new]
     fn new(
         reference_date: &PyDate,
@@ -615,13 +680,19 @@ impl PyInterpolatedZeroInflationCurve {
         )
     }
 
-    /// The node times, measured from the reference date; the first is negative
-    /// whenever the base date precedes it.
+    /// Return the node times, measured from the reference date.
+    ///
+    /// Returns:
+    ///     list[float]: The node times; the first is negative whenever the
+    ///         base date precedes the reference date.
     fn times(&self) -> Vec<f64> {
         self.concrete.times().to_vec()
     }
 
-    /// The node dates, the first of which is the base date.
+    /// Return the node dates.
+    ///
+    /// Returns:
+    ///     list[Date]: The nodes, the first of which is the base date.
     fn dates(&self) -> Vec<PyDate> {
         self.concrete
             .dates()
@@ -631,7 +702,10 @@ impl PyInterpolatedZeroInflationCurve {
             .collect()
     }
 
-    /// The `(date, zero-rate)` nodes.
+    /// Return the curve's nodes as pairs.
+    ///
+    /// Returns:
+    ///     list[tuple[Date, float]]: One (date, zero rate) pair per node.
     fn nodes(&self) -> Vec<(PyDate, f64)> {
         self.concrete
             .nodes()
@@ -641,23 +715,11 @@ impl PyInterpolatedZeroInflationCurve {
     }
 }
 
-/// Python `ZeroInflationHelper`: the shared base for every zero-inflation
-/// bootstrap helper
-/// (`termstructures::inflation::inflationhelpers::ZeroInflationHelper`).
+/// Shared base for every zero-inflation bootstrap helper: the two dates the
+/// bootstrap places a curve node by.
 ///
-/// Holds the erased `Shared<dyn ZeroInflationHelper>` and exposes the two dates
-/// the bootstrap places a curve node by, the shape
-/// [`PyDefaultProbabilityHelper`](crate::credithelpers::PyDefaultProbabilityHelper)
-/// already uses on the credit side. Concrete helpers such as
-/// [`PyZeroCouponInflationSwapHelper`] subclass this and supply only their
-/// constructor.
-///
-/// Deferred (visible): the core trait's `earliest_date`, `maturity_date` and
-/// `latest_relevant_date` are not exposed. On the one concrete helper reachable
-/// here all five dates collapse onto the same fixing-period start
-/// (`inflationhelpers.rs:288-290`), so the three would report exactly what
-/// [`pillar_date`](Self::pillar_date) reports; they follow with a helper whose
-/// dates straddle a period.
+/// Concrete helpers such as ZeroCouponInflationSwapHelper subclass this and
+/// supply only their constructor.
 #[pyclass(name = "ZeroInflationHelper", subclass, unsendable)]
 pub struct PyZeroInflationHelper {
     inner: Shared<dyn ZeroInflationHelper>,
@@ -665,13 +727,18 @@ pub struct PyZeroInflationHelper {
 
 #[pymethods]
 impl PyZeroInflationHelper {
-    /// The pillar date, at which the curve node this helper sets sits.
+    /// Return the date the curve node this helper sets sits at.
+    ///
+    /// Returns:
+    ///     Date: The pillar date.
     fn pillar_date(&self) -> PyDate {
         PyDate::from_inner(self.inner.pillar_date())
     }
 
-    /// The latest date the helper needs curve data at (equal to the pillar
-    /// date).
+    /// Return the latest date the helper needs curve data at.
+    ///
+    /// Returns:
+    ///     Date: The latest date, equal to the pillar date.
     fn latest_date(&self) -> PyDate {
         PyDate::from_inner(self.inner.latest_date())
     }
@@ -690,34 +757,19 @@ impl PyZeroInflationHelper {
     }
 }
 
-/// Python `ZeroCouponInflationSwapHelper`: the bootstrap helper fitting a
-/// zero-coupon inflation swap quoted as a rate
-/// (`termstructures::inflation::inflationhelpers::ZeroCouponInflationSwapHelper`).
+/// The bootstrap helper fitting a zero-coupon inflation swap quoted as a
+/// rate.
 ///
 /// The helper prices a unit-notional, zero-strike swap of its own and reports
 /// that contract's fair rate; the bootstrap drives the quoted rate less that
-/// fair rate to zero. It needs no nominal curve, building itself a flat 0 % one,
-/// because both legs pay on the same adjusted maturity and their discount
-/// factors cancel out of the fair rate.
+/// fair rate to zero. The swap starts at the evaluation date, so that date must
+/// be set before this constructor runs, not merely before the bootstrap.
 ///
-/// The swap starts at the evaluation date held by `settings` and is rebuilt
-/// whenever that date moves, so the evaluation date must be set *before* the
-/// constructor runs, not merely before the bootstrap. The helper retains the
-/// caller's [`PySimpleQuote`], so a later `set_value` re-drives the bootstrap.
+/// It prices through a copy of index linked to a handle of its own, so the
+/// caller's index need not be linked to any curve.
 ///
-/// It prices through a *copy* of `index` linked to a handle of its own, which
-/// the bootstrap points at the curve under construction; the caller's index
-/// keeps whatever curve it had and need not be linked at all.
-///
-/// `pillar` picks which of the two nodes an interpolated swap straddles the
-/// helper fits; a flat swap reads a single fixing and ignores it.
-///
-/// Fallible: the core rejects an observation lag the index cannot observe
-/// through, the swap being built here too, and under
-/// [`CpiInterpolationType.Linear`](PyCpiInterpolationType) one that leaves less
-/// than a whole index period over the index's availability lag, interpolation
-/// reading the month after the one the lag lands in. Both raise
-/// [`struct@crate::ItofinError`].
+/// pillar picks which of the two nodes an interpolated swap straddles the helper
+/// fits; a flat swap reads a single fixing and ignores it.
 #[pyclass(
     name = "ZeroCouponInflationSwapHelper",
     extends = PyZeroInflationHelper,
@@ -729,7 +781,39 @@ pub struct PyZeroCouponInflationSwapHelper {
 
 #[pymethods]
 impl PyZeroCouponInflationSwapHelper {
-    /// A helper fitting `quote` on a swap maturing at `maturity`.
+    /// Build the helper on a swap maturing at maturity.
+    ///
+    /// It needs no nominal curve, building itself a flat zero-rate one,
+    /// because both legs pay on the same adjusted maturity and their discount
+    /// factors cancel out of the fair rate.
+    ///
+    /// Args:
+    ///     quote (SimpleQuote): The quoted swap rate; the caller keeps it, so
+    ///         a later set_value re-drives the bootstrap.
+    ///     swap_obs_lag (Period): How far back the maturity fixing is
+    ///         observed.
+    ///     maturity (Date): The swap's maturity.
+    ///     calendar (Calendar): The calendar the payment rolls on.
+    ///     payment_convention (BusinessDayConvention): The roll applied to the
+    ///         payment date.
+    ///     day_counter (DayCounter): The day count the fixed amount accrues
+    ///         on.
+    ///     index (ZeroInflationIndex): The index observed; the helper prices
+    ///         through a copy linked to a handle of its own, so the caller's
+    ///         index need not be linked to any curve.
+    ///     observation_interpolation (CpiInterpolationType): How the observed
+    ///         fixing is interpolated.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date the swap starts at, which must be set before this
+    ///         constructor runs.
+    ///     pillar (Pillar): Which of the two nodes an interpolated swap
+    ///         straddles the helper fits; a flat swap reads a single fixing
+    ///         and ignores it.
+    ///
+    /// Raises:
+    ///     ItofinError: On an observation lag the index cannot observe
+    ///         through, and under Linear interpolation on one that leaves less
+    ///         than a whole index period over the index's availability lag.
     #[new]
     #[pyo3(signature = (
         quote,
@@ -776,17 +860,19 @@ impl PyZeroCouponInflationSwapHelper {
         )
     }
 
-    /// The date the maturity fixing is observed at on the helper's own swap:
-    /// `maturity` less the observation lag, unsnapped to its inflation period.
+    /// Return the maturity observation date on the helper's own swap.
     ///
     /// Read off the cached contract's indexed flow, so it reports the date the
-    /// helper actually prices at rather than one recomputed here. It is *not*
-    /// [`pillar_date`](PyZeroInflationHelper::pillar_date), which is the first
-    /// day of the period containing it - the quantization being the helper's
-    /// rounding and not the contract's.
+    /// helper actually prices at rather than one recomputed here. It is not
+    /// pillar_date, which is the first day of the period containing it, that
+    /// quantization being the helper's rounding and not the contract's.
     ///
-    /// Fallible: the cached swap carries the error that stopped it being built,
-    /// notably an evaluation date that was never set.
+    /// Returns:
+    ///     Date: The maturity less the observation lag, unsnapped.
+    ///
+    /// Raises:
+    ///     ItofinError: If the cached swap carries the error that stopped it
+    ///         being built, notably an evaluation date that was never set.
     fn inflation_fixing_date(&self) -> PyResult<PyDate> {
         let swap = self.concrete.swap();
         let swap = swap
@@ -796,48 +882,15 @@ impl PyZeroCouponInflationSwapHelper {
     }
 }
 
-/// Python `PiecewiseZeroInflationCurve`: a zero-coupon inflation curve
-/// bootstrapped from inflation helpers, solving one zero-rate node per helper
-/// (`termstructures::inflation::PiecewiseZeroInflationCurve<Linear>`).
+/// A zero-coupon inflation curve bootstrapped from inflation helpers,
+/// solving one zero-rate node per helper fixing period.
 ///
-/// Extends [`PyZeroInflationTermStructure`], which carries the whole query
-/// surface. Each helper's observed fixing period marks a segment boundary, and
-/// its node is solved so the helper reprices its own quote off the curve.
+/// Node zero sits on base_date, not on reference_date, so times()[0] is
+/// negative - the one structural difference from every other piecewise curve.
 ///
-/// Node zero sits on `base_date`, not on `reference_date`: the base date is the
-/// last date for which a fixing is known - in practice
-/// [`ZeroInflationIndex.last_fixing_date`](PyZeroInflationIndex::last_fixing_date)
-/// - and precedes the reference date, so [`times`](Self::times)`[0]` is
-/// negative. That is the one structural difference from every other piecewise
-/// curve, whose first node is its own reference date at time zero.
-///
-/// Lazy, like the credit-side [`PyPiecewiseDefaultCurve`](crate::credit): the
-/// constructor only registers on the helpers, and the bootstrap runs on the
-/// first read - a query, an inspector, or an explicit
-/// [`calculate`](Self::calculate). A helper quote moving invalidates the cache,
-/// so the next read re-bootstraps. The evaluation date must therefore be in
-/// place before that first read as well as before the helpers were built.
-///
-/// The concrete curve is retained alongside the erased handle so the node
-/// inspectors stay reachable, as [`PyInterpolatedZeroInflationCurve`] and
-/// [`PyPiecewiseDefaultCurve`](crate::credit) both do.
-///
-/// Fallible: the core rejects an empty helper set, and every inspector
-/// propagates a bootstrap failure as [`struct@crate::ItofinError`].
-///
-/// `Linear` is pinned at the boundary: it is the only interpolator the core
-/// constructs (`piecewisezeroinflationcurve.rs:105-125`), so no interpolation
-/// argument is offered.
-///
-/// A seasonality installed through
-/// [`set_seasonality`](PyZeroInflationTermStructure::set_seasonality)
-/// invalidates the bootstrap, so the next read re-solves every node against the
-/// correction and the quoted swaps still reprice to nothing.
-///
-/// Deferred (visible): the core's `data()` inspector is omitted, being the rate
-/// half of [`nodes`](Self::nodes) - the choice
-/// [`PyInterpolatedZeroInflationCurve`] already made on this side, where the
-/// credit curve exposes both.
+/// Lazy: the bootstrap runs on the first read, so the evaluation date must be
+/// in place before that read as well as before the helpers were built. A helper
+/// quote moving invalidates the cache.
 #[pyclass(
     name = "PiecewiseZeroInflationCurve",
     extends = PyZeroInflationTermStructure,
@@ -849,9 +902,18 @@ pub struct PyPiecewiseZeroInflationCurve {
 
 #[pymethods]
 impl PyPiecewiseZeroInflationCurve {
-    /// A curve over `helpers` with a fixed `reference_date` and a `base_date`
-    /// preceding it. `helpers` accepts any
-    /// [`ZeroInflationHelper`](PyZeroInflationHelper) subclass.
+    /// Build the curve over helpers, registering on them without solving.
+    ///
+    /// Args:
+    ///     reference_date (Date): The curve's reference date.
+    ///     base_date (Date): The last date for which a fixing is known, where
+    ///         node zero sits.
+    ///     frequency (Frequency): The frequency of the inflation fixings.
+    ///     day_counter (DayCounter): The day count turning dates into times.
+    ///     helpers (list[ZeroInflationHelper]): The bootstrap instruments.
+    ///
+    /// Raises:
+    ///     ItofinError: On an empty helper list.
     #[new]
     fn new(
         reference_date: &PyDate,
@@ -880,20 +942,36 @@ impl PyPiecewiseZeroInflationCurve {
         )
     }
 
-    /// Runs the bootstrap if the cache is stale, so a solver failure surfaces
-    /// here rather than inside a later query.
+    /// Run the bootstrap if the cache is stale.
+    ///
+    /// Calling it explicitly makes a solver failure surface here rather than
+    /// inside a later query.
+    ///
+    /// Raises:
+    ///     ItofinError: On a bootstrap failure.
     fn calculate(&self) -> PyResult<()> {
         Ok(self.concrete.calculate().map_err(PyQlError::from)?)
     }
 
-    /// The node times, measured from the reference date in the curve's own day
-    /// count; the first is negative (triggers the bootstrap).
+    /// Return the node times, triggering the bootstrap.
+    ///
+    /// Returns:
+    ///     list[float]: The nodes measured from the reference date; the first
+    ///         is negative, node zero sitting on the base date.
+    ///
+    /// Raises:
+    ///     ItofinError: On a bootstrap failure.
     fn times(&self) -> PyResult<Vec<f64>> {
         Ok(self.concrete.times().map_err(PyQlError::from)?)
     }
 
-    /// The node dates, the first of which is the base date (triggers the
-    /// bootstrap).
+    /// Return the node dates, triggering the bootstrap.
+    ///
+    /// Returns:
+    ///     list[Date]: The nodes, the first of which is the base date.
+    ///
+    /// Raises:
+    ///     ItofinError: On a bootstrap failure.
     fn dates(&self) -> PyResult<Vec<PyDate>> {
         Ok(self
             .concrete
@@ -904,7 +982,13 @@ impl PyPiecewiseZeroInflationCurve {
             .collect())
     }
 
-    /// The solved `(date, zero-rate)` nodes (triggers the bootstrap).
+    /// Return the solved nodes as pairs, triggering the bootstrap.
+    ///
+    /// Returns:
+    ///     list[tuple[Date, float]]: One (date, zero rate) pair per node.
+    ///
+    /// Raises:
+    ///     ItofinError: On a bootstrap failure.
     fn nodes(&self) -> PyResult<Vec<(PyDate, f64)>> {
         Ok(self
             .concrete
@@ -916,35 +1000,20 @@ impl PyPiecewiseZeroInflationCurve {
     }
 }
 
-/// Python `ZeroCouponInflationSwap`: one fixed flow against one
-/// inflation-indexed flow, both exchanged at maturity
-/// (`instruments::zerocouponinflationswap`).
+/// One fixed flow against one inflation-indexed flow, both exchanged at maturity.
 ///
-/// The quoted `fixed_rate` is the `K` that at inception matches the inflation
-/// growth. [`SwapType`](crate::swap::PySwapType) names the *inflation* leg, so a
-/// `Payer` pays inflation and receives fixed.
+/// fixed_rate is the K that at inception matches the inflation growth.
+/// SwapType names the inflation leg, so a Payer pays inflation and receives
+/// fixed.
 ///
-/// `maturity` is pre-adjustment: each leg's payment date is it rolled on that
+/// maturity is pre-adjustment: each leg's payment date is it rolled on that
 /// leg's calendar and convention, while the year fraction behind the fixed
-/// amount stays on the raw date. `inflation_calendar` and
-/// `inflation_convention` fall back to the fixed-leg ones when `None`, and are
-/// stored resolved.
+/// amount stays on the raw date. inflation_calendar and inflation_convention
+/// fall back to the fixed-leg ones when None.
 ///
-/// Fallible at construction: the observation lag must let the index observe
-/// fixings that exist, which under
-/// [`Linear`](PyCpiInterpolationType::Linear) costs a further publication
-/// period (`zerocouponinflationswap.rs:156-176`).
-///
-/// Pricing needs an engine: call [`set_engine`](Self::set_engine) before
-/// [`npv`](Self::npv). [`fair_rate`](Self::fair_rate) is the exception - it
-/// reads the indexed flow directly and prices with no engine at all - but it
-/// does need the index linked to a curve.
-///
-/// Deferred (visible): the core omits `adjust_inf_obs_dates` from its own
-/// signature, so there is nothing to expose here; the leg and cash-flow
-/// accessors are not surfaced either, there being no cash-flow facade, and
-/// [`inflation_fixing_date`](Self::inflation_fixing_date) carries the one datum
-/// off the indexed flow that the fixtures read.
+/// The core omits adjust_inf_obs_dates from its own signature, so there is
+/// nothing to expose here; the leg and cash-flow accessors are not surfaced
+/// either, there being no cash-flow facade.
 #[pyclass(name = "ZeroCouponInflationSwap", unsendable)]
 pub struct PyZeroCouponInflationSwap {
     inner: SharedMut<ZeroCouponInflationSwap>,
@@ -952,6 +1021,39 @@ pub struct PyZeroCouponInflationSwap {
 
 #[pymethods]
 impl PyZeroCouponInflationSwap {
+    /// Build the swap from its two exchanged flows.
+    ///
+    /// Args:
+    ///     swap_type (SwapType): Which side the inflation leg is seen from; a
+    ///         Payer pays inflation and receives fixed.
+    ///     nominal (float): The notional both flows are quoted on.
+    ///     start_date (Date): The inception the index ratio is measured from.
+    ///     maturity (Date): The raw, pre-adjustment maturity.
+    ///     fixed_calendar (Calendar): The calendar the fixed payment rolls on.
+    ///     fixed_convention (BusinessDayConvention): The roll applied to the
+    ///         fixed payment date.
+    ///     day_counter (DayCounter): The day count behind the fixed amount,
+    ///         which stays on the raw maturity.
+    ///     fixed_rate (float): The K that at inception matches the inflation
+    ///         growth.
+    ///     inflation_index (ZeroInflationIndex): The index the indexed flow
+    ///         observes.
+    ///     observation_lag (Period): How far back the maturity fixing is
+    ///         observed.
+    ///     observation_interpolation (CpiInterpolationType): How the observed
+    ///         fixing is interpolated.
+    ///     inflation_calendar (Calendar | None): The calendar the inflation
+    ///         payment rolls on; None falls back to fixed_calendar.
+    ///     inflation_convention (BusinessDayConvention | None): The roll
+    ///         applied to the inflation payment date; None falls back to
+    ///         fixed_convention.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date and the stored fixings.
+    ///
+    /// Raises:
+    ///     ItofinError: If the observation lag is too short for the index to
+    ///         observe fixings that exist, which under Linear interpolation
+    ///         costs a further publication period.
     #[new]
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (
@@ -1009,10 +1111,11 @@ impl PyZeroCouponInflationSwap {
         })
     }
 
-    /// Attaches a [`PyDiscountingSwapEngine`] so the swap prices.
+    /// Attach a discounting engine so the swap prices.
     ///
-    /// The engine must resolve its dates against the same `Settings` object
-    /// this swap was built with.
+    /// Args:
+    ///     engine (DiscountingSwapEngine): The engine, which must resolve its
+    ///         dates against the same Settings object as this swap.
     fn set_engine(&mut self, engine: &PyDiscountingSwapEngine) {
         self.inner
             .borrow_mut()
@@ -1020,8 +1123,11 @@ impl PyZeroCouponInflationSwap {
             .set_pricing_engine(engine.engine());
     }
 
-    /// Forces the valuation, idempotent and fallible as
-    /// [`VanillaOption.calculate`](crate::option::PyVanillaOption::calculate).
+    /// Force the valuation. Idempotent.
+    ///
+    /// Raises:
+    ///     ItofinError: If no engine is attached, no evaluation date is set,
+    ///         or the engine refuses the swap.
     fn calculate(&mut self) -> PyResult<()> {
         Ok(self
             .inner
@@ -1030,46 +1136,77 @@ impl PyZeroCouponInflationSwap {
             .map_err(PyQlError::from)?)
     }
 
-    /// Whether the cached results are currently valid.
+    /// Return whether the cached results are currently valid.
+    ///
+    /// Returns:
+    ///     bool: True when the next accessor reads the cache.
     fn is_calculated(&self) -> bool {
         self.inner.borrow().base().is_calculated()
     }
 
-    /// Attaches `engine` and returns the NPV, the one-shot form of
-    /// [`set_engine`](Self::set_engine) followed by [`npv`](Self::npv).
+    /// Attach engine and return the NPV.
+    ///
+    /// Args:
+    ///     engine (DiscountingSwapEngine): The engine to install and price on.
+    ///
+    /// Returns:
+    ///     float: The swap value.
+    ///
+    /// Raises:
+    ///     ItofinError: On anything that makes the valuation fail.
     fn price(&mut self, engine: &PyDiscountingSwapEngine) -> PyResult<f64> {
         self.set_engine(engine);
         self.calculate()?;
         self.npv()
     }
 
-    /// A frozen [`Results`] copy of the valuation, calculating first.
+    /// Return a frozen snapshot of the valuation, calculating first.
+    ///
+    /// Returns:
+    ///     Results: A copy of the valuation results.
+    ///
+    /// Raises:
+    ///     ItofinError: On anything that makes the valuation fail.
     fn results(&mut self) -> PyResult<Results> {
         self.calculate()?;
         let inner = self.inner.borrow();
         Ok(Results::snapshot(inner.base()))
     }
 
-    /// The swap NPV under the attached engine.
+    /// Return the swap NPV under the attached engine.
     ///
-    /// Fallible: with no engine attached the core reports `"null pricing
-    /// engine"`, and with no curve linked into the index the indexed flow
-    /// cannot be forecast.
+    /// Returns:
+    ///     float: The present value.
+    ///
+    /// Raises:
+    ///     ItofinError: If no engine is attached, and if no curve is linked
+    ///         into the index, which leaves the indexed flow unforecastable.
     fn npv(&mut self) -> PyResult<f64> {
         Ok(self.inner.borrow_mut().npv().map_err(PyQlError::from)?)
     }
 
-    /// The rate that would price the swap at zero: the index ratio
-    /// `I(T)/I(0)` de-compounded over the swap's own year fraction.
+    /// Return the index ratio de-compounded over the swap's own year fraction.
     ///
     /// Needs no engine - it reads the indexed flow rather than any priced
-    /// result - but does need the index linked, the flow's amount being a
-    /// forecast off the inflation curve.
+    /// result.
+    ///
+    /// Returns:
+    ///     float: The rate that would price the swap at zero.
+    ///
+    /// Raises:
+    ///     ItofinError: If no curve is linked into the index, the flow's
+    ///         amount being a forecast off the inflation curve.
     fn fair_rate(&self) -> PyResult<f64> {
         Ok(self.inner.borrow().fair_rate().map_err(PyQlError::from)?)
     }
 
-    /// The fixed leg's NPV, priced on demand. Fallible as [`npv`](Self::npv).
+    /// Return the fixed leg's NPV, priced on demand.
+    ///
+    /// Returns:
+    ///     float: The present value of the fixed flow.
+    ///
+    /// Raises:
+    ///     ItofinError: On the same conditions npv reports.
     fn fixed_leg_npv(&mut self) -> PyResult<f64> {
         Ok(self
             .inner
@@ -1078,8 +1215,13 @@ impl PyZeroCouponInflationSwap {
             .map_err(PyQlError::from)?)
     }
 
-    /// The inflation leg's NPV, priced on demand. Fallible as
-    /// [`npv`](Self::npv).
+    /// Return the inflation leg's NPV, priced on demand.
+    ///
+    /// Returns:
+    ///     float: The present value of the indexed flow.
+    ///
+    /// Raises:
+    ///     ItofinError: On the same conditions npv reports.
     fn inflation_leg_npv(&mut self) -> PyResult<f64> {
         Ok(self
             .inner
@@ -1088,12 +1230,18 @@ impl PyZeroCouponInflationSwap {
             .map_err(PyQlError::from)?)
     }
 
-    /// The fixed leg's sensitivity to a basis point on the quoted rate,
-    /// computed in closed form rather than read off the engine, whose own leg
+    /// Return the fixed leg's sensitivity to a basis point on the quoted rate.
+    ///
+    /// Computed in closed form rather than read off the engine, whose own leg
     /// BPS is zero for a non-coupon flow.
     ///
-    /// Fallible as [`npv`](Self::npv): it needs the engine's discount factor at
-    /// the fixed leg's end date.
+    /// Returns:
+    ///     float: The basis-point value of the fixed flow.
+    ///
+    /// Raises:
+    ///     ItofinError: On the same conditions npv reports, the calculation
+    ///         needing the engine's discount factor at the fixed leg's end
+    ///         date.
     fn fixed_leg_bps(&mut self) -> PyResult<f64> {
         Ok(self
             .inner
@@ -1102,53 +1250,46 @@ impl PyZeroCouponInflationSwap {
             .map_err(PyQlError::from)?)
     }
 
-    /// The contract maturity, raw and pre-adjustment - not either leg's
-    /// payment date.
+    /// Return the contract maturity, raw and pre-adjustment.
+    ///
+    /// Returns:
+    ///     Date: The maturity, which is not either leg's payment date.
     fn maturity_date(&self) -> PyDate {
         PyDate::from_inner(self.inner.borrow().maturity_date())
     }
 
-    /// The date the maturity fixing is observed at, `maturity` less the
-    /// observation lag, unsnapped.
+    /// Return the date the maturity fixing is observed at.
+    ///
+    /// Returns:
+    ///     Date: The maturity less the observation lag, unsnapped.
     fn obs_date(&self) -> PyDate {
         PyDate::from_inner(self.inner.borrow().obs_date())
     }
 
-    /// The same date as [`obs_date`](Self::obs_date), read off the indexed flow
-    /// rather than off the swap: the core's `obs_date()` is that call
-    /// (`zerocouponinflationswap.rs:315-317`). Both names are kept because both
-    /// exist in the core, and the oracle asserts they coincide.
+    /// Return the observation date, read off the indexed flow.
+    ///
+    /// Both names are kept because both exist in the core, and the oracle
+    /// asserts they coincide.
+    ///
+    /// Returns:
+    ///     Date: The same date as obs_date.
     fn inflation_fixing_date(&self) -> PyDate {
         PyDate::from_inner(self.inner.borrow().inflation_cash_flow().fixing_date())
     }
 }
 
-/// Python `YoYInflationTermStructure`: the shared base for every year-on-year
-/// inflation curve (`termstructures::inflation::inflationtermstructure`).
+/// Shared base for every year-on-year inflation curve: the year-on-year
+/// rate in a year-fraction and a date form, the base date, the base rate, the
+/// fixing frequency and the seasonality correction the curve carries.
 ///
-/// Holds the erased `Handle<dyn YoYInflationTermStructure>` and exposes the
-/// query surface every concrete curve inherits, the shape
-/// [`PyZeroInflationTermStructure`] already uses on the zero side. Concrete
-/// curves such as [`PyInterpolatedYoYInflationCurve`] subclass this and supply
-/// only their constructor and node inspectors.
+/// The two rate reads are not interchangeable. yoy_rate_date snaps its date to
+/// the start of the inflation period containing it and is the only one that
+/// folds in any seasonality; yoy_rate takes a year-fraction already measured
+/// under the curve's own day counter and quantizes nothing. Neither is the
+/// year-on-year swap rate, which comes from the instrument.
 ///
-/// The two rate reads are not interchangeable, exactly as on the zero side.
-/// [`yoy_rate_date`](Self::yoy_rate_date) snaps its date to the start of the
-/// inflation period containing it before the curve sees it, and is the only one
-/// that folds in a seasonality correction;
-/// [`yoy_rate`](Self::yoy_rate) takes a year-fraction already measured under the
-/// curve's own day counter and quantizes nothing.
-///
-/// [`base_rate`](Self::base_rate) is exposed here where the zero base defers it:
-/// a year-on-year curve carries the rate observed over the period ending on its
-/// base date, C++ forwarding `baseYoYRate` into the base constructor's
-/// `baseRate` slot (`inflationtermstructure.rs:198`), so every curve reachable
-/// through this facade answers rather than raising.
-///
-/// Deferred (visible): the core's `seasonality()` getter, for the reason
-/// [`PyZeroInflationTermStructure`] omits it - it hands back an erased
-/// `Shared<dyn Seasonality>` there is no downcast surface to recover the
-/// concrete correction from.
+/// base_rate is answered here where the zero base defers it: a year-on-year
+/// curve carries the rate observed over the period ending on its base date.
 #[pyclass(name = "YoYInflationTermStructure", subclass, unsendable)]
 pub struct PyYoYInflationTermStructure {
     inner: Handle<dyn YoYInflationTermStructure>,
@@ -1156,11 +1297,20 @@ pub struct PyYoYInflationTermStructure {
 
 #[pymethods]
 impl PyYoYInflationTermStructure {
-    /// The year-on-year inflation rate at year-fraction `t`.
+    /// Return the year-on-year inflation rate at year-fraction t.
     ///
-    /// `t` must be measured with the curve's own day counter, and is negative
-    /// for the base period. This is not the year-on-year swap rate, which comes
-    /// from the instrument.
+    /// Args:
+    ///     t (float): The year fraction, measured with the curve's own day
+    ///         counter; it is negative for the base period.
+    ///     extrapolate (bool): Whether to answer past the curve's range.
+    ///
+    /// Returns:
+    ///     float: The year-on-year rate, which is not the year-on-year swap
+    ///         rate: that comes from the instrument.
+    ///
+    /// Raises:
+    ///     ItofinError: If t is past the curve's range and extrapolation is
+    ///         not allowed.
     #[pyo3(signature = (t, extrapolate = false))]
     fn yoy_rate(&self, t: f64, extrapolate: bool) -> PyResult<f64> {
         Ok(self
@@ -1171,13 +1321,23 @@ impl PyYoYInflationTermStructure {
             .map_err(PyQlError::from)?)
     }
 
-    /// The year-on-year inflation rate for the inflation period containing
-    /// `date`.
+    /// Return the year-on-year rate for the inflation period containing date.
     ///
     /// The date is quantized to that period's first day before both the range
-    /// check and the time conversion, so every day inside one period reads the
-    /// same rate. Any seasonality correction is folded in last, at the
-    /// *original* date rather than the period start, as C++ does on this path.
+    /// check and the time conversion. Any seasonality correction is folded in
+    /// last, at the original date rather than the period start, as C++ does on
+    /// this path.
+    ///
+    /// Args:
+    ///     date (Date): The date the rate is read at.
+    ///     extrapolate (bool): Whether to answer past the curve's range.
+    ///
+    /// Returns:
+    ///     float: The year-on-year rate for that period.
+    ///
+    /// Raises:
+    ///     ItofinError: If the period is past the curve's range and
+    ///         extrapolation is not allowed.
     #[pyo3(signature = (date, extrapolate = false))]
     fn yoy_rate_date(&self, date: &PyDate, extrapolate: bool) -> PyResult<f64> {
         Ok(self
@@ -1188,8 +1348,11 @@ impl PyYoYInflationTermStructure {
             .map_err(PyQlError::from)?)
     }
 
-    /// The base date: the last date for which the fixing is known. It precedes
-    /// the reference date, so its year-fraction is negative.
+    /// Return the base date, the last date for which the fixing is known.
+    ///
+    /// Returns:
+    ///     Date: The base date; it precedes the reference date, so its year
+    ///         fraction is negative.
     fn base_date(&self) -> PyResult<PyDate> {
         Ok(PyDate::from_inner(
             self.inner
@@ -1199,8 +1362,13 @@ impl PyYoYInflationTermStructure {
         ))
     }
 
-    /// The year-on-year rate observed over the period ending on the base date,
-    /// which node zero is seeded with and keeps.
+    /// Return the rate observed over the period ending on the base date.
+    ///
+    /// Returns:
+    ///     float: The base rate, which node zero is seeded with and keeps.
+    ///
+    /// Raises:
+    ///     ItofinError: On a curve that carries no base rate.
     fn base_rate(&self) -> PyResult<f64> {
         Ok(self
             .inner
@@ -1210,7 +1378,10 @@ impl PyYoYInflationTermStructure {
             .map_err(PyQlError::from)?)
     }
 
-    /// The frequency of the inflation fixings the curve is built on.
+    /// Return the frequency of the inflation fixings the curve is built on.
+    ///
+    /// Returns:
+    ///     Frequency: The fixing frequency.
     fn frequency(&self) -> PyResult<PyFrequency> {
         PyFrequency::from_inner(
             self.inner
@@ -1220,13 +1391,16 @@ impl PyYoYInflationTermStructure {
         )
     }
 
-    /// Installs `seasonality` on the curve, replacing whatever it carried;
-    /// `None` clears it.
+    /// Install seasonality on the curve, replacing whatever it carried.
     ///
-    /// # Errors
+    /// Args:
+    ///     seasonality (MultiplicativePriceSeasonality | None): The correction
+    ///         to install; None clears it.
     ///
-    /// Reports the consistency gate, and leaves a rejected correction installed
-    /// as C++ does - see [`PyZeroInflationTermStructure::set_seasonality`].
+    /// Raises:
+    ///     ItofinError: From the consistency gate, which leaves a rejected
+    ///         correction installed as C++ does; see the zero-curve base for
+    ///         the full account.
     #[pyo3(signature = (seasonality))]
     fn set_seasonality(
         &self,
@@ -1240,7 +1414,11 @@ impl PyYoYInflationTermStructure {
             .map_err(PyQlError::from)?)
     }
 
-    /// Whether the curve carries a seasonality correction.
+    /// Return whether the curve carries a seasonality correction.
+    ///
+    /// Returns:
+    ///     bool: True also for a correction left installed by a
+    ///         set_seasonality that raised.
     fn has_seasonality(&self) -> PyResult<bool> {
         Ok(self
             .inner
@@ -1262,26 +1440,13 @@ impl PyYoYInflationTermStructure {
     }
 }
 
-/// Python `InterpolatedYoYInflationCurve`: a year-on-year inflation curve built
-/// from (date, year-on-year-rate) nodes, interpolating linearly in rate space
-/// (`termstructures::inflation::InterpolatedYoYInflationCurve<Linear>`).
+/// A year-on-year inflation curve built from (date, year-on-year rate)
+/// nodes, interpolating linearly in rate space.
 ///
-/// Extends [`PyYoYInflationTermStructure`], which carries the whole query
-/// surface. The first date is the *base* date rather than the reference date,
-/// which is passed separately and normally follows it; the first rate is the
-/// base rate the curve publishes, and node times are measured from the
-/// reference date, so the first one is negative.
-///
-/// The concrete curve is retained alongside the erased handle so the node
-/// inspectors stay reachable, as [`PyInterpolatedZeroInflationCurve`] does.
-///
-/// Fallible: the core rejects fewer than two dates, a dates/rates count
-/// mismatch and, from the second node on, a rate at or below -100 %, the base
-/// rate being left unconstrained
-/// (`interpolatedyoyinflationcurve.rs:100-117`).
-///
-/// `Linear` is pinned at the boundary: it is the interpolator C++'s
-/// `YoYInflationCurve` typedef fixes, so no interpolation argument is offered.
+/// The first date is the base date rather than the reference date, which is
+/// passed separately and normally follows it; the first rate is the base rate
+/// the curve publishes, and node times are measured from the reference date, so
+/// the first one is negative.
 #[pyclass(
     name = "InterpolatedYoYInflationCurve",
     extends = PyYoYInflationTermStructure,
@@ -1293,8 +1458,21 @@ pub struct PyInterpolatedYoYInflationCurve {
 
 #[pymethods]
 impl PyInterpolatedYoYInflationCurve {
-    /// A curve through the `rates` quoted at `dates`, with `dates[0]` as the
-    /// base date and `reference_date` given separately.
+    /// Build the curve through the rates quoted at dates.
+    ///
+    /// Args:
+    ///     reference_date (Date): The curve's reference date, given separately
+    ///         and normally following the base date.
+    ///     dates (list[Date]): The node dates, the first being the base date.
+    ///     rates (list[float]): The year-on-year rate at each node; the first
+    ///         is the base rate the curve publishes.
+    ///     frequency (Frequency): The frequency of the inflation fixings.
+    ///     day_counter (DayCounter): The day count turning dates into times.
+    ///
+    /// Raises:
+    ///     ItofinError: On fewer than two dates, a dates and rates count
+    ///         mismatch, or a rate at or below -100 per cent from the second
+    ///         node on; the base rate is left unconstrained.
     #[new]
     fn new(
         reference_date: &PyDate,
@@ -1325,13 +1503,19 @@ impl PyInterpolatedYoYInflationCurve {
         )
     }
 
-    /// The node times, measured from the reference date; the first is negative
-    /// whenever the base date precedes it.
+    /// Return the node times, measured from the reference date.
+    ///
+    /// Returns:
+    ///     list[float]: The node times; the first is negative whenever the
+    ///         base date precedes the reference date.
     fn times(&self) -> Vec<f64> {
         self.concrete.times().to_vec()
     }
 
-    /// The node dates, the first of which is the base date.
+    /// Return the node dates.
+    ///
+    /// Returns:
+    ///     list[Date]: The nodes, the first of which is the base date.
     fn dates(&self) -> Vec<PyDate> {
         self.concrete
             .dates()
@@ -1341,7 +1525,11 @@ impl PyInterpolatedYoYInflationCurve {
             .collect()
     }
 
-    /// The `(date, year-on-year rate)` nodes.
+    /// Return the curve's nodes as pairs.
+    ///
+    /// Returns:
+    ///     list[tuple[Date, float]]: One (date, year-on-year rate) pair per
+    ///         node.
     fn nodes(&self) -> Vec<(PyDate, f64)> {
         self.concrete
             .nodes()
@@ -1351,20 +1539,11 @@ impl PyInterpolatedYoYInflationCurve {
     }
 }
 
-/// Python `YoYInflationHelper`: the shared base for every year-on-year
-/// bootstrap helper
-/// (`termstructures::inflation::inflationhelpers::YoYInflationHelper`).
+/// Shared base for every year-on-year bootstrap helper: the two dates the
+/// bootstrap places a curve node by.
 ///
-/// Holds the erased `Shared<dyn YoYInflationHelper>` and exposes the two dates
-/// the bootstrap places a curve node by, the shape [`PyZeroInflationHelper`]
-/// already uses. Concrete helpers such as [`PyYearOnYearInflationSwapHelper`]
-/// subclass this and supply only their constructor.
-///
-/// Deferred (visible): the core trait's `earliest_date`, `maturity_date` and
-/// `latest_relevant_date` are omitted, as on the zero side - on the one
-/// concrete helper reachable here they collapse onto the same fixing-period
-/// start (`inflationhelpers.rs:730-731`), so all three would report what
-/// [`pillar_date`](Self::pillar_date) reports.
+/// Concrete helpers such as YearOnYearInflationSwapHelper subclass this and
+/// supply only their constructor.
 #[pyclass(name = "YoYInflationHelper", subclass, unsendable)]
 pub struct PyYoYInflationHelper {
     inner: Shared<dyn YoYInflationHelper>,
@@ -1372,13 +1551,18 @@ pub struct PyYoYInflationHelper {
 
 #[pymethods]
 impl PyYoYInflationHelper {
-    /// The pillar date, at which the curve node this helper sets sits.
+    /// Return the date the curve node this helper sets sits at.
+    ///
+    /// Returns:
+    ///     Date: The pillar date.
     fn pillar_date(&self) -> PyDate {
         PyDate::from_inner(self.inner.pillar_date())
     }
 
-    /// The latest date the helper needs curve data at (equal to the pillar
-    /// date).
+    /// Return the latest date the helper needs curve data at.
+    ///
+    /// Returns:
+    ///     Date: The latest date, equal to the pillar date.
     fn latest_date(&self) -> PyDate {
         PyDate::from_inner(self.inner.latest_date())
     }
@@ -1397,27 +1581,21 @@ impl PyYoYInflationHelper {
     }
 }
 
-/// Python `YoYInflationIndex`: an index publishing one year-on-year inflation
-/// rate per period, read back as a stored figure or forecast off its
-/// year-on-year curve (core `indexes::inflationindex::YoYInflationIndex`).
+/// An index publishing one year-on-year inflation rate per period, read
+/// back as a stored figure or forecast off its year-on-year curve.
 ///
-/// Two forms, as in the core. A **ratio** index
-/// ([`from_underlying`](Self::from_underlying)) derives its rate from two
-/// [`PyZeroInflationIndex`] fixings a year apart and owns no history of its
-/// own; a **quoted** one (the constructor) is published as a rate in its own
-/// right and keeps its own history through [`add_fixing`](Self::add_fixing).
+/// Two forms. A ratio index (from_underlying) derives its rate from two
+/// ZeroInflationIndex fixings a year apart and owns no history of its own; a
+/// quoted one (the constructor) is published as a rate in its own right and
+/// keeps its own history through add_fixing.
 ///
-/// The curve is reached through a [`RelinkableHandle`] the facade owns and both
-/// forms link at construction, for the reason [`PyZeroInflationIndex`]
-/// documents: the core's `with_term_structure` takes a plain
-/// [`Handle`](libitofin::handle::Handle), so an index that did not take this
-/// facade's relinkable handle up front could never be pointed at a curve later
-/// and [`link_to`](Self::link_to) would silently do nothing. The handle starts
-/// empty, so a forecast before any link raises the empty-handle error.
+/// Both forms link to a relinkable handle the index owns, so an index can be
+/// built before the curve it forecasts off exists. The handle starts empty and
+/// a forecast before any link raises ItofinError; link_to fills it.
 ///
 /// The quoted constructor spells its region and currency out as their component
-/// fields: neither core type has a Python facade, and inventing a name lookup
-/// or defaulting the currency metadata would put made-up values on the index.
+/// fields: neither core type has a Python facade, and defaulting the currency
+/// metadata would put made-up values on the index.
 #[pyclass(name = "YoYInflationIndex", unsendable)]
 pub struct PyYoYInflationIndex {
     inner: Shared<YoYInflationIndex>,
@@ -1449,8 +1627,30 @@ impl PyYoYInflationIndex {
 
 #[pymethods]
 impl PyYoYInflationIndex {
-    /// A quoted year-on-year index, published as a rate in its own right and
-    /// keeping its own fixing history.
+    /// Build a quoted year-on-year index, keeping its own fixing history.
+    ///
+    /// The rate is published in its own right rather than derived from a price
+    /// index, so fixings are filed here through add_fixing.
+    ///
+    /// Args:
+    ///     family_name (str): The index family the fixings are stored under.
+    ///     region_name (str): The name of the region the index measures.
+    ///     region_code (str): The region's code.
+    ///     revised (bool): Whether the published figures are subject to
+    ///         revision.
+    ///     frequency (Frequency): How often the index publishes.
+    ///     availability_lag (Period): How long after a period ends its figure
+    ///         is published.
+    ///     currency_name (str): The currency's name.
+    ///     currency_code (str): The currency's ISO 4217 three-letter code.
+    ///     currency_numeric_code (int): The currency's ISO 4217 numeric code.
+    ///     currency_symbol (str): The currency's symbol.
+    ///     currency_fraction_symbol (str): The symbol of the currency's
+    ///         fractional unit.
+    ///     currency_fractions_per_unit (int): How many fractional units make
+    ///         one currency unit.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date and the stored fixings.
     #[new]
     #[pyo3(signature = (
         family_name,
@@ -1504,13 +1704,18 @@ impl PyYoYInflationIndex {
         })
     }
 
-    /// A ratio year-on-year index over `underlying`, dividing that index's
-    /// figure for a period by its figure a year earlier.
+    /// Build a ratio index dividing a price index's figure by its figure a year earlier.
     ///
-    /// The metadata is inherited wholesale bar the family name, which is
-    /// prefixed `YYR_`, so a `"UK RPI"` underlying yields `"UK YYR_RPI"`. The
-    /// index files no fixings of its own and reads the underlying's history
-    /// instead, so [`add_fixing`](Self::add_fixing) belongs on the underlying.
+    /// The metadata is inherited bar the family name, which is prefixed YYR_,
+    /// so a "UK RPI" underlying yields "UK YYR_RPI"; fixings belong on the
+    /// underlying.
+    ///
+    /// Args:
+    ///     underlying (ZeroInflationIndex): The price index whose consecutive
+    ///         figures the rate is derived from.
+    ///
+    /// Returns:
+    ///     YoYInflationIndex: The ratio index, over an empty curve handle.
     #[staticmethod]
     fn from_underlying(underlying: &Bound<'_, PyZeroInflationIndex>) -> Self {
         let zero = underlying.borrow().shared();
@@ -1520,32 +1725,51 @@ impl PyYoYInflationIndex {
         })
     }
 
-    /// The index name, e.g. `"UK YYR_RPI"`, under which fixings are stored.
+    /// Return the index name, under which fixings are stored.
+    ///
+    /// Returns:
+    ///     str: The name, e.g. "UK YYR_RPI".
     fn name(&self) -> String {
         self.inner.name()
     }
 
-    /// Whether this index is the ratio of two price-index fixings rather than a
-    /// quoted rate.
+    /// Return whether this index is the ratio of two price-index fixings.
+    ///
+    /// Returns:
+    ///     bool: True for a ratio index, False for a quoted rate.
     fn ratio(&self) -> bool {
         self.inner.ratio()
     }
 
-    /// The price index a ratio index divides, `None` on a quoted one.
+    /// Return the price index a ratio index divides, None on a quoted one.
     ///
-    /// This is the very object [`from_underlying`](Self::from_underlying) was
-    /// handed, not a fresh facade around the same core index: a rebuilt one
-    /// would carry a relinkable handle this index never sees, so linking it
-    /// would silently forecast off nothing.
+    /// This is the very object from_underlying was handed, not a fresh facade
+    /// around the same core index: a rebuilt one would carry a relinkable
+    /// handle this index never sees, so linking it would silently forecast off
+    /// nothing.
+    ///
+    /// Returns:
+    ///     ZeroInflationIndex | None: The underlying price index, or None.
     fn underlying_index(&self, py: Python<'_>) -> Option<Py<PyZeroInflationIndex>> {
         self.underlying
             .as_ref()
             .map(|underlying| underlying.clone_ref(py))
     }
 
-    /// Records a published year-on-year rate across the whole inflation period
-    /// it describes. A ratio index reads the underlying's history, so filing
-    /// here records a figure it will never consult.
+    /// Record a published year-on-year rate across the whole inflation period.
+    ///
+    /// A ratio index reads the underlying's history, so filing here records a
+    /// figure it will never consult.
+    ///
+    /// Args:
+    ///     fixing_date (Date): Any date inside the inflation period the rate
+    ///         describes.
+    ///     value (float): The published year-on-year rate.
+    ///
+    /// Raises:
+    ///     ItofinError: If the index frequency has no expressible inflation
+    ///         period, or a different figure is already stored on a date in
+    ///         that period.
     fn add_fixing(&self, fixing_date: &PyDate, value: f64) -> PyResult<()> {
         Ok(self
             .inner
@@ -1553,11 +1777,18 @@ impl PyYoYInflationIndex {
             .map_err(PyQlError::from)?)
     }
 
-    /// The rate at `fixing_date`, stored or forecast off the linked curve.
+    /// Return the rate at fixing_date, stored or forecast off the linked curve.
     ///
-    /// `forecast_todays_fixing` is accepted and ignored, as in the core:
-    /// [`needs_forecast`](Self::needs_forecast) alone decides. A forecast with
-    /// no curve linked raises the empty-handle error.
+    /// Args:
+    ///     fixing_date (Date): The date the rate is read or forecast for.
+    ///     forecast_todays_fixing (bool): Accepted and ignored, as in the core:
+    ///         needs_forecast alone decides between history and forecast.
+    ///
+    /// Returns:
+    ///     float: The year-on-year inflation rate.
+    ///
+    /// Raises:
+    ///     ItofinError: If a forecast is asked for with no curve linked.
     #[pyo3(signature = (fixing_date, forecast_todays_fixing = false))]
     fn fixing(&self, fixing_date: &PyDate, forecast_todays_fixing: bool) -> PyResult<f64> {
         Ok(self
@@ -1566,32 +1797,51 @@ impl PyYoYInflationIndex {
             .map_err(PyQlError::from)?)
     }
 
-    /// The first day of the inflation period the latest figure on record
-    /// describes, read off the underlying on a ratio index. An index with no
-    /// history is an error.
+    /// Return the first day of the period the latest figure on record describes.
+    ///
+    /// Read off the underlying on a ratio index.
+    ///
+    /// Returns:
+    ///     Date: The start of that inflation period.
+    ///
+    /// Raises:
+    ///     ItofinError: If the index has no fixing history.
     fn last_fixing_date(&self) -> PyResult<PyDate> {
         Ok(PyDate::from_inner(
             self.inner.last_fixing_date().map_err(PyQlError::from)?,
         ))
     }
 
-    /// Points the index at `curve`, so every forecast from here on reads it.
+    /// Point the index at curve, so every forecast from here on reads it.
     ///
-    /// Takes the [`PyYoYInflationTermStructure`] base, so any subclass links.
-    /// It is the curve *behind* `curve`'s handle at call time that is stored,
-    /// not the handle itself.
+    /// Takes the YoYInflationTermStructure base, so any subclass links. It is
+    /// the curve behind that facade's handle at call time that is stored, not
+    /// the handle itself.
     ///
-    /// # Errors
+    /// Args:
+    ///     curve (YoYInflationTermStructure): The curve forecasts are read off.
     ///
-    /// Reports the empty-handle error if `curve` somehow carries no link.
+    /// Raises:
+    ///     ItofinError: If curve somehow carries no link.
     fn link_to(&self, curve: &PyYoYInflationTermStructure) -> PyResult<()> {
         self.curve
             .link_to(curve.handle().current_link().map_err(PyQlError::from)?);
         Ok(())
     }
 
-    /// Whether `fixing_date` has to be forecast rather than read from history,
-    /// a ratio index deferring the question to its underlying.
+    /// Return whether fixing_date has to be forecast rather than read from history.
+    ///
+    /// A ratio index defers the question to its underlying.
+    ///
+    /// Args:
+    ///     fixing_date (Date): The date in question.
+    ///
+    /// Returns:
+    ///     bool: True if the date has to be forecast off the curve.
+    ///
+    /// Raises:
+    ///     ItofinError: If the evaluation date is unset, or the index frequency
+    ///         has no expressible inflation period.
     fn needs_forecast(&self, fixing_date: &PyDate) -> PyResult<bool> {
         Ok(self
             .inner
@@ -1599,6 +1849,10 @@ impl PyYoYInflationIndex {
             .map_err(PyQlError::from)?)
     }
 
+    /// Return the printable representation.
+    ///
+    /// Returns:
+    ///     str: A string of the form YoYInflationIndex(UK YYR_RPI).
     fn __repr__(&self) -> String {
         format!("YoYInflationIndex({})", self.inner.name())
     }
@@ -1611,9 +1865,8 @@ impl PyYoYInflationIndex {
     }
 }
 
-/// Python `YearOnYearInflationSwapHelper`: the bootstrap helper fitting a
-/// year-on-year inflation swap quoted as a rate
-/// (`termstructures::inflation::inflationhelpers::YearOnYearInflationSwapHelper`).
+/// The bootstrap helper fitting a year-on-year inflation swap quoted as a
+/// rate.
 ///
 /// The helper prices a unit-notional, zero-strike swap of its own and reports
 /// that contract's fair rate; the bootstrap drives the quoted rate less that
@@ -1621,28 +1874,13 @@ impl PyYoYInflationIndex {
 /// the year-on-year legs pay on a schedule of dates rather than one, so their
 /// discount factors do not cancel.
 ///
-/// The swap starts at the evaluation date held by `settings` and is rebuilt
-/// whenever that date moves, so the evaluation date must be set *before* the
-/// constructor runs, not merely before the bootstrap. The helper retains the
-/// caller's [`PySimpleQuote`], so a later `set_value` re-drives the bootstrap.
+/// The swap starts at the evaluation date, so that date must be set before this
+/// constructor runs, not merely before the bootstrap. It prices through a copy
+/// of index linked to a handle of its own, so the caller's index need not be
+/// linked to any curve.
 ///
-/// It prices through a *copy* of `index` linked to a handle of its own, which
-/// the bootstrap points at the curve under construction; the caller's index
-/// keeps whatever curve it had and need not be linked at all.
-///
-/// `pillar` is accepted for signature parity but never read: it only ever
-/// discriminates on the interpolated path, which is refused below.
-///
-/// Fallible: [`CpiInterpolationType.Linear`](PyCpiInterpolationType) is refused
-/// outright (`inflationhelpers.rs:701-706`), the interpolated branch of the C++
-/// constructor being deferred with the rest of `CPI::Linear` (#847); and the
-/// swap is built here, so an observation lag its legs cannot be built under
-/// fails at construction. Both raise [`struct@crate::ItofinError`].
-///
-/// Deferred (visible): the zero twin's `inflation_fixing_date` has no
-/// counterpart here - a year-on-year contract observes once per coupon rather
-/// than once at maturity, and there is no cash-flow facade to enumerate them
-/// through (#848).
+/// pillar is accepted for signature parity but never read: it only ever
+/// discriminates on the interpolated path, which is refused.
 #[pyclass(
     name = "YearOnYearInflationSwapHelper",
     extends = PyYoYInflationHelper,
@@ -1652,8 +1890,37 @@ pub struct PyYearOnYearInflationSwapHelper;
 
 #[pymethods]
 impl PyYearOnYearInflationSwapHelper {
-    /// A helper fitting `quote` on a swap maturing at `maturity`, discounted on
-    /// `nominal_term_structure`.
+    /// Build the helper on a swap maturing at maturity.
+    ///
+    /// Args:
+    ///     quote (SimpleQuote): The quoted swap rate; the caller keeps it, so
+    ///         a later set_value re-drives the bootstrap.
+    ///     swap_obs_lag (Period): How far back each coupon's fixings are
+    ///         observed.
+    ///     maturity (Date): The swap's maturity.
+    ///     calendar (Calendar): The calendar the payments roll on.
+    ///     payment_convention (BusinessDayConvention): The roll applied to the
+    ///         payment dates.
+    ///     day_counter (DayCounter): The day count the legs accrue on.
+    ///     index (YoYInflationIndex): The index observed; the helper prices
+    ///         through a copy linked to a handle of its own, so the caller's
+    ///         index need not be linked to any curve.
+    ///     interpolation (CpiInterpolationType): How the observed fixings are
+    ///         interpolated.
+    ///     nominal_term_structure (YieldTermStructure): The discount curve,
+    ///         which this helper does need: its legs pay on a schedule of
+    ///         dates rather than one, so their discount factors do not cancel.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date the swap starts at, which must be set before this
+    ///         constructor runs.
+    ///     pillar (Pillar): Accepted for signature parity but never read; it
+    ///         only ever discriminates on the interpolated path.
+    ///
+    /// Raises:
+    ///     ItofinError: On Linear interpolation, which the core refuses
+    ///         outright pending the interpolated branch (#847), and on an
+    ///         observation lag the helper's own swap legs cannot be built
+    ///         under.
     #[new]
     #[pyo3(signature = (
         quote,
@@ -1704,25 +1971,16 @@ impl PyYearOnYearInflationSwapHelper {
     }
 }
 
-/// Python `PiecewiseYoYInflationCurve`: a year-on-year inflation curve
-/// bootstrapped from year-on-year helpers, solving one rate node per helper
-/// (`termstructures::inflation::PiecewiseYoYInflationCurve<Linear>`).
+/// A year-on-year inflation curve bootstrapped from year-on-year helpers,
+/// solving one rate node per helper fixing period.
 ///
-/// Extends [`PyYoYInflationTermStructure`], which carries the whole query
-/// surface. Node zero sits on `base_date` at `base_yoy_rate` and is kept rather
-/// than solved: the base date is the last date for which a fixing is known and
-/// precedes the reference date, so [`times`](Self::times)`[0]` is negative.
-/// Each helper's observed fixing period marks a later segment boundary, and its
-/// node is solved so the helper reprices its own quote off the curve.
+/// Node zero sits on base_date at base_yoy_rate and is kept rather than solved,
+/// so times()[0] is negative. Each helper's observed fixing period marks a
+/// later segment boundary.
 ///
-/// Lazy, like [`PyPiecewiseZeroInflationCurve`]: the constructor only registers
-/// on the helpers, and the bootstrap runs on the first read - a query, an
-/// inspector, or an explicit [`calculate`](Self::calculate). A helper quote
-/// moving invalidates the cache.
-///
-/// Fallible: the core rejects an empty helper set, and every inspector
-/// propagates a bootstrap failure as [`struct@crate::ItofinError`]. `Linear` is
-/// pinned at the boundary, it being the only interpolator the core constructs.
+/// Lazy: the bootstrap runs on the first read, so the evaluation date must be
+/// in place before that read as well as before the helpers were built. A helper
+/// quote moving invalidates the cache.
 #[pyclass(
     name = "PiecewiseYoYInflationCurve",
     extends = PyYoYInflationTermStructure,
@@ -1734,10 +1992,20 @@ pub struct PyPiecewiseYoYInflationCurve {
 
 #[pymethods]
 impl PyPiecewiseYoYInflationCurve {
-    /// A curve over `helpers` with a fixed `reference_date`, a `base_date`
-    /// preceding it and the `base_yoy_rate` observed over the period ending
-    /// there. `helpers` accepts any [`YoYInflationHelper`](PyYoYInflationHelper)
-    /// subclass.
+    /// Build the curve over helpers, registering on them without solving.
+    ///
+    /// Args:
+    ///     reference_date (Date): The curve's reference date.
+    ///     base_date (Date): The last date for which a fixing is known, where
+    ///         node zero sits.
+    ///     base_yoy_rate (float): The rate node zero is seeded with and keeps,
+    ///         rather than solved for.
+    ///     frequency (Frequency): The frequency of the inflation fixings.
+    ///     day_counter (DayCounter): The day count turning dates into times.
+    ///     helpers (list[YoYInflationHelper]): The bootstrap instruments.
+    ///
+    /// Raises:
+    ///     ItofinError: On an empty helper list.
     #[new]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -1769,20 +2037,36 @@ impl PyPiecewiseYoYInflationCurve {
         )
     }
 
-    /// Runs the bootstrap if the cache is stale, so a solver failure surfaces
-    /// here rather than inside a later query.
+    /// Run the bootstrap if the cache is stale.
+    ///
+    /// Calling it explicitly makes a solver failure surface here rather than
+    /// inside a later query.
+    ///
+    /// Raises:
+    ///     ItofinError: On a bootstrap failure.
     fn calculate(&self) -> PyResult<()> {
         Ok(self.concrete.calculate().map_err(PyQlError::from)?)
     }
 
-    /// The node times, measured from the reference date in the curve's own day
-    /// count; the first is negative (triggers the bootstrap).
+    /// Return the node times, triggering the bootstrap.
+    ///
+    /// Returns:
+    ///     list[float]: The nodes measured from the reference date; the first
+    ///         is negative, node zero sitting on the base date.
+    ///
+    /// Raises:
+    ///     ItofinError: On a bootstrap failure.
     fn times(&self) -> PyResult<Vec<f64>> {
         Ok(self.concrete.times().map_err(PyQlError::from)?)
     }
 
-    /// The node dates, the first of which is the base date (triggers the
-    /// bootstrap).
+    /// Return the node dates, triggering the bootstrap.
+    ///
+    /// Returns:
+    ///     list[Date]: The nodes, the first of which is the base date.
+    ///
+    /// Raises:
+    ///     ItofinError: On a bootstrap failure.
     fn dates(&self) -> PyResult<Vec<PyDate>> {
         Ok(self
             .concrete
@@ -1793,7 +2077,14 @@ impl PyPiecewiseYoYInflationCurve {
             .collect())
     }
 
-    /// The solved `(date, year-on-year rate)` nodes (triggers the bootstrap).
+    /// Return the solved nodes as pairs, triggering the bootstrap.
+    ///
+    /// Returns:
+    ///     list[tuple[Date, float]]: One (date, year-on-year rate) pair per
+    ///         node.
+    ///
+    /// Raises:
+    ///     ItofinError: On a bootstrap failure.
     fn nodes(&self) -> PyResult<Vec<(PyDate, f64)>> {
         Ok(self
             .concrete
@@ -1805,33 +2096,19 @@ impl PyPiecewiseYoYInflationCurve {
     }
 }
 
-/// Python `YearOnYearInflationSwap`: a fixed leg against a leg of year-on-year
-/// inflation coupons, both paid over a schedule
-/// (`instruments::yearonyearinflationswap`).
+/// A fixed leg against a leg of year-on-year inflation coupons, both paid over a schedule.
 ///
-/// [`SwapType`](crate::swap::PySwapType) names the *fixed* leg, so a `Payer`
-/// pays fixed and receives inflation - the opposite reading from
-/// [`PyZeroCouponInflationSwap`], where it names the inflation leg.
+/// SwapType names the fixed leg, so a Payer pays fixed and receives inflation -
+/// the opposite reading from ZeroCouponInflationSwap, where it names the
+/// inflation leg.
 ///
 /// The two schedules are independent inputs. The fixed leg takes its payment
 /// calendar from its own schedule while the year-on-year leg pays on
-/// `payment_calendar`, the inflation index carrying no calendar of its own;
-/// both legs adjust with `payment_convention`, which C++ defaults to
-/// `ModifiedFollowing` and the port takes explicitly. `spread` is added to
+/// payment_calendar; both adjust with payment_convention. spread is added to
 /// every forecast rate on the year-on-year leg.
 ///
-/// Fallible at construction: both leg builds propagate, so a coupon the
-/// observation lag leaves unbuildable fails here.
-///
-/// Pricing needs an engine: call [`set_engine`](Self::set_engine) before
-/// anything else. Every accessor below is `&mut self` where the zero-coupon
-/// swap's [`fair_rate`](PyZeroCouponInflationSwap::fair_rate) is not: this
-/// contract recovers both fair values from a priced result rather than reading
-/// a single indexed flow (`yearonyearinflationswap.rs:311,326`), so each one
-/// drives the calculation.
-///
-/// Deferred (visible): the leg and coupon accessors are not surfaced, there
-/// being no cash-flow facade to hand them back through (#848).
+/// Pricing needs an engine: call set_engine first. Every priced accessor drives
+/// the calculation, so all of them mutate.
 #[pyclass(name = "YearOnYearInflationSwap", unsendable)]
 pub struct PyYearOnYearInflationSwap {
     inner: SharedMut<YearOnYearInflationSwap>,
@@ -1839,6 +2116,35 @@ pub struct PyYearOnYearInflationSwap {
 
 #[pymethods]
 impl PyYearOnYearInflationSwap {
+    /// Build the swap from its two schedules.
+    ///
+    /// Args:
+    ///     swap_type (SwapType): Which side the fixed leg is seen from; a
+    ///         Payer pays fixed and receives inflation.
+    ///     nominal (float): The notional both legs accrue on.
+    ///     fixed_schedule (Schedule): The fixed leg's payment schedule, which
+    ///         also supplies its payment calendar.
+    ///     fixed_rate (float): The rate the fixed leg accrues at.
+    ///     fixed_day_count (DayCounter): The day count of the fixed leg.
+    ///     yoy_schedule (Schedule): The year-on-year leg's schedule.
+    ///     yoy_index (YoYInflationIndex): The index the coupons fix off.
+    ///     observation_lag (Period): How far back each coupon's fixings are
+    ///         observed.
+    ///     interpolation (CpiInterpolationType): How the observed fixings are
+    ///         interpolated.
+    ///     spread (float): Added to every forecast rate on the year-on-year
+    ///         leg.
+    ///     yoy_day_count (DayCounter): The day count of the year-on-year leg.
+    ///     payment_calendar (Calendar): The calendar the year-on-year leg pays
+    ///         on.
+    ///     payment_convention (BusinessDayConvention): The roll both legs
+    ///         adjust their payment dates with.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date and the stored fixings.
+    ///
+    /// Raises:
+    ///     ItofinError: If either leg cannot be built, notably from an
+    ///         observation lag that leaves a coupon unbuildable.
     #[new]
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (
@@ -1896,10 +2202,12 @@ impl PyYearOnYearInflationSwap {
         })
     }
 
-    /// Attaches a [`PyDiscountingSwapEngine`] so the swap prices.
+    /// Attach a discounting engine so the swap prices.
     ///
-    /// The engine must resolve its dates against the same `Settings` object
-    /// this swap was built with.
+    /// Args:
+    ///     engine (DiscountingSwapEngine): The engine, which must resolve its
+    ///         dates against the same Settings object this swap was built
+    ///         with.
     fn set_engine(&mut self, engine: &PyDiscountingSwapEngine) {
         self.inner
             .borrow_mut()
@@ -1907,8 +2215,11 @@ impl PyYearOnYearInflationSwap {
             .set_pricing_engine(engine.engine());
     }
 
-    /// Forces the valuation, idempotent and fallible as
-    /// [`VanillaOption.calculate`](crate::option::PyVanillaOption::calculate).
+    /// Force the valuation. Idempotent.
+    ///
+    /// Raises:
+    ///     ItofinError: If no engine is attached, no evaluation date is set,
+    ///         or the engine refuses the swap.
     fn calculate(&mut self) -> PyResult<()> {
         Ok(self
             .inner
@@ -1917,37 +2228,65 @@ impl PyYearOnYearInflationSwap {
             .map_err(PyQlError::from)?)
     }
 
-    /// Whether the cached results are currently valid.
+    /// Return whether the cached results are currently valid.
+    ///
+    /// Returns:
+    ///     bool: True when the next accessor reads the cache.
     fn is_calculated(&self) -> bool {
         self.inner.borrow().base().is_calculated()
     }
 
-    /// Attaches `engine` and returns the NPV, the one-shot form of
-    /// [`set_engine`](Self::set_engine) followed by [`npv`](Self::npv).
+    /// Attach engine and return the NPV.
+    ///
+    /// Args:
+    ///     engine (DiscountingSwapEngine): The engine to install and price on.
+    ///
+    /// Returns:
+    ///     float: The swap value.
+    ///
+    /// Raises:
+    ///     ItofinError: On anything that makes the valuation fail.
     fn price(&mut self, engine: &PyDiscountingSwapEngine) -> PyResult<f64> {
         self.set_engine(engine);
         self.calculate()?;
         self.npv()
     }
 
-    /// A frozen [`Results`] copy of the valuation, calculating first.
+    /// Return a frozen snapshot of the valuation, calculating first.
+    ///
+    /// Returns:
+    ///     Results: A copy of the valuation results.
+    ///
+    /// Raises:
+    ///     ItofinError: On anything that makes the valuation fail.
     fn results(&mut self) -> PyResult<Results> {
         self.calculate()?;
         let inner = self.inner.borrow();
         Ok(Results::snapshot(inner.base()))
     }
 
-    /// The swap NPV under the attached engine.
+    /// Return the swap NPV under the attached engine.
     ///
-    /// Fallible: with no engine attached the core reports `"null pricing
-    /// engine"`, and with no curve linked into the index the coupons cannot be
-    /// forecast.
+    /// Returns:
+    ///     float: The present value.
+    ///
+    /// Raises:
+    ///     ItofinError: If no engine is attached, and if no curve is linked
+    ///         into the index, which leaves the coupons unforecastable.
     fn npv(&mut self) -> PyResult<f64> {
         Ok(self.inner.borrow_mut().npv().map_err(PyQlError::from)?)
     }
 
-    /// The fixed rate that would price the swap at zero, recovered from the NPV
-    /// and the fixed leg's BPS. Prices on demand, so it needs an engine.
+    /// Return the fixed rate that would price the swap at zero.
+    ///
+    /// Recovered from the NPV and the fixed leg's BPS, so it prices on demand
+    /// and needs an engine.
+    ///
+    /// Returns:
+    ///     float: The fair fixed rate.
+    ///
+    /// Raises:
+    ///     ItofinError: On the same conditions npv reports.
     fn fair_rate(&mut self) -> PyResult<f64> {
         Ok(self
             .inner
@@ -1956,8 +2295,15 @@ impl PyYearOnYearInflationSwap {
             .map_err(PyQlError::from)?)
     }
 
-    /// The spread over the index that would price the swap at zero, recovered
-    /// off the year-on-year leg. Fallible as [`fair_rate`](Self::fair_rate).
+    /// Return the spread over the index that would price the swap at zero.
+    ///
+    /// Recovered off the year-on-year leg.
+    ///
+    /// Returns:
+    ///     float: The fair spread.
+    ///
+    /// Raises:
+    ///     ItofinError: On the same conditions fair_rate reports.
     fn fair_spread(&mut self) -> PyResult<f64> {
         Ok(self
             .inner
@@ -1966,7 +2312,13 @@ impl PyYearOnYearInflationSwap {
             .map_err(PyQlError::from)?)
     }
 
-    /// The fixed leg's NPV, priced on demand. Fallible as [`npv`](Self::npv).
+    /// Return the fixed leg's NPV, priced on demand.
+    ///
+    /// Returns:
+    ///     float: The present value of the fixed leg.
+    ///
+    /// Raises:
+    ///     ItofinError: On the same conditions npv reports.
     fn fixed_leg_npv(&mut self) -> PyResult<f64> {
         Ok(self
             .inner
@@ -1975,8 +2327,13 @@ impl PyYearOnYearInflationSwap {
             .map_err(PyQlError::from)?)
     }
 
-    /// The year-on-year leg's NPV, priced on demand. Fallible as
-    /// [`npv`](Self::npv).
+    /// Return the year-on-year leg's NPV, priced on demand.
+    ///
+    /// Returns:
+    ///     float: The present value of the inflation leg.
+    ///
+    /// Raises:
+    ///     ItofinError: On the same conditions npv reports.
     fn yoy_leg_npv(&mut self) -> PyResult<f64> {
         Ok(self
             .inner
@@ -1985,34 +2342,35 @@ impl PyYearOnYearInflationSwap {
             .map_err(PyQlError::from)?)
     }
 
-    /// The quoted fixed rate the swap was struck at.
+    /// Return the quoted fixed rate the swap was struck at.
+    ///
+    /// Returns:
+    ///     float: The fixed-leg rate.
     fn fixed_rate(&self) -> f64 {
         self.inner.borrow().fixed_rate()
     }
 
-    /// The spread the year-on-year coupons carry over the index.
+    /// Return the spread the year-on-year coupons carry over the index.
+    ///
+    /// Returns:
+    ///     float: The quoted spread.
     fn spread(&self) -> f64 {
         self.inner.borrow().spread()
     }
 }
 
-/// Python `ConstantYoYOptionletVolatility`: one volatility for every strike and
-/// every date (`termstructures::volatility::ConstantYoYOptionletVolatility`).
+/// One year-on-year optionlet volatility for every strike and every date.
 ///
-/// The reference date moves with the evaluation date carried by `settings`,
-/// `settlement_days` business days on from it, so that date must be set before
+/// The reference date moves with the evaluation date carried by settings,
+/// settlement_days business days on from it, so that date must be set before
 /// anything is priced off the surface.
 ///
-/// `min_strike` and `max_strike` bound the strike domain a query is answered
-/// over; C++ defaults them to `-1.0` and `100.0` and the port carries no default
+/// min_strike and max_strike bound the strike domain a query is answered over;
+/// C++ defaults them to -1.0 and 100.0 and the port carries no default
 /// arguments, so both are passed here too.
 ///
-/// Both constructors are bound: the flat one taking a value, and
-/// [`with_quote`](Self::with_quote) taking a live quote whose changes notify the
-/// surface's observers.
-///
-/// The stripped side of the hierarchy is bound as
-/// [`PyKInterpolatedYoYOptionletVolatilitySurface`] (#874/#910).
+/// Both constructors are bound: __init__ takes a value, with_quote a live
+/// quote. The whole stripped/interpolated hierarchy is deferred (#874).
 #[pyclass(name = "ConstantYoYOptionletVolatility", unsendable)]
 pub struct PyConstantYoYOptionletVolatility {
     inner: Shared<ConstantYoYOptionletVolatility>,
@@ -2020,12 +2378,31 @@ pub struct PyConstantYoYOptionletVolatility {
 
 #[pymethods]
 impl PyConstantYoYOptionletVolatility {
-    /// A flat surface at `volatility`, observing inflation `observation_lag`
-    /// back on an index publishing at `frequency`.
+    /// Build a flat surface at a fixed volatility.
     ///
-    /// Infallible, unlike most curve constructors: nothing is resolved here.
-    /// The reference date, the base date and the strike range are all read at
-    /// query time, so an unset evaluation date surfaces then.
+    /// Nothing is resolved here: the reference date, the base date and the
+    /// strike range are all read at query time, so an unset evaluation date
+    /// surfaces then rather than now.
+    ///
+    /// Args:
+    ///     volatility (float): The single volatility answered everywhere.
+    ///     settlement_days (int): The business days the reference date sits
+    ///         past the evaluation date.
+    ///     calendar (Calendar): The calendar those days are counted on.
+    ///     business_day_convention (BusinessDayConvention): The roll applied
+    ///         when resolving a date.
+    ///     day_counter (DayCounter): The day count times are measured in.
+    ///     observation_lag (Period): The lag the surface itself observes
+    ///         inflation with.
+    ///     frequency (Frequency): How often the observed index publishes.
+    ///     index_is_interpolated (bool): Whether the observed index
+    ///         interpolates between publications.
+    ///     min_strike (float): The lower bound of the strike domain; C++
+    ///         defaults it to -1.0 and the port carries no default arguments.
+    ///     max_strike (float): The upper bound of the strike domain; C++
+    ///         defaults it to 100.0.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date the reference date moves with.
     #[new]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -2058,12 +2435,33 @@ impl PyConstantYoYOptionletVolatility {
         }
     }
 
-    /// A flat surface quoted by `volatility`: the quote is retained rather than
-    /// read once, so a later `set_value` on it notifies the surface's observers
-    /// and anything priced off the surface reprices at the new level.
+    /// Build a flat surface reading its volatility from a live quote.
     ///
-    /// Infallible, and otherwise as [`new`](Self::new), which the arguments
+    /// The quote is retained rather than read once, so a later set_value on it
+    /// notifies the surface's observers and anything priced off the surface
+    /// reprices at the new level. Otherwise as __init__, which the arguments
     /// after the first mirror exactly.
+    ///
+    /// Args:
+    ///     volatility (SimpleQuote): The volatility answered everywhere.
+    ///     settlement_days (int): The business days the reference date sits
+    ///         past the evaluation date.
+    ///     calendar (Calendar): The calendar those days are counted on.
+    ///     business_day_convention (BusinessDayConvention): The roll applied
+    ///         when resolving a date.
+    ///     day_counter (DayCounter): The day count times are measured in.
+    ///     observation_lag (Period): The lag the surface itself observes
+    ///         inflation with.
+    ///     frequency (Frequency): How often the observed index publishes.
+    ///     index_is_interpolated (bool): Whether the observed index
+    ///         interpolates between publications.
+    ///     min_strike (float): The lower bound of the strike domain.
+    ///     max_strike (float): The upper bound of the strike domain.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date the reference date moves with.
+    ///
+    /// Returns:
+    ///     ConstantYoYOptionletVolatility: The surface over that quote.
     #[staticmethod]
     #[allow(clippy::too_many_arguments)]
     fn with_quote(
@@ -2096,46 +2494,65 @@ impl PyConstantYoYOptionletVolatility {
         }
     }
 
-    /// The lag the surface itself observes inflation with.
+    /// Return the lag the surface itself observes inflation with.
+    ///
+    /// Returns:
+    ///     Period: The observation lag, which is what to pass as obs_lag for
+    ///         the surface's own.
     fn observation_lag(&self) -> PyPeriod {
         PyPeriod::from_inner(self.inner.observation_lag())
     }
 
-    /// How often the observed index publishes.
+    /// Return how often the observed index publishes.
+    ///
+    /// Returns:
+    ///     Frequency: The publication frequency.
     fn frequency(&self) -> PyResult<PyFrequency> {
         PyFrequency::from_inner(self.inner.frequency())
     }
 
-    /// Whether the observed index interpolates between publications.
+    /// Return whether the observed index interpolates between publications.
+    ///
+    /// Returns:
+    ///     bool: True when the index interpolates.
     fn index_is_interpolated(&self) -> bool {
         self.inner.index_is_interpolated()
     }
 
-    /// The date the surface measures its variance from: the reference date
-    /// pulled back by the surface's own observation lag, snapped to the start of
-    /// the publication period unless the index is interpolated.
+    /// Return the date the surface measures its variance from.
     ///
-    /// # Errors
+    /// The reference date pulled back by the surface's own observation lag,
+    /// snapped to the start of the publication period unless the index is
+    /// interpolated.
     ///
-    /// Reports an unset evaluation date, and a frequency admitting no
-    /// publication period.
+    /// Returns:
+    ///     Date: The base date.
+    ///
+    /// Raises:
+    ///     ItofinError: On an unset evaluation date, and on a frequency
+    ///         admitting no publication period.
     fn base_date(&self) -> PyResult<PyDate> {
         Ok(PyDate::from_inner(
             self.inner.base_date().map_err(PyQlError::from)?,
         ))
     }
 
-    /// The volatility for an exercise on `date` struck at `strike`, observing
-    /// inflation `obs_lag` back.
+    /// Return the volatility for an exercise on date struck at strike.
     ///
-    /// The lag is explicit rather than defaulted: C++ substitutes the surface's
-    /// own for a sentinel period, and the port has no sentinel to carry, so a
-    /// caller wanting it passes [`observation_lag`](Self::observation_lag).
+    /// Args:
+    ///     date (Date): The exercise date.
+    ///     strike (float): The strike the volatility is read at.
+    ///     obs_lag (Period): How far back inflation is observed; the lag is
+    ///         explicit rather than defaulted, because C++ substitutes the
+    ///         surface's own for a sentinel period and the port has no
+    ///         sentinel to carry. Pass observation_lag() for that behaviour.
     ///
-    /// # Errors
+    /// Returns:
+    ///     float: The optionlet volatility.
     ///
-    /// Reports an observed date before [`base_date`](Self::base_date), and a
-    /// `strike` outside the surface's strike domain.
+    /// Raises:
+    ///     ItofinError: On an observed date before base_date(), and on a
+    ///         strike outside the surface's strike domain.
     fn volatility(&self, date: &PyDate, strike: f64, obs_lag: &PyPeriod) -> PyResult<f64> {
         Ok(self
             .inner
@@ -2143,13 +2560,21 @@ impl PyConstantYoYOptionletVolatility {
             .map_err(PyQlError::from)?)
     }
 
-    /// The total integrated variance for an exercise on `date` struck at
-    /// `strike`: the figure that scales time out of the optionlet formulae
-    /// without committing to the distribution reading it.
+    /// Return the total integrated variance for an exercise on date.
     ///
-    /// # Errors
+    /// The figure that scales time out of the optionlet formulae without
+    /// committing to the distribution reading it.
     ///
-    /// As [`volatility`](Self::volatility).
+    /// Args:
+    ///     date (Date): The exercise date.
+    ///     strike (float): The strike the variance is read at.
+    ///     obs_lag (Period): How far back inflation is observed.
+    ///
+    /// Returns:
+    ///     float: The total integrated variance.
+    ///
+    /// Raises:
+    ///     ItofinError: On the same conditions volatility() reports.
     fn total_variance(&self, date: &PyDate, strike: f64, obs_lag: &PyPeriod) -> PyResult<f64> {
         Ok(self
             .inner
@@ -2165,17 +2590,15 @@ impl PyConstantYoYOptionletVolatility {
     }
 }
 
-/// Python `YoYInflationCapFloorEngine`: prices a year-on-year cap or floor
-/// optionlet by optionlet (`pricingengines::YoYInflationCapFloorEngine`).
+/// Prices a year-on-year inflation cap or floor optionlet by optionlet.
 ///
 /// The distribution is chosen by the constructor rather than passed as an
-/// argument, mirroring the core's three constructors and C++'s three engine
-/// classes: [`black`](Self::black) is lognormal, `unit_displaced` lognormal in
-/// `1 + rate` and `bachelier` normal. The core
-/// `YoYOptionletDistribution` enum is not bound - nothing takes one by value -
-/// so [`distribution`](Self::distribution) reads back as a string.
+/// argument, mirroring C++'s three engine classes: black is lognormal,
+/// unit_displaced lognormal in 1 + rate and bachelier normal. The core
+/// YoYOptionletDistribution enum is not bound, so distribution() reads back as
+/// a string.
 ///
-/// The `settings` behind the volatility surface and behind the cap/floor this
+/// The settings behind the volatility surface and behind the cap/floor this
 /// engine prices must be the same object, or the two resolve their dates
 /// against different evaluation dates and the NPV is silently wrong.
 ///
@@ -2188,9 +2611,17 @@ pub struct PyYoYInflationCapFloorEngine {
 
 #[pymethods]
 impl PyYoYInflationCapFloorEngine {
-    /// Optionlets under the lognormal model (C++
-    /// `YoYInflationBlackCapFloorEngine`), forwards read off `index`,
-    /// volatilities off `volatility` and discounting on `nominal_ts`.
+    /// Build an engine valuing optionlets under the lognormal model.
+    ///
+    /// Args:
+    ///     index (YoYInflationIndex): The index forwards are read off.
+    ///     volatility (ConstantYoYOptionletVolatility): The surface optionlet
+    ///         volatilities are read off.
+    ///     nominal_ts (YieldTermStructure): The nominal curve optionlets are
+    ///         discounted on.
+    ///
+    /// Returns:
+    ///     YoYInflationCapFloorEngine: The lognormal engine.
     #[staticmethod]
     fn black(
         index: &PyYoYInflationIndex,
@@ -2206,9 +2637,20 @@ impl PyYoYInflationCapFloorEngine {
         }
     }
 
-    /// Optionlets under the unit-displaced lognormal model (C++
-    /// `YoYInflationUnitDisplacedBlackCapFloorEngine`), the usual quoting
-    /// convention for a rate that may be negative. See [`black`](Self::black).
+    /// Build an engine valuing optionlets under the unit-displaced lognormal model.
+    ///
+    /// Lognormal in 1 + rate, the usual quoting convention for a rate that may
+    /// be negative.
+    ///
+    /// Args:
+    ///     index (YoYInflationIndex): The index forwards are read off.
+    ///     volatility (ConstantYoYOptionletVolatility): The surface optionlet
+    ///         volatilities are read off.
+    ///     nominal_ts (YieldTermStructure): The nominal curve optionlets are
+    ///         discounted on.
+    ///
+    /// Returns:
+    ///     YoYInflationCapFloorEngine: The unit-displaced lognormal engine.
     #[staticmethod]
     fn unit_displaced(
         index: &PyYoYInflationIndex,
@@ -2224,8 +2666,17 @@ impl PyYoYInflationCapFloorEngine {
         }
     }
 
-    /// Optionlets under the normal model (C++
-    /// `YoYInflationBachelierCapFloorEngine`). See [`black`](Self::black).
+    /// Build an engine valuing optionlets under the normal model.
+    ///
+    /// Args:
+    ///     index (YoYInflationIndex): The index forwards are read off.
+    ///     volatility (ConstantYoYOptionletVolatility): The surface optionlet
+    ///         volatilities are read off.
+    ///     nominal_ts (YieldTermStructure): The nominal curve optionlets are
+    ///         discounted on.
+    ///
+    /// Returns:
+    ///     YoYInflationCapFloorEngine: The normal engine.
     #[staticmethod]
     fn bachelier(
         index: &PyYoYInflationIndex,
@@ -2241,8 +2692,10 @@ impl PyYoYInflationCapFloorEngine {
         }
     }
 
-    /// The distribution optionlets are valued under, as `"black"`,
-    /// `"unit_displaced"` or `"bachelier"`.
+    /// Return the distribution optionlets are valued under.
+    ///
+    /// Returns:
+    ///     str: "black", "unit_displaced" or "bachelier".
     fn distribution(&self) -> String {
         match self.inner.borrow().distribution() {
             YoYOptionletDistribution::Black => "black",
@@ -2260,32 +2713,28 @@ impl PyYoYInflationCapFloorEngine {
     }
 }
 
-/// Python `MakeYoYInflationCapFloor`: the standard market builder for a
-/// year-on-year inflation cap or floor
-/// (`instruments::makeyoyinflationcapfloor`).
+/// The standard market builder for a year-on-year inflation cap or floor.
 ///
 /// It derives an annual year-on-year leg from a length in years, trims that leg
-/// to the optionlets asked for, and strikes it either at an explicit `strike` or
-/// at the money off `atm_strike`. Exactly one of the two is required: the core
+/// to the optionlets asked for, and strikes it either at an explicit strike or
+/// at the money off atm_strike. Exactly one of the two is required: the core
 /// refuses both together and neither at all, at build time rather than at the
-/// setters, so both surface from [`build`](Self::build).
+/// setters, so both surface from build().
 ///
 /// The core builder is a consumed-self fluent chain, which does not cross the
 /// FFI boundary; this facade takes the whole configuration up front and
-/// assembles the chain inside [`build`](Self::build), as
-/// [`MakeVanillaSwap`](crate::swap::PyMakeVanillaSwap) does. An unset optional
-/// leaves the core default in place: a 1,000,000 nominal, a `ModifiedFollowing`
-/// payment roll, a 30/360 bond-basis day counter, no fixing days, every
-/// optionlet kept and no forward start.
+/// assembles the chain inside build(), as MakeVanillaSwap does. An unset
+/// optional leaves the core default in place: a 1,000,000 nominal, a
+/// ModifiedFollowing payment roll, a 30/360 bond-basis day counter, no fixing
+/// days, every optionlet kept and no forward start.
 ///
-/// Trimming happens *before* the at-the-money fill, so `as_optionlet` and
-/// `first_caplet_excluded` change what an unset strike resolves to: the rate
-/// that reprices whatever survives, not the whole leg's.
+/// Trimming happens before the at-the-money fill, so as_optionlet and
+/// first_caplet_excluded change what an unset strike resolves to: the rate that
+/// reprices whatever survives, not the whole leg's.
 ///
-/// `CapFloorType.Collar` has no path through the builder - it carries a single
-/// strike, and a collar needs two strike vectors - so a collar is built through
-/// [`YoYInflationCapFloor::collar`](PyYoYInflationCapFloor::collar) over a leg
-/// of its own instead.
+/// CapFloorType.Collar has no path here - the builder carries a single strike,
+/// and a collar needs two strike vectors - so a collar is built through
+/// YoYInflationCapFloor.collar over a leg of its own instead.
 #[pyclass(name = "MakeYoYInflationCapFloor", unsendable)]
 pub struct PyMakeYoYInflationCapFloor {
     cap_floor_type: PyCapFloorType,
@@ -2310,9 +2759,41 @@ pub struct PyMakeYoYInflationCapFloor {
 
 #[pymethods]
 impl PyMakeYoYInflationCapFloor {
-    /// A builder for a `cap_floor_type` cap/floor of `length` years on `index`,
-    /// observed `observation_lag` back under `interpolation` and paying on
-    /// `calendar`.
+    /// Store the configuration the chain is assembled from in build().
+    ///
+    /// Args:
+    ///     cap_floor_type (CapFloorType): Cap or Floor; Collar has no path
+    ///         here.
+    ///     index (YoYInflationIndex): The index the optionlets fix off.
+    ///     length (int): The length of the derived annual leg, in years.
+    ///     calendar (Calendar): The calendar the payments roll on.
+    ///     observation_lag (Period): How far back each coupon's fixings are
+    ///         observed.
+    ///     interpolation (CpiInterpolationType): How the observed fixings are
+    ///         interpolated.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date and the stored fixings.
+    ///     nominal (float | None): The notional; None keeps the core default
+    ///         of 1,000,000.
+    ///     effective_date (Date | None): The start date; None derives it from
+    ///         the evaluation date.
+    ///     payment_day_counter (DayCounter | None): The day count; None keeps
+    ///         the core default of 30/360 bond basis.
+    ///     payment_adjustment (BusinessDayConvention | None): The payment
+    ///         roll; None keeps the core default of ModifiedFollowing.
+    ///     fixing_days (int | None): The fixing days of the coupons; None
+    ///         keeps the core default of none.
+    ///     engine (YoYInflationCapFloorEngine | None): An engine installed on
+    ///         the built instrument; None leaves it unpriced.
+    ///     as_optionlet (bool): Whether to keep only the last optionlet.
+    ///     forward_start (Period | None): The delay before the leg starts;
+    ///         None keeps the core default of no forward start.
+    ///     first_caplet_excluded (bool): Whether to drop the front optionlet.
+    ///     strike (float | None): The explicit strike; exactly one of this and
+    ///         atm_strike is required.
+    ///     atm_strike (YieldTermStructure | None): The curve the at-the-money
+    ///         strike is filled off; exactly one of this and strike is
+    ///         required.
     #[new]
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (
@@ -2377,15 +2858,16 @@ impl PyMakeYoYInflationCapFloor {
         }
     }
 
-    /// Builds the cap/floor, which already carries its engine when one was
-    /// given.
+    /// Build the cap/floor, which already carries its engine when one was given.
     ///
-    /// # Errors
+    /// Returns:
+    ///     YoYInflationCapFloor: The built instrument.
     ///
-    /// Reports both an explicit `strike` and an `atm_strike` given together and
-    /// neither given at all; an unset evaluation date when the start date has to
-    /// be derived; and whatever the leg construction and the at-the-money fill
-    /// report.
+    /// Raises:
+    ///     ItofinError: If both strike and atm_strike are given or neither is;
+    ///         if the start date has to be derived and no evaluation date is
+    ///         set; and on whatever the leg construction and the at-the-money
+    ///         fill report.
     fn build(&self) -> PyResult<PyYoYInflationCapFloor> {
         let mut maker = MakeYoYInflationCapFloor::new(
             self.cap_floor_type.inner(),
@@ -2435,22 +2917,17 @@ impl PyMakeYoYInflationCapFloor {
     }
 }
 
-/// Python `YoYInflationCapFloor`: a cap or floor over a year-on-year inflation
-/// leg (`instruments::inflationcapfloor::YoYInflationCapFloor`).
+/// A cap, floor or collar over a year-on-year inflation leg.
 ///
-/// Built either through [`MakeYoYInflationCapFloor`](PyMakeYoYInflationCapFloor),
-/// the standard market builder, or through the raw constructors
-/// [`new`](Self::new), [`cap`](Self::cap), [`floor`](Self::floor),
-/// [`collar`](Self::collar) and [`with_strikes`](Self::with_strikes), which take
-/// the coupon vector [`YoYInflationLeg`](crate::cashflows::PyYoYInflationLeg)
-/// hands back (#848). The raw route is the only one that reaches a collar: the
-/// builder carries a single strike.
+/// Built either through MakeYoYInflationCapFloor, the standard market builder,
+/// or through the raw constructors below, which take the coupon vector
+/// YoYInflationLeg.coupons() hands back (#848). The raw route is the only one
+/// that reaches a collar: the builder carries a single strike.
 ///
 /// Unlike a nominal cap/floor this instrument keeps its first optionlet, so the
 /// strip spans its leg exactly and cap - floor is the year-on-year swap.
 ///
-/// Pricing needs an engine: call [`set_engine`](Self::set_engine) before
-/// [`npv`](Self::npv).
+/// Pricing needs an engine: call set_engine before npv.
 #[pyclass(name = "YoYInflationCapFloor", unsendable)]
 pub struct PyYoYInflationCapFloor {
     inner: SharedMut<YoYInflationCapFloor>,
@@ -2458,16 +2935,26 @@ pub struct PyYoYInflationCapFloor {
 
 #[pymethods]
 impl PyYoYInflationCapFloor {
-    /// A `cap_floor_type` instrument over `coupons`, struck at `cap_rates` and
-    /// `floor_rates` (`inflationcapfloor.rs:141`).
+    /// Build an instrument of cap_floor_type over coupons, struck at both vectors.
     ///
     /// Each strike vector is padded to the leg length by repeating its last
     /// entry, so a single strike stands for every optionlet.
     ///
-    /// # Errors
+    /// Args:
+    ///     cap_floor_type (CapFloorType): Cap, Floor or Collar.
+    ///     coupons (list[YoYInflationCoupon]): The leg the optionlets sit on.
+    ///     cap_rates (list[float]): The cap strikes.
+    ///     floor_rates (list[float]): The floor strikes.
+    ///     settings (Settings): The explicit settings the instrument resolves
+    ///         its dates against.
     ///
-    /// Reports an empty leg, and a strike vector the type needs and did not
-    /// get: a cap or a collar needs cap rates, a floor or a collar floor rates.
+    /// Returns:
+    ///     YoYInflationCapFloor: The built instrument.
+    ///
+    /// Raises:
+    ///     ItofinError: On an empty leg, and on a strike vector the type needs
+    ///         and did not get: a cap or a collar needs cap rates, a floor or
+    ///         a collar floor rates.
     #[staticmethod]
     fn new(
         cap_floor_type: PyCapFloorType,
@@ -2488,8 +2975,19 @@ impl PyYoYInflationCapFloor {
         )))
     }
 
-    /// A cap over `coupons` struck at `strikes`. Fallible as
-    /// [`new`](Self::new).
+    /// Build a cap over coupons struck at strikes.
+    ///
+    /// Args:
+    ///     coupons (list[YoYInflationCoupon]): The leg the optionlets sit on.
+    ///     strikes (list[float]): The cap strikes, padded as new() pads.
+    ///     settings (Settings): The explicit settings the instrument resolves
+    ///         its dates against.
+    ///
+    /// Returns:
+    ///     YoYInflationCapFloor: The cap over that leg.
+    ///
+    /// Raises:
+    ///     ItofinError: On the same conditions new() reports.
     #[staticmethod]
     fn cap(
         coupons: Vec<PyRef<PyYoYInflationCoupon>>,
@@ -2506,8 +3004,19 @@ impl PyYoYInflationCapFloor {
         )))
     }
 
-    /// A floor over `coupons` struck at `strikes`. Fallible as
-    /// [`new`](Self::new).
+    /// Build a floor over coupons struck at strikes.
+    ///
+    /// Args:
+    ///     coupons (list[YoYInflationCoupon]): The leg the optionlets sit on.
+    ///     strikes (list[float]): The floor strikes, padded as new() pads.
+    ///     settings (Settings): The explicit settings the instrument resolves
+    ///         its dates against.
+    ///
+    /// Returns:
+    ///     YoYInflationCapFloor: The floor over that leg.
+    ///
+    /// Raises:
+    ///     ItofinError: On the same conditions new() reports.
     #[staticmethod]
     fn floor(
         coupons: Vec<PyRef<PyYoYInflationCoupon>>,
@@ -2524,8 +3033,20 @@ impl PyYoYInflationCapFloor {
         )))
     }
 
-    /// A collar over `coupons`, long the cap at `cap_rates` and short the floor
-    /// at `floor_rates`. Fallible as [`new`](Self::new).
+    /// Build a collar: long the cap at cap_rates, short the floor at floor_rates.
+    ///
+    /// Args:
+    ///     coupons (list[YoYInflationCoupon]): The leg the optionlets sit on.
+    ///     cap_rates (list[float]): The cap strikes, padded as new() pads.
+    ///     floor_rates (list[float]): The floor strikes, padded the same way.
+    ///     settings (Settings): The explicit settings the instrument resolves
+    ///         its dates against.
+    ///
+    /// Returns:
+    ///     YoYInflationCapFloor: The collar over that leg.
+    ///
+    /// Raises:
+    ///     ItofinError: On the same conditions new() reports.
     #[staticmethod]
     fn collar(
         coupons: Vec<PyRef<PyYoYInflationCoupon>>,
@@ -2544,14 +3065,23 @@ impl PyYoYInflationCapFloor {
         )))
     }
 
-    /// The single-vector constructor: `strikes` are cap rates for a
-    /// `CapFloorType.Cap` and floor rates for a `CapFloorType.Floor`.
+    /// Build a cap or a floor from a single strike vector.
     ///
-    /// # Errors
+    /// Args:
+    ///     cap_floor_type (CapFloorType): Cap or Floor.
+    ///     coupons (list[YoYInflationCoupon]): The leg the optionlets sit on.
+    ///     strikes (list[float]): Cap rates for a Cap and floor rates for a
+    ///         Floor.
+    ///     settings (Settings): The explicit settings the instrument resolves
+    ///         its dates against.
     ///
-    /// Reports an empty `strikes`, a `CapFloorType.Collar` - which needs two
-    /// vectors, so [`collar`](Self::collar) is its constructor - and as
-    /// [`new`](Self::new).
+    /// Returns:
+    ///     YoYInflationCapFloor: The built instrument.
+    ///
+    /// Raises:
+    ///     ItofinError: On an empty strikes, on a Collar - which needs two
+    ///         vectors, so collar() is its constructor - and on the same
+    ///         conditions new() reports.
     #[staticmethod]
     fn with_strikes(
         cap_floor_type: PyCapFloorType,
@@ -2570,34 +3100,51 @@ impl PyYoYInflationCapFloor {
         )))
     }
 
-    /// The cap strikes, one per coupon; empty on a floor.
+    /// Return the cap strikes, one per coupon.
+    ///
+    /// Returns:
+    ///     list[float]: The cap strikes; empty on a floor.
     fn cap_rates(&self) -> Vec<f64> {
         self.inner.borrow().cap_rates().to_vec()
     }
 
-    /// The floor strikes, one per coupon; empty on a cap.
+    /// Return the floor strikes, one per coupon.
+    ///
+    /// Returns:
+    ///     list[float]: The floor strikes; empty on a cap.
     fn floor_rates(&self) -> Vec<f64> {
         self.inner.borrow().floor_rates().to_vec()
     }
 
-    /// The number of optionlets, one per year-on-year coupon.
+    /// Return the number of optionlets.
+    ///
+    /// Returns:
+    ///     int: One per year-on-year coupon on the leg.
     fn coupon_count(&self) -> usize {
         self.inner.borrow().yoy_leg().len()
     }
 
-    /// The leg's earliest accrual start.
+    /// Return the leg's earliest accrual start.
     ///
-    /// # Errors
+    /// Returns:
+    ///     Date: The first accrual start date.
     ///
-    /// Reports an empty leg, which the constructors already refuse.
+    /// Raises:
+    ///     ItofinError: On an empty leg, which the constructors already
+    ///         refuse.
     fn start_date(&self) -> PyResult<PyDate> {
         Ok(PyDate::from_inner(
             self.inner.borrow().start_date().map_err(PyQlError::from)?,
         ))
     }
 
-    /// The leg's latest accrual end. Fallible as
-    /// [`start_date`](Self::start_date).
+    /// Return the leg's latest accrual end.
+    ///
+    /// Returns:
+    ///     Date: The last accrual end date.
+    ///
+    /// Raises:
+    ///     ItofinError: On the same conditions start_date reports.
     fn maturity_date(&self) -> PyResult<PyDate> {
         Ok(PyDate::from_inner(
             self.inner
@@ -2607,16 +3154,21 @@ impl PyYoYInflationCapFloor {
         ))
     }
 
-    /// The at-the-money rate: the strike at which the leg reprices on
-    /// `discount_curve`.
+    /// Return the strike at which the leg reprices on discount_curve.
     ///
     /// The core takes the curve itself rather than a handle, so the link is
-    /// resolved here and held for the call.
+    /// resolved for the call.
     ///
-    /// # Errors
+    /// Args:
+    ///     discount_curve (YieldTermStructure): The curve the leg reprices on.
     ///
-    /// Reports an unlinked `discount_curve`, a curve with no reference date and
-    /// a leg with no basis-point sensitivity to solve over.
+    /// Returns:
+    ///     float: The at-the-money rate.
+    ///
+    /// Raises:
+    ///     ItofinError: On an unlinked discount_curve, a curve with no
+    ///         reference date, and a leg with no basis-point sensitivity to
+    ///         solve over.
     fn atm_rate(&self, discount_curve: &PyYieldTermStructure) -> PyResult<f64> {
         let handle = discount_curve.handle();
         let link = handle.current_link().map_err(PyQlError::from)?;
@@ -2627,12 +3179,13 @@ impl PyYoYInflationCapFloor {
             .map_err(PyQlError::from)?)
     }
 
-    /// Attaches a [`PyYoYInflationCapFloorEngine`], replacing whatever engine
-    /// the factory installed.
+    /// Attach an engine, replacing whatever the factory installed.
     ///
-    /// The engine must resolve its dates against the same `Settings` object this
-    /// cap/floor was built with: two different ones would price the leg and the
-    /// optionlets on different dates with no error raised.
+    /// Args:
+    ///     engine (YoYInflationCapFloorEngine): The engine, which must resolve
+    ///         its dates against the same Settings object this cap/floor was
+    ///         built with: two different ones would price the leg and the
+    ///         optionlets on different dates with no error raised.
     fn set_engine(&mut self, engine: &PyYoYInflationCapFloorEngine) {
         self.inner
             .borrow_mut()
@@ -2640,8 +3193,11 @@ impl PyYoYInflationCapFloor {
             .set_pricing_engine(engine.engine());
     }
 
-    /// Forces the valuation, idempotent and fallible as
-    /// [`VanillaOption.calculate`](crate::option::PyVanillaOption::calculate).
+    /// Force the valuation. Idempotent.
+    ///
+    /// Raises:
+    ///     ItofinError: If no engine is attached, no evaluation date is set,
+    ///         or the engine refuses the instrument.
     fn calculate(&mut self) -> PyResult<()> {
         Ok(self
             .inner
@@ -2650,33 +3206,54 @@ impl PyYoYInflationCapFloor {
             .map_err(PyQlError::from)?)
     }
 
-    /// Whether the cached results are currently valid.
+    /// Return whether the cached results are currently valid.
+    ///
+    /// Returns:
+    ///     bool: True when the next accessor reads the cache.
     fn is_calculated(&self) -> bool {
         self.inner.borrow().base().is_calculated()
     }
 
-    /// Attaches `engine`, replacing whatever the factory installed, and returns
-    /// the NPV: the one-shot form of [`set_engine`](Self::set_engine) followed
-    /// by [`npv`](Self::npv).
+    /// Attach engine and return the NPV.
+    ///
+    /// Replaces whatever engine the factory installed.
+    ///
+    /// Args:
+    ///     engine (YoYInflationCapFloorEngine): The engine to install and
+    ///         price on.
+    ///
+    /// Returns:
+    ///     float: The cap/floor value.
+    ///
+    /// Raises:
+    ///     ItofinError: On anything that makes the valuation fail.
     fn price(&mut self, engine: &PyYoYInflationCapFloorEngine) -> PyResult<f64> {
         self.set_engine(engine);
         self.calculate()?;
         self.npv()
     }
 
-    /// A frozen [`Results`] copy of the valuation, calculating first.
+    /// Return a frozen snapshot of the valuation, calculating first.
+    ///
+    /// Returns:
+    ///     Results: A copy of the valuation results.
+    ///
+    /// Raises:
+    ///     ItofinError: On anything that makes the valuation fail.
     fn results(&mut self) -> PyResult<Results> {
         self.calculate()?;
         let inner = self.inner.borrow();
         Ok(Results::snapshot(inner.base()))
     }
 
-    /// The cap/floor NPV under the attached engine.
+    /// Return the cap/floor NPV under the attached engine.
     ///
-    /// # Errors
+    /// Returns:
+    ///     float: The present value.
     ///
-    /// Reports `"null pricing engine"` with no engine attached, and whatever the
-    /// engine reports.
+    /// Raises:
+    ///     ItofinError: If no engine is attached, which the core reports as
+    ///         "null pricing engine", and on whatever the engine reports.
     fn npv(&mut self) -> PyResult<f64> {
         Ok(self.inner.borrow_mut().npv().map_err(PyQlError::from)?)
     }
@@ -2689,27 +3266,19 @@ impl PyYoYInflationCapFloor {
     }
 }
 
-/// Python `YoYCapFloorTermPriceSurface`: the quoted year-on-year cap/floor
-/// price grid, bicubic-interpolated over strike and maturity with a cubic ATM
-/// swap rate curve through the cap/floor intersections (core
-/// `termstructures::inflation::yoycapfloortermpricesurface`, C++'s
-/// `InterpolatedYoYCapFloorTermPriceSurface<Bicubic, Cubic>`).
+/// The quoted year-on-year cap/floor price grid, bicubic-interpolated over
+/// strike and maturity with a cubic ATM swap rate curve through the cap/floor
+/// intersections.
 ///
-/// The facade holds the concrete interpolated surface; the K-interpolated
-/// optionlet stripping pipeline (#910) reads it back erased through a
-/// crate-internal upcast accessor, the same seam the engine facades use.
-///
-/// Construction only validates and stores the quotes. The calculations - the
+/// Construction only validates and stores the quotes; the calculations - the
 /// cap/floor intersection and the year-on-year bootstrap over its ATM swap
-/// rates - run on the first read and are cached, so a bad grid surfaces at the
-/// constructor and a failed solve at the first price or rate query. The
-/// reference date moves with the evaluation date carried by `settings`, which
-/// must be set before construction: the maturity checks resolve against it.
+/// rates - run on the first read and are cached. The reference date moves with
+/// the evaluation date carried by settings, which must be set before
+/// construction.
 ///
-/// Deferred (visible): the remaining trait surface - `price` and the by-tenor
-/// query forms, `atm_yoy_rate`, the `atm_yoy_swap_time_rates`/`date_rates`
-/// vectors, the cap/floor strike splits, `yoy_ts` and `base_date` - is not
-/// exposed; nothing downstream of #909/#910 reads it from Python yet.
+/// A price alone does not say cap or floor without the ATM level, and ATM
+/// prices are generally inaccurate, coming from extrapolation and
+/// intersection: the quoted grid is the data, the ATM curve a derived read.
 #[pyclass(name = "YoYCapFloorTermPriceSurface", unsendable)]
 pub struct PyYoYCapFloorTermPriceSurface {
     inner: Shared<InterpolatedYoYCapFloorTermPriceSurface>,
@@ -2717,14 +3286,39 @@ pub struct PyYoYCapFloorTermPriceSurface {
 
 #[pymethods]
 impl PyYoYCapFloorTermPriceSurface {
-    /// A surface over quoted cap and floor prices by strike (rows) and
-    /// maturity (columns).
+    /// Build the surface over quoted cap and floor prices.
     ///
-    /// # Errors
+    /// Args:
+    ///     fixing_days (int): The fixing days of the quoted instruments.
+    ///     yy_lag (Period): The observation lag of the quoted instruments.
+    ///     yoy_index (YoYInflationIndex): The year-on-year index the surface
+    ///         is quoted on.
+    ///     interpolation (CpiInterpolationType): How an observation
+    ///         interpolates between the index fixings bracketing it.
+    ///     nominal_term_structure (YieldTermStructure): The nominal discount
+    ///         curve the derived year-on-year bootstrap prices against.
+    ///     day_counter (DayCounter): The day count times are measured in.
+    ///     calendar (Calendar): The calendar maturities resolve on.
+    ///     business_day_convention (BusinessDayConvention): The roll applied
+    ///         when resolving a date.
+    ///     c_strikes (list[float]): The quoted cap strikes, one per cap grid
+    ///         row; strictly increasing.
+    ///     f_strikes (list[float]): The quoted floor strikes, one per floor
+    ///         grid row; strictly increasing.
+    ///     cf_maturities (list[Period]): The quoted maturities, one per grid
+    ///         column; shared by both grids.
+    ///     c_price (list[list[float]]): The cap prices, one row per cap
+    ///         strike and one column per maturity.
+    ///     f_price (list[list[float]]): The floor prices, one row per floor
+    ///         strike and one column per maturity.
+    ///     settings (Settings): The explicit settings supplying the
+    ///         evaluation date the reference date moves with.
     ///
-    /// Reports an empty or ragged price grid, and the core's data-consistency
-    /// gate: mismatched strike/maturity/grid dimensions, a non-increasing
-    /// axis, or a cap/floor strike union that overlaps the wrong way round.
+    /// Raises:
+    ///     ItofinError: On an empty or ragged price grid, on grid dimensions
+    ///         that do not match the strikes and maturities, on a
+    ///         non-increasing axis, and on a cap/floor strike union that
+    ///         overlaps the wrong way round.
     #[new]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -2765,15 +3359,24 @@ impl PyYoYCapFloorTermPriceSurface {
         })
     }
 
-    /// The interpolated cap price at `date` struck at `strike`, a pure surface
-    /// lookup with the spline's extrapolation enabled as in C++.
+    /// Return the interpolated cap price at date struck at strike.
     ///
-    /// # Errors
+    /// A pure surface lookup with the spline's extrapolation enabled, as in
+    /// C++.
     ///
-    /// Reports an unset evaluation date, and whatever stops the first-read
-    /// calculations: a failed intersection solve, an intersection outside its
-    /// arbitrage bounds past the extrapolation horizon, or a bootstrap that
-    /// cannot reprice its helpers.
+    /// Args:
+    ///     date (Date): The maturity the price is read at.
+    ///     strike (float): The strike the price is read at.
+    ///
+    /// Returns:
+    ///     float: The interpolated cap price.
+    ///
+    /// Raises:
+    ///     ItofinError: On an unset evaluation date, and on whatever stops
+    ///         the first-read calculations: a failed intersection solve, an
+    ///         intersection outside its arbitrage bounds past the
+    ///         extrapolation horizon, or a bootstrap that cannot reprice its
+    ///         helpers.
     fn cap_price(&self, date: &PyDate, strike: f64) -> PyResult<f64> {
         Ok(self
             .inner
@@ -2781,8 +3384,17 @@ impl PyYoYCapFloorTermPriceSurface {
             .map_err(PyQlError::from)?)
     }
 
-    /// The interpolated floor price at `date` struck at `strike`. See
-    /// [`cap_price`](Self::cap_price).
+    /// Return the interpolated floor price at date struck at strike.
+    ///
+    /// Args:
+    ///     date (Date): The maturity the price is read at.
+    ///     strike (float): The strike the price is read at.
+    ///
+    /// Returns:
+    ///     float: The interpolated floor price.
+    ///
+    /// Raises:
+    ///     ItofinError: On the same conditions cap_price() reports.
     fn floor_price(&self, date: &PyDate, strike: f64) -> PyResult<f64> {
         Ok(self
             .inner
@@ -2790,15 +3402,21 @@ impl PyYoYCapFloorTermPriceSurface {
             .map_err(PyQlError::from)?)
     }
 
-    /// The ATM year-on-year swap rate at `date`, read off the cubic curve
-    /// through the cap/floor intersections. `extrapolate` defaults `True` as
-    /// in C++; passed `False`, a date outside the quoted maturities is an
-    /// error instead.
+    /// Return the ATM year-on-year swap rate at date.
     ///
-    /// # Errors
+    /// Read off the cubic curve through the cap/floor intersections.
     ///
-    /// As [`cap_price`](Self::cap_price), plus the range check when
-    /// `extrapolate` is `False`.
+    /// Args:
+    ///     date (Date): The maturity the rate is read at.
+    ///     extrapolate (bool): Whether to answer outside the quoted
+    ///         maturities; defaults True as in C++.
+    ///
+    /// Returns:
+    ///     float: The ATM year-on-year swap rate.
+    ///
+    /// Raises:
+    ///     ItofinError: On the same conditions cap_price() reports, and on a
+    ///         date outside the quoted maturities when extrapolate is False.
     #[pyo3(signature = (date, extrapolate = true))]
     fn atm_yoy_swap_rate(&self, date: &PyDate, extrapolate: bool) -> PyResult<f64> {
         Ok(self
@@ -2807,13 +3425,20 @@ impl PyYoYCapFloorTermPriceSurface {
             .map_err(PyQlError::from)?)
     }
 
-    /// The cap/floor strike union: every floor strike, then the cap strikes
-    /// above them.
+    /// Return the cap/floor strike union.
+    ///
+    /// Every floor strike, then the cap strikes above them.
+    ///
+    /// Returns:
+    ///     list[float]: The strike union, strictly increasing.
     fn strikes(&self) -> Vec<f64> {
         self.inner.strikes().to_vec()
     }
 
-    /// The quoted maturities, one per grid column.
+    /// Return the quoted maturities, one per grid column.
+    ///
+    /// Returns:
+    ///     list[Period]: The maturities.
     fn maturities(&self) -> Vec<PyPeriod> {
         self.inner
             .maturities()
@@ -2832,34 +3457,21 @@ impl PyYoYCapFloorTermPriceSurface {
     }
 }
 
-/// Python `KInterpolatedYoYOptionletVolatilitySurface`: the year-on-year
-/// optionlet volatility surface stripped out of a quoted
-/// [`PyYoYCapFloorTermPriceSurface`], interpolating linearly across the quoted
-/// strikes of each date's slice (core
-/// `termstructures::volatility::KInterpolatedYoYOptionletVolatilitySurface<Linear>`).
+/// The year-on-year optionlet volatility surface stripped out of a quoted
+/// YoYCapFloorTermPriceSurface, interpolating linearly across the quoted
+/// strikes of each date's slice.
 ///
-/// The stripping pipeline is built *inside* the constructor rather than passed
-/// in: the stripper reprices each optionlet through an engine whose volatility
-/// link it relinks every solver iteration, so engine and stripper must share
-/// one relinkable handle that starts empty. A caller-supplied engine would
-/// carry a handle the stripper never touches and the stripping would silently
-/// solve against nothing (the #387 cached-NPV trap the core test pins). The
-/// constructor therefore takes the `index` and `nominal_term_structure` the
-/// engine needs and wires the handle itself.
+/// The stripping pipeline is built inside the constructor rather than passed
+/// in: the stripper reprices each optionlet through an engine whose
+/// volatility link it relinks every solver iteration, so engine and stripper
+/// must share one relinkable handle that starts empty. The constructor
+/// therefore takes the index and nominal curve the engine needs and wires the
+/// handle itself; a caller-supplied engine would silently strip against
+/// nothing.
 ///
-/// Construction runs the stripping, C++'s constructor-run
-/// `performCalculations`, so it is fallible and the evaluation date carried by
-/// `settings` must be set first.
-///
-/// [`volatility`](Self::volatility) observes inflation the surface's own
-/// `observation_lag` back, C++'s default-lag behaviour; the flat surface's
-/// explicit-lag form is not offered here because the K-surface's lag is fixed
-/// by the price surface it strips.
-///
-/// Deferred (visible): the pricer is pinned to the unit-displaced lognormal
-/// model, the one the oracle strips under; a standard-Black or Bachelier
-/// variant would need a distribution argument nothing reads from Python yet.
-/// `total_variance` is likewise not exposed.
+/// Construction runs the stripping, so it is fallible and the evaluation date
+/// carried by settings must be set first. The pricer is pinned to the
+/// unit-displaced lognormal model.
 #[pyclass(name = "KInterpolatedYoYOptionletVolatilitySurface", unsendable)]
 pub struct PyKInterpolatedYoYOptionletVolatilitySurface {
     inner: Shared<KInterpolatedYoYOptionletVolatilitySurface<Linear>>,
@@ -2868,21 +3480,36 @@ pub struct PyKInterpolatedYoYOptionletVolatilitySurface {
 
 #[pymethods]
 impl PyKInterpolatedYoYOptionletVolatilitySurface {
-    /// A surface stripped from `cap_floor_prices`, optionlets repriced
-    /// through a unit-displaced engine forecasting off `index` and
-    /// discounting on `nominal_term_structure`; `slope` is the assumed
-    /// proportional change per year of the unobserved initial caplet
-    /// volatility.
+    /// Strip cap_floor_prices into an optionlet volatility surface.
     ///
-    /// `index` must be linked to a year-on-year curve: the engine forecasts
-    /// each optionlet's forward off the index's own curve, not the price
-    /// surface's bootstrapped one.
+    /// Args:
+    ///     settlement_days (int): Days from the evaluation date to the
+    ///         surface's reference date.
+    ///     calendar (Calendar): The calendar the reference date resolves on.
+    ///     business_day_convention (BusinessDayConvention): The roll applied
+    ///         when resolving a date.
+    ///     day_counter (DayCounter): The day count times are measured in.
+    ///     observation_lag (Period): The lag the surface observes inflation
+    ///         with, normally the price surface's own.
+    ///     cap_floor_prices (YoYCapFloorTermPriceSurface): The quoted
+    ///         cap/floor price grid to strip.
+    ///     index (YoYInflationIndex): The year-on-year index the internal
+    ///         engine forecasts off; it must be linked to a year-on-year
+    ///         curve, which is the index's own rather than the price
+    ///         surface's bootstrapped one.
+    ///     nominal_term_structure (YieldTermStructure): The nominal discount
+    ///         curve the internal engine discounts on.
+    ///     slope (float): The assumed proportional change per year of the
+    ///         unobserved initial caplet volatility, which the stripper
+    ///         extends each strike's first observable volatility back with.
+    ///     settings (Settings): The explicit settings supplying the
+    ///         evaluation date; it must match the one behind index and
+    ///         cap_floor_prices.
     ///
-    /// # Errors
-    ///
-    /// Reports whatever stops the stripping: an unset evaluation date, an
-    /// unlinked index, or a Brent solve that cannot bracket an optionlet
-    /// volatility.
+    /// Raises:
+    ///     ItofinError: On whatever stops the stripping: an unset evaluation
+    ///         date, an unlinked index, or a solve that cannot bracket an
+    ///         optionlet volatility.
     #[new]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -2925,38 +3552,57 @@ impl PyKInterpolatedYoYOptionletVolatilitySurface {
         })
     }
 
-    /// The stripped (strikes, volatilities) profile at `date`, C++'s `Dslice`:
-    /// one volatility per strike of the price surface's cap/floor union.
+    /// Return the stripped (strikes, volatilities) profile at date.
     ///
-    /// # Errors
+    /// C++'s Dslice: one volatility per strike of the price surface's
+    /// cap/floor union.
     ///
-    /// Reports a date the stripper cannot price a slice at.
+    /// Args:
+    ///     date (Date): The date the slice is stripped at.
+    ///
+    /// Returns:
+    ///     tuple[list[float], list[float]]: The quoted strike union and the
+    ///         volatility stripped at each strike.
+    ///
+    /// Raises:
+    ///     ItofinError: On a date the stripper cannot price a slice at.
     fn d_slice(&self, date: &PyDate) -> PyResult<(Vec<f64>, Vec<f64>)> {
         Ok(self.inner.d_slice(date.inner()).map_err(PyQlError::from)?)
     }
 
-    /// The date the surface measures its variance from: the reference date
-    /// pulled back by the surface's own observation lag, snapped to the start
-    /// of the publication period.
+    /// Return the date the surface measures its variance from.
     ///
-    /// # Errors
+    /// The reference date pulled back by the surface's own observation lag,
+    /// snapped to the start of the publication period.
     ///
-    /// Reports an unset evaluation date, and a frequency admitting no
-    /// publication period.
+    /// Returns:
+    ///     Date: The base date.
+    ///
+    /// Raises:
+    ///     ItofinError: On an unset evaluation date, and on a frequency
+    ///         admitting no publication period.
     fn base_date(&self) -> PyResult<PyDate> {
         Ok(PyDate::from_inner(
             self.inner.base_date().map_err(PyQlError::from)?,
         ))
     }
 
-    /// The volatility for an exercise on `date` struck at `strike`, observing
-    /// inflation the surface's own observation lag back: the slice at the
-    /// observed date interpolated across its strikes.
+    /// Return the volatility for an exercise on date struck at strike.
     ///
-    /// # Errors
+    /// Observes inflation the surface's own observation lag back, C++'s
+    /// default-lag behaviour: the slice at the observed date interpolated
+    /// across its strikes.
     ///
-    /// Reports an observed date before [`base_date`](Self::base_date), and a
-    /// `strike` outside the surface's strike domain.
+    /// Args:
+    ///     date (Date): The exercise date.
+    ///     strike (float): The strike the volatility is read at.
+    ///
+    /// Returns:
+    ///     float: The optionlet volatility.
+    ///
+    /// Raises:
+    ///     ItofinError: On an observed date before base_date(), and on a
+    ///         strike outside the surface's strike domain.
     fn volatility(&self, date: &PyDate, strike: f64) -> PyResult<f64> {
         Ok(self
             .inner
@@ -2964,18 +3610,29 @@ impl PyKInterpolatedYoYOptionletVolatilitySurface {
             .map_err(PyQlError::from)?)
     }
 
-    /// The lowest quoted strike of the price surface's cap/floor union.
+    /// Return the lowest quoted strike of the cap/floor union.
+    ///
+    /// Returns:
+    ///     float: The lowest strike the surface answers for.
     fn min_strike(&self) -> f64 {
         self.inner.min_strike()
     }
 
-    /// The highest quoted strike of the price surface's cap/floor union.
+    /// Return the highest quoted strike of the cap/floor union.
+    ///
+    /// Returns:
+    ///     float: The highest strike the surface answers for.
     fn max_strike(&self) -> f64 {
         self.inner.max_strike()
     }
 
-    /// The last date the surface answers for: the reference date advanced by
-    /// the price surface's last quoted maturity.
+    /// Return the last date the surface answers for.
+    ///
+    /// The reference date advanced by the price surface's last quoted
+    /// maturity.
+    ///
+    /// Returns:
+    ///     Date: The last queryable date.
     fn max_date(&self) -> PyDate {
         PyDate::from_inner(self.inner.max_date())
     }

--- a/crates/itofin-py/src/inflation.rs
+++ b/crates/itofin-py/src/inflation.rs
@@ -891,6 +891,9 @@ impl PyZeroCouponInflationSwapHelper {
 /// Lazy: the bootstrap runs on the first read, so the evaluation date must be
 /// in place before that read as well as before the helpers were built. A helper
 /// quote moving invalidates the cache.
+///
+/// A seasonality installed later through set_seasonality() invalidates the
+/// bootstrap, so the next read re-solves every node against the correction.
 #[pyclass(
     name = "PiecewiseZeroInflationCurve",
     extends = PyZeroInflationTermStructure,
@@ -1014,6 +1017,10 @@ impl PyPiecewiseZeroInflationCurve {
 /// The core omits adjust_inf_obs_dates from its own signature, so there is
 /// nothing to expose here; the leg and cash-flow accessors are not surfaced
 /// either, there being no cash-flow facade.
+///
+/// Pricing needs an engine: call set_engine() before npv(). fair_rate() is the
+/// exception, reading the indexed flow directly and pricing with no engine at
+/// all, though it does need the index linked to a curve.
 #[pyclass(name = "ZeroCouponInflationSwap", unsendable)]
 pub struct PyZeroCouponInflationSwap {
     inner: SharedMut<ZeroCouponInflationSwap>,
@@ -1881,6 +1888,10 @@ impl PyYoYInflationIndex {
 ///
 /// pillar is accepted for signature parity but never read: it only ever
 /// discriminates on the interpolated path, which is refused.
+///
+/// Fallible: CpiInterpolationType.Linear is refused outright, and the swap is
+/// built here, so an observation lag its legs cannot be built under fails at
+/// construction.
 #[pyclass(
     name = "YearOnYearInflationSwapHelper",
     extends = PyYoYInflationHelper,

--- a/crates/itofin-py/src/inflation.rs
+++ b/crates/itofin-py/src/inflation.rs
@@ -1,21 +1,18 @@
-//! Facades for the inflation slice: the [`PyDiscountingSwapEngine`] every
-//! inflation swap prices through, the [`PyCpiInterpolationType`] observation
-//! flag, the [`PyZeroInflationIndex`] family, the
-//! [`PyZeroInflationTermStructure`] curve hierarchy, the
-//! [`PyMultiplicativePriceSeasonality`] correction any of its curves can carry,
-//! the [`PyZeroInflationHelper`] bootstrap helpers that fit its piecewise member
-//! and the [`PyZeroCouponInflationSwap`] the rest of them price together, plus
-//! the year-on-year family that mirrors it: the
-//! [`PyYoYInflationTermStructure`] curve hierarchy and the
-//! [`PyYoYInflationHelper`] helpers that fit its piecewise member, and the
-//! optionlet stack written over that curve: the flat
-//! [`PyConstantYoYOptionletVolatility`] surface, the
-//! [`PyYoYInflationCapFloorEngine`] pricing against it and the
-//! [`PyYoYInflationCapFloor`] it prices, which
-//! [`PyMakeYoYInflationCapFloor`] is the only way to build, the quoted
-//! [`PyYoYCapFloorTermPriceSurface`] cap/floor price grid the optionlet
-//! strippers read, and the [`PyKInterpolatedYoYOptionletVolatilitySurface`]
-//! stripping that grid into an optionlet volatility surface.
+//! Facades for the inflation slice: the DiscountingSwapEngine every inflation
+//! swap prices through, the CpiInterpolationType observation flag, the
+//! ZeroInflationIndex family, the ZeroInflationTermStructure curve hierarchy,
+//! the MultiplicativePriceSeasonality correction any of its curves can carry,
+//! the ZeroInflationHelper bootstrap helpers that fit its piecewise member and
+//! the ZeroCouponInflationSwap the rest of them price together, plus the
+//! year-on-year family that mirrors it: the YoYInflationTermStructure curve
+//! hierarchy and the YoYInflationHelper helpers that fit its piecewise member,
+//! and the optionlet stack written over that curve: the flat
+//! ConstantYoYOptionletVolatility surface, the YoYInflationCapFloorEngine
+//! pricing against it and the YoYInflationCapFloor it prices, which
+//! MakeYoYInflationCapFloor is the only way to build, the quoted
+//! YoYCapFloorTermPriceSurface cap/floor price grid the optionlet strippers
+//! read, and the KInterpolatedYoYOptionletVolatilitySurface stripping that grid
+//! into an optionlet volatility surface.
 //!
 //! The swap engine is generic rather than inflation-specific - it prices any
 //! swap - but is homed here because the inflation tickets are the first to need
@@ -143,7 +140,7 @@ pub enum PyCpiInterpolationType {
 }
 
 impl PyCpiInterpolationType {
-    /// The core [`CpiInterpolationType`] this variant stands for.
+    /// The core CpiInterpolationType this variant stands for.
     pub(crate) fn inner(&self) -> CpiInterpolationType {
         match self {
             PyCpiInterpolationType::Flat => CpiInterpolationType::Flat,
@@ -151,8 +148,8 @@ impl PyCpiInterpolationType {
         }
     }
 
-    /// The variant standing for a core [`CpiInterpolationType`] a facade read
-    /// back off an object it built.
+    /// The variant standing for a core CpiInterpolationType a facade read back
+    /// off an object it built.
     pub(crate) fn from_inner(inner: CpiInterpolationType) -> Self {
         match inner {
             CpiInterpolationType::Flat => PyCpiInterpolationType::Flat,
@@ -346,7 +343,7 @@ impl PyZeroInflationIndex {
 impl PyZeroInflationIndex {
     /// Points the internal handle at `curve`, so the index forecasts off it.
     ///
-    /// The seam [`link_to`](Self::link_to) dereferences a curve facade into.
+    /// The seam link_to() dereferences a curve facade into.
     pub(crate) fn relink(&self, curve: Shared<dyn ZeroInflationTermStructure>) {
         self.curve.link_to(curve);
     }
@@ -604,7 +601,7 @@ impl PyZeroInflationTermStructure {
 }
 
 impl PyZeroInflationTermStructure {
-    /// The base half of a concrete curve's [`PyClassInitializer`] chain.
+    /// The base half of a concrete curve's initializer chain.
     pub(crate) fn from_handle(inner: Handle<dyn ZeroInflationTermStructure>) -> Self {
         PyZeroInflationTermStructure { inner }
     }
@@ -745,7 +742,7 @@ impl PyZeroInflationHelper {
 }
 
 impl PyZeroInflationHelper {
-    /// The base half of a concrete helper's [`PyClassInitializer`] chain.
+    /// The base half of a concrete helper's initializer chain.
     pub(crate) fn from_shared(inner: Shared<dyn ZeroInflationHelper>) -> Self {
         PyZeroInflationHelper { inner }
     }
@@ -1436,7 +1433,7 @@ impl PyYoYInflationTermStructure {
 }
 
 impl PyYoYInflationTermStructure {
-    /// The base half of a concrete curve's [`PyClassInitializer`] chain.
+    /// The base half of a concrete curve's initializer chain.
     pub(crate) fn from_handle(inner: Handle<dyn YoYInflationTermStructure>) -> Self {
         PyYoYInflationTermStructure { inner }
     }
@@ -1576,7 +1573,7 @@ impl PyYoYInflationHelper {
 }
 
 impl PyYoYInflationHelper {
-    /// The base half of a concrete helper's [`PyClassInitializer`] chain.
+    /// The base half of a concrete helper's initializer chain.
     pub(crate) fn from_shared(inner: Shared<dyn YoYInflationHelper>) -> Self {
         PyYoYInflationHelper { inner }
     }
@@ -1614,10 +1611,9 @@ impl PyYoYInflationIndex {
     /// Wraps `build` over a fresh empty relinkable handle the index observes.
     ///
     /// Both constructors route through here: the core's `from_underlying` and
-    /// `new` alike leave the curve handle empty
-    /// (`inflationindex.rs:661,684`), and it is
-    /// [`with_term_structure`](YoYInflationIndex::with_term_structure) that
-    /// registers the index on a handle it will keep seeing.
+    /// `new` alike leave the curve handle empty, and it is
+    /// with_term_structure() that registers the index on a handle it will keep
+    /// seeing.
     fn with_curve_handle(
         underlying: Option<Py<PyZeroInflationIndex>>,
         build: impl FnOnce(&RelinkableHandle<dyn YoYInflationTermStructure>) -> YoYInflationIndex,

--- a/crates/itofin-py/src/lib.rs
+++ b/crates/itofin-py/src/lib.rs
@@ -1,9 +1,9 @@
 //! Python bindings for `libitofin`, published as the `itofin` extension module.
 //!
 //! This crate is the walking skeleton (issue #484): it builds an `abi3-py313`
-//! wheel, imports as `itofin`, and bridges [`QlError`] to the Python-visible
-//! [`struct@ItofinError`] exception. The pricing facades land in follow-up
-//! tickets (#485-#487).
+//! wheel, imports as `itofin`, and bridges QlError to the Python-visible
+//! ItofinError exception. The pricing facades land in follow-up tickets
+//! (#485-#487).
 
 mod calibration;
 mod capfloor;
@@ -117,14 +117,13 @@ use vol::{
 
 create_exception!(itofin, ItofinError, PyException);
 
-/// Newtype bridging [`QlError`] to [`PyErr`] across the crate boundary.
+/// Newtype bridging QlError to Err across the crate boundary.
 ///
-/// A direct `impl From<QlError> for PyErr` is an orphan-rule violation
-/// (E0117): both types are foreign to this crate. This wrapper carries the
-/// two conversions instead, so fallible facades can return
-/// `Result<T, PyQlError>` and use `?` on any `QlResult`. The Python-visible
-/// contract is unchanged: the error surfaces as an [`struct@ItofinError`]
-/// carrying the located `Display` form (`"file:line: message"`).
+/// A direct conversion cannot be written here, both the core error and the
+/// binding error type being foreign to this crate. This wrapper carries the two
+/// conversions instead, so fallible facades can propagate any core result. The
+/// Python-visible contract is unchanged: the error surfaces as an ItofinError
+/// carrying the located message.
 pub struct PyQlError(QlError);
 
 impl From<QlError> for PyQlError {
@@ -141,7 +140,7 @@ impl From<PyQlError> for PyErr {
 
 /// Registers the eleven `ql/`-faithful submodules on `itofin`.
 ///
-/// Nested PyO3 modules give attribute access (`itofin.time.Date`) but do not
+/// Nested native modules give attribute access (`itofin.time.Date`) but do not
 /// form a Python package, so `import itofin.time` / `from itofin.time import
 /// Date` fail unless each submodule is also inserted into `sys.modules` under
 /// its dotted name. The loop below does both: `add_submodule` for attribute

--- a/crates/itofin-py/src/market.rs
+++ b/crates/itofin-py/src/market.rs
@@ -1,4 +1,4 @@
-//! Facades for the market inputs: [`PySimpleQuote`] and [`PyBlackScholesProcess`].
+//! Facades for the market inputs: SimpleQuote and BlackScholesProcess.
 
 use crate::PyQlError;
 use crate::curve::PyYieldTermStructure;
@@ -58,10 +58,10 @@ impl PySimpleQuote {
 }
 
 impl PySimpleQuote {
-    /// A `Handle` wrapping the retained quote, for the rate-helper facades
-    /// (#528) whose ctors take `Handle<dyn Quote>`. The handle clones the same
-    /// inner `Shared`, so a later `set_value` on this `PySimpleQuote` is
-    /// observed by any helper built from it (the laziness contract T5 checks).
+    /// A handle wrapping the retained quote, for the rate-helper facades (#528)
+    /// that take one. The handle shares the same quote, so a later `set_value`
+    /// on this SimpleQuote is observed by any helper built from it (the
+    /// laziness contract T5 checks).
     #[allow(dead_code)]
     pub(crate) fn handle(&self) -> Handle<dyn Quote> {
         Handle::new(Shared::clone(&self.inner) as Shared<dyn Quote>)

--- a/crates/itofin-py/src/market.rs
+++ b/crates/itofin-py/src/market.rs
@@ -39,6 +39,8 @@ impl PySimpleQuote {
 
     /// Return the current value.
     ///
+    /// Fallible: a quote whose value was never set raises ItofinError.
+    ///
     /// Returns:
     ///     float: The quote's current market value.
     fn value(&self) -> PyResult<f64> {

--- a/crates/itofin-py/src/market.rs
+++ b/crates/itofin-py/src/market.rs
@@ -15,11 +15,10 @@ use libitofin::termstructures::yieldtermstructure::YieldTermStructure;
 use libitofin::time::frequency::Frequency;
 use pyo3::prelude::*;
 
-/// Python `SimpleQuote`: a mutable, observable market element (D1).
+/// A mutable, observable market element (D1).
 ///
-/// Wraps a `Shared<SimpleQuote>` so the same interior-mutable quote can be
-/// read while observers are notified of a change. The inner `Shared` is
-/// `Rc`-based and therefore `!Send`, hence `unsendable`.
+/// Wraps a single value that pricing inputs observe; setting a new value
+/// notifies dependents so any cached valuation recomputes lazily.
 #[pyclass(name = "SimpleQuote", unsendable)]
 pub struct PySimpleQuote {
     inner: Shared<SimpleQuote>,
@@ -27,6 +26,10 @@ pub struct PySimpleQuote {
 
 #[pymethods]
 impl PySimpleQuote {
+    /// Initialize the quote.
+    ///
+    /// Args:
+    ///     value (float): The initial market value.
     #[new]
     fn new(value: f64) -> Self {
         PySimpleQuote {
@@ -34,12 +37,19 @@ impl PySimpleQuote {
         }
     }
 
-    /// The stored value, erroring when the quote is unset.
+    /// Return the current value.
+    ///
+    /// Returns:
+    ///     float: The quote's current market value.
     fn value(&self) -> PyResult<f64> {
         Ok(self.inner.value().map_err(PyQlError::from)?)
     }
 
-    /// Sets a new value, notifying observers when it actually changes.
+    /// Set a new value and notify observers.
+    ///
+    /// Args:
+    ///     value (float): The new value; observers are notified when it actually
+    ///         changes, so dependent valuations recompute on next access.
     fn set_value(&self, value: f64) {
         self.inner.set_value(value);
     }
@@ -56,14 +66,12 @@ impl PySimpleQuote {
     }
 }
 
-/// Python `BlackScholesProcess`: a flat-market generalized Black-Scholes
-/// process (processes/blackscholesprocess.rs).
+/// A generalized Black-Scholes process, built from scalars or curve objects.
 ///
-/// The `Handle<dyn ...>` plumbing is assembled internally from scalar inputs
-/// so it never crosses the PyO3 boundary. The Python constructor takes the
-/// conventional `(risk_free_rate, dividend_yield, ...)` order; the core's
-/// `new` takes `(x0, dividend_yield, risk_free_rate, vol)`, so the two curves
-/// are bound by name and placed in the core's order at the single call site.
+/// The Handle plumbing is assembled internally, so no handle crosses the
+/// binding boundary. The constructor takes the conventional
+/// (risk_free_rate, dividend_yield) order and places the two curves in the
+/// core's own order at a single call site.
 #[pyclass(name = "BlackScholesProcess", unsendable)]
 pub struct PyBlackScholesProcess {
     inner: Shared<GeneralizedBlackScholesProcess>,
@@ -71,6 +79,17 @@ pub struct PyBlackScholesProcess {
 
 #[pymethods]
 impl PyBlackScholesProcess {
+    /// Build a flat-market process from scalar inputs.
+    ///
+    /// Args:
+    ///     spot (float): The spot level, held as a quote.
+    ///     risk_free_rate (float): The flat risk-free rate, made into a curve
+    ///         compounded continuously on an annual frequency.
+    ///     dividend_yield (float): The flat dividend yield, made into a curve on the
+    ///         same convention as the risk-free rate.
+    ///     volatility (float): The flat Black volatility.
+    ///     reference_date (Date): The date the three flat curves are anchored on.
+    ///     day_counter (DayCounter): The day count the curves accrue on.
     #[new]
     fn new(
         spot: f64,
@@ -113,12 +132,20 @@ impl PyBlackScholesProcess {
         }
     }
 
-    /// Builds a process from term-structure objects instead of scalars: a spot
-    /// level plus the risk-free curve, dividend curve, and Black vol surface.
+    /// Build a process from term-structure objects instead of scalars.
     ///
-    /// The three legs are bound by name and placed in the core's
-    /// `(x0, dividend, risk_free, vol)` order at the single call site, the same
-    /// r/q footgun the scalar constructor guards against.
+    /// The three legs are bound by name and placed in the core's order at a
+    /// single call site, the same risk-free/dividend argument-order footgun the
+    /// scalar constructor guards against.
+    ///
+    /// Args:
+    ///     spot (float): The spot level, held as a quote.
+    ///     risk_free (YieldTermStructure): The risk-free discount curve.
+    ///     dividend (YieldTermStructure): The dividend curve.
+    ///     vol (BlackVolTermStructure): The Black volatility surface.
+    ///
+    /// Returns:
+    ///     BlackScholesProcess: A process over the three supplied term structures.
     #[staticmethod]
     fn from_curves(
         spot: f64,
@@ -137,14 +164,20 @@ impl PyBlackScholesProcess {
         }
     }
 
-    /// The continuously compounded zero rate carried by the risk-free curve at
-    /// the reference date; the pin that the r/q arg-order was not swapped.
+    /// Return the risk-free rate carried by the process.
+    ///
+    /// Returns:
+    ///     float: The continuously compounded zero rate on the risk-free curve at the
+    ///     reference date.
     fn risk_free_rate(&self) -> PyResult<f64> {
         Ok(zero_rate(&self.inner.risk_free_rate()).map_err(PyQlError::from)?)
     }
 
-    /// The continuously compounded zero rate carried by the dividend curve at
-    /// the reference date; the pin that the r/q arg-order was not swapped.
+    /// Return the dividend yield carried by the process.
+    ///
+    /// Returns:
+    ///     float: The continuously compounded zero rate on the dividend curve at the
+    ///     reference date.
     fn dividend_yield(&self) -> PyResult<f64> {
         Ok(zero_rate(&self.inner.dividend_yield()).map_err(PyQlError::from)?)
     }

--- a/crates/itofin-py/src/mcengine.rs
+++ b/crates/itofin-py/src/mcengine.rs
@@ -1,5 +1,5 @@
-//! Facades for the Monte Carlo pricing engines: [`PyMCEuropeanEngine`],
-//! [`PyMCEuropeanHestonEngine`] and [`PyMCAmericanEngine`].
+//! Facades for the Monte Carlo pricing engines: MCEuropeanEngine,
+//! MCEuropeanHestonEngine and MCAmericanEngine.
 //!
 //! The core engines are generic over their RNG policy, which does not cross FFI
 //! (D7), so the facades pin `PseudoRandom` - the policy that carries an error

--- a/crates/itofin-py/src/mcengine.rs
+++ b/crates/itofin-py/src/mcengine.rs
@@ -20,21 +20,12 @@ use libitofin::pricingengines::vanilla::{
 use libitofin::shared::{SharedMut, shared_mut};
 use pyo3::prelude::*;
 
-/// Python `MCEuropeanEngine`: the Monte Carlo engine for European payoffs
-/// (`pricingengines::vanilla::MCEuropeanEngine`), built through the core's
-/// `MakeMcEuropeanEngine` factory.
+/// The Monte Carlo engine for European payoffs, over the pseudo-random RNG
+/// policy. The low-discrepancy policy is not exposed (#454).
 ///
-/// Every argument past `process` is optional and left unset when omitted, so
-/// the core's own validation reports the illegal combinations as
-/// `ItofinError`: exactly one of `steps` / `steps_per_year` must be given, and
-/// `samples` and `absolute_tolerance` are mutually exclusive.
-///
-/// `antithetic` enables the antithetic-variate variance reduction in the core
-/// engine (#772 lifted the former construction-time rejection).
-///
-/// Pricing is seeded and deterministic: the same `seed` reproduces the NPV
-/// bitwise, and the resulting standard error is read back through
-/// `VanillaOption.error_estimate()`.
+/// Pricing is seeded and deterministic: the same seed reproduces the NPV
+/// bitwise, and the standard error is read back through
+/// VanillaOption.error_estimate().
 #[pyclass(name = "MCEuropeanEngine", unsendable)]
 pub struct PyMCEuropeanEngine {
     inner: SharedMut<MCEuropeanEngine<PseudoRandom>>,
@@ -42,7 +33,29 @@ pub struct PyMCEuropeanEngine {
 
 #[pymethods]
 impl PyMCEuropeanEngine {
-    /// An engine over `process`, configured through the core factory.
+    /// Build an engine over process, configured through the core factory.
+    ///
+    /// Every argument past process is left unset when omitted, so the core's
+    /// own validation reports the illegal combinations.
+    ///
+    /// Args:
+    ///     process (BlackScholesProcess): The process paths are drawn from.
+    ///     steps (int | None): The fixed number of time steps per path.
+    ///     steps_per_year (int | None): The time steps per year, the
+    ///         alternative to steps.
+    ///     samples (int | None): The fixed number of paths to draw.
+    ///     absolute_tolerance (float | None): The target standard error, the
+    ///         alternative to samples.
+    ///     max_samples (int | None): The cap on paths drawn when running to a
+    ///         tolerance.
+    ///     seed (int | None): The RNG seed; the same seed reproduces the NPV
+    ///         bitwise.
+    ///     antithetic (bool | None): The antithetic variate, supported since
+    ///         #772 lifted the former construction-time rejection.
+    ///
+    /// Raises:
+    ///     ItofinError: If neither or both of steps and steps_per_year are
+    ///         given, or if both samples and absolute_tolerance are given.
     #[new]
     #[pyo3(signature = (
         process,
@@ -101,20 +114,12 @@ impl PyMCEuropeanEngine {
     }
 }
 
-/// Python `MCEuropeanHestonEngine`: the Monte Carlo engine pricing European
-/// payoffs on a Heston process (`pricingengines::vanilla::
-/// MCEuropeanHestonEngine`), built through the core's
-/// `MakeMcEuropeanHestonEngine` factory.
+/// The Monte Carlo engine for European payoffs on a Heston process, over the
+/// pseudo-random RNG policy. The low-discrepancy policy is not exposed (#454).
 ///
-/// Same optional-argument contract as [`PyMCEuropeanEngine`]: everything past
-/// `process` is left unset when omitted, so the core reports the illegal
-/// combinations as `ItofinError`. Unlike that engine, `antithetic` is supported
-/// here - the multi-factor path generator wires the antithetic negation - and
-/// the core cached oracle prices with it on.
-///
-/// Pricing is seeded and deterministic: the same `seed` reproduces the NPV
-/// bitwise, and the resulting standard error is read back through
-/// `VanillaOption.error_estimate()`.
+/// Pricing is seeded and deterministic: the same seed reproduces the NPV
+/// bitwise, and the standard error is read back through
+/// VanillaOption.error_estimate().
 #[pyclass(name = "MCEuropeanHestonEngine", unsendable)]
 pub struct PyMCEuropeanHestonEngine {
     inner: SharedMut<MCEuropeanHestonEngine<PseudoRandom>>,
@@ -122,7 +127,29 @@ pub struct PyMCEuropeanHestonEngine {
 
 #[pymethods]
 impl PyMCEuropeanHestonEngine {
-    /// An engine over `process`, configured through the core factory.
+    /// Build an engine over process, configured through the core factory.
+    ///
+    /// Every argument past process is left unset when omitted, so the core's
+    /// own validation reports the illegal combinations.
+    ///
+    /// Args:
+    ///     process (HestonProcess): The Heston process paths are drawn from.
+    ///     steps (int | None): The fixed number of time steps per path.
+    ///     steps_per_year (int | None): The time steps per year, the
+    ///         alternative to steps.
+    ///     samples (int | None): The fixed number of paths to draw.
+    ///     absolute_tolerance (float | None): The target standard error, the
+    ///         alternative to samples.
+    ///     max_samples (int | None): The cap on paths drawn when running to a
+    ///         tolerance.
+    ///     seed (int | None): The RNG seed; the same seed reproduces the NPV
+    ///         bitwise.
+    ///     antithetic (bool | None): The antithetic variate, supported here;
+    ///         the core cached oracle prices with it on.
+    ///
+    /// Raises:
+    ///     ItofinError: If neither or both of steps and steps_per_year are
+    ///         given, or if both samples and absolute_tolerance are given.
     #[new]
     #[pyo3(signature = (
         process,
@@ -181,25 +208,19 @@ impl PyMCEuropeanHestonEngine {
     }
 }
 
-/// Python `MCAmericanEngine`: the Longstaff-Schwartz least-squares Monte Carlo
-/// engine for American payoffs (`pricingengines::vanilla::MCAmericanEngine`),
-/// built through the core's `MakeMcAmericanEngine` factory.
+/// The Longstaff-Schwartz least-squares Monte Carlo engine for American
+/// payoffs, over the pseudo-random RNG policy. The low-discrepancy policy is
+/// not exposed (#454), and the Monomial regression basis is not selectable
+/// (#453).
 ///
-/// Same optional-argument contract as [`PyMCEuropeanEngine`], plus the two
-/// regression settings: `polynomial_order` (default 2) and
-/// `calibration_samples` (default 2048). The basis family is `Monomial` and is
-/// not selectable (#453). The antithetic variate is supported here, and the
-/// core oracle prices with it on.
+/// The option priced must come from VanillaOption.american(...): a
+/// European-exercise option raises ItofinError ("wrong exercise given") when
+/// priced here.
 ///
-/// The option this engine prices must carry an American exercise that does not
-/// pay at expiry - `VanillaOption.american(...)` builds exactly that. Pricing a
-/// European-exercise option on this engine raises `ItofinError` ("wrong
-/// exercise given").
-///
-/// Pricing is seeded and deterministic: the same `seed` reproduces the NPV
-/// bitwise. The standard error is read back through
-/// `VanillaOption.error_estimate()` and the fraction of paths exercised early
-/// through `VanillaOption.exercise_probability()`.
+/// Pricing is seeded and deterministic: the same seed reproduces the NPV
+/// bitwise, the standard error is read back through
+/// VanillaOption.error_estimate() and the early-exercise fraction through
+/// VanillaOption.exercise_probability().
 #[pyclass(name = "MCAmericanEngine", unsendable)]
 pub struct PyMCAmericanEngine {
     inner: SharedMut<MCAmericanEngine<PseudoRandom>>,
@@ -207,7 +228,33 @@ pub struct PyMCAmericanEngine {
 
 #[pymethods]
 impl PyMCAmericanEngine {
-    /// An engine over `process`, configured through the core factory.
+    /// Build an engine over process, configured through the core factory.
+    ///
+    /// Every argument past process is left unset when omitted, so the core's
+    /// own validation reports the illegal combinations.
+    ///
+    /// Args:
+    ///     process (BlackScholesProcess): The process paths are drawn from.
+    ///     steps (int | None): The fixed number of time steps per path.
+    ///     steps_per_year (int | None): The time steps per year, the
+    ///         alternative to steps.
+    ///     samples (int | None): The fixed number of paths to draw.
+    ///     absolute_tolerance (float | None): The target standard error, the
+    ///         alternative to samples.
+    ///     max_samples (int | None): The cap on paths drawn when running to a
+    ///         tolerance.
+    ///     seed (int | None): The RNG seed; the same seed reproduces the NPV
+    ///         bitwise.
+    ///     antithetic (bool | None): The antithetic variate, supported here;
+    ///         the core oracle prices with it on.
+    ///     polynomial_order (int | None): The order of the Monomial regression
+    ///         basis. The core default is 2.
+    ///     calibration_samples (int | None): The paths the regression is fitted
+    ///         on. The core default is 2048.
+    ///
+    /// Raises:
+    ///     ItofinError: If neither or both of steps and steps_per_year are
+    ///         given, or if both samples and absolute_tolerance are given.
     #[new]
     #[pyo3(signature = (
         process,

--- a/crates/itofin-py/src/ois.rs
+++ b/crates/itofin-py/src/ois.rs
@@ -27,22 +27,11 @@ use libitofin::time::timeunit::TimeUnit;
 use libitofin::types::{Integer, Real};
 use pyo3::prelude::*;
 
-/// Python `OvernightIndexedSwap`: a fixed leg versus a compounded overnight leg
-/// (`instruments::overnightindexedswap::OvernightIndexedSwap`).
+/// A fixed leg versus a compounded overnight leg.
 ///
-/// Held as the OIS type rather than lowered to its [`FixedVsFloatingSwap`] base
-/// (unlike [`crate::swap::PyVanillaSwap`], which a swaption underlying needs in
-/// the base shape): nothing here consumes the base, and keeping the OIS type
-/// leaves the overnight accessors reachable for a later widening. The base's
-/// rate and nominal are read through `fixed_vs_floating`
-/// (`overnightindexedswap.rs:235-241`).
-///
-/// Only [`PyMakeOis`] builds one, so the swap always arrives priced; there is
-/// no `set_engine` and no raw constructor. Both are deferred with the
-/// two-schedule master ctor (`overnightindexedswap.rs:169`), which needs a
-/// [`crate::time::PySchedule`] pair the OIS oracle does not build.
-///
-/// [`FixedVsFloatingSwap`]: libitofin::instruments::FixedVsFloatingSwap
+/// Only MakeOis builds one, so it always arrives priced; there is no
+/// set_engine and no raw constructor (both deferred with the two-schedule
+/// master ctor).
 #[pyclass(name = "OvernightIndexedSwap", unsendable)]
 pub struct PyOvernightIndexedSwap {
     inner: SharedMut<OvernightIndexedSwap>,
@@ -50,10 +39,13 @@ pub struct PyOvernightIndexedSwap {
 
 #[pymethods]
 impl PyOvernightIndexedSwap {
-    /// The fair fixed rate that zeroes the swap NPV (`fairRate()`), read
-    /// through the base (`overnightindexedswap.rs:241`).
+    /// Return the fixed rate that zeroes the swap NPV.
     ///
-    /// Fallible: the swap must be non-expired and its engine must price.
+    /// Returns:
+    ///     float: The fair fixed rate, read through the swap's base.
+    ///
+    /// Raises:
+    ///     ItofinError: If the swap has expired or its engine fails to price.
     fn fair_rate(&mut self) -> PyResult<f64> {
         Ok(self
             .inner
@@ -63,8 +55,11 @@ impl PyOvernightIndexedSwap {
             .map_err(PyQlError::from)?)
     }
 
-    /// Forces the valuation, idempotent and fallible as
-    /// [`VanillaOption.calculate`](crate::option::PyVanillaOption::calculate).
+    /// Force the valuation. Idempotent.
+    ///
+    /// Raises:
+    ///     ItofinError: If no evaluation date is set or the engine refuses the
+    ///         swap.
     fn calculate(&mut self) -> PyResult<()> {
         Ok(self
             .inner
@@ -73,38 +68,63 @@ impl PyOvernightIndexedSwap {
             .map_err(PyQlError::from)?)
     }
 
-    /// Whether the cached results are currently valid.
+    /// Return whether the cached results are currently valid.
+    ///
+    /// Returns:
+    ///     bool: True when the next accessor reads the cache.
     fn is_calculated(&self) -> bool {
         self.inner.borrow().base().is_calculated()
     }
 
-    /// Prices and returns the NPV.
+    /// Price the swap and return the NPV.
     ///
-    /// The only no-argument `price()` of the nine facades: [`PyMakeOis::build`]
-    /// attaches the discounting engine, so there is no engine left to install
-    /// here. A swap that somehow reached Python without one surfaces the core's
-    /// `"null pricing engine"`, exactly as [`npv`](Self::npv) does.
+    /// The only no-argument price(): MakeOis already attached the discounting
+    /// engine, so none is left to install.
+    ///
+    /// Returns:
+    ///     float: The present value.
+    ///
+    /// Raises:
+    ///     ItofinError: On anything that makes the valuation fail, including
+    ///         the "null pricing engine" a swap that somehow arrived without
+    ///         one reports.
     fn price(&mut self) -> PyResult<f64> {
         self.calculate()?;
         self.npv()
     }
 
-    /// A frozen [`Results`] copy of the valuation, calculating first.
+    /// Return a frozen snapshot of the valuation, calculating first.
+    ///
+    /// Returns:
+    ///     Results: A copy of the valuation results.
+    ///
+    /// Raises:
+    ///     ItofinError: On anything that makes the valuation fail.
     fn results(&mut self) -> PyResult<Results> {
         self.calculate()?;
         let inner = self.inner.borrow();
         Ok(Results::snapshot(inner.base()))
     }
 
-    /// The swap NPV under the engine [`PyMakeOis::build`] attached.
+    /// Return the swap NPV under the engine the builder attached.
+    ///
+    /// Returns:
+    ///     float: The present value.
+    ///
+    /// Raises:
+    ///     ItofinError: On anything that makes the valuation fail.
     fn npv(&mut self) -> PyResult<f64> {
         Ok(self.inner.borrow_mut().npv().map_err(PyQlError::from)?)
     }
 
-    /// The swap nominal, read through the base (`nominal()`).
+    /// Return the notional both legs accrue on.
     ///
-    /// Fallible: the base errors on a swap whose legs carry per-coupon
-    /// nominals, which has no single one to report.
+    /// Returns:
+    ///     float: The single nominal, read through the swap's base.
+    ///
+    /// Raises:
+    ///     ItofinError: If the legs carry per-coupon nominals, which leaves no
+    ///         single one to report.
     fn nominal(&self) -> PyResult<f64> {
         Ok(self
             .inner
@@ -114,8 +134,11 @@ impl PyOvernightIndexedSwap {
             .map_err(PyQlError::from)?)
     }
 
-    /// The fixed-leg rate: the rate given to the builder, or the fair rate it
-    /// filled in for a `fixed_rate=None` par swap.
+    /// Return the fixed-leg rate.
+    ///
+    /// Returns:
+    ///     float: The rate given to the builder, or the fair rate it filled in
+    ///         for a par swap.
     fn fixed_rate(&self) -> f64 {
         self.inner.borrow().fixed_vs_floating().fixed_rate()
     }
@@ -128,26 +151,21 @@ impl PyOvernightIndexedSwap {
     }
 }
 
-/// Python `MakeOis`: the market-convention builder for a
-/// [`PyOvernightIndexedSwap`] (`instruments::makeois::MakeOis`).
+/// Market-convention builder for an OvernightIndexedSwap.
 ///
 /// Derives the start and end dates, both schedules and the discounting engine
 /// from a swap tenor and an overnight index, so the caller states conventions
-/// instead of hand-building two schedules. `fixed_rate=None` builds a par swap:
-/// the fair rate is computed off a temporary swap and written into the fixed
-/// leg (`makeois.rs:461-469`), so the result prices to a zero NPV.
+/// instead of hand-building two schedules. ``fixed_rate=None`` builds a par
+/// swap: the fair rate is computed off a temporary swap and written into the
+/// fixed leg, so the result prices to a zero NPV.
 ///
-/// The core's `with_*` chain consumes the builder by value, which a
-/// `#[pyclass]` cannot hand out, so the overrides are constructor keywords
-/// instead and the chain is assembled inside [`build`](Self::build). Only the
-/// five the OIS reprice oracle needs are exposed - `effective_date`,
-/// `nominal`, `payment_lag`, `discounting_term_structure` and
-/// `averaging_method`. Every other core override (the swap type, the overnight
-/// spread, the fixed-leg day count, the settlement days, the termination date,
-/// the payment frequency and calendar, the schedule conventions and rule, the
-/// end-of-month flag) is deferred and keeps its core default; the four the core
-/// rejects outright (telescopic value dates, lookback, lockout, observation
-/// shift, `makeois.rs:364-387`) are unreachable from here by construction.
+/// The core builder is a consumed-self fluent chain, which does not cross the
+/// FFI boundary; this facade takes the overrides as constructor keywords and
+/// assembles the chain inside build(). Only five overrides are exposed; every
+/// other core one keeps its default, and the four the core rejects outright
+/// (telescopic value dates, lookback, lockout and observation shift) are
+/// unreachable from here by construction. The built swap already carries its
+/// DiscountingSwapEngine.
 #[pyclass(name = "MakeOis", unsendable)]
 pub struct PyMakeOis {
     swap_tenor: Period,
@@ -164,6 +182,27 @@ pub struct PyMakeOis {
 
 #[pymethods]
 impl PyMakeOis {
+    /// Store the configuration the chain is assembled from in build().
+    ///
+    /// Args:
+    ///     swap_tenor (Period): The length of the swap.
+    ///     overnight_index (OvernightIndex): The index the overnight leg
+    ///         compounds.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date and the stored fixings.
+    ///     fixed_rate (float | None): The rate of the fixed leg; None builds a
+    ///         par swap.
+    ///     forward_start (Period | None): The delay before the swap starts;
+    ///         None starts it spot, at a zero-day period.
+    ///     effective_date (Date | None): The start date; None derives it from
+    ///         the evaluation date.
+    ///     nominal (float | None): The notional; None keeps the core default.
+    ///     payment_lag (int | None): The days between accrual end and payment;
+    ///         None keeps the core default.
+    ///     discounting_term_structure (YieldTermStructure | None): The curve
+    ///         the flows discount on; None keeps the core default.
+    ///     averaging_method (RateAveraging | None): Whether the overnight
+    ///         fixings compound or are averaged; None keeps the core default.
     #[new]
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (
@@ -206,12 +245,16 @@ impl PyMakeOis {
         }
     }
 
-    /// Builds the priced swap.
+    /// Build the priced swap.
     ///
-    /// Fallible: without an `effective_date` the start date is derived from the
-    /// evaluation date, so an unset one is an error (D10); the schedule and the
-    /// overnight leg can be degenerate; and the par-rate fill propagates a
-    /// pricing failure.
+    /// Returns:
+    ///     OvernightIndexedSwap: The swap, already carrying its discounting
+    ///         engine.
+    ///
+    /// Raises:
+    ///     ItofinError: If effective_date is unset and no evaluation date is
+    ///         set to derive the start from; if the schedule or the overnight
+    ///         leg is degenerate; or if the par-rate fill fails to price.
     fn build(&self) -> PyResult<PyOvernightIndexedSwap> {
         let mut maker = MakeOis::new(
             self.swap_tenor,

--- a/crates/itofin-py/src/ois.rs
+++ b/crates/itofin-py/src/ois.rs
@@ -1,11 +1,10 @@
-//! Facades for the overnight-indexed-swap stack: [`PyOvernightIndexedSwap`]
-//! and the [`PyMakeOis`] builder.
+//! Facades for the overnight-indexed-swap stack: OvernightIndexedSwap and the
+//! MakeOis builder.
 //!
-//! The OIS analogue of [`crate::swap`]: the builder derives both schedules and
-//! the discounting engine from a swap tenor and an overnight index, and
-//! [`PyMakeOis::build`] returns a swap that already carries its
-//! [`DiscountingSwapEngine`] (`makeois.rs:508-516`), so it prices straight
-//! away.
+//! The OIS analogue of swap(): the builder derives both schedules and the
+//! discounting engine from a swap tenor and an overnight index, and
+//! MakeOis.build() returns a swap that already carries its
+//! DiscountingSwapEngine, so it prices straight away.
 
 use crate::PyQlError;
 use crate::curve::PyYieldTermStructure;
@@ -145,7 +144,7 @@ impl PyOvernightIndexedSwap {
 }
 
 impl PyOvernightIndexedSwap {
-    /// Wraps the swap [`PyMakeOis::build`] hands back.
+    /// Wraps the swap MakeOis.build() hands back.
     fn from_inner(inner: SharedMut<OvernightIndexedSwap>) -> PyOvernightIndexedSwap {
         PyOvernightIndexedSwap { inner }
     }

--- a/crates/itofin-py/src/option.rs
+++ b/crates/itofin-py/src/option.rs
@@ -19,11 +19,10 @@ use libitofin::types::Real;
 use pyo3::prelude::*;
 use pyo3::types::PyType;
 
-/// Python `OptionType`: the call/put flag (core `option::OptionType`).
+/// The call/put flag.
 ///
-/// A fieldless pyo3 enum exposing `OptionType.Call` / `OptionType.Put`; the
-/// signed discriminant convention lives in the core, so the facade only maps
-/// the variant across.
+/// A fieldless enum mirroring the core option type; the signed discriminant
+/// convention behind the two variants stays in the core.
 #[pyclass(name = "OptionType", eq, eq_int, from_py_object)]
 #[derive(Clone, Copy, PartialEq)]
 pub enum PyOptionType {
@@ -41,15 +40,11 @@ impl PyOptionType {
     }
 }
 
-/// Python `VanillaOption`: a single-asset vanilla option (core
-/// `instruments::VanillaOption`, an alias of `OneAssetOption`).
+/// A single-asset vanilla option: European by construction, American through american().
 ///
-/// The constructor builds the European-exercise option; the `american`
-/// classmethod builds the American-exercise one.
-///
-/// Holds the option by value so the lazily-computed results can be produced
-/// through `&mut self` accessors; the inner instrument is `Rc`/`RefCell`-based
-/// and therefore `!Send`, hence `unsendable`.
+/// Valuation is lazy: an accessor reprices only once an observed input - the
+/// attached engine, or the evaluation date on the Settings the option
+/// registered with - has notified it.
 #[pyclass(name = "VanillaOption", unsendable)]
 pub struct PyVanillaOption {
     inner: VanillaOption,
@@ -57,6 +52,14 @@ pub struct PyVanillaOption {
 
 #[pymethods]
 impl PyVanillaOption {
+    /// Build the European-exercise option, exercisable only at expiry.
+    ///
+    /// Args:
+    ///     option_type (OptionType): Whether the payoff is a call or a put.
+    ///     strike (float): The strike of the plain vanilla payoff.
+    ///     expiry (Date): The single date the option may be exercised on.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date the option prices against.
     #[new]
     fn new(option_type: PyOptionType, strike: f64, expiry: &PyDate, settings: &PySettings) -> Self {
         let payoff = shared(PlainVanillaPayoff::new(option_type.inner(), strike))
@@ -67,13 +70,25 @@ impl PyVanillaOption {
         }
     }
 
-    /// The same option struck at `strike` but exercisable at any time over
-    /// `[earliest, latest]`, paying on exercise rather than at expiry.
+    /// Build the option exercisable at any time over [earliest, latest].
     ///
-    /// This is the exercise the Monte Carlo American engine requires; the
-    /// analytic European engine rejects it.
+    /// The option pays on exercise rather than at expiry. This is the exercise
+    /// the Monte Carlo American engine requires; the analytic European engine
+    /// rejects it.
     ///
-    /// Raises `ItofinError` when `earliest` is after `latest`.
+    /// Args:
+    ///     option_type (OptionType): Whether the payoff is a call or a put.
+    ///     strike (float): The strike of the plain vanilla payoff.
+    ///     earliest (Date): The first date the option may be exercised on.
+    ///     latest (Date): The last date the option may be exercised on.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date the option prices against.
+    ///
+    /// Returns:
+    ///     VanillaOption: The American-exercise option.
+    ///
+    /// Raises:
+    ///     ItofinError: If earliest is after latest.
     #[classmethod]
     fn american(
         _cls: &Bound<'_, PyType>,
@@ -93,8 +108,11 @@ impl PyVanillaOption {
         })
     }
 
-    /// Attaches an analytic European engine built on `process`, threading in
-    /// the exact same Black-Scholes process the Python object holds.
+    /// Attach an analytic European engine built on process.
+    ///
+    /// Args:
+    ///     process (BlackScholesProcess): The process the engine prices on;
+    ///         the exact object this Python instance holds is threaded in.
     fn set_engine(&mut self, process: &PyBlackScholesProcess) {
         let engine = shared_mut(AnalyticEuropeanEngine::new(process.inner()));
         self.inner
@@ -102,12 +120,18 @@ impl PyVanillaOption {
             .set_pricing_engine(engine as SharedMut<dyn PricingEngine>);
     }
 
-    /// Attaches an analytic Heston engine built on `model` with a Gauss-Laguerre
-    /// integration of `integration_order` (fallible: order > 192 errors).
+    /// Attach an analytic Heston engine built on model.
     ///
-    /// The analytic Heston engine fills only `results.value`, so `npv()` works
-    /// but the greeks (`delta()`, `gamma()`, ...) raise `ItofinError` ("not
-    /// provided") on this path.
+    /// The analytic Heston engine fills only the value, so npv() works but the
+    /// greeks raise on this path.
+    ///
+    /// Args:
+    ///     model (HestonModel): The calibrated Heston model to price under.
+    ///     integration_order (int): The order of the Gauss-Laguerre
+    ///         integration.
+    ///
+    /// Raises:
+    ///     ItofinError: If integration_order exceeds 192.
     fn set_heston_engine(
         &mut self,
         model: &PyHestonModel,
@@ -121,160 +145,275 @@ impl PyVanillaOption {
         Ok(())
     }
 
-    /// Attaches the Monte Carlo European engine `engine`, which already holds
-    /// the process it prices on.
+    /// Attach the Monte Carlo European engine.
+    ///
+    /// Args:
+    ///     engine (MCEuropeanEngine): The engine, which already holds the
+    ///         process it prices on.
     fn set_mc_engine(&mut self, engine: &PyMCEuropeanEngine) {
         self.inner.base_mut().set_pricing_engine(engine.engine());
     }
 
-    /// Attaches the Monte Carlo Heston engine `engine`, which already holds the
-    /// Heston process it prices on.
+    /// Attach the Monte Carlo Heston engine.
+    ///
+    /// Args:
+    ///     engine (MCEuropeanHestonEngine): The engine, which already holds
+    ///         the Heston process it prices on.
     fn set_mc_heston_engine(&mut self, engine: &PyMCEuropeanHestonEngine) {
         self.inner.base_mut().set_pricing_engine(engine.engine());
     }
 
-    /// Attaches the Monte Carlo American engine `engine`, which already holds
-    /// the process it prices on.
+    /// Attach the Monte Carlo American engine.
     ///
-    /// The option must have been built through `american`: pricing a
-    /// European-exercise option on this engine raises `ItofinError` ("wrong
-    /// exercise given") from `npv()`.
+    /// The option must have been built through american(): a European-exercise
+    /// option raises ItofinError ("wrong exercise given") from npv().
+    ///
+    /// Args:
+    ///     engine (MCAmericanEngine): The engine, which already holds the
+    ///         process it prices on.
     fn set_mc_american_engine(&mut self, engine: &PyMCAmericanEngine) {
         self.inner.base_mut().set_pricing_engine(engine.engine());
     }
 
-    /// Forces the valuation, so a later accessor reads a cache that is already
-    /// warm.
+    /// Force the valuation, so a later accessor reads a warm cache.
     ///
     /// Idempotent: the core short-circuits on a valid cache, and the option
-    /// only reprices once an observed input - the engine, or the settings
-    /// evaluation date it registered with - has notified it.
+    /// reprices only once an observed input notified it.
     ///
-    /// Fallible for everything a pricing accessor is: no engine attached, no
-    /// evaluation date set, an engine that refuses the option.
+    /// Raises:
+    ///     ItofinError: If no engine is attached, no evaluation date is set,
+    ///         or the attached engine refuses the option.
     fn calculate(&mut self) -> PyResult<()> {
         Ok(self.inner.calculate().map_err(PyQlError::from)?)
     }
 
-    /// Whether the cached results are currently valid, that is, whether the
-    /// next accessor reads the cache or reprices.
+    /// Return whether the cached results are currently valid.
+    ///
+    /// Returns:
+    ///     bool: True when the next accessor reads the cache rather than
+    ///         repricing.
     fn is_calculated(&self) -> bool {
         self.inner.base().is_calculated()
     }
 
-    /// Attaches an analytic European engine on `process` and returns the NPV,
-    /// the one-shot form of [`set_engine`](Self::set_engine) followed by
-    /// [`npv`](Self::npv).
+    /// Attach an analytic European engine on process and return the NPV.
     ///
-    /// The other engines have their own one-shots:
-    /// [`price_heston`](Self::price_heston), [`price_mc`](Self::price_mc),
-    /// [`price_mc_heston`](Self::price_mc_heston) and
-    /// [`price_mc_american`](Self::price_mc_american).
+    /// The one-shot form of set_engine followed by npv. The other engines have
+    /// their own one-shots: price_heston, price_mc, price_mc_heston and
+    /// price_mc_american.
+    ///
+    /// Args:
+    ///     process (BlackScholesProcess): The process the engine prices on.
+    ///
+    /// Returns:
+    ///     float: The present value under the analytic European engine.
+    ///
+    /// Raises:
+    ///     ItofinError: If no evaluation date is set or the engine refuses the
+    ///         option.
     fn price(&mut self, process: &PyBlackScholesProcess) -> PyResult<f64> {
         self.set_engine(process);
         self.calculate()?;
         self.npv()
     }
 
-    /// Attaches an analytic Heston engine on `model` at `integration_order` and
-    /// returns the NPV, the one-shot form of
-    /// [`set_heston_engine`](Self::set_heston_engine) followed by
-    /// [`npv`](Self::npv).
+    /// Attach an analytic Heston engine on model and return the NPV.
     ///
-    /// Fallible where the setter is: an `integration_order` above 192 raises
-    /// `ItofinError` before any engine is attached. The greeks stay unavailable
-    /// on this path.
+    /// The one-shot form of set_heston_engine followed by npv. The greeks stay
+    /// unavailable on this path.
+    ///
+    /// Args:
+    ///     model (HestonModel): The calibrated Heston model to price under.
+    ///     integration_order (int): The order of the Gauss-Laguerre
+    ///         integration.
+    ///
+    /// Returns:
+    ///     float: The present value under the analytic Heston engine.
+    ///
+    /// Raises:
+    ///     ItofinError: If integration_order exceeds 192, no evaluation date is
+    ///         set, or the engine refuses the option.
     fn price_heston(&mut self, model: &PyHestonModel, integration_order: usize) -> PyResult<f64> {
         self.set_heston_engine(model, integration_order)?;
         self.calculate()?;
         self.npv()
     }
 
-    /// Attaches the Monte Carlo European engine `engine` and returns the NPV,
-    /// the one-shot form of [`set_mc_engine`](Self::set_mc_engine) followed by
-    /// [`npv`](Self::npv).
+    /// Attach the Monte Carlo European engine and return the NPV.
+    ///
+    /// The one-shot form of set_mc_engine followed by npv.
+    ///
+    /// Args:
+    ///     engine (MCEuropeanEngine): The engine, which already holds the
+    ///         process it prices on.
+    ///
+    /// Returns:
+    ///     float: The present value under the Monte Carlo European engine.
+    ///
+    /// Raises:
+    ///     ItofinError: If no evaluation date is set or the engine refuses the
+    ///         option.
     fn price_mc(&mut self, engine: &PyMCEuropeanEngine) -> PyResult<f64> {
         self.set_mc_engine(engine);
         self.calculate()?;
         self.npv()
     }
 
-    /// Attaches the Monte Carlo Heston engine `engine` and returns the NPV, the
-    /// one-shot form of
-    /// [`set_mc_heston_engine`](Self::set_mc_heston_engine) followed by
-    /// [`npv`](Self::npv).
+    /// Attach the Monte Carlo Heston engine and return the NPV.
+    ///
+    /// The one-shot form of set_mc_heston_engine followed by npv.
+    ///
+    /// Args:
+    ///     engine (MCEuropeanHestonEngine): The engine, which already holds
+    ///         the Heston process it prices on.
+    ///
+    /// Returns:
+    ///     float: The present value under the Monte Carlo Heston engine.
+    ///
+    /// Raises:
+    ///     ItofinError: If no evaluation date is set or the engine refuses the
+    ///         option.
     fn price_mc_heston(&mut self, engine: &PyMCEuropeanHestonEngine) -> PyResult<f64> {
         self.set_mc_heston_engine(engine);
         self.calculate()?;
         self.npv()
     }
 
-    /// Attaches the Monte Carlo American engine `engine` and returns the NPV,
-    /// the one-shot form of
-    /// [`set_mc_american_engine`](Self::set_mc_american_engine) followed by
-    /// [`npv`](Self::npv).
+    /// Attach the Monte Carlo American engine and return the NPV.
     ///
-    /// The option must have been built through `american`: a European-exercise
-    /// option raises `ItofinError` ("wrong exercise given").
+    /// The one-shot form of set_mc_american_engine followed by npv. The option
+    /// must have been built through american(): a European-exercise option
+    /// raises ItofinError ("wrong exercise given").
+    ///
+    /// Args:
+    ///     engine (MCAmericanEngine): The engine, which already holds the
+    ///         process it prices on.
+    ///
+    /// Returns:
+    ///     float: The present value under the Monte Carlo American engine.
+    ///
+    /// Raises:
+    ///     ItofinError: If the option is not American-exercise, no evaluation
+    ///         date is set, or the engine refuses the option.
     fn price_mc_american(&mut self, engine: &PyMCAmericanEngine) -> PyResult<f64> {
         self.set_mc_american_engine(engine);
         self.calculate()?;
         self.npv()
     }
 
-    /// A frozen [`Results`] copy of the valuation, calculating first.
+    /// Return a frozen snapshot of the valuation, calculating first.
     ///
     /// The snapshot does not track the option: once taken, an evaluation-date
     /// or engine change reprices the live accessors and leaves it alone.
+    ///
+    /// Returns:
+    ///     Results: A copy of the valuation results.
+    ///
+    /// Raises:
+    ///     ItofinError: On anything that makes the valuation fail.
     fn results(&mut self) -> PyResult<Results> {
         self.calculate()?;
         Ok(Results::snapshot(self.inner.base()))
     }
 
-    /// The present value, erroring when no evaluation date or engine is set.
+    /// Return the present value.
+    ///
+    /// Returns:
+    ///     float: The option value under the attached engine.
+    ///
+    /// Raises:
+    ///     ItofinError: If no evaluation date or no engine is set.
     fn npv(&mut self) -> PyResult<f64> {
         Ok(self.inner.npv().map_err(PyQlError::from)?)
     }
 
-    /// The option delta.
+    /// Return the option delta.
+    ///
+    /// Returns:
+    ///     float: The sensitivity to the underlying spot.
+    ///
+    /// Raises:
+    ///     ItofinError: If the attached engine does not provide it, which the
+    ///         analytic Heston engine does not.
     fn delta(&mut self) -> PyResult<f64> {
         Ok(self.inner.delta().map_err(PyQlError::from)?)
     }
 
-    /// The option gamma.
+    /// Return the option gamma.
+    ///
+    /// Returns:
+    ///     float: The second-order sensitivity to the underlying spot.
+    ///
+    /// Raises:
+    ///     ItofinError: If the attached engine does not provide it.
     fn gamma(&mut self) -> PyResult<f64> {
         Ok(self.inner.gamma().map_err(PyQlError::from)?)
     }
 
-    /// The option theta.
+    /// Return the option theta.
+    ///
+    /// Returns:
+    ///     float: The sensitivity to the passage of time.
+    ///
+    /// Raises:
+    ///     ItofinError: If the attached engine does not provide it.
     fn theta(&mut self) -> PyResult<f64> {
         Ok(self.inner.theta().map_err(PyQlError::from)?)
     }
 
-    /// The option vega.
+    /// Return the option vega.
+    ///
+    /// Returns:
+    ///     float: The sensitivity to the volatility.
+    ///
+    /// Raises:
+    ///     ItofinError: If the attached engine does not provide it.
     fn vega(&mut self) -> PyResult<f64> {
         Ok(self.inner.vega().map_err(PyQlError::from)?)
     }
 
-    /// The option rho.
+    /// Return the option rho.
+    ///
+    /// Returns:
+    ///     float: The sensitivity to the risk-free rate.
+    ///
+    /// Raises:
+    ///     ItofinError: If the attached engine does not provide it.
     fn rho(&mut self) -> PyResult<f64> {
         Ok(self.inner.rho().map_err(PyQlError::from)?)
     }
 
-    /// The option dividend rho.
+    /// Return the option dividend rho.
+    ///
+    /// Returns:
+    ///     float: The sensitivity to the dividend yield.
+    ///
+    /// Raises:
+    ///     ItofinError: If the attached engine does not provide it.
     fn dividend_rho(&mut self) -> PyResult<f64> {
         Ok(self.inner.dividend_rho().map_err(PyQlError::from)?)
     }
 
-    /// The standard error on the present value, raising `ItofinError` on the
-    /// engines that do not produce one (every analytic engine here).
+    /// Return the standard error on the present value.
+    ///
+    /// Returns:
+    ///     float: The Monte Carlo standard error.
+    ///
+    /// Raises:
+    ///     ItofinError: On the engines that do not produce one, which is every
+    ///         analytic engine here.
     fn error_estimate(&mut self) -> PyResult<f64> {
         Ok(self.inner.error_estimate().map_err(PyQlError::from)?)
     }
 
-    /// The fraction of simulated paths exercised before expiry, raising
-    /// `ItofinError` on every engine that does not report it - only the Monte
-    /// Carlo American engine does.
+    /// Return the fraction of simulated paths exercised before expiry.
+    ///
+    /// Returns:
+    ///     float: The exercise probability reported by the engine.
+    ///
+    /// Raises:
+    ///     ItofinError: On every engine that does not report it - only
+    ///         MCAmericanEngine does.
     fn exercise_probability(&mut self) -> PyResult<f64> {
         Ok(self
             .inner

--- a/crates/itofin-py/src/option.rs
+++ b/crates/itofin-py/src/option.rs
@@ -1,4 +1,4 @@
-//! Facades for the option instrument: [`PyOptionType`] and [`PyVanillaOption`].
+//! Facades for the option instrument: OptionType and VanillaOption.
 
 use crate::PyQlError;
 use crate::heston::PyHestonModel;
@@ -31,7 +31,7 @@ pub enum PyOptionType {
 }
 
 impl PyOptionType {
-    /// The core [`OptionType`] this variant stands for.
+    /// The core OptionType this variant stands for.
     pub(crate) fn inner(self) -> OptionType {
         match self {
             PyOptionType::Call => OptionType::Call,

--- a/crates/itofin-py/src/optionletvol.rs
+++ b/crates/itofin-py/src/optionletvol.rs
@@ -37,15 +37,11 @@ use libitofin::termstructures::volatility::{
 use libitofin::termstructures::yieldtermstructure::YieldTermStructure;
 use pyo3::prelude::*;
 
-/// Python `OptionletVolatilityStructure`: the shared base for every caplet
-/// volatility surface
-/// (`termstructures::volatility::OptionletVolatilityStructure`).
+/// Shared base for every caplet/floorlet volatility surface: volatility,
+/// Black variance and the lognormal displacement.
 ///
-/// The option axis is addressed by tenor, the form the surfaces are quoted in;
-/// the core resolves the tenor against the surface's reference date and calendar
-/// before reading the volatility. The date form is exposed too, since the
-/// optionlet stripper and the cap/floor engine both address the surface by a
-/// coupon's fixing date.
+/// A single option axis, unlike the swaption surfaces: a query takes one option
+/// tenor (or date) and a strike.
 #[pyclass(name = "OptionletVolatilityStructure", subclass, unsendable)]
 pub struct PyOptionletVolatilityStructure {
     inner: Handle<dyn OptionletVolatilityStructure>,
@@ -53,7 +49,20 @@ pub struct PyOptionletVolatilityStructure {
 
 #[pymethods]
 impl PyOptionletVolatilityStructure {
-    /// The caplet volatility for an option tenor and strike.
+    /// Return the caplet volatility for an option tenor and strike.
+    ///
+    /// Args:
+    ///     option_tenor (Period): The option's tenor, resolved against the
+    ///         surface's reference date and calendar.
+    ///     strike (float): The strike the volatility is read at.
+    ///     extrapolate (bool): Whether to answer outside the surface's grid.
+    ///
+    /// Returns:
+    ///     float: The caplet volatility.
+    ///
+    /// Raises:
+    ///     ItofinError: If the query falls outside the grid and extrapolation
+    ///         is not allowed.
     #[pyo3(signature = (option_tenor, strike, extrapolate = false))]
     fn volatility(&self, option_tenor: &PyPeriod, strike: f64, extrapolate: bool) -> PyResult<f64> {
         Ok(self
@@ -64,7 +73,22 @@ impl PyOptionletVolatilityStructure {
             .map_err(PyQlError::from)?)
     }
 
-    /// The caplet volatility for an option date and strike.
+    /// Return the caplet volatility for an option date and strike.
+    ///
+    /// The date form the optionlet stripper and the cap/floor engine use, both
+    /// addressing the surface by a coupon's fixing date.
+    ///
+    /// Args:
+    ///     option_date (Date): The option date the volatility is read at.
+    ///     strike (float): The strike the volatility is read at.
+    ///     extrapolate (bool): Whether to answer outside the surface's grid.
+    ///
+    /// Returns:
+    ///     float: The caplet volatility.
+    ///
+    /// Raises:
+    ///     ItofinError: If the query falls outside the grid and extrapolation
+    ///         is not allowed.
     #[pyo3(signature = (option_date, strike, extrapolate = false))]
     fn volatility_date(
         &self,
@@ -80,7 +104,19 @@ impl PyOptionletVolatilityStructure {
             .map_err(PyQlError::from)?)
     }
 
-    /// The Black variance (`vol^2 * option_time`) for an option tenor and strike.
+    /// Return the Black variance, the squared volatility times option time.
+    ///
+    /// Args:
+    ///     option_tenor (Period): The option's tenor.
+    ///     strike (float): The strike the variance is read at.
+    ///     extrapolate (bool): Whether to answer outside the surface's grid.
+    ///
+    /// Returns:
+    ///     float: The Black variance.
+    ///
+    /// Raises:
+    ///     ItofinError: If the query falls outside the grid and extrapolation
+    ///         is not allowed.
     #[pyo3(signature = (option_tenor, strike, extrapolate = false))]
     fn black_variance(
         &self,
@@ -96,7 +132,10 @@ impl PyOptionletVolatilityStructure {
             .map_err(PyQlError::from)?)
     }
 
-    /// Whether the surface answers dates/times beyond its maximum.
+    /// Return whether the surface answers dates and times beyond its maximum.
+    ///
+    /// Returns:
+    ///     bool: True when extrapolation is enabled on the surface itself.
     fn allows_extrapolation(&self) -> PyResult<bool> {
         Ok(self
             .inner
@@ -105,12 +144,10 @@ impl PyOptionletVolatilityStructure {
             .allows_extrapolation())
     }
 
-    /// Allows extrapolation past the maximum date/time.
+    /// Allow extrapolation past the maximum date and time.
     ///
-    /// A stripped surface ends at its last optionlet fixing, so a cap whose own
-    /// last caplet fixes there queries the boundary; the core's round-trip
-    /// fixture enables extrapolation before repricing
-    /// (`strippedoptionletadapter.rs:393`).
+    /// A stripped surface ends at its last optionlet fixing, so a cap whose
+    /// own last caplet fixes there queries the boundary.
     fn enable_extrapolation(&self) -> PyResult<()> {
         self.inner
             .current_link()
@@ -119,7 +156,7 @@ impl PyOptionletVolatilityStructure {
         Ok(())
     }
 
-    /// Forbids extrapolation past the maximum date/time.
+    /// Forbid extrapolation past the maximum date and time.
     fn disable_extrapolation(&self) -> PyResult<()> {
         self.inner
             .current_link()
@@ -128,11 +165,14 @@ impl PyOptionletVolatilityStructure {
         Ok(())
     }
 
-    /// The lognormal shift applied to forwards and strikes; `0.0` for the
-    /// unshifted lognormal and the normal model.
+    /// Return the lognormal shift applied to forwards and strikes.
     ///
-    /// This is what `BlackCapFloorEngine` checks a caller-supplied displacement
+    /// This is what BlackCapFloorEngine checks a caller-supplied displacement
     /// against, so it is the number to read before pinning one on the engine.
+    ///
+    /// Returns:
+    ///     float: The shift; zero for the unshifted lognormal and the normal
+    ///         model.
     fn displacement(&self) -> PyResult<f64> {
         Ok(self
             .inner
@@ -141,11 +181,18 @@ impl PyOptionletVolatilityStructure {
             .displacement())
     }
 
-    /// The date every option time is measured from.
+    /// Return the date every option time is measured from.
     ///
-    /// Pinned at construction on the fixed-reference surfaces; derived from the
-    /// `Settings` evaluation date (settlement days on the calendar) on the
-    /// moving ones, so it follows a later `set_evaluation_date`.
+    /// Pinned at construction on the fixed-reference surfaces; derived from
+    /// the Settings evaluation date (settlement days on the calendar) on the
+    /// moving ones, so it follows a later set_evaluation_date.
+    ///
+    /// Returns:
+    ///     Date: The surface's reference date.
+    ///
+    /// Raises:
+    ///     ItofinError: On a moving surface whose Settings has no evaluation
+    ///         date set.
     fn reference_date(&self) -> PyResult<PyDate> {
         Ok(PyDate::from_inner(
             self.inner
@@ -172,23 +219,33 @@ impl PyOptionletVolatilityStructure {
     }
 }
 
-/// Python `ConstantOptionletVolatility`: a single caplet volatility with no
-/// option-time or strike dependence
-/// (`termstructures::volatility::ConstantOptionletVolatility`).
+/// A single caplet volatility with no option-time or strike dependence.
 ///
-/// Extends [`PyOptionletVolatilityStructure`] and supplies only the
-/// constructors; the query surface is inherited. Unbounded in time and strike,
-/// so queries never need extrapolation enabled. [`new`](Self::new) and
-/// [`with_quote`](Self::with_quote) pin the reference date;
-/// [`moving`](Self::moving) and [`moving_with_quote`](Self::moving_with_quote)
-/// float it off the `Settings` evaluation date (#627).
+/// The constructor and with_quote pin the reference date, so every query's
+/// option time runs from reference_date rather than the evaluation date. The
+/// moving and moving_with_quote forms float the reference date off the
+/// Settings evaluation date instead (#627).
 #[pyclass(name = "ConstantOptionletVolatility", extends = PyOptionletVolatilityStructure, unsendable)]
 pub struct PyConstantOptionletVolatility;
 
 #[pymethods]
 impl PyConstantOptionletVolatility {
-    /// A constant surface at a fixed `volatility`, wrapped in an internal quote
-    /// the caller cannot later mutate.
+    /// Build the surface at a fixed volatility.
+    ///
+    /// Args:
+    ///     reference_date (Date): The date every query's option time runs
+    ///         from.
+    ///     calendar (Calendar): The calendar option tenors resolve on.
+    ///     business_day_convention (BusinessDayConvention): The roll applied
+    ///         when resolving a tenor to a date.
+    ///     volatility (float): The single volatility answered everywhere,
+    ///         wrapped in an internal quote the caller cannot later mutate.
+    ///     day_counter (DayCounter): The day count option times are measured
+    ///         in.
+    ///     volatility_type (VolatilityType): Whether the quote is
+    ///         shifted-lognormal or normal.
+    ///     displacement (float): The lognormal shift applied to forwards and
+    ///         strikes.
     #[new]
     #[pyo3(signature = (reference_date, calendar, business_day_convention, volatility, day_counter, volatility_type, displacement = 0.0))]
     fn new(
@@ -215,8 +272,25 @@ impl PyConstantOptionletVolatility {
         .add_subclass(PyConstantOptionletVolatility)
     }
 
-    /// A constant surface reading `volatility` from the caller's quote; a later
-    /// `set_value` on that quote notifies the surface's observers.
+    /// Build the surface reading its volatility from a live quote.
+    ///
+    /// Args:
+    ///     reference_date (Date): The date every query's option time runs
+    ///         from.
+    ///     calendar (Calendar): The calendar option tenors resolve on.
+    ///     business_day_convention (BusinessDayConvention): The roll applied
+    ///         when resolving a tenor to a date.
+    ///     volatility (SimpleQuote): The volatility; a later set_value
+    ///         notifies the surface's observers.
+    ///     day_counter (DayCounter): The day count option times are measured
+    ///         in.
+    ///     volatility_type (VolatilityType): Whether the quote is
+    ///         shifted-lognormal or normal.
+    ///     displacement (float): The lognormal shift applied to forwards and
+    ///         strikes.
+    ///
+    /// Returns:
+    ///     ConstantOptionletVolatility: The surface over that quote.
     #[staticmethod]
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (reference_date, calendar, business_day_convention, volatility, day_counter, volatility_type, displacement = 0.0))]
@@ -248,9 +322,31 @@ impl PyConstantOptionletVolatility {
         )
     }
 
-    /// A constant surface whose reference date floats off `settings`'
-    /// evaluation date by `settlement_days` on `calendar`, at a fixed
-    /// `volatility` wrapped in an internal quote the caller cannot later mutate.
+    /// Build the surface with a reference date floating off the evaluation date.
+    ///
+    /// The reference date is the evaluation date advanced by settlement_days
+    /// business days on calendar, so it follows a later set_evaluation_date.
+    ///
+    /// Args:
+    ///     settlement_days (int): Business days between the evaluation date
+    ///         and the reference date.
+    ///     calendar (Calendar): The calendar the reference date is derived on
+    ///         and option tenors resolve on.
+    ///     business_day_convention (BusinessDayConvention): The roll applied
+    ///         when resolving a tenor to a date.
+    ///     volatility (float): The single volatility answered everywhere,
+    ///         wrapped in an internal quote the caller cannot later mutate.
+    ///     day_counter (DayCounter): The day count option times are measured
+    ///         in.
+    ///     volatility_type (VolatilityType): Whether the quote is
+    ///         shifted-lognormal or normal.
+    ///     settings (Settings): The evaluation context the reference date
+    ///         floats off.
+    ///     displacement (float): The lognormal shift applied to forwards and
+    ///         strikes.
+    ///
+    /// Returns:
+    ///     ConstantOptionletVolatility: The moving surface.
     #[staticmethod]
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (settlement_days, calendar, business_day_convention, volatility, day_counter, volatility_type, settings, displacement = 0.0))]
@@ -284,9 +380,28 @@ impl PyConstantOptionletVolatility {
         )
     }
 
-    /// A constant surface whose reference date floats off `settings`'
-    /// evaluation date, reading `volatility` from the caller's quote; a later
-    /// `set_value` on that quote notifies the surface's observers.
+    /// Build the moving surface reading its volatility from a live quote.
+    ///
+    /// Args:
+    ///     settlement_days (int): Business days between the evaluation date
+    ///         and the reference date.
+    ///     calendar (Calendar): The calendar the reference date is derived on
+    ///         and option tenors resolve on.
+    ///     business_day_convention (BusinessDayConvention): The roll applied
+    ///         when resolving a tenor to a date.
+    ///     volatility (SimpleQuote): The volatility; a later set_value
+    ///         notifies the surface's observers.
+    ///     day_counter (DayCounter): The day count option times are measured
+    ///         in.
+    ///     volatility_type (VolatilityType): Whether the quote is
+    ///         shifted-lognormal or normal.
+    ///     settings (Settings): The evaluation context the reference date
+    ///         floats off.
+    ///     displacement (float): The lognormal shift applied to forwards and
+    ///         strikes.
+    ///
+    /// Returns:
+    ///     ConstantOptionletVolatility: The moving surface over that quote.
     #[staticmethod]
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (settlement_days, calendar, business_day_convention, volatility, day_counter, volatility_type, settings, displacement = 0.0))]
@@ -321,20 +436,17 @@ impl PyConstantOptionletVolatility {
     }
 }
 
-/// Python `OptionletStripper1`: bootstraps caplet volatilities out of a market
-/// cap/floor term-volatility surface
-/// (`termstructures::volatility::OptionletStripper1`).
+/// Bootstraps caplet volatilities out of a market cap/floor term-volatility
+/// surface.
 ///
-/// The stripper is not itself a volatility surface: it produces a grid of
-/// caplet volatilities that [`PyStrippedOptionletAdapter`] interpolates into
-/// one. It prices a cap at each of its own lengths off `term_vol_surface`,
-/// differences consecutive prices into a single caplet price, and inverts that
-/// for the caplet's implied volatility.
+/// Not itself a volatility surface: it produces a grid of caplet volatilities
+/// that StrippedOptionletAdapter interpolates into one. Stripping is lazy and
+/// cached, and re-runs only when a surface quote or the index changes.
 ///
-/// Stripping is lazy and cached: nothing runs until a query needs the grid, and
-/// it re-runs only when a surface quote or the index changes. The
-/// [`Normal`](crate::swaptionvol::PyVolatilityType::Normal) model is deferred
-/// (#440/#577) and fails at the strip rather than at construction.
+/// term_vol_surface must come from CapFloorTermVolSurface.moving or
+/// moving_with_quotes; a pinned-reference surface carries no settlement days
+/// and fails the adapter. VolatilityType.Normal is deferred (#440/#577) and
+/// fails at the strip, not at construction.
 #[pyclass(name = "OptionletStripper1", unsendable)]
 pub struct PyOptionletStripper1 {
     inner: Shared<OptionletStripper1>,
@@ -342,14 +454,31 @@ pub struct PyOptionletStripper1 {
 
 #[pymethods]
 impl PyOptionletStripper1 {
-    /// A stripper over `term_vol_surface` and `ibor_index`.
+    /// Build the stripper over a term-volatility surface and an index.
     ///
-    /// `term_vol_surface` must be one of the MOVING forms: the adapter reads
-    /// its settlement days back off the surface, and a pinned-reference surface
-    /// has none. `discount` is the curve the caps are priced on; `None` falls
-    /// back to the index's own forwarding curve. `accuracy` and `max_iter` size
-    /// the implied-volatility solve, and `optionlet_frequency` overrides the
-    /// index tenor as the caplet step.
+    /// It prices a cap at each of its own lengths off term_vol_surface,
+    /// differences consecutive prices into a single caplet price, and inverts
+    /// that for the caplet's implied volatility.
+    ///
+    /// Args:
+    ///     term_vol_surface (CapFloorTermVolSurface): The market term
+    ///         volatilities; it must be one of the moving forms, a
+    ///         pinned-reference surface carrying no settlement days.
+    ///     ibor_index (IborIndex): The index the caplets fix off.
+    ///     volatility_type (VolatilityType): The quoting convention; Normal is
+    ///         deferred and fails at the strip, not here.
+    ///     accuracy (float): The tolerance of the implied-volatility solve.
+    ///     max_iter (int): The iteration cap of that solve.
+    ///     displacement (float): The lognormal shift applied to forwards and
+    ///         strikes.
+    ///     discount (YieldTermStructure | None): The curve the caps are priced
+    ///         on; None falls back to the index's own forwarding curve.
+    ///     optionlet_frequency (Period | None): The caplet step; None uses the
+    ///         index tenor.
+    ///
+    /// Raises:
+    ///     ItofinError: On whatever the core rejects about the surface, the
+    ///         index or the solve parameters.
     #[new]
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (term_vol_surface, ibor_index, volatility_type, accuracy = 1e-6, max_iter = 100, displacement = 0.0, discount = None, optionlet_frequency = None))]
@@ -384,15 +513,28 @@ impl PyOptionletStripper1 {
         })
     }
 
-    /// The floating switch strike: the mean at-the-money caplet rate, which
-    /// decides whether each strike is stripped out of caps or out of floors.
+    /// Return the floating switch strike, the mean at-the-money caplet rate.
     ///
-    /// Fallible, and the first call triggers the strip.
+    /// It decides whether each strike is stripped out of caps or out of
+    /// floors. The first call triggers the strip.
+    ///
+    /// Returns:
+    ///     float: The switch strike.
+    ///
+    /// Raises:
+    ///     ItofinError: On a stripping failure, which a Normal volatility_type
+    ///         always is.
     fn switch_strike(&self) -> PyResult<f64> {
         Ok(self.inner.switch_strike().map_err(PyQlError::from)?)
     }
 
-    /// The at-the-money forward rate of each caplet, one per maturity.
+    /// Return the at-the-money forward rate of each caplet.
+    ///
+    /// Returns:
+    ///     list[float]: One rate per maturity.
+    ///
+    /// Raises:
+    ///     ItofinError: On a stripping failure.
     fn atm_optionlet_rates(&self) -> PyResult<Vec<f64>> {
         Ok(self.inner.atm_optionlet_rates().map_err(PyQlError::from)?)
     }
@@ -405,32 +547,36 @@ impl PyOptionletStripper1 {
     }
 }
 
-/// Python `StrippedOptionletAdapter`: serves a stripper's caplet volatility
-/// grid as an [`PyOptionletVolatilityStructure`]
-/// (`termstructures::volatility::StrippedOptionletAdapter`).
+/// Serves a stripper's caplet volatility grid as an
+/// OptionletVolatilityStructure: linear in strike within each maturity, then
+/// linear across maturities.
 ///
-/// This is what closes the cap/floor volatility loop: a
-/// [`PyBlackCapFloorEngine`](crate::capfloorengine::PyBlackCapFloorEngine)
-/// built on this surface reprices the caps the term volatilities were quoted
-/// on. Linear in strike within each maturity, then linear across maturities.
-///
-/// Extends [`PyOptionletVolatilityStructure`] and supplies only the
-/// constructor; the query surface is inherited. Its reference date floats off
-/// the evaluation date carried by `settings`, advanced by the settlement days
-/// the underlying term-volatility surface carries. The surface ends at the last
-/// caplet fixing, so pricing a cap that reaches it wants
-/// `enable_extrapolation()`.
+/// This closes the cap/floor volatility loop - a BlackCapFloorEngine on this
+/// surface reprices the caps the term volatilities were quoted on. The
+/// reference date floats off the evaluation date carried by settings, advanced
+/// by the term-volatility surface's settlement days. The surface ends at the
+/// last caplet fixing, so pricing a cap that reaches it wants
+/// enable_extrapolation().
 #[pyclass(name = "StrippedOptionletAdapter", extends = PyOptionletVolatilityStructure, unsendable)]
 pub struct PyStrippedOptionletAdapter;
 
 #[pymethods]
 impl PyStrippedOptionletAdapter {
-    /// The interpolated surface over `stripper`.
+    /// Build the interpolated surface over a stripper.
     ///
-    /// Fallible, and it strips eagerly: the constructor reads the caplet
-    /// strikes and fixing dates to snapshot its strike domain and maximum date.
-    /// It fails on a stripper whose term-volatility surface carries no
-    /// settlement days, which is every pinned-reference surface.
+    /// It strips eagerly: the constructor reads the caplet strikes and fixing
+    /// dates to snapshot its strike domain and maximum date.
+    ///
+    /// Args:
+    ///     stripper (OptionletStripper1): The stripper whose caplet grid is
+    ///         served.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date the reference date floats off.
+    ///
+    /// Raises:
+    ///     ItofinError: On a stripper whose term-volatility surface carries no
+    ///         settlement days, which is every pinned-reference surface, and
+    ///         on a stripping failure.
     #[new]
     fn new(
         stripper: &PyOptionletStripper1,

--- a/crates/itofin-py/src/optionletvol.rs
+++ b/crates/itofin-py/src/optionletvol.rs
@@ -1,15 +1,14 @@
 //! Facades for the optionlet (caplet/floorlet) volatility stack: the
-//! [`PyOptionletVolatilityStructure`] base, the constant surface
-//! [`PyConstantOptionletVolatility`], and the stripping pair
-//! [`PyOptionletStripper1`] / [`PyStrippedOptionletAdapter`] that turns market
-//! cap term volatilities into a caplet surface.
+//! OptionletVolatilityStructure base, the constant surface
+//! ConstantOptionletVolatility, and the stripping pair OptionletStripper1 /
+//! StrippedOptionletAdapter that turns market cap term volatilities into a
+//! caplet surface.
 //!
-//! The base holds the erased `Handle<dyn OptionletVolatilityStructure>` and
-//! exposes the queries every concrete surface inherits; concrete surfaces
+//! The base holds the surface type-erased and exposes the queries every
+//! concrete surface inherits; concrete surfaces
 //! subclass it and supply only their constructor. They build the base through
-//! [`from_handle`](PyOptionletVolatilityStructure::from_handle) rather than a
-//! struct literal, so the surfaces stacking on it in later tickets never need
-//! access to the private field.
+//! from_handle() rather than a struct literal, so the surfaces stacking on it
+//! in later tickets never need access to the private field.
 //!
 //! Unlike the swaption surfaces, an optionlet surface has a single option axis:
 //! a query takes one option tenor (or date) and a strike, not an option/swap

--- a/crates/itofin-py/src/results.rs
+++ b/crates/itofin-py/src/results.rs
@@ -13,23 +13,22 @@ use libitofin::types::Real;
 use pyo3::prelude::*;
 use std::collections::BTreeMap;
 
-/// Python `Results`: a read-only snapshot of one instrument valuation
-/// (core `instrument::InstrumentResults`).
+/// A read-only snapshot of one instrument valuation.
 ///
-/// Handed back by every facade's `results()`, which forces the calculation and
-/// then copies the four fields out. The object holds no borrow on the
-/// instrument and no handle to its inputs, so it keeps reporting the valuation
-/// it was taken from even after the instrument reprices.
+/// Handed back by every instrument facade's results(), which forces the
+/// calculation and then copies the four fields out. It holds a copy, not a
+/// view: once taken, an input change reprices the instrument's live accessors
+/// and leaves the snapshot reporting the valuation it was taken from.
 ///
-/// Every field is optional because the core stores it that way: an engine
+/// Every field is optional because the core stores it that way - an engine
 /// fills what it computes and leaves the rest unset. The analytic European
-/// engine, for instance, provides a value but neither an error estimate nor a
+/// engine, for one, provides a value but neither an error estimate nor a
 /// valuation date.
 ///
-/// `additional_results` is REAL-ONLY. The core keeps the engine's extra outputs
-/// as `Shared<dyn Any>` and the only sanctioned downcast in this crate is to
-/// `Real` (`option.rs`'s `exercise_probability`), so a tag holding anything
-/// else is omitted from the dict rather than guessed at.
+/// additional_results is REAL-ONLY: the core keeps the engine's extra outputs
+/// behind a type-erased handle whose only sanctioned downcast is to a real, so
+/// tags holding anything else are OMITTED from the dict rather than guessed
+/// at.
 #[pyclass(name = "Results", frozen)]
 pub struct Results {
     npv: Option<Real>,
@@ -40,27 +39,40 @@ pub struct Results {
 
 #[pymethods]
 impl Results {
-    /// The net present value, or `None` when the engine provided none.
+    /// The net present value.
+    ///
+    /// Returns:
+    ///     float | None: The value, or None when the engine provided none.
     #[getter]
     fn npv(&self) -> Option<f64> {
         self.npv
     }
 
-    /// The standard error on the value, or `None` on the engines that do not
-    /// produce one - every analytic engine here.
+    /// The standard error on the value.
+    ///
+    /// Returns:
+    ///     float | None: The standard error, or None on the engines that do
+    ///         not produce one, which is every analytic engine here.
     #[getter]
     fn error_estimate(&self) -> Option<f64> {
         self.error_estimate
     }
 
-    /// The date the value refers to, or `None` when the engine did not say.
+    /// The date the value refers to.
+    ///
+    /// Returns:
+    ///     Date | None: The valuation date, or None when the engine did not
+    ///         say.
     #[getter]
     fn valuation_date(&self) -> Option<PyDate> {
         self.valuation_date.map(PyDate::from_inner)
     }
 
-    /// The engine's extra named outputs, restricted to the real-valued tags;
-    /// see the class docs.
+    /// The engine's extra named outputs, restricted to the real-valued tags.
+    ///
+    /// Returns:
+    ///     dict[str, float]: The real-valued tags; see the class docs for why
+    ///         the others are omitted.
     #[getter]
     fn additional_results(&self) -> BTreeMap<String, f64> {
         self.additional_results.clone()

--- a/crates/itofin-py/src/results.rs
+++ b/crates/itofin-py/src/results.rs
@@ -1,10 +1,10 @@
-//! The frozen [`Results`] snapshot the instrument facades hand back.
+//! The frozen `Results` snapshot the instrument facades hand back.
 //!
-//! Every instrument caches the outputs of its last valuation in the core
-//! `InstrumentResults` bundle (`instrument.rs:36-45`), and the live accessors
-//! (`npv()`, the greeks, `fair_rate()`, ...) re-run the lazy calculation
-//! whenever an observed input moved. [`Results`] is the opposite: a plain copy
-//! of that bundle taken at one moment, which no later input change can move.
+//! Every instrument caches the outputs of its last valuation, and the live
+//! accessors (`npv()`, the greeks, `fair_rate()`, ...) re-run the lazy
+//! calculation whenever an observed input moved. `Results` is the opposite: a
+//! plain copy of those outputs taken at one moment, which no later input
+//! change can move.
 
 use crate::time::PyDate;
 use libitofin::instrument::InstrumentBase;

--- a/crates/itofin-py/src/settings.rs
+++ b/crates/itofin-py/src/settings.rs
@@ -6,11 +6,11 @@ use libitofin::shared::{Shared, shared};
 use libitofin::time::date::Date;
 use pyo3::prelude::*;
 
-/// Python `Settings`: the explicit, non-global evaluation-date store (D5).
+/// The explicit, non-global evaluation-date store (D5).
 ///
-/// Wraps a `Shared<Settings<Date>>` so the exact same object threads into every
-/// option built against it; there is no global singleton. The inner `Shared` is
-/// `Rc`-based and therefore `!Send`, hence `unsendable`.
+/// There is no global singleton: the exact settings object passed to a
+/// construction is the one it reads, so instruments built against different
+/// Settings do not see each other's evaluation date.
 #[pyclass(name = "Settings", unsendable)]
 pub struct PySettings {
     inner: Shared<Settings<Date>>,
@@ -18,6 +18,7 @@ pub struct PySettings {
 
 #[pymethods]
 impl PySettings {
+    /// Create settings with no evaluation date set.
     #[new]
     fn new() -> Self {
         PySettings {
@@ -25,25 +26,37 @@ impl PySettings {
         }
     }
 
-    /// Sets the evaluation date, notifying observers if it changed.
+    /// Set the evaluation date, notifying observers if it changed.
+    ///
+    /// The new date is in place before the notification goes out, so an
+    /// observer that recomputes on the update reads the date that triggered it.
+    ///
+    /// Args:
+    ///     date (time.Date): The new evaluation date. Observers are notified only when this
+    ///         differs from the date already set.
     fn set_evaluation_date(&self, date: &PyDate) {
         self.inner.set_evaluation_date(date.inner());
     }
 
-    /// Sets whether cash flows falling on today's date enter an NPV.
+    /// Set whether cash flows on today's date enter an NPV; None clears.
     ///
-    /// The flag is three-valued, as in the core (`settings.rs:141`): `True` and
-    /// `False` decide the question outright, and `None` clears it, restoring the
-    /// unset state in which each pricing site applies its own default. `value`
-    /// is required, so clearing is always deliberate.
+    /// The flag is three-valued, as in the core.
+    ///
+    /// Args:
+    ///     value (bool | None): True or False decides the question outright; None clears it,
+    ///         restoring the unset state in which each pricing site applies its
+    ///         own default. The argument is required, so clearing is always
+    ///         deliberate.
     #[pyo3(signature = (value))]
     fn set_include_todays_cash_flows(&self, value: Option<bool>) {
         self.inner.set_include_todays_cash_flows(value);
     }
 
-    /// The current setting of
-    /// [`set_include_todays_cash_flows`](Self::set_include_todays_cash_flows),
-    /// or `None` while it is unset.
+    /// Return the current setting, or None while it is unset.
+    ///
+    /// Returns:
+    ///     bool | None: The three-valued flag last set, or None if it has never been set or
+    ///     was cleared.
     fn include_todays_cash_flows(&self) -> Option<bool> {
         self.inner.include_todays_cash_flows()
     }

--- a/crates/itofin-py/src/settings.rs
+++ b/crates/itofin-py/src/settings.rs
@@ -1,4 +1,4 @@
-//! Facade for the D5 evaluation-date [`Settings`].
+//! Facade for the D5 evaluation-date Settings.
 
 use crate::time::PyDate;
 use libitofin::settings::Settings;

--- a/crates/itofin-py/src/smilesection.rs
+++ b/crates/itofin-py/src/smilesection.rs
@@ -1,6 +1,5 @@
-//! Facade for [`PySabrSmileSection`], a single option expiry's volatility smile
-//! at fixed Hagan SABR parameters
-//! (`termstructures::volatility::SabrSmileSection`).
+//! Facade for SabrSmileSection, a single option expiry's volatility smile at
+//! fixed Hagan SABR parameters.
 //!
 //! The core `SmileSection` trait is not exposed as a Python base class: the SABR
 //! section is the only implementor a caller of this crate has a constructor for,

--- a/crates/itofin-py/src/smilesection.rs
+++ b/crates/itofin-py/src/smilesection.rs
@@ -22,12 +22,11 @@ use crate::swaptionvol::PyVolatilityType;
 use libitofin::termstructures::volatility::{SabrSmileSection, SmileSection};
 use pyo3::prelude::*;
 
-/// Python `SabrSmileSection`: the volatility smile of one option expiry, read
-/// off the closed-form Hagan SABR formula at fixed parameters
-/// (`termstructures::volatility::SabrSmileSection`).
+/// One option expiry's volatility smile, read off the closed-form Hagan SABR
+/// formula at fixed parameters.
 ///
 /// There is no calibration here: the four parameters are inputs. A fitted smile
-/// is what the SABR swaption vol cube serves; this class is for querying a smile
+/// is what SabrSwaptionVolatilityCube serves; this class is for querying a smile
 /// whose parameters are already known.
 #[pyclass(name = "SabrSmileSection", unsendable)]
 pub struct PySabrSmileSection {
@@ -36,12 +35,28 @@ pub struct PySabrSmileSection {
 
 #[pymethods]
 impl PySabrSmileSection {
-    /// A smile at `exercise_time` years, centred on `forward`.
+    /// Build the smile at a given exercise time and forward.
     ///
-    /// Raises `ItofinError` on a non-zero `shift` or a `Normal`
-    /// `volatility_type` (both deferred to #586), on a non-positive shifted
-    /// forward, and on SABR parameters outside their admissible ranges
-    /// (`alpha > 0`, `beta` in `[0, 1]`, `nu >= 0`, `rho^2 < 1`).
+    /// Only the exercise-time form is wrapped; the date-anchored one differs
+    /// from it only in computing that time from a reference date and a day
+    /// counter, which a caller can do with DayCounter.year_fraction.
+    ///
+    /// Args:
+    ///     exercise_time (float): The option's exercise time, in years.
+    ///     forward (float): The forward the smile is centred on.
+    ///     alpha (float): The SABR alpha, which must be positive.
+    ///     beta (float): The SABR beta, which must lie in [0, 1].
+    ///     nu (float): The SABR nu, which must be non-negative.
+    ///     rho (float): The SABR rho, whose square must be below 1.
+    ///     shift (float): The lognormal shift; a non-zero shift is deferred
+    ///         and refused.
+    ///     volatility_type (VolatilityType): The quoting convention; Normal is
+    ///         deferred and refused.
+    ///
+    /// Raises:
+    ///     ItofinError: On a non-zero shift or a Normal volatility_type, both
+    ///         deferred to #586; on a non-positive shifted forward; and on
+    ///         SABR parameters outside their admissible ranges.
     #[new]
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (exercise_time, forward, alpha, beta, nu, rho, shift = 0.0, volatility_type = PyVolatilityType::ShiftedLognormal))]
@@ -70,24 +85,48 @@ impl PySabrSmileSection {
         })
     }
 
-    /// The volatility at `strike`. Strikes below the shifted domain floor are
-    /// clamped to it rather than rejected, as the core does.
+    /// Return the volatility at strike.
+    ///
+    /// Args:
+    ///     strike (float): The strike; strikes below the shifted domain floor
+    ///         are clamped to it rather than rejected, as the core does.
+    ///
+    /// Returns:
+    ///     float: The Hagan SABR volatility.
+    ///
+    /// Raises:
+    ///     ItofinError: On whatever the closed-form evaluation rejects.
     fn volatility(&self, strike: f64) -> PyResult<f64> {
         Ok(self.inner.volatility(strike).map_err(PyQlError::from)?)
     }
 
-    /// The Black variance at `strike`: `volatility(strike)^2 * exercise_time`.
+    /// Return the Black variance at strike.
+    ///
+    /// Args:
+    ///     strike (float): The strike the variance is read at.
+    ///
+    /// Returns:
+    ///     float: The squared volatility times the exercise time.
+    ///
+    /// Raises:
+    ///     ItofinError: On whatever the closed-form evaluation rejects.
     fn variance(&self, strike: f64) -> PyResult<f64> {
         Ok(self.inner.variance(strike).map_err(PyQlError::from)?)
     }
 
-    /// The exercise time the smile was built for, in years.
+    /// The exercise time the smile was built for.
+    ///
+    /// Returns:
+    ///     float: The exercise time, in years.
     #[getter]
     fn exercise_time(&self) -> f64 {
         self.inner.exercise_time()
     }
 
-    /// The at-the-money level: the forward the smile is centred on.
+    /// The at-the-money level.
+    ///
+    /// Returns:
+    ///     float: The forward the smile is centred on.
     #[getter]
     fn atm_level(&self) -> f64 {
         self.inner
@@ -95,25 +134,37 @@ impl PySabrSmileSection {
             .expect("a SABR smile section always carries its forward as the atm level")
     }
 
-    /// The SABR `alpha` parameter.
+    /// The SABR alpha parameter.
+    ///
+    /// Returns:
+    ///     float: The alpha the smile was built with.
     #[getter]
     fn alpha(&self) -> f64 {
         self.inner.alpha()
     }
 
-    /// The SABR `beta` parameter.
+    /// The SABR beta parameter.
+    ///
+    /// Returns:
+    ///     float: The beta the smile was built with.
     #[getter]
     fn beta(&self) -> f64 {
         self.inner.beta()
     }
 
-    /// The SABR `nu` parameter.
+    /// The SABR nu parameter.
+    ///
+    /// Returns:
+    ///     float: The nu the smile was built with.
     #[getter]
     fn nu(&self) -> f64 {
         self.inner.nu()
     }
 
-    /// The SABR `rho` parameter.
+    /// The SABR rho parameter.
+    ///
+    /// Returns:
+    ///     float: The rho the smile was built with.
     #[getter]
     fn rho(&self) -> f64 {
         self.inner.rho()

--- a/crates/itofin-py/src/swap.rs
+++ b/crates/itofin-py/src/swap.rs
@@ -1,10 +1,10 @@
-//! Facades for the plain-vanilla swap stack: [`PySwapType`], [`PyVanillaSwap`]
-//! and the [`PyMakeVanillaSwap`] builder.
+//! Facades for the plain-vanilla swap stack: SwapType, VanillaSwap and the
+//! MakeVanillaSwap builder.
 //!
-//! [`PyVanillaSwap`] wraps a `SharedMut<FixedVsFloatingSwap>` (the shape a
-//! swaption underlying needs, X3) and is priced with a [`DiscountingSwapEngine`]
-//! attached through [`set_engine`](PyVanillaSwap::set_engine), so the facade
-//! pins a real number rather than a construction-only object.
+//! VanillaSwap wraps the fixed-vs-floating swap a swaption underlying needs
+//! (X3) and is priced with a DiscountingSwapEngine attached through
+//! set_engine(), so the facade pins a real number rather than a
+//! construction-only object.
 
 use crate::PyQlError;
 use crate::curve::PyYieldTermStructure;
@@ -37,7 +37,7 @@ pub enum PySwapType {
 }
 
 impl PySwapType {
-    /// The core [`SwapType`] this variant stands for.
+    /// The core SwapType this variant stands for.
     pub(crate) fn inner(&self) -> SwapType {
         match self {
             PySwapType::Payer => SwapType::Payer,
@@ -239,8 +239,8 @@ impl PyVanillaSwap {
         SharedMut::clone(&self.inner)
     }
 
-    /// Wraps an already-lowered swap, the shape [`PyMakeVanillaSwap::build`]
-    /// hands back.
+    /// Wraps an already-lowered swap, the shape MakeVanillaSwap.build() hands
+    /// back.
     fn from_inner(inner: SharedMut<FixedVsFloatingSwap>) -> PyVanillaSwap {
         PyVanillaSwap { inner }
     }

--- a/crates/itofin-py/src/swap.rs
+++ b/crates/itofin-py/src/swap.rs
@@ -25,11 +25,10 @@ use libitofin::time::period::Period;
 use libitofin::time::timeunit::TimeUnit;
 use pyo3::prelude::*;
 
-/// Python `SwapType`: which side of the named leg the swap is seen from
-/// (`instruments::swap::SwapType`, re-exported as `instruments::SwapType`).
+/// Which side of the named leg the swap is seen from.
 ///
-/// A fieldless pyo3 enum exposing `SwapType.Payer` / `SwapType.Receiver`; the
-/// signed `+1`/`-1` leg multiplier stays in the core.
+/// A fieldless enum; the signed leg multiplier the two variants stand for
+/// stays in the core.
 #[pyclass(name = "SwapType", eq, eq_int, from_py_object)]
 #[derive(Clone, Copy, PartialEq)]
 pub enum PySwapType {
@@ -47,16 +46,9 @@ impl PySwapType {
     }
 }
 
-/// Python `VanillaSwap`: a fixed-vs-Ibor interest-rate swap
-/// (`instruments::vanillaswap::VanillaSwap`).
+/// A fixed-vs-Ibor interest-rate swap.
 ///
-/// Built with [`VanillaSwap::new`] and immediately lowered to its
-/// [`FixedVsFloatingSwap`] base via `into_fixed_vs_floating` (the shape X3's
-/// swaption consumes), held behind a `SharedMut`. The ctor is fallible
-/// (`vanillaswap.rs:88`): it builds the floating [`IborLeg`], so a degenerate
-/// leg surfaces as an `ItofinError`. Pricing needs an engine: call
-/// [`set_engine`](Self::set_engine) before [`fair_rate`](Self::fair_rate) or
-/// [`npv`](Self::npv).
+/// Pricing needs an engine: call set_engine before fair_rate or npv.
 #[pyclass(name = "VanillaSwap", unsendable)]
 pub struct PyVanillaSwap {
     inner: SharedMut<FixedVsFloatingSwap>,
@@ -64,6 +56,24 @@ pub struct PyVanillaSwap {
 
 #[pymethods]
 impl PyVanillaSwap {
+    /// Build the swap from both schedules spelled out.
+    ///
+    /// Args:
+    ///     swap_type (SwapType): Whether the fixed leg is paid or received.
+    ///     nominal (float): The notional both legs accrue on.
+    ///     fixed_schedule (Schedule): The fixed leg's payment schedule.
+    ///     fixed_rate (float): The rate the fixed leg accrues at.
+    ///     fixed_day_count (DayCounter): The day count of the fixed leg.
+    ///     float_schedule (Schedule): The floating leg's payment schedule.
+    ///     ibor_index (IborIndex): The index the floating leg fixes off.
+    ///     spread (float): The spread added to every floating fixing.
+    ///     floating_day_count (DayCounter): The day count of the floating leg.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date and the stored fixings.
+    ///
+    /// Raises:
+    ///     ItofinError: If the floating leg cannot be built, a degenerate leg
+    ///         being the usual cause.
     #[new]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -97,12 +107,15 @@ impl PyVanillaSwap {
         })
     }
 
-    /// Attaches a [`DiscountingSwapEngine`] over `curve` so the swap prices.
+    /// Attach a discounting engine over curve so the swap prices.
     ///
-    /// The engine is built with the settings-driven flow defaults
-    /// (`include_settlement_date_flows`, `settlement_date`, `npv_date` all
-    /// unset) and installed on the swap's [`InstrumentBase`] via
-    /// `set_pricing_engine`.
+    /// The engine is built with the settings-driven flow defaults, leaving the
+    /// settlement date, the NPV date and the settlement-date-flows flag unset.
+    ///
+    /// Args:
+    ///     curve (YieldTermStructure): The curve the flows discount on.
+    ///     settings (Settings): The settings the engine resolves its dates
+    ///         against.
     fn set_engine(&mut self, curve: &PyYieldTermStructure, settings: &PySettings) {
         let engine = shared_mut(DiscountingSwapEngine::new(
             curve.handle(),
@@ -117,8 +130,11 @@ impl PyVanillaSwap {
             .set_pricing_engine(engine);
     }
 
-    /// Forces the valuation, idempotent and fallible as
-    /// [`VanillaOption.calculate`](crate::option::PyVanillaOption::calculate).
+    /// Force the valuation. Idempotent.
+    ///
+    /// Raises:
+    ///     ItofinError: If no engine is attached, no evaluation date is set,
+    ///         or the attached engine refuses the swap.
     fn calculate(&mut self) -> PyResult<()> {
         Ok(self
             .inner
@@ -127,30 +143,55 @@ impl PyVanillaSwap {
             .map_err(PyQlError::from)?)
     }
 
-    /// Whether the cached results are currently valid.
+    /// Return whether the cached results are currently valid.
+    ///
+    /// Returns:
+    ///     bool: True when the next accessor reads the cache.
     fn is_calculated(&self) -> bool {
         self.inner.borrow().base().is_calculated()
     }
 
-    /// Builds a discounting engine over `curve` and returns the NPV: the
-    /// one-shot form of [`set_engine`](Self::set_engine) plus [`npv`](Self::npv),
-    /// and it takes the same two arguments for the same reason.
+    /// Attach a discounting engine over curve and return the NPV.
+    ///
+    /// set_engine followed by npv, in one call, and it takes the same two
+    /// arguments for the same reason.
+    ///
+    /// Args:
+    ///     curve (YieldTermStructure): The curve the flows discount on.
+    ///     settings (Settings): The settings the engine resolves its dates
+    ///         against.
+    ///
+    /// Returns:
+    ///     float: The swap value under the freshly built engine.
+    ///
+    /// Raises:
+    ///     ItofinError: On anything that makes the valuation fail.
     fn price(&mut self, curve: &PyYieldTermStructure, settings: &PySettings) -> PyResult<f64> {
         self.set_engine(curve, settings);
         self.calculate()?;
         self.npv()
     }
 
-    /// A frozen [`Results`] copy of the valuation, calculating first.
+    /// Return a frozen snapshot of the valuation, calculating first.
+    ///
+    /// Returns:
+    ///     Results: A copy of the valuation results.
+    ///
+    /// Raises:
+    ///     ItofinError: On anything that makes the valuation fail.
     fn results(&mut self) -> PyResult<Results> {
         self.calculate()?;
         let inner = self.inner.borrow();
         Ok(Results::snapshot(inner.base()))
     }
 
-    /// The fair fixed rate that zeroes the swap NPV (`fairRate()`).
+    /// Return the fixed rate that zeroes the swap NPV.
     ///
-    /// Fallible: an engine must be attached and the swap non-expired.
+    /// Returns:
+    ///     float: The fair fixed rate.
+    ///
+    /// Raises:
+    ///     ItofinError: If no engine is attached or the swap has expired.
     fn fair_rate(&mut self) -> PyResult<f64> {
         Ok(self
             .inner
@@ -159,19 +200,33 @@ impl PyVanillaSwap {
             .map_err(PyQlError::from)?)
     }
 
-    /// The swap NPV under the attached engine.
+    /// Return the swap NPV under the attached engine.
     ///
-    /// Fallible: an engine must be attached (`set_engine`).
+    /// Returns:
+    ///     float: The present value.
+    ///
+    /// Raises:
+    ///     ItofinError: If no engine is attached.
     fn npv(&mut self) -> PyResult<f64> {
         Ok(self.inner.borrow_mut().npv().map_err(PyQlError::from)?)
     }
 
-    /// The swap nominal (`nominal()`).
+    /// Return the notional both legs accrue on.
+    ///
+    /// Returns:
+    ///     float: The single nominal.
+    ///
+    /// Raises:
+    ///     ItofinError: If the legs carry per-coupon nominals, which leaves no
+    ///         single one to report.
     fn nominal(&self) -> PyResult<f64> {
         Ok(self.inner.borrow().nominal().map_err(PyQlError::from)?)
     }
 
-    /// The fixed-leg rate (`fixedRate()`).
+    /// Return the fixed-leg rate.
+    ///
+    /// Returns:
+    ///     float: The rate the fixed leg accrues at.
     fn fixed_rate(&self) -> f64 {
         self.inner.borrow().fixed_rate()
     }
@@ -191,30 +246,20 @@ impl PyVanillaSwap {
     }
 }
 
-/// Python `MakeVanillaSwap`: the market-convention builder for a
-/// [`PyVanillaSwap`] (`instruments::makevanillaswap::MakeVanillaSwap`).
+/// Market-convention builder for a VanillaSwap.
 ///
-/// Derives the start and end dates, both schedules, the fixed-leg tenor and day
-/// count and the discounting engine from a swap tenor and an Ibor index, so the
-/// caller states conventions instead of hand-building two [`PySchedule`]s.
-/// `fixed_rate=None` builds a par swap: the fair rate is computed and written
-/// into the fixed leg, so the result prices to a zero NPV
-/// (`makevanillaswap.rs:364-376`).
+/// Derives the start and end dates, both schedules, the fixed-leg tenor and
+/// day count and the discounting engine from a swap tenor and an Ibor index,
+/// so the caller states conventions instead of hand-building two schedules.
+/// ``fixed_rate=None`` builds a par swap: the fair rate is computed and written
+/// into the fixed leg, so the result prices to a zero NPV.
 ///
-/// The core's `with_*` chain consumes the builder by value, which a `#[pyclass]`
-/// cannot hand out, so the overrides are constructor keywords instead and the
-/// chain is assembled inside [`build`](Self::build). Only the four the pass-A
-/// swaption fixture needs are exposed - `effective_date`, `nominal`,
-/// `fixed_leg_tenor`, `fixed_leg_day_count`. Every other core override
-/// (termination date, settlement days, the leg calendars / conventions /
-/// end-of-month flags, the discounting term structure, the indexed-coupon mode)
-/// is deferred and keeps its core default; the discounting curve is therefore
-/// always the index's forwarding curve.
-///
-/// [`build`](Self::build) returns a swap that already carries its
-/// [`DiscountingSwapEngine`] (`makevanillaswap.rs:514-522`), so it prices
-/// straight away. Calling [`PyVanillaSwap::set_engine`] on it replaces that
-/// engine with one built on the settings-driven flow defaults.
+/// The core builder is a consumed-self fluent chain, which does not cross the
+/// FFI boundary; this facade takes the overrides as constructor keywords and
+/// assembles the chain inside build(). Only four overrides are exposed; every
+/// other core one keeps its default, so the discounting curve is always the
+/// index's forwarding curve. The built swap already carries its
+/// DiscountingSwapEngine.
 #[pyclass(name = "MakeVanillaSwap", unsendable)]
 pub struct PyMakeVanillaSwap {
     swap_tenor: Period,
@@ -230,6 +275,25 @@ pub struct PyMakeVanillaSwap {
 
 #[pymethods]
 impl PyMakeVanillaSwap {
+    /// Store the configuration the chain is assembled from in build().
+    ///
+    /// Args:
+    ///     swap_tenor (Period): The length of the swap.
+    ///     ibor_index (IborIndex): The index the floating leg fixes off, and
+    ///         whose forwarding curve discounts.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date and the stored fixings.
+    ///     fixed_rate (float | None): The rate of the fixed leg; None builds a
+    ///         par swap.
+    ///     forward_start (Period | None): The delay before the swap starts;
+    ///         None starts it spot, at a zero-day period.
+    ///     effective_date (Date | None): The start date; None derives it from
+    ///         the evaluation date.
+    ///     nominal (float | None): The notional; None keeps the core default.
+    ///     fixed_leg_tenor (Period | None): The fixed-leg payment tenor; None
+    ///         takes the currency's market convention.
+    ///     fixed_leg_day_count (DayCounter | None): The fixed-leg day count;
+    ///         None takes the currency's market convention.
     #[new]
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (
@@ -269,12 +333,16 @@ impl PyMakeVanillaSwap {
         }
     }
 
-    /// Builds the priced swap.
+    /// Build the priced swap.
     ///
-    /// Fallible: without an `effective_date` the start date is derived from the
-    /// evaluation date, so an unset one is an error (D10); the fixed-leg
-    /// defaults are only known for EUR and USD indexes; and the par-rate fill
-    /// propagates a pricing failure.
+    /// Returns:
+    ///     VanillaSwap: The swap, already carrying its discounting engine.
+    ///
+    /// Raises:
+    ///     ItofinError: If effective_date is unset and no evaluation date is
+    ///         set to derive the start from; if the index is neither EUR nor
+    ///         USD, the two the fixed-leg defaults are known for; or if the
+    ///         par-rate fill fails to price.
     fn build(&self) -> PyResult<PyVanillaSwap> {
         let mut maker = MakeVanillaSwap::new(
             self.swap_tenor,

--- a/crates/itofin-py/src/swapindex.rs
+++ b/crates/itofin-py/src/swapindex.rs
@@ -1,16 +1,15 @@
-//! Facade for the swap-rate index [`PySwapIndex`] (`indexes::SwapIndex`), the
-//! index whose fixing is a vanilla swap's fair rate.
+//! Facade for the swap-rate index SwapIndex, the index whose fixing is a
+//! vanilla swap's fair rate.
 //!
 //! The swaption volatility cubes take two of these (a long and a short base) and
 //! read the at-the-money forward off them, so this is the index the cube facades
 //! stack on rather than one the Python user prices with directly.
 //!
-//! Both constructors take the currency as a [`PyCurrency`](crate::currency::PyCurrency)
-//! and the forecasting index as the general [`PyIborIndex`](crate::hullwhite::PyIborIndex)
-//! (#868). The currency stays inert for every ported consumer - `underlying_swap`
-//! never reads it, and the cube's at-the-money forward is a fair rate, not an
-//! amount - so [`currency`](PySwapIndex::currency) reads it back off the core
-//! index, which is the only place it shows.
+//! Both constructors take the currency as a Currency and the forecasting index
+//! as the general IborIndex (#868). The currency stays inert for every ported
+//! consumer - `underlying_swap` never reads it, and the cube's at-the-money
+//! forward is a fair rate, not an amount - so currency() reads it back off the
+//! core index, which is the only place it shows.
 //!
 //! Deferred (visible): the `clone` family (re-curving / re-tenoring) is deferred
 //! in the core itself.

--- a/crates/itofin-py/src/swapindex.rs
+++ b/crates/itofin-py/src/swapindex.rs
@@ -26,14 +26,18 @@ use libitofin::shared::{Shared, shared};
 use libitofin::types::Natural;
 use pyo3::prelude::*;
 
-/// Python `SwapIndex`: the index whose fixing is the fair rate of an on-the-fly
-/// vanilla swap (`indexes::SwapIndex`).
+/// The index whose fixing is the fair rate of an on-the-fly vanilla swap,
+/// assembled from the index tenor, the forecasting Ibor index and the fixed-leg
+/// conventions.
 ///
-/// The swap is assembled from the index tenor, the forecasting `IborIndex` and
-/// the fixed-leg conventions, off the value date the fixing date implies.
-/// [`new`](PySwapIndex::new) forecasts and discounts off the ibor index's
-/// forwarding curve; [`with_exogenous_discount`](PySwapIndex::with_exogenous_discount)
-/// discounts off a separate curve.
+/// The swap is assembled off the value date the fixing date implies. The
+/// swaption volatility cubes take two of these (a long and a short base) and
+/// read the at-the-money forward off them, so this is the index the cube
+/// facades stack on rather than one priced with directly.
+///
+/// The currency is inert for every ported consumer, so currency() reading it
+/// back off the core index is the only place it shows. Deferred (visible): the
+/// clone family (re-curving / re-tenoring) is deferred in the core itself.
 #[pyclass(name = "SwapIndex", unsendable)]
 pub struct PySwapIndex {
     inner: Shared<SwapIndex>,
@@ -41,9 +45,27 @@ pub struct PySwapIndex {
 
 #[pymethods]
 impl PySwapIndex {
-    /// A swap index forecasting and discounting off `ibor_index`'s forwarding
-    /// curve, registering with that index so a relinked curve notifies
-    /// observers.
+    /// Build a swap index forecasting and discounting off one curve.
+    ///
+    /// Both legs use the ibor index's forwarding curve. The index registers
+    /// with that index, so a relinked curve notifies observers.
+    ///
+    /// Args:
+    ///     family_name (str): The index family the fixings are stored under.
+    ///     tenor (Period): The tenor of the underlying swap.
+    ///     settlement_days (int): The business days between the fixing date and
+    ///         the swap's start.
+    ///     currency (Currency): The index currency, inert for every ported
+    ///         consumer and read back only by currency().
+    ///     calendar (Calendar): The calendar the swap's dates roll on.
+    ///     fixed_leg_tenor (Period): The fixed leg's payment tenor.
+    ///     fixed_leg_convention (BusinessDayConvention): The fixed leg's
+    ///         business-day convention.
+    ///     fixed_leg_day_counter (DayCounter): The fixed leg's day count.
+    ///     ibor_index (IborIndex): The index forecasting the floating leg,
+    ///         whose forwarding curve also discounts.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date and the stored fixings.
     #[new]
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (family_name, tenor, settlement_days, currency, calendar, fixed_leg_tenor, fixed_leg_convention, fixed_leg_day_counter, ibor_index, settings))]
@@ -75,8 +97,31 @@ impl PySwapIndex {
         }
     }
 
-    /// A swap index forecasting off `ibor_index`'s forwarding curve but
-    /// discounting off the separate `discount` curve, registering with both.
+    /// Build a swap index discounting off a separate curve.
+    ///
+    /// The floating leg is still forecast off the ibor index's forwarding
+    /// curve, but discounting uses discount. The index registers with both.
+    ///
+    /// Args:
+    ///     family_name (str): The index family the fixings are stored under.
+    ///     tenor (Period): The tenor of the underlying swap.
+    ///     settlement_days (int): The business days between the fixing date and
+    ///         the swap's start.
+    ///     currency (Currency): The index currency, inert for every ported
+    ///         consumer and read back only by currency().
+    ///     calendar (Calendar): The calendar the swap's dates roll on.
+    ///     fixed_leg_tenor (Period): The fixed leg's payment tenor.
+    ///     fixed_leg_convention (BusinessDayConvention): The fixed leg's
+    ///         business-day convention.
+    ///     fixed_leg_day_counter (DayCounter): The fixed leg's day count.
+    ///     ibor_index (IborIndex): The index forecasting the floating leg.
+    ///     discount (YieldTermStructure): The separate curve both legs are
+    ///         discounted on.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date and the stored fixings.
+    ///
+    /// Returns:
+    ///     SwapIndex: The index discounting off the exogenous curve.
     #[staticmethod]
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (family_name, tenor, settlement_days, currency, calendar, fixed_leg_tenor, fixed_leg_convention, fixed_leg_day_counter, ibor_index, discount, settings))]
@@ -110,10 +155,21 @@ impl PySwapIndex {
         }
     }
 
-    /// The index's fixing for `fixing_date`: the fair rate of the underlying
-    /// swap, the number the volatility cubes read as the at-the-money forward.
-    /// Fallible: an empty forwarding handle, an unset evaluation date or an
-    /// invalid fixing date is an error.
+    /// Return the underlying swap's fair rate for fixing_date.
+    ///
+    /// This is the at-the-money forward the volatility cubes read.
+    ///
+    /// Args:
+    ///     fixing_date (Date): The date the underlying swap is struck off.
+    ///     forecast_todays_fixing (bool): Whether a fixing dated today is
+    ///         forecast rather than looked up.
+    ///
+    /// Returns:
+    ///     float: The fair rate of the underlying swap.
+    ///
+    /// Raises:
+    ///     ItofinError: If the forwarding handle is empty, the evaluation date
+    ///         is unset, or the fixing date is invalid.
     #[pyo3(signature = (fixing_date, forecast_todays_fixing = false))]
     fn fixing(&self, fixing_date: &PyDate, forecast_todays_fixing: bool) -> PyResult<f64> {
         Ok(self
@@ -122,17 +178,26 @@ impl PySwapIndex {
             .map_err(PyQlError::from)?)
     }
 
-    /// The index currency, read back off the core index.
+    /// Return the index currency, read back off the core index.
+    ///
+    /// Returns:
+    ///     Currency: The currency the index was built with.
     fn currency(&self) -> PyCurrency {
         PyCurrency::from_inner(self.inner.currency().clone())
     }
 
-    /// The fixed-leg tenor.
+    /// Return the fixed leg's payment tenor.
+    ///
+    /// Returns:
+    ///     Period: The fixed-leg tenor.
     fn fixed_leg_tenor(&self) -> PyPeriod {
         PyPeriod::from_inner(self.inner.fixed_leg_tenor())
     }
 
-    /// Whether the index discounts off a separate curve.
+    /// Return whether the index discounts off a separate curve.
+    ///
+    /// Returns:
+    ///     bool: True if the index was built by with_exogenous_discount.
     fn exogenous_discount(&self) -> bool {
         self.inner.exogenous_discount()
     }

--- a/crates/itofin-py/src/swaption.rs
+++ b/crates/itofin-py/src/swaption.rs
@@ -1,10 +1,10 @@
-//! Facades for the European swaption stack: [`PyEuropeanExercise`],
-//! [`PySettlementType`], [`PySettlementMethod`] and [`PySwaption`].
+//! Facades for the European swaption stack: EuropeanExercise, SettlementType,
+//! SettlementMethod and Swaption.
 //!
-//! [`PySwaption`] wraps a [`Swaption`] by value and prices it through the
-//! [`JamshidianSwaptionEngine`] built on a [`PyHullWhite`](crate::hullwhite::PyHullWhite)
-//! model (`set_jamshidian_engine`); the engine reads the swap's arguments, so
-//! the underlying swap needs no discounting engine of its own.
+//! Swaption wraps a Swaption by value and prices it through the
+//! JamshidianSwaptionEngine built on a HullWhite model
+//! (`set_jamshidian_engine`); the engine reads the swap's arguments, so the
+//! underlying swap needs no discounting engine of its own.
 //!
 //! Deferred (visible): the Bermudan `TreeSwaptionEngine` and a `BermudanExercise`
 //! facade are omitted. `BermudanExercise` has no public constructor on `main`
@@ -51,7 +51,7 @@ impl PyEuropeanExercise {
 
 impl PyEuropeanExercise {
     /// A clone of the inner exercise for the swaption facade, which takes the
-    /// exercise as a `Shared<dyn Exercise>`.
+    /// exercise type-erased.
     pub(crate) fn inner(&self) -> Shared<dyn Exercise> {
         Shared::clone(&self.inner)
     }
@@ -66,7 +66,7 @@ pub enum PySettlementType {
 }
 
 impl PySettlementType {
-    /// The core [`SettlementType`] this variant stands for.
+    /// The core SettlementType this variant stands for.
     fn inner(&self) -> SettlementType {
         match self {
             PySettlementType::Physical => SettlementType::Physical,
@@ -91,7 +91,7 @@ pub enum PySettlementMethod {
 }
 
 impl PySettlementMethod {
-    /// The core [`SettlementMethod`] this variant stands for.
+    /// The core SettlementMethod this variant stands for.
     fn inner(&self) -> SettlementMethod {
         match self {
             PySettlementMethod::PhysicalOTC => SettlementMethod::PhysicalOTC,

--- a/crates/itofin-py/src/swaption.rs
+++ b/crates/itofin-py/src/swaption.rs
@@ -26,11 +26,10 @@ use libitofin::pricingengines::JamshidianSwaptionEngine;
 use libitofin::shared::{Shared, SharedMut, shared, shared_mut};
 use pyo3::prelude::*;
 
-/// Python `EuropeanExercise`: a single-date exercise schedule
-/// (`exercise::EuropeanExercise`).
+/// A single-date exercise schedule.
 ///
-/// Wraps a `Shared<dyn Exercise>` so the [`Swaption`] constructor, which takes
-/// the exercise as a trait object, can hold the same value.
+/// Held as the exercise trait object the swaption constructor takes, so the
+/// same value reaches the instrument.
 #[pyclass(name = "EuropeanExercise", unsendable)]
 pub struct PyEuropeanExercise {
     inner: Shared<dyn Exercise>,
@@ -38,6 +37,10 @@ pub struct PyEuropeanExercise {
 
 #[pymethods]
 impl PyEuropeanExercise {
+    /// Build the exercise schedule.
+    ///
+    /// Args:
+    ///     date (Date): The single date the option may be exercised on.
     #[new]
     fn new(date: &PyDate) -> Self {
         PyEuropeanExercise {
@@ -54,10 +57,7 @@ impl PyEuropeanExercise {
     }
 }
 
-/// Python `SettlementType`: how a swaption settles on exercise
-/// (`instruments::swaption::SettlementType`).
-///
-/// A fieldless pyo3 enum exposing `SettlementType.Physical` / `SettlementType.Cash`.
+/// How a swaption settles on exercise.
 #[pyclass(name = "SettlementType", eq, eq_int, from_py_object)]
 #[derive(Clone, Copy, PartialEq)]
 pub enum PySettlementType {
@@ -75,13 +75,12 @@ impl PySettlementType {
     }
 }
 
-/// Python `SettlementMethod`: the settlement mechanics under a
-/// [`SettlementType`] (`instruments::swaption::SettlementMethod`).
+/// The settlement mechanics under a settlement type.
 ///
-/// Physical pairs with `PhysicalOTC` / `PhysicalCleared`; cash pairs with
-/// `CollateralizedCashPrice` / `ParYieldCurve`. The consistency check runs at
-/// pricing time (`SwaptionArguments::validate`), not construction, so a
-/// mismatched pair only surfaces as an `ItofinError` from `npv()`.
+/// Physical pairs with PhysicalOTC or PhysicalCleared, cash with
+/// CollateralizedCashPrice or ParYieldCurve. The consistency check runs at
+/// pricing time, not construction, so a mismatched pair only surfaces from
+/// npv().
 #[pyclass(name = "SettlementMethod", eq, eq_int, from_py_object)]
 #[derive(Clone, Copy, PartialEq)]
 pub enum PySettlementMethod {
@@ -105,15 +104,11 @@ impl PySettlementMethod {
     }
 }
 
-/// Python `Swaption`: a European option to enter a [`VanillaSwap`](PyVanillaSwap)
-/// (`instruments::swaption::Swaption`).
+/// A European option to enter a vanilla swap.
 ///
-/// Built with [`Swaption::new`] (infallible): it registers with the underlying
-/// swap and the settings evaluation date (D5). Pricing needs an engine: call
-/// [`set_jamshidian_engine`](Self::set_jamshidian_engine) or
-/// [`set_black_engine`](Self::set_black_engine) before [`npv`](Self::npv).
-/// The (settlement type, method) consistency check runs at pricing time, so a
-/// mismatched pair surfaces as an `ItofinError` from `npv()`, not the ctor.
+/// The swaption registers with the underlying swap and with the evaluation
+/// date on the Settings it was built with (D5). Pricing needs an engine: call
+/// one of the three setters before npv.
 #[pyclass(name = "Swaption", unsendable)]
 pub struct PySwaption {
     inner: Swaption,
@@ -121,6 +116,19 @@ pub struct PySwaption {
 
 #[pymethods]
 impl PySwaption {
+    /// Build the swaption over swap.
+    ///
+    /// Args:
+    ///     swap (VanillaSwap): The swap the option enters; it needs no
+    ///         discounting engine of its own, the swaption engine reading its
+    ///         arguments instead.
+    ///     exercise (EuropeanExercise): The single exercise date.
+    ///     settlement_type (SettlementType): Whether exercise settles
+    ///         physically or in cash.
+    ///     settlement_method (SettlementMethod): The mechanics under that
+    ///         type; an inconsistent pair surfaces from npv(), not here.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date the swaption prices against.
     #[new]
     fn new(
         swap: &PyVanillaSwap,
@@ -140,78 +148,102 @@ impl PySwaption {
         }
     }
 
-    /// Attaches a [`JamshidianSwaptionEngine`] built on `model` so the swaption
-    /// prices analytically off the Hull-White dynamics.
+    /// Attach a Jamshidian engine so the swaption prices off Hull-White.
     ///
-    /// The engine (`jamshidianswaptionengine.rs:92`, infallible) is European-only:
-    /// a non-European exercise errors at pricing time. It is installed on the
-    /// swaption's [`InstrumentBase`](libitofin::instrument) via `set_pricing_engine`.
+    /// The engine is European-only: a non-European exercise errors at pricing
+    /// time.
+    ///
+    /// Args:
+    ///     model (HullWhite): The short-rate model supplying the dynamics.
     fn set_jamshidian_engine(&mut self, model: &PyHullWhite) {
         let engine = shared_mut(JamshidianSwaptionEngine::new(model.inner()))
             as SharedMut<dyn PricingEngine>;
         self.inner.base_mut().set_pricing_engine(engine);
     }
 
-    /// Attaches a [`PyBlackSwaptionEngine`] so the swaption prices off a
-    /// swaption volatility surface rather than a short-rate model.
+    /// Attach a Black engine, pricing off a swaption volatility surface.
     ///
-    /// The engine is built separately and installed here, so the same engine can
-    /// be shared across swaptions. It must carry the same `Settings` object this
-    /// swaption was built with: the engine resolves its own evaluation date, and
-    /// two different settings would price the swap and the option on different
-    /// dates without any error being raised.
+    /// The engine is built separately, so the same one can be shared across
+    /// swaptions. It must carry the same Settings object as this swaption: two
+    /// different settings would price the swap and the option on different
+    /// dates with no error raised.
+    ///
+    /// Args:
+    ///     engine (BlackSwaptionEngine): The engine and its volatility
+    ///         surface.
     fn set_black_engine(&mut self, engine: &PyBlackSwaptionEngine) {
         self.inner.base_mut().set_pricing_engine(engine.engine());
     }
 
-    /// Attaches a [`PyBachelierSwaptionEngine`] so the swaption prices off a
-    /// normal-volatility swaption surface.
+    /// Attach a Bachelier engine, pricing off a normal-volatility surface.
     ///
-    /// The same `Settings` requirement as [`set_black_engine`](Self::set_black_engine)
-    /// applies: the engine resolves its own evaluation date, and two different
-    /// settings would price the swap and the option on different dates without
-    /// any error being raised.
+    /// The same-Settings requirement as set_black_engine applies.
+    ///
+    /// Args:
+    ///     engine (BachelierSwaptionEngine): The engine and its
+    ///         normal-volatility surface.
     fn set_bachelier_engine(&mut self, engine: &PyBachelierSwaptionEngine) {
         self.inner.base_mut().set_pricing_engine(engine.engine());
     }
 
-    /// Forces the valuation, idempotent and fallible as
-    /// [`VanillaOption.calculate`](crate::option::PyVanillaOption::calculate);
-    /// here it also surfaces an inconsistent (settlement type, method) pair.
+    /// Force the valuation. Idempotent.
+    ///
+    /// Raises:
+    ///     ItofinError: If no engine is attached, no evaluation date is set,
+    ///         or the (settlement type, method) pair is inconsistent, which
+    ///         the core checks here rather than at construction.
     fn calculate(&mut self) -> PyResult<()> {
         Ok(self.inner.calculate().map_err(PyQlError::from)?)
     }
 
-    /// Whether the cached results are currently valid.
+    /// Return whether the cached results are currently valid.
+    ///
+    /// Returns:
+    ///     bool: True when the next accessor reads the cache.
     fn is_calculated(&self) -> bool {
         self.inner.base().is_calculated()
     }
 
-    /// Attaches the Black engine `engine` and returns the NPV, the one-shot
-    /// form of [`set_black_engine`](Self::set_black_engine) followed by
-    /// [`npv`](Self::npv).
+    /// Attach the Black engine and return the NPV.
     ///
-    /// Black is the primary because it is the standard swaption engine; the
-    /// Jamshidian and Bachelier engines keep their own setters and compose with
-    /// [`calculate`](Self::calculate) and [`results`](Self::results) as before.
+    /// set_black_engine followed by npv, in one call. Black is the primary
+    /// because it is the standard swaption engine; the Jamshidian and
+    /// Bachelier engines keep their own setters.
+    ///
+    /// Args:
+    ///     engine (BlackSwaptionEngine): The engine to install and price on.
+    ///
+    /// Returns:
+    ///     float: The swaption value.
+    ///
+    /// Raises:
+    ///     ItofinError: On anything that makes the valuation fail.
     fn price(&mut self, engine: &PyBlackSwaptionEngine) -> PyResult<f64> {
         self.set_black_engine(engine);
         self.calculate()?;
         self.npv()
     }
 
-    /// A frozen [`Results`] copy of the valuation, calculating first.
+    /// Return a frozen snapshot of the valuation, calculating first.
+    ///
+    /// Returns:
+    ///     Results: A copy of the valuation results.
+    ///
+    /// Raises:
+    ///     ItofinError: On anything that makes the valuation fail.
     fn results(&mut self) -> PyResult<Results> {
         self.calculate()?;
         Ok(Results::snapshot(self.inner.base()))
     }
 
-    /// The swaption NPV under the attached engine.
+    /// Return the swaption NPV under the attached engine.
     ///
-    /// Fallible: an engine must be attached ([`set_jamshidian_engine`](Self::set_jamshidian_engine),
-    /// [`set_black_engine`](Self::set_black_engine) or
-    /// [`set_bachelier_engine`](Self::set_bachelier_engine)) and the (settlement
-    /// type, method) pair consistent.
+    /// Returns:
+    ///     float: The present value.
+    ///
+    /// Raises:
+    ///     ItofinError: If no engine is attached or the (settlement type,
+    ///         method) pair is inconsistent.
     fn npv(&mut self) -> PyResult<f64> {
         Ok(self.inner.npv().map_err(PyQlError::from)?)
     }

--- a/crates/itofin-py/src/swaptionengine.rs
+++ b/crates/itofin-py/src/swaptionengine.rs
@@ -1,6 +1,5 @@
-//! Facade for the Black-style swaption pricing engines:
-//! [`PyCashAnnuityModel`], [`PyBlackSwaptionEngine`] and
-//! [`PyBachelierSwaptionEngine`].
+//! Facade for the Black-style swaption pricing engines: CashAnnuityModel,
+//! BlackSwaptionEngine and BachelierSwaptionEngine.
 //!
 //! The core engine is generic over a formula spec, which does not cross FFI
 //! (D7), so both spec instantiations - the shifted-lognormal
@@ -33,7 +32,7 @@ pub enum PyCashAnnuityModel {
 }
 
 impl PyCashAnnuityModel {
-    /// The core [`CashAnnuityModel`] this variant stands for.
+    /// The core CashAnnuityModel this variant stands for.
     fn inner(&self) -> CashAnnuityModel {
         match self {
             PyCashAnnuityModel::SwapRate => CashAnnuityModel::SwapRate,

--- a/crates/itofin-py/src/swaptionengine.rs
+++ b/crates/itofin-py/src/swaptionengine.rs
@@ -19,13 +19,12 @@ use libitofin::pricingengines::swaption::{
 use libitofin::shared::{SharedMut, shared_mut};
 use pyo3::prelude::*;
 
-/// Python `CashAnnuityModel`: which date a cash-settled par-yield annuity
-/// discounts to (`pricingengines::swaption::CashAnnuityModel`).
+/// Which date a cash-settled par-yield annuity discounts to.
 ///
-/// A fieldless pyo3 enum. Only the `Cash` / `ParYieldCurve` settlement pair
-/// reads it; every other pair takes the fixed-leg BPS annuity and is
-/// insensitive to the choice. The facade defaults to `SwapRate`, the branch
-/// every ported core test exercises, where C++ defaults to `DiscountCurve`.
+/// Only the (Cash, ParYieldCurve) settlement pair reads it; every other pair
+/// takes the fixed-leg BPS annuity and is insensitive to the choice. The
+/// swaption engines default to SwapRate, the branch every ported core test
+/// exercises, where C++ defaults to DiscountCurve.
 #[pyclass(name = "CashAnnuityModel", eq, eq_int, from_py_object)]
 #[derive(Clone, Copy, PartialEq)]
 pub enum PyCashAnnuityModel {
@@ -43,17 +42,14 @@ impl PyCashAnnuityModel {
     }
 }
 
-/// Python `BlackSwaptionEngine`: the shifted-lognormal Black-formula swaption
-/// engine (`pricingengines::swaption::BlackSwaptionEngine`).
+/// The shifted-lognormal Black-formula swaption engine, European-only.
 ///
-/// European-only, and it prices the underlying swap itself: it installs its own
-/// discounting engine on the swap silently, so the swap needs none of its own.
-/// The `settings` handed here must be the same object driving the swaption and
-/// its swap, or the evaluation dates disagree and the NPV is silently wrong.
-///
-/// The surface's volatility type is checked against the Black formula at
-/// pricing time, not construction, so a normal-volatility surface surfaces as
-/// an `ItofinError` from `Swaption.npv()`.
+/// It prices the underlying swap itself, so that swap needs no engine of its
+/// own. The settings passed here must be the same object driving the swaption
+/// and its swap: a mismatch prices the two on different evaluation dates with
+/// no error raised. The surface's volatility type is checked against the Black
+/// formula at pricing time, not construction, so a normal-volatility surface
+/// raises from Swaption.npv().
 #[pyclass(name = "BlackSwaptionEngine", unsendable)]
 pub struct PyBlackSwaptionEngine {
     inner: SharedMut<BlackSwaptionEngine>,
@@ -61,7 +57,17 @@ pub struct PyBlackSwaptionEngine {
 
 #[pymethods]
 impl PyBlackSwaptionEngine {
-    /// An engine reading volatilities off `vol` and discounting on `discount`.
+    /// Build an engine reading volatilities off vol and discounting on discount.
+    ///
+    /// Args:
+    ///     vol (SwaptionVolatilityStructure): The surface volatilities are read
+    ///         off.
+    ///     discount (YieldTermStructure): The curve both legs are discounted
+    ///         on.
+    ///     settings (Settings): The explicit settings; must be the same object
+    ///         driving the swaption and its swap.
+    ///     model (CashAnnuityModel): Which date a cash-settled par-yield
+    ///         annuity discounts to. Defaults to SwapRate.
     #[new]
     #[pyo3(signature = (vol, discount, settings, model = PyCashAnnuityModel::SwapRate))]
     fn new(
@@ -80,9 +86,25 @@ impl PyBlackSwaptionEngine {
         }
     }
 
-    /// An engine over a flat volatility quote, which it wraps in a constant
-    /// surface on a null calendar whose reference date tracks the evaluation
-    /// date. `displacement` is the surface's lognormal shift.
+    /// Build an engine over a flat volatility quote.
+    ///
+    /// The quote is wrapped internally in a constant surface on a null calendar
+    /// whose reference date tracks the evaluation date.
+    ///
+    /// Args:
+    ///     discount (YieldTermStructure): The curve both legs are discounted
+    ///         on.
+    ///     vol (SimpleQuote): The flat Black volatility.
+    ///     day_counter (DayCounter): The day count the constant surface
+    ///         measures time on.
+    ///     displacement (float): The constant surface's lognormal shift.
+    ///     settings (Settings): The explicit settings; must be the same object
+    ///         driving the swaption and its swap.
+    ///     model (CashAnnuityModel): Which date a cash-settled par-yield
+    ///         annuity discounts to. Defaults to SwapRate.
+    ///
+    /// Returns:
+    ///     BlackSwaptionEngine: The engine over the flat surface.
     #[staticmethod]
     #[pyo3(signature = (discount, vol, day_counter, displacement, settings, model = PyCashAnnuityModel::SwapRate))]
     fn with_flat_vol(
@@ -113,18 +135,13 @@ impl PyBlackSwaptionEngine {
     }
 }
 
-/// Python `BachelierSwaptionEngine`: the normal-volatility swaption engine
-/// (`pricingengines::swaption::BachelierSwaptionEngine`), the Bachelier spec of
-/// the same template [`PyBlackSwaptionEngine`] instantiates.
+/// The normal-volatility swaption engine, European-only.
 ///
-/// European-only, and it prices the underlying swap itself: it installs its own
-/// discounting engine on the swap silently, so the swap needs none of its own.
-/// The `settings` handed here must be the same object driving the swaption and
-/// its swap, or the evaluation dates disagree and the NPV is silently wrong.
-///
-/// The surface's volatility type is checked against the normal formula at
-/// pricing time, not construction, so a shifted-lognormal surface surfaces as
-/// an `ItofinError` from `Swaption.npv()`.
+/// The Bachelier spec of the template BlackSwaptionEngine instantiates: same
+/// constructors, same settings requirement, same silent discounting engine on
+/// the underlying swap. The surface's volatility type is checked against the
+/// normal formula at pricing time, not construction, so a shifted-lognormal
+/// surface raises from Swaption.npv().
 #[pyclass(name = "BachelierSwaptionEngine", unsendable)]
 pub struct PyBachelierSwaptionEngine {
     inner: SharedMut<BachelierSwaptionEngine>,
@@ -132,8 +149,17 @@ pub struct PyBachelierSwaptionEngine {
 
 #[pymethods]
 impl PyBachelierSwaptionEngine {
-    /// An engine reading normal volatilities off `vol` and discounting on
-    /// `discount`.
+    /// Build an engine reading normal volatilities off vol.
+    ///
+    /// Args:
+    ///     vol (SwaptionVolatilityStructure): The surface normal volatilities
+    ///         are read off.
+    ///     discount (YieldTermStructure): The curve both legs are discounted
+    ///         on.
+    ///     settings (Settings): The explicit settings; must be the same object
+    ///         driving the swaption and its swap.
+    ///     model (CashAnnuityModel): Which date a cash-settled par-yield
+    ///         annuity discounts to. Defaults to SwapRate.
     #[new]
     #[pyo3(signature = (vol, discount, settings, model = PyCashAnnuityModel::SwapRate))]
     fn new(
@@ -152,11 +178,26 @@ impl PyBachelierSwaptionEngine {
         }
     }
 
-    /// An engine over a flat normal volatility quote, which it wraps in a
-    /// constant surface on a null calendar whose reference date tracks the
-    /// evaluation date. `displacement` is kept for signature parity with
-    /// [`PyBlackSwaptionEngine::with_flat_vol`]; the normal model has no shift
-    /// and ignores it.
+    /// Build an engine over a flat normal volatility quote.
+    ///
+    /// The quote is wrapped internally in a constant surface on a null calendar
+    /// whose reference date tracks the evaluation date.
+    ///
+    /// Args:
+    ///     discount (YieldTermStructure): The curve both legs are discounted
+    ///         on.
+    ///     vol (SimpleQuote): The flat normal volatility.
+    ///     day_counter (DayCounter): The day count the constant surface
+    ///         measures time on.
+    ///     displacement (float): Kept for signature parity with the Black
+    ///         engine; the normal model has no shift and ignores it.
+    ///     settings (Settings): The explicit settings; must be the same object
+    ///         driving the swaption and its swap.
+    ///     model (CashAnnuityModel): Which date a cash-settled par-yield
+    ///         annuity discounts to. Defaults to SwapRate.
+    ///
+    /// Returns:
+    ///     BachelierSwaptionEngine: The engine over the flat surface.
     #[staticmethod]
     #[pyo3(signature = (discount, vol, day_counter, displacement, settings, model = PyCashAnnuityModel::SwapRate))]
     fn with_flat_vol(

--- a/crates/itofin-py/src/swaptionvol.rs
+++ b/crates/itofin-py/src/swaptionvol.rs
@@ -37,12 +37,8 @@ use pyo3::prelude::*;
 /// in the order `[alpha, beta, nu, rho]`.
 const SABR_PARAMETERS: usize = 4;
 
-/// Python `SwaptionVolatilityStructure`: the shared base for every swaption
-/// volatility surface (`termstructures::volatility::SwaptionVolatilityStructure`).
-///
-/// The option and swap axes are addressed by tenor, the form the surfaces are
-/// quoted in; the core resolves each tenor against the surface's reference date
-/// and calendar before reading the volatility.
+/// Shared base for every swaption volatility surface: volatility, Black
+/// variance and lognormal shift, addressed by option and swap tenor.
 #[pyclass(name = "SwaptionVolatilityStructure", subclass, unsendable)]
 pub struct PySwaptionVolatilityStructure {
     inner: Handle<dyn SwaptionVolatilityStructure>,
@@ -50,7 +46,21 @@ pub struct PySwaptionVolatilityStructure {
 
 #[pymethods]
 impl PySwaptionVolatilityStructure {
-    /// The volatility for an option tenor, swap tenor and strike.
+    /// Return the volatility for an option tenor, swap tenor and strike.
+    ///
+    /// Args:
+    ///     option_tenor (Period): The option's tenor, resolved against the
+    ///         surface's reference date and calendar.
+    ///     swap_tenor (Period): The underlying swap's tenor.
+    ///     strike (float): The strike the volatility is read at.
+    ///     extrapolate (bool): Whether to answer outside the surface's grid.
+    ///
+    /// Returns:
+    ///     float: The volatility, in whichever type the surface quotes.
+    ///
+    /// Raises:
+    ///     ItofinError: If the query falls outside the grid and extrapolation
+    ///         is not allowed.
     #[pyo3(signature = (option_tenor, swap_tenor, strike, extrapolate = false))]
     fn volatility(
         &self,
@@ -72,8 +82,20 @@ impl PySwaptionVolatilityStructure {
             .map_err(PyQlError::from)?)
     }
 
-    /// The Black variance (`vol^2 * option_time`) for an option tenor, swap
-    /// tenor and strike.
+    /// Return the Black variance, the squared volatility times option time.
+    ///
+    /// Args:
+    ///     option_tenor (Period): The option's tenor.
+    ///     swap_tenor (Period): The underlying swap's tenor.
+    ///     strike (float): The strike the variance is read at.
+    ///     extrapolate (bool): Whether to answer outside the surface's grid.
+    ///
+    /// Returns:
+    ///     float: The Black variance.
+    ///
+    /// Raises:
+    ///     ItofinError: If the query falls outside the grid and extrapolation
+    ///         is not allowed.
     #[pyo3(signature = (option_tenor, swap_tenor, strike, extrapolate = false))]
     fn black_variance(
         &self,
@@ -95,12 +117,22 @@ impl PySwaptionVolatilityStructure {
             .map_err(PyQlError::from)?)
     }
 
-    /// The lognormal shift for an option date and swap length in years.
+    /// Return the lognormal shift, in the date form.
     ///
     /// Taken in the date form because the core trait has no tenor overload for
-    /// the shift (only `shift` and `shift_time`), unlike the volatility and
-    /// variance queries above. Errors on a normal-volatility surface, where a
-    /// shift has no meaning.
+    /// the shift, unlike the volatility and variance queries above.
+    ///
+    /// Args:
+    ///     option_date (Date): The option date the shift is read at.
+    ///     swap_length (float): The underlying swap's length, in years.
+    ///     extrapolate (bool): Whether to answer outside the surface's grid.
+    ///
+    /// Returns:
+    ///     float: The lognormal shift.
+    ///
+    /// Raises:
+    ///     ItofinError: On a normal-volatility surface, where a shift has no
+    ///         meaning, and on an out-of-grid query without extrapolation.
     #[pyo3(signature = (option_date, swap_length, extrapolate = false))]
     fn shift(&self, option_date: &PyDate, swap_length: f64, extrapolate: bool) -> PyResult<f64> {
         Ok(self
@@ -111,11 +143,18 @@ impl PySwaptionVolatilityStructure {
             .map_err(PyQlError::from)?)
     }
 
-    /// The date every option time is measured from.
+    /// Return the date every option time is measured from.
     ///
-    /// Pinned at construction on the fixed-reference surfaces; derived from the
-    /// `Settings` evaluation date (settlement days on the calendar) on the
-    /// moving ones, so it follows a later `set_evaluation_date`.
+    /// Pinned at construction on the fixed-reference surfaces; derived from
+    /// the Settings evaluation date (settlement days on the calendar) on the
+    /// moving ones, so it follows a later set_evaluation_date.
+    ///
+    /// Returns:
+    ///     Date: The surface's reference date.
+    ///
+    /// Raises:
+    ///     ItofinError: On a moving surface whose Settings has no evaluation
+    ///         date set.
     fn reference_date(&self) -> PyResult<PyDate> {
         Ok(PyDate::from_inner(
             self.inner
@@ -142,14 +181,8 @@ impl PySwaptionVolatilityStructure {
     }
 }
 
-/// Python `VolatilityType`: whether a surface quotes shifted-lognormal (Black)
-/// or normal (Bachelier) volatilities
-/// (`termstructures::volatility::VolatilityType`).
-///
-/// A fieldless pyo3 enum. The engine checks the surface it is handed against
-/// its own formula and errors at pricing time on a mismatch, so a `Normal`
-/// surface fed to `BlackSwaptionEngine` surfaces as an `ItofinError` from
-/// `npv()`, not from the constructor.
+/// Whether a surface quotes shifted-lognormal (Black) or normal (Bachelier)
+/// volatilities. A mismatch with the engine's formula surfaces at pricing time.
 #[pyclass(name = "VolatilityType", eq, eq_int, from_py_object)]
 #[derive(Clone, Copy, PartialEq)]
 pub enum PyVolatilityType {
@@ -167,23 +200,32 @@ impl PyVolatilityType {
     }
 }
 
-/// Python `ConstantSwaptionVolatility`: a single volatility with no option-time,
-/// swap-length or strike dependence
-/// (`termstructures::volatility::ConstantSwaptionVolatility`).
+/// A single volatility with no option-time, swap-length or strike dependence.
 ///
-/// Extends [`PySwaptionVolatilityStructure`] and supplies only the constructors;
-/// the query surface is inherited. Unbounded in time and strike, so queries
-/// never need extrapolation enabled. [`new`](Self::new) and
-/// [`with_quote`](Self::with_quote) pin the reference date;
-/// [`moving`](Self::moving) and [`moving_with_quote`](Self::moving_with_quote)
-/// float it off the `Settings` evaluation date (#627).
+/// The constructor and with_quote pin the reference date, so every query's
+/// option time runs from reference_date rather than the evaluation date. The
+/// moving and moving_with_quote forms float the reference date off the
+/// Settings evaluation date instead (#627).
 #[pyclass(name = "ConstantSwaptionVolatility", extends = PySwaptionVolatilityStructure, unsendable)]
 pub struct PyConstantSwaptionVolatility;
 
 #[pymethods]
 impl PyConstantSwaptionVolatility {
-    /// A constant surface at a fixed `volatility`, wrapped in an internal quote
-    /// the caller cannot later mutate.
+    /// Build the surface at a fixed volatility.
+    ///
+    /// Args:
+    ///     reference_date (Date): The date every query's option time runs
+    ///         from.
+    ///     calendar (Calendar): The calendar option tenors resolve on.
+    ///     business_day_convention (BusinessDayConvention): The roll applied
+    ///         when resolving a tenor to a date.
+    ///     volatility (float): The single volatility answered everywhere,
+    ///         wrapped in an internal quote the caller cannot later mutate.
+    ///     day_counter (DayCounter): The day count option times are measured
+    ///         in.
+    ///     volatility_type (VolatilityType): Whether the quote is
+    ///         shifted-lognormal or normal.
+    ///     shift (float): The lognormal shift.
     #[new]
     #[pyo3(signature = (reference_date, calendar, business_day_convention, volatility, day_counter, volatility_type, shift = 0.0))]
     fn new(
@@ -210,8 +252,24 @@ impl PyConstantSwaptionVolatility {
         .add_subclass(PyConstantSwaptionVolatility)
     }
 
-    /// A constant surface reading `volatility` from the caller's quote; a later
-    /// `set_value` on that quote notifies the surface's observers.
+    /// Build the surface reading its volatility from a live quote.
+    ///
+    /// Args:
+    ///     reference_date (Date): The date every query's option time runs
+    ///         from.
+    ///     calendar (Calendar): The calendar option tenors resolve on.
+    ///     business_day_convention (BusinessDayConvention): The roll applied
+    ///         when resolving a tenor to a date.
+    ///     volatility (SimpleQuote): The volatility; a later set_value
+    ///         notifies the surface's observers.
+    ///     day_counter (DayCounter): The day count option times are measured
+    ///         in.
+    ///     volatility_type (VolatilityType): Whether the quote is
+    ///         shifted-lognormal or normal.
+    ///     shift (float): The lognormal shift.
+    ///
+    /// Returns:
+    ///     ConstantSwaptionVolatility: The surface over that quote.
     #[staticmethod]
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (reference_date, calendar, business_day_convention, volatility, day_counter, volatility_type, shift = 0.0))]
@@ -243,9 +301,30 @@ impl PyConstantSwaptionVolatility {
         )
     }
 
-    /// A constant surface whose reference date floats off `settings`'
-    /// evaluation date by `settlement_days` on `calendar`, at a fixed
-    /// `volatility` wrapped in an internal quote the caller cannot later mutate.
+    /// Build the surface with a reference date floating off the evaluation date.
+    ///
+    /// The reference date is the evaluation date advanced by settlement_days
+    /// business days on calendar, so it follows a later set_evaluation_date.
+    ///
+    /// Args:
+    ///     settlement_days (int): Business days between the evaluation date
+    ///         and the reference date.
+    ///     calendar (Calendar): The calendar the reference date is derived on
+    ///         and option tenors resolve on.
+    ///     business_day_convention (BusinessDayConvention): The roll applied
+    ///         when resolving a tenor to a date.
+    ///     volatility (float): The single volatility answered everywhere,
+    ///         wrapped in an internal quote the caller cannot later mutate.
+    ///     day_counter (DayCounter): The day count option times are measured
+    ///         in.
+    ///     volatility_type (VolatilityType): Whether the quote is
+    ///         shifted-lognormal or normal.
+    ///     settings (Settings): The evaluation context the reference date
+    ///         floats off.
+    ///     shift (float): The lognormal shift.
+    ///
+    /// Returns:
+    ///     ConstantSwaptionVolatility: The moving surface.
     #[staticmethod]
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (settlement_days, calendar, business_day_convention, volatility, day_counter, volatility_type, settings, shift = 0.0))]
@@ -279,9 +358,27 @@ impl PyConstantSwaptionVolatility {
         )
     }
 
-    /// A constant surface whose reference date floats off `settings`'
-    /// evaluation date, reading `volatility` from the caller's quote; a later
-    /// `set_value` on that quote notifies the surface's observers.
+    /// Build the moving surface reading its volatility from a live quote.
+    ///
+    /// Args:
+    ///     settlement_days (int): Business days between the evaluation date
+    ///         and the reference date.
+    ///     calendar (Calendar): The calendar the reference date is derived on
+    ///         and option tenors resolve on.
+    ///     business_day_convention (BusinessDayConvention): The roll applied
+    ///         when resolving a tenor to a date.
+    ///     volatility (SimpleQuote): The volatility; a later set_value
+    ///         notifies the surface's observers.
+    ///     day_counter (DayCounter): The day count option times are measured
+    ///         in.
+    ///     volatility_type (VolatilityType): Whether the quote is
+    ///         shifted-lognormal or normal.
+    ///     settings (Settings): The evaluation context the reference date
+    ///         floats off.
+    ///     shift (float): The lognormal shift.
+    ///
+    /// Returns:
+    ///     ConstantSwaptionVolatility: The moving surface over that quote.
     #[staticmethod]
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (settlement_days, calendar, business_day_convention, volatility, day_counter, volatility_type, settings, shift = 0.0))]
@@ -316,24 +413,47 @@ impl PyConstantSwaptionVolatility {
     }
 }
 
-/// Python `SwaptionVolatilityMatrix`: the at-the-money volatility grid,
-/// bilinear over an option-tenor x swap-tenor lattice
-/// (`termstructures::volatility::SwaptionVolatilityMatrix`).
+/// An at-the-money volatility grid, bilinear over an option-tenor x
+/// swap-tenor lattice.
 ///
-/// Extends [`PySwaptionVolatilityStructure`] and supplies only the
-/// constructors. Every grid is a row per option tenor and a column per swap
-/// tenor; `shifts`, when given, must match that shape, and `None` means
-/// all-zero shifts. The grid is at the money, so a query's strike argument is
-/// range-checked and then ignored. `flat_extrapolation` selects C++'s
-/// `flatExtrapolation = true`, under which a query past the grid clamps to the
-/// nearest edge or corner vol instead of extending the boundary surface.
+/// Every grid is a row per option tenor and a column per swap tenor; shifts,
+/// when given, must match that shape, and None means all-zero shifts. The grid
+/// is at the money, so a query's strike is range-checked and then ignored.
+/// flat_extrapolation clamps a query past the grid to the nearest edge or
+/// corner vol instead of extending the boundary surface.
 #[pyclass(name = "SwaptionVolatilityMatrix", extends = PySwaptionVolatilityStructure, unsendable)]
 pub struct PySwaptionVolatilityMatrix;
 
 #[pymethods]
 impl PySwaptionVolatilityMatrix {
-    /// A grid on a pinned reference date over fixed volatilities: every query's
-    /// option time runs from `reference_date`, not from the evaluation date.
+    /// Build the grid on a pinned reference date over fixed volatilities.
+    ///
+    /// Every query's option time runs from reference_date rather than from the
+    /// evaluation date.
+    ///
+    /// Args:
+    ///     reference_date (Date): The date option times run from.
+    ///     calendar (Calendar): The calendar option tenors resolve on.
+    ///     business_day_convention (BusinessDayConvention): The roll applied
+    ///         when resolving a tenor to a date.
+    ///     option_tenors (list[Period]): The option axis, one per grid row.
+    ///     swap_tenors (list[Period]): The swap axis, one per grid column.
+    ///     volatilities (list[list[float]]): The at-the-money volatilities,
+    ///         one row per option tenor.
+    ///     day_counter (DayCounter): The day count option times are measured
+    ///         in.
+    ///     volatility_type (VolatilityType): Whether the grid is
+    ///         shifted-lognormal or normal.
+    ///     shifts (list[list[float]] | None): The lognormal shifts in the same
+    ///         shape as volatilities; None means all-zero shifts.
+    ///     flat_extrapolation (bool): Whether a query past the grid clamps to
+    ///         the nearest edge or corner vol instead of extending the
+    ///         boundary surface.
+    ///
+    /// Raises:
+    ///     ItofinError: On an empty or ragged grid, a shifts grid that does
+    ///         not match the volatilities shape, and on whatever the core
+    ///         rejects about the axes.
     #[new]
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (reference_date, calendar, business_day_convention, option_tenors, swap_tenors, volatilities, day_counter, volatility_type, shifts = None, flat_extrapolation = false))]
@@ -381,10 +501,37 @@ impl PySwaptionVolatilityMatrix {
         )
     }
 
-    /// A grid whose reference date floats off `settings`' evaluation date (zero
-    /// settlement days), reading each node from the caller's quote: a later
-    /// `set_value` on any of them rebuilds the interpolation and notifies the
-    /// grid's observers.
+    /// Build a grid whose reference date floats off the evaluation date.
+    ///
+    /// The reference date sits at zero settlement days from the evaluation
+    /// date, and each node is read from the caller's quote.
+    ///
+    /// Args:
+    ///     calendar (Calendar): The calendar option tenors resolve on.
+    ///     business_day_convention (BusinessDayConvention): The roll applied
+    ///         when resolving a tenor to a date.
+    ///     option_tenors (list[Period]): The option axis, one per grid row.
+    ///     swap_tenors (list[Period]): The swap axis, one per grid column.
+    ///     volatilities (list[list[SimpleQuote]]): The at-the-money volatility
+    ///         quotes; a later set_value on any of them rebuilds the
+    ///         interpolation and notifies the grid's observers.
+    ///     day_counter (DayCounter): The day count option times are measured
+    ///         in.
+    ///     volatility_type (VolatilityType): Whether the grid is
+    ///         shifted-lognormal or normal.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date the reference date floats off.
+    ///     shifts (list[list[float]] | None): The lognormal shifts in the same
+    ///         shape as volatilities; None means all-zero shifts.
+    ///     flat_extrapolation (bool): Whether a query past the grid clamps to
+    ///         the nearest edge or corner vol.
+    ///
+    /// Returns:
+    ///     SwaptionVolatilityMatrix: The moving grid.
+    ///
+    /// Raises:
+    ///     ItofinError: On an empty or ragged grid, a mismatched shifts shape,
+    ///         and on whatever the core rejects about the axes.
     #[staticmethod]
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (calendar, business_day_convention, option_tenors, swap_tenors, volatilities, day_counter, volatility_type, settings, shifts = None, flat_extrapolation = false))]
@@ -442,26 +589,17 @@ impl PySwaptionVolatilityMatrix {
     }
 }
 
-/// Python `InterpolatedSwaptionVolatilityCube`: a smile cube adding
-/// bilinearly-interpolated volatility spreads to an at-the-money surface
-/// (`termstructures::volatility::InterpolatedSwaptionVolatilityCube`).
+/// A smile cube adding bilinearly-interpolated volatility spreads to an
+/// at-the-money surface.
 ///
-/// Extends [`PySwaptionVolatilityStructure`], so the inherited `volatility`
-/// query now takes a real strike: the cube reads the at-the-money forward off
-/// its base swap indexes, the at-the-money volatility off `atm_vol`, and adds
-/// the spread interpolated at `strike - atm_strike`. `atm_strike` is served by
-/// [`atm_strike_from_tenor`](PyInterpolatedSwaptionVolatilityCube::atm_strike_from_tenor),
-/// which is what a caller needs to place a query on the smile.
+/// The inherited volatility query now takes a real strike: the cube reads the
+/// at-the-money forward off its base swap indexes, the at-the-money volatility
+/// off atm_vol, and adds the spread interpolated at strike - atm_strike.
 ///
-/// `vol_spreads` is **row-major over the `(option tenor, swap tenor)` nodes**:
-/// row `i * len(swap_tenors) + j` is the smile at `(option_tenors[i],
-/// swap_tenors[j])`, holding one quote per entry of `strike_spreads`. The shape
-/// is checked here rather than left to the core's dimension error. A later
-/// `set_value` on any of those quotes rebuilds the per-strike interpolators.
-///
-/// `swap_index_base` is the long base index and `short_swap_index_base` the
-/// short one; the cube picks between them per query by swap tenor, so the short
-/// index's tenor must not exceed the long one's.
+/// vol_spreads is row-major over the (option tenor, swap tenor) nodes: row
+/// i * len(swap_tenors) + j is the smile at (option_tenors[i], swap_tenors[j]),
+/// holding one quote per entry of strike_spreads. A later set_value on any of
+/// those quotes rebuilds the per-strike interpolators.
 #[pyclass(name = "InterpolatedSwaptionVolatilityCube", extends = PySwaptionVolatilityStructure, unsendable)]
 pub struct PyInterpolatedSwaptionVolatilityCube {
     concrete: Shared<InterpolatedSwaptionVolatilityCube>,
@@ -469,6 +607,30 @@ pub struct PyInterpolatedSwaptionVolatilityCube {
 
 #[pymethods]
 impl PyInterpolatedSwaptionVolatilityCube {
+    /// Build the cube over an at-the-money surface and its vol spreads.
+    ///
+    /// Args:
+    ///     atm_vol (SwaptionVolatilityStructure): The at-the-money surface the
+    ///         spreads are added to.
+    ///     option_tenors (list[Period]): The option axis of the node grid.
+    ///     swap_tenors (list[Period]): The swap axis of the node grid.
+    ///     strike_spreads (list[float]): The moneyness offsets each smile is
+    ///         quoted at.
+    ///     vol_spreads (list[list[SimpleQuote]]): The spread quotes, row-major
+    ///         over the nodes with one quote per strike spread; a later
+    ///         set_value rebuilds the per-strike interpolators.
+    ///     swap_index_base (SwapIndex): The long base swap index.
+    ///     short_swap_index_base (SwapIndex): The short base swap index, whose
+    ///         tenor must not exceed the long one's.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date and the stored fixings.
+    ///     vega_weighted_smile_fit (bool): Whether the smile fit is
+    ///         vega-weighted.
+    ///
+    /// Raises:
+    ///     ItofinError: On an empty or ragged vol_spreads grid, on a row count
+    ///         that is not one per node or a row length that is not one per
+    ///         strike spread, and on whatever the core rejects.
     #[new]
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (atm_vol, option_tenors, swap_tenors, strike_spreads, vol_spreads, swap_index_base, short_swap_index_base, settings, vega_weighted_smile_fit = false))]
@@ -523,12 +685,24 @@ impl PyInterpolatedSwaptionVolatilityCube {
         )
     }
 
-    /// The at-the-money strike for an option tenor and swap tenor: the fixing of
-    /// whichever base swap index the swap tenor selects, off the option date the
-    /// tenor resolves to against the cube's reference date and calendar.
+    /// Return the at-the-money strike for an option tenor and swap tenor.
     ///
-    /// Lives on the concrete cube rather than the inherited base because it is
-    /// the cube framework's, not the volatility structure trait's.
+    /// The fixing of whichever base swap index the swap tenor selects, off the
+    /// option date the tenor resolves to against the cube's reference date and
+    /// calendar. It lives on the concrete cube rather than the inherited base
+    /// because it belongs to the cube framework, not the volatility structure.
+    ///
+    /// Args:
+    ///     option_tenor (Period): The option's tenor.
+    ///     swap_tenor (Period): The underlying swap's tenor, which selects the
+    ///         base index.
+    ///
+    /// Returns:
+    ///     float: The at-the-money strike a query is centred on.
+    ///
+    /// Raises:
+    ///     ItofinError: On whatever the selected index's fixing reports, an
+    ///         unset evaluation date or an unlinked forwarding curve included.
     fn atm_strike_from_tenor(
         &self,
         option_tenor: &PyPeriod,
@@ -542,34 +716,29 @@ impl PyInterpolatedSwaptionVolatilityCube {
     }
 }
 
-/// Python `SabrSwaptionVolatilityCube`: a smile cube whose every node is a SABR
-/// smile fitted to the at-the-money volatility plus the market vol spreads
-/// (`termstructures::volatility::SabrSwaptionVolatilityCube`).
+/// A smile cube whose every node is a SABR smile fitted to the at-the-money
+/// volatility plus the market vol spreads.
 ///
-/// Extends [`PySwaptionVolatilityStructure`], so the inherited `volatility`
-/// query takes a real strike and answers off the fitted smile rather than an
-/// interpolated spread. Construction is where the work happens: every node is
-/// calibrated by Levenberg-Marquardt, and with `is_atm_calibrated` a second
-/// dense pass re-anchors the fitted smiles on the at-the-money surface.
+/// The inherited volatility query takes a real strike and answers off the fitted
+/// smile rather than an interpolated spread. Construction is where the work
+/// happens: every node is calibrated by Levenberg-Marquardt, and with
+/// is_atm_calibrated a second dense pass re-anchors the fitted smiles on the
+/// at-the-money surface.
 ///
-/// `vol_spreads` and `parameters_guess` are both **row-major over the
-/// `(option tenor, swap tenor)` nodes**, as in
-/// [`PyInterpolatedSwaptionVolatilityCube`]: row `i * len(swap_tenors) + j` is
-/// the node at `(option_tenors[i], swap_tenors[j])`. A `vol_spreads` row holds
-/// one quote per entry of `strike_spreads`; a `parameters_guess` row holds the
-/// four SABR starting values `[alpha, beta, nu, rho]`. `is_parameter_fixed` pins
-/// a parameter at its guess across every node, in that same order.
+/// vol_spreads and parameters_guess are both row-major over the (option tenor,
+/// swap tenor) nodes: row i * len(swap_tenors) + j is the node at
+/// (option_tenors[i], swap_tenors[j]). A vol_spreads row holds one quote per
+/// entry of strike_spreads; a parameters_guess row holds the four SABR starting
+/// values [alpha, beta, nu, rho]. is_parameter_fixed pins a parameter at its
+/// guess across every node, in that same order.
 ///
-/// Deferred (visible): backward-flat interpolation is not ported (core #606) and
-/// is not exposed; the optimisation method is always the core's default
-/// Levenberg-Marquardt, since a trait object does not cross FFI (D7); a normal
-/// (Bachelier) at-the-money surface needs the normal SABR formula, deferred to
-/// core #586, and surfaces as an `ItofinError` from the constructor. ZABR and
-/// the generic XABR cube are a separate core track (#597), so SABR is the only
-/// smile model bound here. The section-recalibration API (C++'s
-/// `recalibration` / `sabrCalibrationSection`) has no binding because the core
-/// does not port it (sabrcube.rs:60-62); a caller re-fits by bumping the guess
-/// or vol-spread quotes, which invalidates the calibration.
+/// The end criteria, maximum error tolerance, optimisation method and accepted
+/// error are left at the core's C++ defaults. Backward-flat interpolation
+/// (core #606) is not exposed, and the optimisation method is always
+/// Levenberg-Marquardt, since a trait object does not cross FFI. ZABR and the
+/// generic XABR cube are a separate core track (#597), and the section-
+/// recalibration API is unported in the core: re-fit by bumping the guess or
+/// vol-spread quotes.
 #[pyclass(name = "SabrSwaptionVolatilityCube", extends = PySwaptionVolatilityStructure, unsendable)]
 pub struct PySabrSwaptionVolatilityCube {
     concrete: Shared<SabrSwaptionVolatilityCube>,
@@ -577,9 +746,44 @@ pub struct PySabrSwaptionVolatilityCube {
 
 #[pymethods]
 impl PySabrSwaptionVolatilityCube {
-    /// A cube calibrating every node on construction. `end_criteria`, the
-    /// maximum error tolerance, the optimisation method and the accepted error
-    /// are left at the core's C++ defaults.
+    /// Build the cube, calibrating every node on construction.
+    ///
+    /// The end criteria, the maximum error tolerance, the optimisation method
+    /// and the accepted error are left at the core's C++ defaults.
+    ///
+    /// Args:
+    ///     atm_vol (SwaptionVolatilityStructure): The at-the-money surface the
+    ///         fitted smiles are anchored on.
+    ///     option_tenors (list[Period]): The option axis of the node grid.
+    ///     swap_tenors (list[Period]): The swap axis of the node grid.
+    ///     strike_spreads (list[float]): The moneyness offsets each smile is
+    ///         quoted at.
+    ///     vol_spreads (list[list[SimpleQuote]]): The spread quotes, row-major
+    ///         over the nodes with one quote per strike spread.
+    ///     swap_index_base (SwapIndex): The long base swap index.
+    ///     short_swap_index_base (SwapIndex): The short base swap index.
+    ///     parameters_guess (list[list[SimpleQuote]]): The SABR starting
+    ///         values, row-major over the nodes, each row holding alpha, beta,
+    ///         nu and rho in that order.
+    ///     is_parameter_fixed (list[bool]): Which of the four parameters are
+    ///         pinned at their guess across every node, in that same order.
+    ///     is_atm_calibrated (bool): Whether a second dense pass re-anchors
+    ///         the fitted smiles on the at-the-money surface.
+    ///     settings (Settings): The explicit settings supplying the evaluation
+    ///         date and the stored fixings.
+    ///     vega_weighted_smile_fit (bool): Whether the smile fit is
+    ///         vega-weighted.
+    ///     use_max_error (bool): Whether the fit is judged on the maximum
+    ///         error rather than the aggregate one.
+    ///     max_guesses (int): How many starting guesses a node may try.
+    ///     cutoff_strike (float): The strike floor the fit is evaluated above.
+    ///
+    /// Raises:
+    ///     ItofinError: On an empty or ragged vol_spreads or parameters_guess
+    ///         grid, on a row count that is not one per node, on an
+    ///         is_parameter_fixed list that is not four entries long, on a
+    ///         normal at-the-money surface, which needs the deferred normal
+    ///         SABR formula, and on a calibration failure.
     #[new]
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (atm_vol, option_tenors, swap_tenors, strike_spreads, vol_spreads, swap_index_base, short_swap_index_base, parameters_guess, is_parameter_fixed, is_atm_calibrated, settings, vega_weighted_smile_fit = false, use_max_error = false, max_guesses = 50, cutoff_strike = 0.0001))]
@@ -655,12 +859,23 @@ impl PySabrSwaptionVolatilityCube {
         )
     }
 
-    /// The at-the-money strike for an option tenor and swap tenor: the fixing of
-    /// whichever base swap index the swap tenor selects, off the option date the
-    /// tenor resolves to against the cube's reference date and calendar.
+    /// Return the at-the-money strike for an option tenor and swap tenor.
     ///
-    /// This is the strike the fitted smile is centred on, so it is what a caller
-    /// needs to place a query at a given moneyness.
+    /// The fixing of whichever base swap index the swap tenor selects, and the
+    /// strike the fitted smile is centred on, so it is what a caller needs to
+    /// place a query at a given moneyness.
+    ///
+    /// Args:
+    ///     option_tenor (Period): The option's tenor.
+    ///     swap_tenor (Period): The underlying swap's tenor, which selects the
+    ///         base index.
+    ///
+    /// Returns:
+    ///     float: The at-the-money strike.
+    ///
+    /// Raises:
+    ///     ItofinError: On whatever the selected index's fixing reports, an
+    ///         unset evaluation date or an unlinked forwarding curve included.
     fn atm_strike_from_tenor(
         &self,
         option_tenor: &PyPeriod,

--- a/crates/itofin-py/src/swaptionvol.rs
+++ b/crates/itofin-py/src/swaptionvol.rs
@@ -600,6 +600,9 @@ impl PySwaptionVolatilityMatrix {
 /// i * len(swap_tenors) + j is the smile at (option_tenors[i], swap_tenors[j]),
 /// holding one quote per entry of strike_spreads. A later set_value on any of
 /// those quotes rebuilds the per-strike interpolators.
+///
+/// swap_index_base is the long base index and short_swap_index_base the short
+/// one; the cube picks between them per query by swap tenor.
 #[pyclass(name = "InterpolatedSwaptionVolatilityCube", extends = PySwaptionVolatilityStructure, unsendable)]
 pub struct PyInterpolatedSwaptionVolatilityCube {
     concrete: Shared<InterpolatedSwaptionVolatilityCube>,

--- a/crates/itofin-py/src/swaptionvol.rs
+++ b/crates/itofin-py/src/swaptionvol.rs
@@ -1,16 +1,15 @@
-//! Facades for the swaption volatility stack: the [`PySwaptionVolatilityStructure`]
-//! base, the [`PyVolatilityType`] flag, the constant surface
-//! [`PyConstantSwaptionVolatility`], the at-the-money grid
-//! [`PySwaptionVolatilityMatrix`], the spread cube over it,
-//! [`PyInterpolatedSwaptionVolatilityCube`], and the calibrated
-//! [`PySabrSwaptionVolatilityCube`].
+//! Facades for the swaption volatility stack: the SwaptionVolatilityStructure
+//! base, the VolatilityType flag, the constant surface
+//! ConstantSwaptionVolatility, the at-the-money grid SwaptionVolatilityMatrix,
+//! the spread cube over it, InterpolatedSwaptionVolatilityCube, and the
+//! calibrated SabrSwaptionVolatilityCube.
 //!
-//! The base holds the erased `Handle<dyn SwaptionVolatilityStructure>` and
-//! exposes the queries every concrete surface inherits; concrete surfaces
+//! The base holds the surface type-erased and exposes the queries every
+//! concrete surface inherits; concrete surfaces
 //! subclass it and supply only their constructor. They build the base through
-//! [`from_handle`](PySwaptionVolatilityStructure::from_handle) rather than a
-//! struct literal, so the later surfaces in this file (and the matrix/cube
-//! facades stacking on it) never need access to the private field.
+//! from_handle() rather than a struct literal, so the later surfaces in this
+//! file (and the matrix/cube facades stacking on it) never need access to the
+//! private field.
 //!
 //! The constant surface exposes both reference-date families (#627): `new` and
 //! `with_quote` pin the reference date, while `moving` and `moving_with_quote`
@@ -191,7 +190,7 @@ pub enum PyVolatilityType {
 }
 
 impl PyVolatilityType {
-    /// The core [`VolatilityType`] this variant stands for.
+    /// The core VolatilityType this variant stands for.
     pub(crate) fn inner(&self) -> VolatilityType {
         match self {
             PyVolatilityType::ShiftedLognormal => VolatilityType::ShiftedLognormal,
@@ -950,7 +949,7 @@ fn node_grid(
         .collect())
 }
 
-/// A `list[list[float]]` as a core [`Matrix`], one row per option tenor.
+/// A `list[list[float]]` as a core Matrix, one row per option tenor.
 fn matrix_from_rows(rows: &[Vec<f64>], label: &str) -> PyResult<Matrix> {
     let columns = check_grid(rows, label)?;
     let mut matrix = Matrix::with_size(rows.len(), columns);

--- a/crates/itofin-py/src/time.rs
+++ b/crates/itofin-py/src/time.rs
@@ -129,6 +129,9 @@ impl PyDate {
 
     /// The signed number of days from other to this date.
     ///
+    /// The other operand may also be an int, which shifts the date back by that
+    /// many calendar days and returns a Date. Anything else raises TypeError.
+    ///
     /// Args:
     ///     other (Date): The date to measure from.
     ///

--- a/crates/itofin-py/src/time.rs
+++ b/crates/itofin-py/src/time.rs
@@ -50,12 +50,10 @@ fn days_in_month(month: i32, year: i32) -> i32 {
     }
 }
 
-/// Python `Date`: a calendar date with a mandatory validation guard.
+/// A calendar date with a validation guard.
 ///
-/// The core's `Date::new`, `Month::from_ordinal` and `Date + i32` all `panic!`
-/// on out-of-range input, and a panic unwinding across the PyO3 boundary is an
-/// abort/UB hazard. Every constructor here validates first and returns
-/// [`struct@ItofinError`] before touching the core.
+/// Every constructor and every arithmetic result is range-checked before the
+/// core is reached, so an out-of-range date is an error rather than a panic.
 #[pyclass(name = "Date", unsendable)]
 pub struct PyDate {
     inner: Date,
@@ -63,6 +61,16 @@ pub struct PyDate {
 
 #[pymethods]
 impl PyDate {
+    /// Build a date from its three components.
+    ///
+    /// Args:
+    ///     day (int): The day of the month, within the length of that month.
+    ///     month (int): The month, from 1 to 12.
+    ///     year (int): The year, from 1901 to 2199.
+    ///
+    /// Raises:
+    ///     ItofinError: If month is outside [1, 12], year is outside
+    ///         [1901, 2199], or day is outside the length of that month.
     #[new]
     fn new(day: i32, month: i32, year: i32) -> PyResult<Self> {
         if !(1..=12).contains(&month) {
@@ -86,33 +94,46 @@ impl PyDate {
         })
     }
 
+    /// The year.
     #[getter]
     fn year(&self) -> i32 {
         self.inner.year()
     }
 
+    /// The month, from 1 to 12.
     #[getter]
     fn month(&self) -> i32 {
         self.inner.month().ordinal()
     }
 
+    /// The day of the month.
     #[getter]
     fn day(&self) -> i32 {
         self.inner.day_of_month()
     }
 
+    /// Shift the date forward by a number of calendar days.
+    ///
+    /// Args:
+    ///     days (int): The number of calendar days to add.
+    ///
+    /// Returns:
+    ///     Date: The shifted date.
+    ///
+    /// Raises:
+    ///     ItofinError: If the result falls outside the representable date
+    ///         range.
     fn __add__(&self, days: i32) -> PyResult<Self> {
         self.shifted(days as i64)
     }
 
-    /// Subtracts either a day count or another date.
+    /// The signed number of days from other to this date.
     ///
-    /// `date - int` shifts back by that many calendar days and returns a
-    /// [`PyDate`]; `date - date` returns the signed number of days between them
-    /// as an `int` (core `impl Sub<Date> for Date`, `date.rs:385`). PyO3 cannot
-    /// declare a type-directed overload, so the argument is taken untyped and
-    /// dispatched by downcast; anything else is a `TypeError` from the failed
-    /// `int` extraction.
+    /// Args:
+    ///     other (Date): The date to measure from.
+    ///
+    /// Returns:
+    ///     int: The signed day count between the two dates.
     fn __sub__(&self, py: Python<'_>, other: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
         if let Ok(other_date) = other.cast::<PyDate>() {
             let subtrahend = other_date.borrow().inner;
@@ -123,16 +144,29 @@ impl PyDate {
         self.shifted(-(days as i64))?.into_py_any(py)
     }
 
+    /// Whether the two dates are the same calendar day.
+    ///
+    /// Args:
+    ///     other (object): The date to compare against.
+    ///
+    /// Returns:
+    ///     bool: True when both stand for the same day.
     fn __eq__(&self, other: &PyDate) -> bool {
         self.inner == other.inner
     }
 
-    /// Hashes the core date, the one field [`__eq__`](Self::__eq__) compares,
-    /// so a date can key a dict or join a set.
+    /// Hashes the calendar day, the field equality compares.
+    ///
+    /// Returns:
+    ///     int: The hash of the date, so equal dates hash equal.
     fn __hash__(&self) -> u64 {
         hash_of(&self.inner)
     }
 
+    /// Return the constructor form of the date.
+    ///
+    /// Returns:
+    ///     str: The date as Date(day, month, year).
     fn __repr__(&self) -> String {
         format!(
             "Date({}, {}, {})",
@@ -170,7 +204,7 @@ impl PyDate {
     }
 }
 
-/// Python `DayCounter`: the year-fraction convention factories.
+/// A year-fraction convention.
 #[pyclass(name = "DayCounter", unsendable)]
 pub struct PyDayCounter {
     inner: DayCounter,
@@ -178,6 +212,10 @@ pub struct PyDayCounter {
 
 #[pymethods]
 impl PyDayCounter {
+    /// The Actual/360 convention.
+    ///
+    /// Returns:
+    ///     DayCounter: An Actual/360 day counter.
     #[staticmethod]
     fn actual360() -> Self {
         PyDayCounter {
@@ -185,6 +223,10 @@ impl PyDayCounter {
         }
     }
 
+    /// The Actual/365 (Fixed) convention.
+    ///
+    /// Returns:
+    ///     DayCounter: An Actual/365 (Fixed) day counter.
     #[staticmethod]
     fn actual365_fixed() -> Self {
         PyDayCounter {
@@ -192,8 +234,10 @@ impl PyDayCounter {
         }
     }
 
-    /// `ActualActual(ActualActual::ISDA)`: the day count the Heston/Hull-White
-    /// flat-curve oracles anchor on (`test-suite` `flatRate`).
+    /// The Actual/Actual (ISDA) convention.
+    ///
+    /// Returns:
+    ///     DayCounter: An Actual/Actual day counter on the ISDA convention.
     #[staticmethod]
     fn actual_actual_isda() -> Self {
         PyDayCounter {
@@ -201,8 +245,10 @@ impl PyDayCounter {
         }
     }
 
-    /// `Thirty360(Thirty360::BondBasis)`: the fixed-leg day count the Hull-White
-    /// swaption-calibration oracle anchors on (`hullwhite.rs:835`).
+    /// The 30/360 (Bond Basis) convention.
+    ///
+    /// Returns:
+    ///     DayCounter: A 30/360 day counter on the bond-basis convention.
     #[staticmethod]
     fn thirty360_bond_basis() -> Self {
         PyDayCounter {
@@ -210,30 +256,42 @@ impl PyDayCounter {
         }
     }
 
-    /// The period `[d1, d2]` as a fraction of a year under this convention
-    /// (`daycounter.rs:99`, the two-argument `yearFraction`).
+    /// The period [d1, d2] as a fraction of a year under this convention.
     ///
-    /// Infallible: the core reads the two dates and divides. The conventions
-    /// that need an explicit reference period (Actual/Actual ISMA) are not
-    /// among the four surfaced here, so the reference-period overload is not
-    /// exposed.
+    /// Args:
+    ///     d1 (Date): The start of the period.
+    ///     d2 (Date): The end of the period.
+    ///
+    /// Returns:
+    ///     float: The year fraction between the two dates.
     fn year_fraction(&self, d1: &PyDate, d2: &PyDate) -> f64 {
         self.inner.year_fraction(d1.inner(), d2.inner())
     }
 
-    /// Equality by convention name, delegating to the core `PartialEq`: two
-    /// independently built `Actual360`s are equal, an `Actual360` and an
-    /// `Actual365Fixed` are not.
+    /// Equality by convention name, so two independently built Actual360s
+    /// are equal.
+    ///
+    /// Args:
+    ///     other (object): The day counter to compare against.
+    ///
+    /// Returns:
+    ///     bool: True when both carry the same convention name.
     fn __eq__(&self, other: &PyDayCounter) -> bool {
         self.inner == other.inner
     }
 
-    /// Hashes the name, the one field [`__eq__`](Self::__eq__) compares, so a
-    /// day counter can key a dict or join a set.
+    /// Hashes the convention name, the field equality compares.
+    ///
+    /// Returns:
+    ///     int: The hash of the convention name, so equal day counters hash equal.
     fn __hash__(&self) -> u64 {
         hash_of(&self.inner.name())
     }
 
+    /// Return the day counter and its convention name.
+    ///
+    /// Returns:
+    ///     str: The day counter as DayCounter(name).
     fn __repr__(&self) -> String {
         format!("DayCounter({})", self.inner.name())
     }
@@ -255,11 +313,7 @@ impl PyDayCounter {
     }
 }
 
-/// Python `Period`: a signed length in one calendar unit.
-///
-/// The unit is taken as a string in {"Days", "Weeks", "Months", "Years"} and
-/// mapped to the core [`TimeUnit`]; an unknown unit returns
-/// [`struct@ItofinError`] rather than reaching the core.
+/// A signed length in one calendar unit (unit: Days, Weeks, Months, Years).
 #[pyclass(name = "Period", unsendable)]
 pub struct PyPeriod {
     inner: Period,
@@ -267,6 +321,14 @@ pub struct PyPeriod {
 
 #[pymethods]
 impl PyPeriod {
+    /// Build a period of n units.
+    ///
+    /// Args:
+    ///     n (int): The length, which may be negative.
+    ///     unit (str): One of "Days", "Weeks", "Months", "Years".
+    ///
+    /// Raises:
+    ///     ItofinError: If unit is not one of the four accepted strings.
     #[new]
     fn new(n: i32, unit: &str) -> PyResult<Self> {
         let units = match unit {
@@ -285,21 +347,34 @@ impl PyPeriod {
         })
     }
 
-    /// Semantic equality, delegating to the core `PartialEq`: `7 Days` equals
-    /// `1 Week` and `12 Months` equals `1 Year`, while a pair no calendar can
-    /// decide (`30 Days` against `1 Month`) is not equal.
+    /// Semantic equality: 7 Days equals 1 Week and 12 Months equals 1 Year,
+    /// while an undecidable pair such as 30 Days against 1 Month is not equal.
+    ///
+    /// Args:
+    ///     other (object): The period to compare against.
+    ///
+    /// Returns:
+    ///     bool: True when the two lengths are decidably the same.
     fn __eq__(&self, other: &PyPeriod) -> bool {
         self.inner == other.inner
     }
 
-    /// Hashes the canonical form, so every decidably equal pair hashes equal:
-    /// normalizing collapses `7 Days` onto `1 Week`, `12 Months` onto `1 Year`
-    /// and every zero length onto `0 Days` before the hash is taken.
+    /// Hashes the canonical form, so equal periods hash equal.
+    ///
+    /// Normalizing collapses 7 Days onto 1 Week, 12 Months onto 1 Year and
+    /// every zero length onto 0 Days before the hash is taken.
+    ///
+    /// Returns:
+    ///     int: The hash of the normalized length and unit.
     fn __hash__(&self) -> u64 {
         let normalized = self.inner.normalized();
         hash_of(&(normalized.length(), normalized.units()))
     }
 
+    /// Return the constructor form of the period.
+    ///
+    /// Returns:
+    ///     str: The period as Period(length, unit).
     fn __repr__(&self) -> String {
         format!("Period({}, {:?})", self.inner.length(), self.inner.units())
     }
@@ -332,7 +407,7 @@ fn parse_time_unit(unit: &str) -> PyResult<TimeUnit> {
     }
 }
 
-/// Python `Calendar`: the business-calendar factories.
+/// A business-day calendar.
 #[pyclass(name = "Calendar", unsendable)]
 pub struct PyCalendar {
     inner: Calendar,
@@ -340,6 +415,10 @@ pub struct PyCalendar {
 
 #[pymethods]
 impl PyCalendar {
+    /// The TARGET calendar.
+    ///
+    /// Returns:
+    ///     Calendar: The TARGET business-day calendar.
     #[staticmethod]
     fn target() -> Self {
         PyCalendar {
@@ -347,6 +426,10 @@ impl PyCalendar {
         }
     }
 
+    /// The calendar holding no holidays at all.
+    ///
+    /// Returns:
+    ///     Calendar: The null calendar, on which every day is a business day.
     #[staticmethod]
     fn null_calendar() -> Self {
         PyCalendar {
@@ -354,12 +437,14 @@ impl PyCalendar {
         }
     }
 
-    /// The weekends-only calendar: every Saturday and Sunday is a holiday and no
-    /// other day is.
+    /// The weekends-only calendar: Saturdays and Sundays are holidays and no
+    /// other day is. The calendar the ISDA CDS conventions roll on.
     ///
-    /// The ISDA CDS conventions roll on it, and it is not substitutable by
-    /// [`Self::null_calendar`] (which holds no holidays at all) or by a national
-    /// calendar (which adds public holidays).
+    /// It is not substitutable by the null calendar, which holds no holidays at
+    /// all, nor by a national calendar, which adds public holidays.
+    ///
+    /// Returns:
+    ///     Calendar: The weekends-only calendar.
     #[staticmethod]
     fn weekends_only() -> Self {
         PyCalendar {
@@ -367,12 +452,12 @@ impl PyCalendar {
         }
     }
 
-    /// The UK settlement calendar, the one the RPI inflation fixtures roll on.
+    /// The UK settlement calendar. Only the Settlement market is exposed:
+    /// the Exchange and Metals markets share an identical business-day rule in
+    /// the core and differ solely in their name.
     ///
-    /// Only [`Market::Settlement`] is exposed: the Exchange and Metals markets
-    /// share an identical `is_business_day` body in the core
-    /// (`unitedkingdom.rs:60-61`) and differ solely in `name()`, so a market
-    /// argument would select between three calendars that behave alike.
+    /// Returns:
+    ///     Calendar: The UK settlement calendar.
     #[staticmethod]
     fn united_kingdom() -> Self {
         PyCalendar {
@@ -380,11 +465,14 @@ impl PyCalendar {
         }
     }
 
-    /// Rolls `date` to the nearest business day per `convention`.
+    /// Roll a date to the nearest business day.
     ///
-    /// The core `Calendar::adjust` `assert!`s on the null date (calendar.rs:248);
-    /// `PyDate` cannot build one today, but the guard mirrors the `PySchedule`
-    /// precedent so no input reaches a core `assert!` across the PyO3 boundary.
+    /// Args:
+    ///     date (Date): The date to roll.
+    ///     convention (BusinessDayConvention): The rolling rule to apply.
+    ///
+    /// Returns:
+    ///     Date: The adjusted date, unchanged when it is already a business day.
     fn adjust(&self, date: &PyDate, convention: &PyBusinessDayConvention) -> PyResult<PyDate> {
         if date.inner() == Date::null() {
             return Err(ItofinError::new_err("cannot adjust the null date"));
@@ -394,11 +482,21 @@ impl PyCalendar {
         ))
     }
 
-    /// Advances `date` by `n` `unit`s, adjusting the result per `convention`.
+    /// Advance a date by n units and adjust the result.
     ///
-    /// `unit` is a string in {"Days", "Weeks", "Months", "Years"} mapped to the
-    /// core [`TimeUnit`]; an unknown unit returns [`struct@ItofinError`] rather
-    /// than reaching the core. The null-date guard mirrors [`Self::adjust`].
+    /// Args:
+    ///     date (Date): The date to advance from.
+    ///     n (int): The number of units to advance, which may be negative.
+    ///     unit (str): One of "Days", "Weeks", "Months", "Years".
+    ///     convention (BusinessDayConvention): The rule the advanced date is rolled under.
+    ///     end_of_month (bool): Keep the result on the month end when the starting
+    ///         date is one.
+    ///
+    /// Returns:
+    ///     Date: The advanced and adjusted date.
+    ///
+    /// Raises:
+    ///     ItofinError: If unit is not one of the four accepted strings.
     fn advance(
         &self,
         date: &PyDate,
@@ -420,6 +518,10 @@ impl PyCalendar {
         )))
     }
 
+    /// Return the calendar and its name.
+    ///
+    /// Returns:
+    ///     str: The calendar as Calendar(name).
     fn __repr__(&self) -> String {
         format!("Calendar({})", self.inner.name())
     }
@@ -440,15 +542,10 @@ impl PyCalendar {
     }
 }
 
-/// Python `Frequency`: the coupon and fixing frequencies the fixtures need.
+/// A coupon or fixing frequency.
 ///
-/// A fieldless pyo3 enum exposing `Frequency.Annual` / `Frequency.Semiannual` /
-/// `Frequency.Quarterly` / `Frequency.Monthly`; only the variants the
-/// Jamshidian, CDS and inflation fixtures use are surfaced. `Monthly` is the
-/// frequency every ported inflation index publishes at, and the only one
-/// [`ZeroInflationTermStructure`](crate::inflation::PyZeroInflationTermStructure)
-/// fixtures build curves under. New variants are appended, so the pyo3
-/// discriminants of the existing ones are unchanged.
+/// Only the variants the ported fixtures use are surfaced; new ones are
+/// appended, so the integer values of the existing variants are unchanged.
 #[pyclass(name = "Frequency", eq, eq_int, from_py_object)]
 #[derive(Clone, Copy, PartialEq)]
 pub enum PyFrequency {
@@ -488,17 +585,8 @@ impl PyFrequency {
     }
 }
 
-/// Python `BusinessDayConvention`: the holiday-rolling rules.
-///
-/// A fieldless pyo3 enum covering every variant the core enum carries
-/// (`businessdayconvention.rs:11-33`); the adjustment logic itself lives in the
-/// core calendar. Exhaustive coverage is what lets an index report its own
-/// convention back through [`Self::from_inner`], whatever it was built with.
-///
-/// The four non-original variants are appended rather than sorted into the core
-/// order, so the pyo3 discriminants of `ModifiedFollowing`, `Following` and
-/// `Unadjusted` are unchanged: the class is `eq_int`, so Python compares these
-/// by integer and a reorder would silently move them.
+/// A holiday-rolling rule. Every core variant is covered; the four listed
+/// last are appended, so the integer values of the first three are unchanged.
 #[pyclass(name = "BusinessDayConvention", eq, eq_int, from_py_object)]
 #[derive(Clone, Copy, PartialEq)]
 pub enum PyBusinessDayConvention {
@@ -544,21 +632,13 @@ impl PyBusinessDayConvention {
     }
 }
 
-/// Python `DateGeneration`: the rule a `Schedule` generates its dates by
-/// (core `time::dategenerationrule::DateGeneration`).
+/// The rule a Schedule generates its dates by.
 ///
-/// A fieldless pyo3 enum exposing every rule the core ports. `Backward` and
-/// `Forward` roll from one end of the range to the other; `Zero` keeps only the
-/// two endpoints; the `ThirdWednesday` and `Twentieth` families snap the
-/// interior dates onto an IMM Wednesday or the twentieth of the month, the
-/// convention CDS schedules are quoted under.
-///
-/// The three post-Big-Bang rules (`OldCDS`, `CDS`, `CDS2015`) are surfaced here
-/// because a `Schedule` builds under them, but
-/// [`SpreadCdsHelper`](crate::credithelpers::PySpreadCdsHelper) rejects them:
-/// their maturity comes from `cdsMaturity`, which the core has not ported
-/// (`defaultprobabilityhelpers.rs:314-319`). That rejection surfaces as an
-/// [`struct@crate::ItofinError`] rather than a silently wrong schedule.
+/// Backward and Forward roll from one end of the range to the other; Zero keeps
+/// only the two endpoints; the ThirdWednesday and Twentieth families snap the
+/// interior dates onto an IMM Wednesday or the twentieth of the month. A
+/// Schedule builds under the three CDS rules, but SpreadCdsHelper rejects them:
+/// their maturity comes from a core routine that is not ported yet.
 #[pyclass(name = "DateGeneration", eq, eq_int, from_py_object)]
 #[derive(Clone, Copy, PartialEq)]
 #[allow(clippy::upper_case_acronyms)]
@@ -593,33 +673,11 @@ impl PyDateGeneration {
     }
 }
 
-/// Python `Schedule`: a sequence of coupon dates built through `MakeSchedule`.
+/// A sequence of coupon dates built through MakeSchedule.
 ///
-/// The core `Schedule::new` (via `MakeSchedule::build`) `panic!`s on degenerate
-/// input - a null date or an effective date not strictly before the termination
-/// date - and a panic unwinding across the PyO3 boundary is an abort/UB hazard.
-/// The constructor supplies every builder input, so the `build`-level checks are
-/// unreachable; the date ordering is the one piece of user input, so it is
-/// validated first and returns [`struct@ItofinError`] before the core is
-/// touched. `date` likewise bounds-checks the index the core would otherwise
-/// panic on.
-///
-/// `rule` selects the date-generation rule and defaults to
-/// [`PyDateGeneration::Forward`], which is exactly what the builder's
-/// `forwards()` sets (`schedule.rs:852-853`), so an omitted `rule` reproduces
-/// every schedule this facade built before. The rule-dependent `panic!`s in
-/// `Schedule::new` (`schedule.rs:151-189`) all guard a non-null `first_date` or
-/// `next_to_last_date`, neither of which this constructor supplies, so no rule
-/// reaches them.
-///
-/// `termination_convention` rolls the last date only (`schedule.rs:415-421`)
-/// and defaults to `convention`, reproducing every schedule this facade built
-/// before it took one. CDS conventions need the two to differ: a credit helper
-/// leaves its maturity unadjusted (`defaultprobabilityhelpers.rs:512`) while
-/// paying `Following`, so under a twentieth rule a maturity landing on a
-/// weekend stays on the twentieth. Rolling it instead lengthens the contract by
-/// the roll, which the bootstrap round trip measures as a 3.6e-6 spread error
-/// on the one pillar it hits.
+/// termination_convention rolls the last date only, and defaults to
+/// convention. CDS conventions need the two to differ: a credit helper leaves
+/// its maturity unadjusted while paying Following.
 #[pyclass(name = "Schedule", unsendable)]
 pub struct PySchedule {
     inner: Schedule,
@@ -627,6 +685,20 @@ pub struct PySchedule {
 
 #[pymethods]
 impl PySchedule {
+    /// Build the schedule.
+    ///
+    /// Args:
+    ///     start (Date): The effective date, which must be strictly before end.
+    ///     end (Date): The termination date.
+    ///     frequency (Frequency): The coupon frequency the interior dates are spaced at.
+    ///     calendar (Calendar): The calendar the dates roll on.
+    ///     convention (BusinessDayConvention): The rule every date but the last is rolled under.
+    ///     rule (DateGeneration): The date-generation rule; defaults to Forward.
+    ///     termination_convention (BusinessDayConvention | None): The rule the last date is rolled under;
+    ///         None applies convention to it as well.
+    ///
+    /// Raises:
+    ///     ItofinError: If start is not strictly before end.
     #[new]
     #[pyo3(signature = (
         start,
@@ -669,12 +741,24 @@ impl PySchedule {
         Ok(PySchedule { inner })
     }
 
-    /// The number of dates in the schedule (one more than the period count).
+    /// The number of dates in the schedule.
+    ///
+    /// Returns:
+    ///     int: The date count, one more than the number of periods.
     fn size(&self) -> usize {
         self.inner.dates().len()
     }
 
-    /// The `i`-th date, erroring when `i` is out of range.
+    /// The i-th date in the schedule.
+    ///
+    /// Args:
+    ///     i (int): The zero-based index into the dates.
+    ///
+    /// Returns:
+    ///     Date: The date at that index.
+    ///
+    /// Raises:
+    ///     ItofinError: If i is out of range.
     fn date(&self, i: usize) -> PyResult<PyDate> {
         let dates = self.inner.dates();
         if i >= dates.len() {
@@ -686,7 +770,10 @@ impl PySchedule {
         Ok(PyDate { inner: dates[i] })
     }
 
-    /// All the schedule dates, as a Python list.
+    /// All the schedule dates.
+    ///
+    /// Returns:
+    ///     list[Date]: The dates in order, from the effective date to the termination date.
     fn dates(&self) -> Vec<PyDate> {
         self.inner
             .dates()
@@ -704,19 +791,33 @@ impl PySchedule {
     }
 }
 
-/// Whether `date` is an IMM date: the third Wednesday of the month, and of
-/// March, June, September or December only when `main_cycle` is set.
+/// Whether date is an IMM date.
 ///
-/// The free-function form QuantLib-SWIG exposes for `IMM::isIMMdate`; it is the
-/// way to build a valid IMM start date for the futures rate helper from Python.
+/// An IMM date is the third Wednesday of the month, and of March, June,
+/// September or December only when main_cycle is set.
+///
+/// Args:
+///     date (Date): The date to test.
+///     main_cycle (bool): Restrict the test to the March/June/September/December
+///         cycle.
+///
+/// Returns:
+///     bool: True when date is an IMM date under the selected cycle.
 #[pyfunction]
 #[pyo3(signature = (date, main_cycle = false))]
 fn is_imm_date(date: &PyDate, main_cycle: bool) -> bool {
     imm::is_imm_date(date.inner(), main_cycle)
 }
 
-/// The next IMM date strictly following `date`, restricted to the March/June/
-/// September/December cycle when `main_cycle` is set (`IMM::nextDate`).
+/// The next IMM date strictly following date.
+///
+/// Args:
+///     date (Date): The date to start from; the result is strictly after it.
+///     main_cycle (bool): Restrict the result to the March/June/September/December
+///         cycle.
+///
+/// Returns:
+///     Date: The next IMM date under the selected cycle.
 #[pyfunction]
 #[pyo3(signature = (date, main_cycle = false))]
 fn next_imm_date(date: &PyDate, main_cycle: bool) -> PyDate {

--- a/crates/itofin-py/src/time.rs
+++ b/crates/itofin-py/src/time.rs
@@ -1,4 +1,4 @@
-//! Facades for the time primitives: [`PyDate`], [`PyDayCounter`], [`PyCalendar`].
+//! Facades for the time primitives: Date, DayCounter, Calendar.
 
 use crate::ItofinError;
 use libitofin::time::businessdayconvention::BusinessDayConvention;
@@ -181,12 +181,12 @@ impl PyDate {
 }
 
 impl PyDate {
-    /// The wrapped core [`Date`] (cheaply `Copy`).
+    /// The wrapped core Date (cheaply `Copy`).
     pub(crate) fn inner(&self) -> Date {
         self.inner
     }
 
-    /// Wraps a core [`Date`] returned from a term-structure query.
+    /// Wraps a core Date returned from a term-structure query.
     pub(crate) fn from_inner(inner: Date) -> Self {
         PyDate { inner }
     }
@@ -301,13 +301,13 @@ impl PyDayCounter {
 }
 
 impl PyDayCounter {
-    /// The wrapped core [`DayCounter`] (cheap `Rc` clone).
+    /// The wrapped core DayCounter (cheap `Rc` clone).
     #[allow(dead_code)]
     pub(crate) fn inner(&self) -> DayCounter {
         self.inner.clone()
     }
 
-    /// Wraps a core [`DayCounter`] a facade read back off an object it built.
+    /// Wraps a core DayCounter a facade read back off an object it built.
     ///
     /// The result carries no factory identity, but equality is by convention
     /// name, so it compares equal to the factory call that built it.
@@ -384,20 +384,20 @@ impl PyPeriod {
 }
 
 impl PyPeriod {
-    /// The wrapped core [`Period`] (cheaply `Copy`).
+    /// The wrapped core Period (cheaply `Copy`).
     pub(crate) fn inner(&self) -> Period {
         self.inner
     }
 
-    /// A facade over a core [`Period`], for the inspectors that return one.
+    /// A facade over a core Period, for the inspectors that return one.
     pub(crate) fn from_inner(inner: Period) -> Self {
         PyPeriod { inner }
     }
 }
 
-/// Maps a `{"Days", "Weeks", "Months", "Years"}` string to a [`TimeUnit`],
-/// the same set [`PyPeriod`] accepts; an unknown unit returns
-/// [`struct@ItofinError`] rather than reaching the core.
+/// Maps a `{"Days", "Weeks", "Months", "Years"}` string to a TimeUnit, the same
+/// set Period accepts; an unknown unit returns ItofinError rather than reaching
+/// the core.
 fn parse_time_unit(unit: &str) -> PyResult<TimeUnit> {
     match unit {
         "Days" => Ok(TimeUnit::Days),
@@ -531,15 +531,15 @@ impl PyCalendar {
 }
 
 impl PyCalendar {
-    /// The wrapped core [`Calendar`] (cheap `Rc` clone).
+    /// The wrapped core Calendar (cheap `Rc` clone).
     pub(crate) fn inner(&self) -> Calendar {
         self.inner.clone()
     }
 
-    /// Wraps a core [`Calendar`] a facade read back off an object it built.
+    /// Wraps a core Calendar a facade read back off an object it built.
     ///
     /// The result carries no factory identity; the calendar it stands for is
-    /// readable through [`Self::__repr__`], which prints the core name.
+    /// readable through Self.__repr__(), which prints the core name.
     pub(crate) fn from_inner(inner: Calendar) -> Self {
         PyCalendar { inner }
     }
@@ -559,7 +559,7 @@ pub enum PyFrequency {
 }
 
 impl PyFrequency {
-    /// The core [`Frequency`] this variant stands for.
+    /// The core Frequency this variant stands for.
     pub(crate) fn inner(&self) -> Frequency {
         match self {
             PyFrequency::Annual => Frequency::Annual,
@@ -574,7 +574,7 @@ impl PyFrequency {
     ///
     /// The core enum carries thirteen values against the four surfaced here, so
     /// this is partial: a frequency with no counterpart is reported as
-    /// [`struct@ItofinError`] rather than mapped onto a neighbour.
+    /// ItofinError rather than mapped onto a neighbour.
     pub(crate) fn from_inner(frequency: Frequency) -> PyResult<PyFrequency> {
         match frequency {
             Frequency::Annual => Ok(PyFrequency::Annual),
@@ -603,7 +603,7 @@ pub enum PyBusinessDayConvention {
 }
 
 impl PyBusinessDayConvention {
-    /// The core [`BusinessDayConvention`] this variant stands for.
+    /// The core BusinessDayConvention this variant stands for.
     pub(crate) fn inner(&self) -> BusinessDayConvention {
         match self {
             PyBusinessDayConvention::ModifiedFollowing => BusinessDayConvention::ModifiedFollowing,
@@ -659,7 +659,7 @@ pub enum PyDateGeneration {
 }
 
 impl PyDateGeneration {
-    /// The core [`DateGeneration`] this variant stands for.
+    /// The core DateGeneration this variant stands for.
     pub(crate) fn inner(self) -> DateGeneration {
         match self {
             PyDateGeneration::Backward => DateGeneration::Backward,
@@ -787,7 +787,7 @@ impl PySchedule {
 }
 
 impl PySchedule {
-    /// The wrapped core [`Schedule`] (clone), for the swap facades in X2.
+    /// The wrapped core Schedule (clone), for the swap facades in X2.
     #[allow(dead_code)]
     pub(crate) fn inner(&self) -> Schedule {
         self.inner.clone()

--- a/crates/itofin-py/src/vol.rs
+++ b/crates/itofin-py/src/vol.rs
@@ -320,6 +320,9 @@ impl PyBlackVolTimeExtrapolation {
 /// maximum, so queries past it require enable_extrapolation(), and
 /// time_extrapolation picks the rule applied there. The interpolation itself
 /// stays linear; only the extrapolation axis is exposed.
+///
+/// Selecting UseInterpolator constructs fine and answers in-range queries, then
+/// errors on an extrapolating one.
 #[pyclass(name = "BlackVarianceCurve", extends = PyBlackVolTermStructure, unsendable)]
 pub struct PyBlackVarianceCurve {
     #[allow(dead_code)]

--- a/crates/itofin-py/src/vol.rs
+++ b/crates/itofin-py/src/vol.rs
@@ -13,13 +13,11 @@ use libitofin::termstructures::volatility::{
 };
 use pyo3::prelude::*;
 
-/// Python `BlackVolTermStructure`: the shared base for every Black-volatility
-/// surface (`termstructures::volatility::BlackVolTermStructure`).
+/// Shared base for every Black-volatility surface: spot and forward vol/variance.
 ///
-/// Holds the erased `Handle<dyn BlackVolTermStructure>` and exposes the spot
-/// and forward volatility/variance queries every concrete surface inherits,
-/// plus the strike domain and the extrapolation toggles. Concrete surfaces
-/// subclass this and supply only their constructor.
+/// Concrete surfaces subclass this and supply only their constructor; the
+/// whole query surface below is inherited, along with the strike domain and
+/// the extrapolation toggles.
 #[pyclass(name = "BlackVolTermStructure", subclass, unsendable)]
 pub struct PyBlackVolTermStructure {
     inner: Handle<dyn BlackVolTermStructure>,
@@ -27,7 +25,19 @@ pub struct PyBlackVolTermStructure {
 
 #[pymethods]
 impl PyBlackVolTermStructure {
-    /// The spot Black volatility at year-fraction `t` and `strike`.
+    /// Return the spot Black volatility at year-fraction t and strike.
+    ///
+    /// Args:
+    ///     t (float): The year fraction, in the surface's own day count.
+    ///     strike (float): The strike the volatility is read at.
+    ///     extrapolate (bool): Whether to answer outside the surface's grid.
+    ///
+    /// Returns:
+    ///     float: The Black volatility.
+    ///
+    /// Raises:
+    ///     ItofinError: If the query falls outside the grid and extrapolation
+    ///         is not allowed.
     #[pyo3(signature = (t, strike, extrapolate = false))]
     fn black_vol(&self, t: f64, strike: f64, extrapolate: bool) -> PyResult<f64> {
         Ok(self
@@ -38,7 +48,19 @@ impl PyBlackVolTermStructure {
             .map_err(PyQlError::from)?)
     }
 
-    /// The spot Black volatility at `date` and `strike`.
+    /// Return the spot Black volatility at date and strike.
+    ///
+    /// Args:
+    ///     date (Date): The expiry the volatility is read at.
+    ///     strike (float): The strike the volatility is read at.
+    ///     extrapolate (bool): Whether to answer outside the surface's grid.
+    ///
+    /// Returns:
+    ///     float: The Black volatility.
+    ///
+    /// Raises:
+    ///     ItofinError: If the query falls outside the grid and extrapolation
+    ///         is not allowed.
     #[pyo3(signature = (date, strike, extrapolate = false))]
     fn black_vol_date(&self, date: &PyDate, strike: f64, extrapolate: bool) -> PyResult<f64> {
         Ok(self
@@ -49,7 +71,19 @@ impl PyBlackVolTermStructure {
             .map_err(PyQlError::from)?)
     }
 
-    /// The spot Black variance at year-fraction `t` and `strike`.
+    /// Return the spot Black variance at year-fraction t and strike.
+    ///
+    /// Args:
+    ///     t (float): The year fraction, in the surface's own day count.
+    ///     strike (float): The strike the variance is read at.
+    ///     extrapolate (bool): Whether to answer outside the surface's grid.
+    ///
+    /// Returns:
+    ///     float: The Black variance.
+    ///
+    /// Raises:
+    ///     ItofinError: If the query falls outside the grid and extrapolation
+    ///         is not allowed.
     #[pyo3(signature = (t, strike, extrapolate = false))]
     fn black_variance(&self, t: f64, strike: f64, extrapolate: bool) -> PyResult<f64> {
         Ok(self
@@ -60,7 +94,19 @@ impl PyBlackVolTermStructure {
             .map_err(PyQlError::from)?)
     }
 
-    /// The spot Black variance at `date` and `strike`.
+    /// Return the spot Black variance at date and strike.
+    ///
+    /// Args:
+    ///     date (Date): The expiry the variance is read at.
+    ///     strike (float): The strike the variance is read at.
+    ///     extrapolate (bool): Whether to answer outside the surface's grid.
+    ///
+    /// Returns:
+    ///     float: The Black variance.
+    ///
+    /// Raises:
+    ///     ItofinError: If the query falls outside the grid and extrapolation
+    ///         is not allowed.
     #[pyo3(signature = (date, strike, extrapolate = false))]
     fn black_variance_date(&self, date: &PyDate, strike: f64, extrapolate: bool) -> PyResult<f64> {
         Ok(self
@@ -71,7 +117,20 @@ impl PyBlackVolTermStructure {
             .map_err(PyQlError::from)?)
     }
 
-    /// The forward Black volatility between year-fractions `t1` and `t2`.
+    /// Return the forward Black volatility between year-fractions t1 and t2.
+    ///
+    /// Args:
+    ///     t1 (float): The start year fraction.
+    ///     t2 (float): The end year fraction.
+    ///     strike (float): The strike the volatility is read at.
+    ///     extrapolate (bool): Whether to answer outside the surface's grid.
+    ///
+    /// Returns:
+    ///     float: The forward Black volatility.
+    ///
+    /// Raises:
+    ///     ItofinError: If the query falls outside the grid and extrapolation
+    ///         is not allowed.
     #[pyo3(signature = (t1, t2, strike, extrapolate = false))]
     fn black_forward_vol(&self, t1: f64, t2: f64, strike: f64, extrapolate: bool) -> PyResult<f64> {
         Ok(self
@@ -82,7 +141,20 @@ impl PyBlackVolTermStructure {
             .map_err(PyQlError::from)?)
     }
 
-    /// The forward Black variance between year-fractions `t1` and `t2`.
+    /// Return the forward Black variance between year-fractions t1 and t2.
+    ///
+    /// Args:
+    ///     t1 (float): The start year fraction.
+    ///     t2 (float): The end year fraction.
+    ///     strike (float): The strike the variance is read at.
+    ///     extrapolate (bool): Whether to answer outside the surface's grid.
+    ///
+    /// Returns:
+    ///     float: The forward Black variance.
+    ///
+    /// Raises:
+    ///     ItofinError: If the query falls outside the grid and extrapolation
+    ///         is not allowed.
     #[pyo3(signature = (t1, t2, strike, extrapolate = false))]
     fn black_forward_variance(
         &self,
@@ -99,7 +171,10 @@ impl PyBlackVolTermStructure {
             .map_err(PyQlError::from)?)
     }
 
-    /// The minimum strike for which the surface can return volatilities.
+    /// Return the minimum strike for which the surface can return volatilities.
+    ///
+    /// Returns:
+    ///     float: The lower bound of the strike domain.
     fn min_strike(&self) -> PyResult<f64> {
         Ok(self
             .inner
@@ -108,7 +183,10 @@ impl PyBlackVolTermStructure {
             .min_strike())
     }
 
-    /// The maximum strike for which the surface can return volatilities.
+    /// Return the maximum strike for which the surface can return volatilities.
+    ///
+    /// Returns:
+    ///     float: The upper bound of the strike domain.
     fn max_strike(&self) -> PyResult<f64> {
         Ok(self
             .inner
@@ -117,7 +195,10 @@ impl PyBlackVolTermStructure {
             .max_strike())
     }
 
-    /// The latest date for which the surface can return values.
+    /// Return the latest date for which the surface can return values.
+    ///
+    /// Returns:
+    ///     Date: The surface's maximum date.
     fn max_date(&self) -> PyResult<PyDate> {
         let date = self
             .inner
@@ -127,7 +208,10 @@ impl PyBlackVolTermStructure {
         Ok(PyDate::from_inner(date))
     }
 
-    /// Whether the surface answers dates/times beyond its maximum.
+    /// Return whether the surface answers dates and times beyond its maximum.
+    ///
+    /// Returns:
+    ///     bool: True when extrapolation is enabled on the surface itself.
     fn allows_extrapolation(&self) -> PyResult<bool> {
         Ok(self
             .inner
@@ -136,7 +220,7 @@ impl PyBlackVolTermStructure {
             .allows_extrapolation())
     }
 
-    /// Allows extrapolation past the maximum date/time.
+    /// Allow extrapolation past the maximum date and time.
     fn enable_extrapolation(&self) -> PyResult<()> {
         self.inner
             .current_link()
@@ -145,7 +229,7 @@ impl PyBlackVolTermStructure {
         Ok(())
     }
 
-    /// Forbids extrapolation past the maximum date/time.
+    /// Forbid extrapolation past the maximum date and time.
     fn disable_extrapolation(&self) -> PyResult<()> {
         self.inner
             .current_link()
@@ -162,17 +246,22 @@ impl PyBlackVolTermStructure {
     }
 }
 
-/// Python `BlackConstantVol`: a flat Black volatility, constant in strike and
-/// time (`termstructures::volatility::BlackConstantVol`).
+/// A flat Black volatility, constant in strike and time.
 ///
-/// Extends [`PyBlackVolTermStructure`] and supplies only the constructor; the
-/// query surface is inherited. Unbounded in both time and strike, so queries
-/// never need extrapolation enabled.
+/// Unbounded in both time and strike, so queries never need extrapolation
+/// enabled.
 #[pyclass(name = "BlackConstantVol", extends = PyBlackVolTermStructure, unsendable)]
 pub struct PyBlackConstantVol;
 
 #[pymethods]
 impl PyBlackConstantVol {
+    /// Build the flat surface.
+    ///
+    /// Args:
+    ///     reference_date (Date): The date times are measured from.
+    ///     volatility (float): The single volatility answered everywhere.
+    ///     day_counter (DayCounter): The day count turning dates into times.
+    ///     calendar (Calendar | None): The surface's calendar, if any.
     #[new]
     #[pyo3(signature = (reference_date, volatility, day_counter, calendar = None))]
     fn new(
@@ -194,16 +283,12 @@ impl PyBlackConstantVol {
     }
 }
 
-/// Python `BlackVolTimeExtrapolation`: how a variance curve extrapolates past
-/// its last node (`termstructures::volatility::BlackVolTimeExtrapolation`).
+/// How a variance curve extrapolates past its last node.
 ///
-/// A fieldless pyo3 enum. `UseInterpolator` is accepted at construction but
-/// **fails on any extrapolating query**: delegating to the interpolation needs
-/// it evaluated past its last node, which the interpolation layer cannot enable
-/// generically (`blackvariancecurve.rs:22-25,156-160`). The core returns an
-/// `Err` there rather than silently substituting another rule, so the Python
-/// boundary surfaces an [`struct@crate::ItofinError`] from the *query*, not the
-/// constructor - the D10 no-silent-fallback line.
+/// ``UseInterpolator`` is accepted at construction but raises ItofinError on
+/// any extrapolating query: the interpolation layer cannot be evaluated past
+/// its last node, and the core errors rather than silently substituting
+/// another rule.
 #[pyclass(name = "BlackVolTimeExtrapolation", eq, eq_int, from_py_object)]
 #[derive(Clone, Copy, PartialEq)]
 pub enum PyBlackVolTimeExtrapolation {
@@ -229,21 +314,12 @@ impl PyBlackVolTimeExtrapolation {
     }
 }
 
-/// Python `BlackVarianceCurve`: a term structure of Black volatility with no
-/// strike dimension, interpolating linearly on variance
-/// (`termstructures::volatility::BlackVarianceCurve<Linear>`).
+/// A term structure of Black volatility with no strike dimension.
 ///
-/// Extends [`PyBlackVolTermStructure`]. Finite in time: the last date is the
-/// maximum, so queries past it require `enable_extrapolation()`, and
-/// `time_extrapolation` picks the rule applied there (default
-/// `FlatVolatility`, the C++ default). The interpolation stays `Linear`: only
-/// the extrapolation axis is exposed, which keeps the concrete
-/// `BlackVarianceCurve<Linear>` handle retained alongside the erased base
-/// handle for a future local-volatility curve facade.
-///
-/// Selecting `UseInterpolator` constructs fine and answers in-range queries,
-/// then errors on an extrapolating one; see
-/// [`PyBlackVolTimeExtrapolation`].
+/// Interpolates linearly on variance. Finite in time: the last date is the
+/// maximum, so queries past it require enable_extrapolation(), and
+/// time_extrapolation picks the rule applied there. The interpolation itself
+/// stays linear; only the extrapolation axis is exposed.
 #[pyclass(name = "BlackVarianceCurve", extends = PyBlackVolTermStructure, unsendable)]
 pub struct PyBlackVarianceCurve {
     #[allow(dead_code)]
@@ -252,6 +328,23 @@ pub struct PyBlackVarianceCurve {
 
 #[pymethods]
 impl PyBlackVarianceCurve {
+    /// Build the variance curve over its (date, volatility) nodes.
+    ///
+    /// Args:
+    ///     reference_date (Date): The date times are measured from.
+    ///     dates (list[Date]): The node dates.
+    ///     black_vol_curve (list[float]): The Black volatility at each node.
+    ///     day_counter (DayCounter): The day count turning dates into times.
+    ///     force_monotone_variance (bool): Whether to require the implied
+    ///         variance to increase across the nodes.
+    ///     time_extrapolation (BlackVolTimeExtrapolation): The rule applied
+    ///         past the last node; defaults to FlatVolatility, the C++
+    ///         default. Selecting UseInterpolator constructs fine and answers
+    ///         in-range queries, then errors on an extrapolating one.
+    ///
+    /// Raises:
+    ///     ItofinError: On whatever the core rejects about the nodes, a
+    ///         non-monotone variance under force_monotone_variance included.
     #[new]
     #[pyo3(signature = (
         reference_date,
@@ -291,19 +384,29 @@ impl PyBlackVarianceCurve {
     }
 }
 
-/// Python `BlackVarianceSurface`: a Black volatility surface in strike and
-/// expiry, interpolating bilinearly on variance
-/// (`termstructures::volatility::BlackVarianceSurface`).
+/// A Black volatility surface in strike and expiry, interpolating bilinearly.
 ///
-/// Extends [`PyBlackVolTermStructure`]. The `black_vol_matrix` is a
-/// `list[list[float]]` with **one row per strike and one column per date**;
-/// the surface is finite in both time and strike, so out-of-grid queries
-/// require `enable_extrapolation()`.
+/// Finite in both time and strike, so out-of-grid queries require
+/// enable_extrapolation().
 #[pyclass(name = "BlackVarianceSurface", extends = PyBlackVolTermStructure, unsendable)]
 pub struct PyBlackVarianceSurface;
 
 #[pymethods]
 impl PyBlackVarianceSurface {
+    /// Build the surface over its strike-by-expiry grid.
+    ///
+    /// Args:
+    ///     reference_date (Date): The date times are measured from.
+    ///     dates (list[Date]): The expiry grid, one per matrix column.
+    ///     strikes (list[float]): The strike grid, one per matrix row.
+    ///     black_vol_matrix (list[list[float]]): The volatilities, one row per
+    ///         strike and one column per date.
+    ///     day_counter (DayCounter): The day count turning dates into times.
+    ///     calendar (Calendar | None): The surface's calendar, if any.
+    ///
+    /// Raises:
+    ///     ItofinError: On an empty or ragged matrix, and on whatever the core
+    ///         rejects about the grid dimensions.
     #[new]
     #[pyo3(signature = (reference_date, dates, strikes, black_vol_matrix, day_counter, calendar = None))]
     fn new(

--- a/crates/itofin-py/src/vol.rs
+++ b/crates/itofin-py/src/vol.rs
@@ -1,5 +1,4 @@
-//! Facade for the Black-volatility term-structure base:
-//! [`PyBlackVolTermStructure`].
+//! Facade for the Black-volatility term-structure base: BlackVolTermStructure.
 
 use crate::PyQlError;
 use crate::time::{PyCalendar, PyDate, PyDayCounter};
@@ -298,7 +297,7 @@ pub enum PyBlackVolTimeExtrapolation {
 }
 
 impl PyBlackVolTimeExtrapolation {
-    /// The core [`BlackVolTimeExtrapolation`] this variant stands for.
+    /// The core BlackVolTimeExtrapolation this variant stands for.
     fn inner(&self) -> BlackVolTimeExtrapolation {
         match self {
             PyBlackVolTimeExtrapolation::FlatVolatility => {
@@ -440,9 +439,9 @@ impl PyBlackVarianceSurface {
     }
 }
 
-/// Converts a Python `list[list[float]]` (row per strike, column per date)
-/// into a core [`Matrix`], rejecting an empty or ragged grid before it reaches
-/// the surface constructor's dimension checks.
+/// Converts a Python `list[list[float]]` (row per strike, column per date) into
+/// a core Matrix, rejecting an empty or ragged grid before it reaches the
+/// surface constructor's dimension checks.
 fn matrix_from_rows(rows: &[Vec<f64>]) -> PyResult<Matrix> {
     let n_rows = rows.len();
     if n_rows == 0 {


### PR DESCRIPTION
- **docs(itofin-py): sync facade doc comments with the hand-written stubs**
- **docs(src): document fallibility and behavior of Python bindings**
- **docs(itofin-py): rewrite module docs and internal doc comments as plain prose**

close #985