### PR TITLE
build(itofin-py): lower minimum Python version to 3.10

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -26,6 +26,10 @@ jobs:
   python-bindings:
     name: python bindings
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.13"]
     steps:
       - name: checkout repository
         uses: actions/checkout@v5
@@ -38,7 +42,7 @@ jobs:
       - name: set up python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: ${{ matrix.python-version }}
 
       - name: install maturin and pytest
         run: pip install --no-cache-dir maturin pytest

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ use libitofin::time::Date;
 ### Python
 
 The same engine is reachable from Python via [`itofin`](https://pypi.org/project/itofin/)
-(Python 3.13+). The API mirrors QuantLib's `ql/` layout: types live in submodules
+(Python 3.10+: 3.13 is the primary tested target, and 3.10-3.12 are supported via
+the abi3 wheel). The API mirrors QuantLib's `ql/` layout: types live in submodules
 (`itofin.time`, `itofin.instruments`, `itofin.processes`, ...), while `Settings`
 and `ItofinError` stay at the top level. Real market data is first-class - yield
 curves (bootstrapped from a deposit/swap strip via `PiecewiseYieldCurve`, or

--- a/crates/itofin-py/Cargo.toml
+++ b/crates/itofin-py/Cargo.toml
@@ -12,4 +12,4 @@ extension-module = ["pyo3/extension-module"]
 
 [dependencies]
 libitofin = { path = "../libitofin" }
-pyo3 = { version = "0.29", features = ["abi3-py313"] }
+pyo3 = { version = "0.29", features = ["abi3-py310"] }

--- a/crates/itofin-py/README.md
+++ b/crates/itofin-py/README.md
@@ -10,7 +10,7 @@ The API mirrors QuantLib's `ql/` layout: types live in submodules (`itofin.time`
 pip install itofin
 ```
 
-Requires Python >= 3.13.
+Requires Python >= 3.10 (3.13 is the primary tested target; 3.10-3.12 are supported via the abi3 wheel).
 
 ## Price a European option and its greeks
 

--- a/crates/itofin-py/pyproject.toml
+++ b/crates/itofin-py/pyproject.toml
@@ -8,10 +8,13 @@ description = "Python bindings for libitofin: a Rust port of QuantLib for pricin
 license = "BSD-3-Clause"
 authors = [{ name = "benbenbang", email = "bn@bitbrew.dev" }]
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: BSD License",
     "Topic :: Office/Business :: Financial :: Investment",
@@ -33,7 +36,7 @@ features = ["itofin-py/extension-module"]
 
 [tool.ruff]
 line-length = 120
-target-version = "py313"
+target-version = "py310"
 exclude = [
     ".bzr",
     ".direnv",


### PR DESCRIPTION
Lower the supported Python floor from 3.13 to 3.10 by switching the
pyo3 abi3 feature to `abi3-py310`, so 3.10-3.12 are covered by the
abi3 wheel while 3.13 remains the primary tested target.

Update `requires-python`, add 3.10-3.12 classifiers, and set the ruff
target to `py310` in pyproject.toml. Extend the CI pull-request
workflow to run the Python bindings job across a 3.10 and 3.13 matrix,
and refresh the README documentation to reflect the new support range.

Closes #987

close #987
