### PR TITLE
feat(itofin-py): support Python 3.10 through 3.13 via the abi3 wheel

### DIFF
--- a/crates/itofin-py/README.md
+++ b/crates/itofin-py/README.md
@@ -10,7 +10,9 @@ The API mirrors QuantLib's `ql/` layout: types live in submodules (`itofin.time`
 pip install itofin
 ```
 
-Requires Python >= 3.10 (3.13 is the primary tested target; 3.10-3.12 are supported via the abi3 wheel).
+## Python versions
+
+itofin ships a single abi3 wheel that runs on CPython 3.10, 3.11, 3.12, and 3.13+. Python 3.13 is the primary, tested target; 3.10 through 3.12 are supported through the stable ABI.
 
 ## Price a European option and its greeks
 


### PR DESCRIPTION
close #989
